### PR TITLE
fix: Add discrimination field to screenerSession responses schema

### DIFF
--- a/models/screenerSession.js
+++ b/models/screenerSession.js
@@ -41,6 +41,7 @@ const screenerSessionSchema = new mongoose.Schema({
         problemId: String,
         skillId: String,
         difficulty: Number,
+        discrimination: Number,  // IRT discrimination parameter (α)
         correct: Boolean,
         responseTime: Number,
         theta: Number,


### PR DESCRIPTION
This was causing NaN theta calculations because Mongoose was stripping the discrimination field when saving responses to the database.

The IRT estimation requires both difficulty and discrimination parameters, but the schema only had difficulty defined, causing discrimination values to be lost on save.