### PR TITLE
fix: Prevent tracking prevention storage access errors

### DIFF
--- a/public/badge-map.html
+++ b/public/badge-map.html
@@ -953,8 +953,9 @@
   </script>
 
   <!-- Auth & Session Scripts -->
-  <script src="/js/logout.js"></script>
+  <!-- Load storage utilities FIRST to prevent tracking prevention errors -->
   <script src="/js/storage-utils.js"></script>
+  <script src="/js/logout.js"></script>
   <script src="/js/auto-logout.js"></script>
 </body>
 </html>

--- a/public/chat.html
+++ b/public/chat.html
@@ -740,8 +740,9 @@
   <!-- Algebra Tiles Container -->
   <div id="algebraTilesContainer"></div>
 
-  <script src="/js/logout.js"></script>
+  <!-- Load storage utilities FIRST to prevent tracking prevention errors -->
   <script src="/js/storage-utils.js"></script>
+  <script src="/js/logout.js"></script>
   <script src="/js/auto-logout.js"></script>
   <script src="/js/algebra-tiles.js"></script>
   <script src="/js/tutor-config-data.js"></script>

--- a/public/js/adaptiveScreener.js
+++ b/public/js/adaptiveScreener.js
@@ -100,10 +100,12 @@ async function startScreener() {
       if (response.status === 401) {
         console.error('Authentication failed - redirecting to login');
         // Clear any stale mastery mode flags
-        sessionStorage.removeItem('masteryModeActive');
-        sessionStorage.removeItem('masteryPhase');
-        sessionStorage.removeItem('activeBadgeId');
-        sessionStorage.removeItem('screenerResults');
+        if (window.StorageUtils) {
+          StorageUtils.session.removeItem('masteryModeActive');
+          StorageUtils.session.removeItem('masteryPhase');
+          StorageUtils.session.removeItem('activeBadgeId');
+          StorageUtils.session.removeItem('screenerResults');
+        }
         alert('Your session has expired. Please log in again.');
         window.location.href = '/login.html';
         return;
@@ -277,15 +279,21 @@ async function handleCompletion(data) {
     const report = completeData.report;
 
     // Save results to sessionStorage for chat to access
-    sessionStorage.setItem('screenerResults', JSON.stringify(report));
-    sessionStorage.setItem('screenerJustCompleted', 'true');
+    if (window.StorageUtils) {
+      StorageUtils.session.setItem('screenerResults', JSON.stringify(report));
+      StorageUtils.session.setItem('screenerJustCompleted', 'true');
+    }
 
     // Check if in Mastery Mode
-    const masteryModeActive = sessionStorage.getItem('masteryModeActive');
+    const masteryModeActive = window.StorageUtils
+      ? StorageUtils.session.getItem('masteryModeActive')
+      : null;
 
     if (masteryModeActive === 'true') {
       // Mastery mode: Set phase for interview
-      sessionStorage.setItem('masteryPhase', 'interview');
+      if (window.StorageUtils) {
+        StorageUtils.session.setItem('masteryPhase', 'interview');
+      }
 
       // Show brief completion message
       displayResults(report);

--- a/public/js/badgeMap.js
+++ b/public/js/badgeMap.js
@@ -75,10 +75,12 @@ async function initialize() {
       if (response.status === 401) {
         console.error('Authentication failed - redirecting to login');
         // Clear any stale mastery mode flags
-        sessionStorage.removeItem('masteryModeActive');
-        sessionStorage.removeItem('masteryPhase');
-        sessionStorage.removeItem('activeBadgeId');
-        sessionStorage.removeItem('screenerResults');
+        if (window.StorageUtils) {
+          StorageUtils.session.removeItem('masteryModeActive');
+          StorageUtils.session.removeItem('masteryPhase');
+          StorageUtils.session.removeItem('activeBadgeId');
+          StorageUtils.session.removeItem('screenerResults');
+        }
         window.location.href = '/login.html';
         return;
       }
@@ -327,8 +329,10 @@ async function selectBadge(badgeId) {
     const data = await response.json();
 
     // Store badge info in sessionStorage
-    sessionStorage.setItem('activeBadgeId', badgeId);
-    sessionStorage.setItem('masteryPhase', 'badge-earning');
+    if (window.StorageUtils) {
+      StorageUtils.session.setItem('activeBadgeId', badgeId);
+      StorageUtils.session.setItem('masteryPhase', 'badge-earning');
+    }
 
     // Redirect to mastery mode interface to begin badge work
     window.location.href = '/mastery-chat.html';

--- a/public/js/badgeProgress.js
+++ b/public/js/badgeProgress.js
@@ -25,7 +25,9 @@ async function initializeBadgeProgress() {
 async function checkActiveBadge() {
   try {
     // Only show badge widget during mastery mode, not during normal tutoring
-    const masteryPhase = sessionStorage.getItem('masteryPhase');
+    const masteryPhase = window.StorageUtils
+      ? StorageUtils.session.getItem('masteryPhase')
+      : null;
     if (!masteryPhase) {
       // Not in mastery mode - hide widget if it exists
       hideBadgeWidget();

--- a/public/js/logout.js
+++ b/public/js/logout.js
@@ -17,7 +17,11 @@ document.addEventListener('DOMContentLoaded', () => {
           console.log("LOG: Logout fetch response:", res.status, res.statusText);
           if (res.ok) {
             console.log("LOG: Logout successful, redirecting.");
-            localStorage.clear(); // Clear all localStorage items related to session
+            // Use StorageUtils to safely clear storage (prevents tracking prevention errors)
+            if (window.StorageUtils) {
+              StorageUtils.local.clear();
+              StorageUtils.session.clear();
+            }
             window.location.href = '/login.html';
           } else {
             const errorText = await res.text();

--- a/public/js/masteryMode.js
+++ b/public/js/masteryMode.js
@@ -56,14 +56,18 @@ function initializeMasteryMode() {
       if (assessmentCompleted) {
         // User already completed placement - skip straight to badge selection
         console.log('[Mastery Mode] User already completed placement screener, skipping to badges');
-        sessionStorage.setItem('masteryModeActive', 'true');
-        sessionStorage.setItem('masteryPhase', 'badges');
+        if (window.StorageUtils) {
+          StorageUtils.session.setItem('masteryModeActive', 'true');
+          StorageUtils.session.setItem('masteryPhase', 'badges');
+        }
         window.location.href = '/badge-map.html';
       } else {
         // User needs placement - redirect to screener
         console.log('[Mastery Mode] User needs placement screener');
-        sessionStorage.setItem('masteryModeActive', 'true');
-        sessionStorage.setItem('masteryPhase', 'placement');
+        if (window.StorageUtils) {
+          StorageUtils.session.setItem('masteryModeActive', 'true');
+          StorageUtils.session.setItem('masteryPhase', 'placement');
+        }
         window.location.href = '/screener.html';
       }
     } catch (error) {
@@ -90,8 +94,12 @@ if (document.readyState === 'loading') {
  * Check if returning from screener and should start interview
  */
 async function checkMasteryPhaseOnLoad() {
-  const masteryActive = sessionStorage.getItem('masteryModeActive');
-  const currentPhase = sessionStorage.getItem('masteryPhase');
+  const masteryActive = window.StorageUtils
+    ? StorageUtils.session.getItem('masteryModeActive')
+    : null;
+  const currentPhase = window.StorageUtils
+    ? StorageUtils.session.getItem('masteryPhase')
+    : null;
 
   if (masteryActive === 'true') {
     if (currentPhase === 'interview') {
@@ -111,7 +119,10 @@ async function startAIInterviewProbe() {
   console.log('Starting AI Interview Probe...');
 
   // Get screener results from session storage
-  const screenerResults = JSON.parse(sessionStorage.getItem('screenerResults') || '{}');
+  const screenerResultsStr = window.StorageUtils
+    ? StorageUtils.session.getItem('screenerResults')
+    : null;
+  const screenerResults = JSON.parse(screenerResultsStr || '{}');
 
   if (!screenerResults || !screenerResults.theta) {
     console.error('No screener results found');
@@ -242,10 +253,14 @@ Reply with the name of the badge you'd like to pursue, or say "show me all" to s
  */
 function completePhase(phase) {
   if (phase === 'placement') {
-    sessionStorage.setItem('masteryPhase', 'interview');
+    if (window.StorageUtils) {
+      StorageUtils.session.setItem('masteryPhase', 'interview');
+    }
     // Results are passed via screener completion
   } else if (phase === 'interview') {
-    sessionStorage.setItem('masteryPhase', 'badges');
+    if (window.StorageUtils) {
+      StorageUtils.session.setItem('masteryPhase', 'badges');
+    }
     masteryState.interviewComplete = true;
   }
 }
@@ -254,9 +269,11 @@ function completePhase(phase) {
  * Exit mastery mode
  */
 function exitMasteryMode() {
-  sessionStorage.removeItem('masteryModeActive');
-  sessionStorage.removeItem('masteryPhase');
-  sessionStorage.removeItem('screenerResults');
+  if (window.StorageUtils) {
+    StorageUtils.session.removeItem('masteryModeActive');
+    StorageUtils.session.removeItem('masteryPhase');
+    StorageUtils.session.removeItem('screenerResults');
+  }
   masteryState.currentPhase = null;
   masteryState.screenerResults = null;
   masteryState.interviewComplete = false;

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1364,8 +1364,12 @@ document.addEventListener("DOMContentLoaded", () => {
     async function getWelcomeMessage() {
         try {
             // Check if user just completed screener
-            const screenerJustCompleted = sessionStorage.getItem('screenerJustCompleted');
-            const screenerResults = sessionStorage.getItem('screenerResults');
+            const screenerJustCompleted = window.StorageUtils
+                ? StorageUtils.session.getItem('screenerJustCompleted')
+                : null;
+            const screenerResults = window.StorageUtils
+                ? StorageUtils.session.getItem('screenerResults')
+                : null;
 
             if (screenerJustCompleted === 'true' && screenerResults) {
                 // User just finished screener - provide personalized welcome
@@ -1381,13 +1385,19 @@ document.addEventListener("DOMContentLoaded", () => {
                 appendMessage(message, "ai");
 
                 // Clear the flag so this only shows once
-                sessionStorage.removeItem('screenerJustCompleted');
+                if (window.StorageUtils) {
+                    StorageUtils.session.removeItem('screenerJustCompleted');
+                }
                 return;
             }
 
             // Check if user just selected a badge to work on
-            const activeBadgeId = sessionStorage.getItem('activeBadgeId');
-            const masteryPhase = sessionStorage.getItem('masteryPhase');
+            const activeBadgeId = window.StorageUtils
+                ? StorageUtils.session.getItem('activeBadgeId')
+                : null;
+            const masteryPhase = window.StorageUtils
+                ? StorageUtils.session.getItem('masteryPhase')
+                : null;
 
             if (activeBadgeId && masteryPhase) {
                 // Fetch active badge details from backend
@@ -1436,7 +1446,9 @@ document.addEventListener("DOMContentLoaded", () => {
                             appendMessage(message, "ai");
 
                             // Clear the flag so this only shows once
-                            sessionStorage.removeItem('activeBadgeId');
+                            if (window.StorageUtils) {
+                                StorageUtils.session.removeItem('activeBadgeId');
+                            }
                             return;
                         }
                     }

--- a/public/js/whiteboard.js
+++ b/public/js/whiteboard.js
@@ -1009,7 +1009,9 @@ class MathmatixWhiteboard {
         };
 
         try {
-            localStorage.setItem('whiteboardLayout', JSON.stringify(layout));
+            if (window.StorageUtils) {
+                StorageUtils.local.setItem('whiteboardLayout', JSON.stringify(layout));
+            }
         } catch (e) {
             console.warn('Failed to save whiteboard layout:', e);
         }
@@ -1019,7 +1021,9 @@ class MathmatixWhiteboard {
         if (!this.panel) return;
 
         try {
-            const saved = localStorage.getItem('whiteboardLayout');
+            const saved = window.StorageUtils
+                ? StorageUtils.local.getItem('whiteboardLayout')
+                : null;
             if (!saved) return;
 
             const layout = JSON.parse(saved);
@@ -1052,7 +1056,9 @@ class MathmatixWhiteboard {
         if (!this.panel) return;
 
         // Clear saved layout
-        localStorage.removeItem('whiteboardLayout');
+        if (window.StorageUtils) {
+            StorageUtils.local.removeItem('whiteboardLayout');
+        }
 
         // Reset to default position and size
         this.panel.style.width = '650px';


### PR DESCRIPTION
Fixed browser tracking prevention errors by ensuring StorageUtils is loaded first and used consistently across all files.

Changes:
- Moved storage-utils.js to load before other scripts in chat.html and badge-map.html
- Updated all direct localStorage/sessionStorage calls to use StorageUtils wrapper
- Added fallback handling when StorageUtils is unavailable
- Affected files: logout.js, masteryMode.js, whiteboard.js, script.js, badgeProgress.js, badgeMap.js, adaptiveScreener.js

This prevents "Tracking Prevention blocked access to storage" errors in Safari and Edge browsers.