### PR TITLE
feat: Add breaks between operations in placement test

### DIFF
--- a/public/css/factFluencyBlaster.css
+++ b/public/css/factFluencyBlaster.css
@@ -237,6 +237,32 @@
     color: #00ff87;
 }
 
+/* Placement Break Screen */
+.break-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1.5rem;
+    margin: 3rem 0;
+}
+
+.break-message {
+    text-align: center;
+    font-size: 1.2rem;
+    color: #b8b8d1;
+    margin: 2rem 0 3rem 0;
+    padding: 2rem;
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 15px;
+}
+
+.break-message p {
+    margin: 0.5rem 0;
+}
+
+.break-message strong {
+    color: #00d4ff;
+}
+
 /* Placement Results */
 .results-content {
     padding: 2rem;

--- a/public/fact-fluency-blaster.html
+++ b/public/fact-fluency-blaster.html
@@ -97,6 +97,36 @@
             </div>
         </div>
 
+        <!-- Break Between Operations -->
+        <div id="placementBreakScreen" class="game-screen">
+            <div class="placement-content">
+                <h1>Great Job! 🎉</h1>
+                <h2 id="breakOperationComplete">Addition Complete!</h2>
+
+                <div class="break-stats">
+                    <div class="stat-card">
+                        <h3>Problems Attempted</h3>
+                        <div class="stat-big" id="breakAttempted">0</div>
+                    </div>
+                    <div class="stat-card">
+                        <h3>Correct</h3>
+                        <div class="stat-big" id="breakCorrect">0</div>
+                    </div>
+                    <div class="stat-card">
+                        <h3>Accuracy</h3>
+                        <div class="stat-big" id="breakAccuracy">0%</div>
+                    </div>
+                </div>
+
+                <div class="break-message">
+                    <p>Take a quick break! When you're ready, click below to continue.</p>
+                    <p><strong>Next:</strong> <span id="breakNextOperation">Subtraction</span></p>
+                </div>
+
+                <button id="continueToNextOperation" class="btn-primary large">Continue to Next Test →</button>
+            </div>
+        </div>
+
         <!-- Placement Results Screen -->
         <div id="placementResultsScreen" class="game-screen">
             <div class="results-content">

--- a/public/js/factFluencyBlaster.js
+++ b/public/js/factFluencyBlaster.js
@@ -165,6 +165,11 @@ function initializeEventListeners() {
     document.getElementById('backBtn').addEventListener('click', () => {
         window.location.href = '/badge-map.html';
     });
+
+    // Break screen continue button
+    document.getElementById('continueToNextOperation').addEventListener('click', () => {
+        startOperationPlacement();
+    });
 }
 
 // Show specific screen
@@ -175,6 +180,7 @@ function showScreen(screenName) {
     const screenMap = {
         'placement': 'placementScreen',
         'placementTest': 'placementTestScreen',
+        'placementBreak': 'placementBreakScreen',
         'placementResults': 'placementResultsScreen',
         'game': 'gameScreen',
         'results': 'resultsScreen',
@@ -313,10 +319,36 @@ function finishOperationPlacement() {
     // Move to next operation or finish
     gameState.placement.currentOperation++;
     if (gameState.placement.currentOperation < gameState.placement.operations.length) {
-        setTimeout(() => startOperationPlacement(), 2000);
+        // Show break screen before next operation
+        showBreakScreen(operation, accuracy);
     } else {
+        // All operations complete
         finishPlacement();
     }
+}
+
+function showBreakScreen(completedOperation, accuracy) {
+    showScreen('placementBreak');
+
+    const operationNames = {
+        'addition': 'Addition',
+        'subtraction': 'Subtraction',
+        'multiplication': 'Multiplication',
+        'division': 'Division'
+    };
+
+    // Show what was just completed
+    document.getElementById('breakOperationComplete').textContent =
+        operationNames[completedOperation] + ' Complete!';
+
+    // Show stats from last operation
+    document.getElementById('breakAttempted').textContent = gameState.placement.attempted;
+    document.getElementById('breakCorrect').textContent = gameState.placement.correct;
+    document.getElementById('breakAccuracy').textContent = accuracy + '%';
+
+    // Show what's next
+    const nextOperation = gameState.placement.operations[gameState.placement.currentOperation];
+    document.getElementById('breakNextOperation').textContent = operationNames[nextOperation];
 }
 
 async function finishPlacement() {


### PR DESCRIPTION
Students now get a break screen between each operation (addition, subtraction, multiplication, division) during the placement test. This prevents fatigue from 4 minutes of continuous testing.

Break screen shows:
- Stats from the completed operation (attempted, correct, accuracy)
- Encouragement message
- What operation is next
- Continue button (student-paced)

Improves UX and follows best practices for student assessment.