### PR TITLE
fix: Remove incorrect smallcele animation trigger for regular AI resp…

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1683,14 +1683,6 @@ document.addEventListener("DOMContentLoaded", () => {
 
         chatBox.appendChild(bubble);
 
-        // 🎬 Trigger speaking animation when AI responds
-        if (sender === 'ai') {
-            if (typeof playTutorAnimation === 'function') {
-                // Play smallcele animation - will automatically crossfade back to idle when done
-                playTutorAnimation('smallcele');
-            }
-        }
-
         if (sender === 'ai' && currentUser?.preferences?.handsFreeModeEnabled) {
             if (currentUser.preferences.autoplayTtsHandsFree && window.TUTOR_CONFIG) {
                  const playButtonForAutoplay = bubble.querySelector('.play-audio-btn');


### PR DESCRIPTION
…onses

The smallcele celebration animation was being triggered for every AI response, causing tutors (especially Mr. Sierawski) to show celebrations too frequently.

Fixed by removing the animation trigger for regular AI responses. Now animations only play when appropriate:
- levelUp animation plays for actual level ups
- smallcele animation plays only for bonus XP rewards
- Regular AI responses keep the tutor in idle state

This resolves the issue where Mr. Sierawski was doing the level up celebration instead of staying calm during regular tutoring conversations.