### PR TITLE
debug: Add detailed error logging to screener problem generation

### DIFF
--- a/routes/screener.js
+++ b/routes/screener.js
@@ -139,7 +139,12 @@ router.get('/next-problem', isAuthenticated, async (req, res) => {
 
   } catch (error) {
     console.error('Error getting next problem:', error);
-    res.status(500).json({ error: 'Failed to get next problem' });
+    console.error('Error stack:', error.stack);
+    res.status(500).json({
+      error: 'Failed to get next problem',
+      details: error.message,
+      stack: process.env.NODE_ENV === 'development' ? error.stack : undefined
+    });
   }
 });
 


### PR DESCRIPTION
Added error details and stack traces to help diagnose why problem generation is failing during screener initialization.

This will help identify if the issue is:
- Database connection
- Problem template generation
- Problem save operation