### PR TITLE
fix: Use pagehide instead of beforeunload for tab-close detection

### DIFF
--- a/public/js/auto-logout.js
+++ b/public/js/auto-logout.js
@@ -126,11 +126,17 @@
     resetInactivityTimer();
 
     // 2. TAB/BROWSER CLOSE LOGOUT
-    // sessionStorage is automatically cleared when tab closes
-    // Send logout beacon to clean up server session
-    window.addEventListener('beforeunload', () => {
-      console.log('[Auto-Logout] Tab closing - sending logout beacon');
-      performLogout(); // Clears sessionStorage and sends logout beacon
+    // Use pagehide instead of beforeunload - more reliable for detecting actual tab close
+    // The 'persisted' property tells us if the page is being cached (navigation) or discarded (tab close)
+    window.addEventListener('pagehide', (event) => {
+      // If persisted = true, page is going into bfcache (back/forward cache) = navigation
+      // If persisted = false, page is being discarded = tab/browser close
+      if (!event.persisted) {
+        console.log('[Auto-Logout] Tab closing (not cached) - sending logout beacon');
+        performLogout(); // Clears sessionStorage and sends logout beacon
+      } else {
+        console.log('[Auto-Logout] Page cached for navigation - keeping session');
+      }
     });
 
     // Alternative: Use visibilitychange for tab switches


### PR DESCRIPTION
- beforeunload fires on ALL page navigation (causing logout during app navigation)
- pagehide with persisted check distinguishes navigation from tab close
- persisted=true: page cached for back/forward navigation (keep session)
- persisted=false: page discarded, tab/browser closing (logout)

Fixes issue where users were logged out when navigating between pages like login → pick-tutor, causing "Unexpected token '<'" JSON errors.