### PR TITLE
fix: Force file-grid-container to display when cards are added

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1504,6 +1504,10 @@ document.addEventListener("DOMContentLoaded", () => {
 
     container.appendChild(card);
     console.log('[createFileCard] Card appended to container. Container children:', container.children.length);
+
+    // Force container to be visible (in case :empty CSS isn't updating)
+    container.style.display = 'grid';
+    console.log('[createFileCard] Forced container display to grid');
   }
 
   /**


### PR DESCRIPTION
The CSS rule .file-grid-container:empty hides the container when empty, but the browser may not immediately re-evaluate the :empty pseudo-class when cards are added via JavaScript. Force display: grid to ensure visibility.