### PR TITLE
fix: Screener authentication using req.user._id instead of req.sessio…

### DIFF
--- a/routes/screener.js
+++ b/routes/screener.js
@@ -30,10 +30,7 @@ const activeSessions = new Map();
  */
 router.post('/start', isAuthenticated, async (req, res) => {
   try {
-    const userId = req.session?.userId;
-    if (!userId) {
-      return res.status(401).json({ error: 'Not authenticated' });
-    }
+    const userId = req.user._id;
 
     const user = await User.findById(userId);
     if (!user) {
@@ -287,7 +284,7 @@ router.get('/report', isAuthenticated, async (req, res) => {
  */
 router.post('/complete', isAuthenticated, async (req, res) => {
   try {
-    const userId = req.session?.userId;
+    const userId = req.user._id;
     const { sessionId } = req.body;
 
     if (!sessionId) {


### PR DESCRIPTION
…n.userId

Fixed authentication error preventing screener from starting:

Problem:
- Screener routes were checking req.session.userId
- Passport authentication populates req.user, not req.session.userId
- Result: "Not authenticated" error even when logged in

Solution:
- Changed both /start and /complete routes to use req.user._id
- The isAuthenticated middleware already verifies req.user exists
- No need for redundant session checks

Files:
- routes/screener.js line 33: req.session?.userId → req.user._id
- routes/screener.js line 287: req.session?.userId → req.user._id

Now Mastery Mode can start the screener properly.