### PR TITLE
fix: Only show badge widget during active badge earning

### DIFF
--- a/public/js/badgeProgress.js
+++ b/public/js/badgeProgress.js
@@ -24,12 +24,12 @@ async function initializeBadgeProgress() {
  */
 async function checkActiveBadge() {
   try {
-    // Only show badge widget during mastery mode, not during normal tutoring
+    // Only show badge widget during ACTIVE badge earning, not during other mastery phases
     const masteryPhase = window.StorageUtils
       ? StorageUtils.session.getItem('masteryPhase')
       : null;
-    if (!masteryPhase) {
-      // Not in mastery mode - hide widget if it exists
+    if (masteryPhase !== 'badge-earning') {
+      // Not actively earning a badge - hide widget if it exists
       hideBadgeWidget();
       return;
     }


### PR DESCRIPTION
The badge progress widget was appearing whenever masteryPhase existed in sessionStorage, even when just browsing mastery mode. Now it only appears when masteryPhase === 'badge-earning', preventing unwanted widget display when returning from mastery mode to regular chat.