### PR TITLE
fix: Add credentials to PDF upload OCR request

### DIFF
--- a/public/js/file-upload.js
+++ b/public/js/file-upload.js
@@ -225,7 +225,8 @@ class FileUploadManager {
             // Call OCR endpoint
             const response = await fetch('/api/upload', {
                 method: 'POST',
-                body: formData
+                body: formData,
+                credentials: 'include'
             });
 
             if (!response.ok) {


### PR DESCRIPTION
- Added 'credentials: include' to /api/upload fetch call
- Fixes 400 error when uploading PDF files for OCR processing
- Ensures session cookie is sent with upload requests