### PR TITLE
fix: Initialize learningProfile if undefined to prevent screener crash

### DIFF
--- a/routes/screener.js
+++ b/routes/screener.js
@@ -48,6 +48,16 @@ router.post('/start', isAuthenticated, async (req, res) => {
       return res.status(404).json({ error: 'User not found' });
     }
 
+    // Initialize learningProfile if it doesn't exist
+    if (!user.learningProfile) {
+      user.learningProfile = {
+        assessmentCompleted: false,
+        abilityEstimate: {},
+        skillMastery: new Map()
+      };
+      await user.save();
+    }
+
     // Check if assessment already completed
     if (user.learningProfile.assessmentCompleted) {
       return res.status(403).json({
@@ -381,6 +391,15 @@ router.post('/complete', isAuthenticated, async (req, res) => {
     const user = await User.findById(userId);
     if (!user) {
       return res.status(404).json({ error: 'User not found' });
+    }
+
+    // Initialize learningProfile if it doesn't exist
+    if (!user.learningProfile) {
+      user.learningProfile = {
+        assessmentCompleted: false,
+        abilityEstimate: {},
+        skillMastery: new Map()
+      };
     }
 
     // Generate final report


### PR DESCRIPTION
- Added null check and initialization for user.learningProfile in /start endpoint
- Added same protection in /complete endpoint
- Prevents 'Cannot read property assessmentCompleted of undefined' error
- Fixes 'Failed to start assessment: Failed to start screener' user-facing error