### PR TITLE
fix: Modal freeze issue - use CSS classes instead of inline styles

### DIFF
--- a/public/admin-dashboard.html
+++ b/public/admin-dashboard.html
@@ -170,7 +170,7 @@
   </div>
 
   <!-- Usage Report Modal -->
-  <div id="usageReportModal" class="modal-overlay" style="display: none;">
+  <div id="usageReportModal" class="modal-overlay">
     <div class="modal-content" style="max-width: 1200px; max-height: 90vh; overflow-y: auto;">
       <button class="modal-close-button" id="closeUsageReportBtn">&times;</button>
       <h2><i class="fas fa-chart-bar"></i> Usage Report</h2>
@@ -275,7 +275,7 @@
   </div>
 
   <!-- Live Activity Modal -->
-  <div id="liveActivityModal" class="modal-overlay" style="display: none;">
+  <div id="liveActivityModal" class="modal-overlay">
     <div class="modal-content" style="max-width: 1000px;">
       <button class="modal-close-button" id="closeLiveActivityBtn">&times;</button>
       <h2><i class="fas fa-broadcast-tower"></i> Live Activity Feed</h2>

--- a/public/js/admin-dashboard.js
+++ b/public/js/admin-dashboard.js
@@ -408,28 +408,28 @@ document.addEventListener("DOMContentLoaded", async () => {
     // Open/Close Usage Report Modal
     if (openUsageReportBtn) {
         openUsageReportBtn.addEventListener('click', () => {
-            usageReportModal.style.display = 'flex';
+            usageReportModal?.classList.add('is-visible');
             loadUsageReport();
         });
     }
 
     if (closeUsageReportBtn) {
         closeUsageReportBtn.addEventListener('click', () => {
-            usageReportModal.style.display = 'none';
+            usageReportModal?.classList.remove('is-visible');
         });
     }
 
     // Open/Close Live Activity Modal
     if (openLiveActivityBtn) {
         openLiveActivityBtn.addEventListener('click', () => {
-            liveActivityModal.style.display = 'flex';
+            liveActivityModal?.classList.add('is-visible');
             loadLiveActivity();
         });
     }
 
     if (closeLiveActivityBtn) {
         closeLiveActivityBtn.addEventListener('click', () => {
-            liveActivityModal.style.display = 'none';
+            liveActivityModal?.classList.remove('is-visible');
         });
     }
 


### PR DESCRIPTION
The usage report and live activity modals were freezing because the code was setting inline style.display instead of using the existing .is-visible class pattern. The modals were technically displayed but invisible due to CSS opacity/transform animations that only trigger with the .is-visible class.

Changes:
- Use classList.add/remove('is-visible') instead of style.display
- Remove redundant inline style='display: none' from modal HTML
- Now properly respects CSS animation system

Fixes modal opening/closing and prevents page freeze.