### PR TITLE
fix: Problem loading error in adaptive screener

### DIFF
--- a/public/js/adaptiveScreener.js
+++ b/public/js/adaptiveScreener.js
@@ -136,7 +136,8 @@ async function loadNextProblem() {
     });
 
     if (!response.ok) {
-      throw new Error('Failed to load problem');
+      const error = await response.json();
+      throw new Error(error.error || 'Failed to load problem');
     }
 
     const data = await response.json();


### PR DESCRIPTION
Fixed two critical issues causing "Failed to load problem" error:

1. Frontend error handling now displays actual backend error messages instead of generic "Failed to load problem" message

2. Fixed invalid MongoDB sort syntax in Problem.findNearDifficulty()
   - Replaced invalid .sort() with $abs/$subtract operators
   - Implemented proper aggregation pipeline to sort by difficulty distance
   - Converted aggregation results back to Mongoose documents

These fixes improve error visibility and resolve database query failures when finding problems at target difficulty levels.