### PR TITLE
Fix tutor selection page layout issues

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1427,6 +1427,8 @@ form label, .password-label-row label {
     flex-direction: column;
     align-items: center;
     padding: 2rem var(--page-horizontal-padding);
+    min-height: auto; /* Allow content to determine height */
+    flex: 1; /* Take available space and allow scrolling */
 }
 
 /* This creates the 5-column grid and uses a fluid gap */
@@ -1452,7 +1454,8 @@ form label, .password-label-row label {
     transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
     border: 2px solid transparent;
     position: relative;
-    overflow: hidden;
+    overflow: visible; /* Changed from hidden to show all content */
+    min-height: fit-content; /* Ensure card grows with content */
 }
 
 .tutor-card-image {


### PR DESCRIPTION
- Changed overflow from hidden to visible on tutor cards to show all text
- Added min-height: fit-content to ensure cards grow with content
- Added flex: 1 to pick-tutor-main to enable proper scrolling
- Fixes cut-off tutor descriptions and scroll button visibility