### PR TITLE
fix: Use is-visible class pattern for Resources modal

### DIFF
--- a/public/js/student-resources.js
+++ b/public/js/student-resources.js
@@ -26,7 +26,7 @@ document.addEventListener('DOMContentLoaded', () => {
             e.preventDefault();
             e.stopPropagation();
             try {
-                resourcesModal.style.display = 'flex';
+                resourcesModal.classList.add('is-visible');
                 await loadResources();
             } catch (error) {
                 console.error('📚 Error opening resources:', error);
@@ -43,7 +43,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Close modal handlers
     function closeModal() {
-        resourcesModal.style.display = 'none';
+        resourcesModal.classList.remove('is-visible');
     }
 
     if (closeResourcesBtn) {


### PR DESCRIPTION
Changed Resources modal to use classList.add('is-visible') instead of style.display = 'flex' to match the pattern used by all other modals in the codebase. This fixes the issue where the Resources button click wasn't showing the modal.