### PR TITLE
fix: Set answerType to multiple-choice for problems with options

### DIFF
--- a/scripts/importItemBank.js
+++ b/scripts/importItemBank.js
@@ -262,6 +262,9 @@ function parseRow(row) {
       { label: 'C', text: optionC || '' },
       { label: 'D', text: optionD || '' }
     ].filter(opt => opt.text); // Remove empty options
+
+    // Set answer type to multiple choice
+    problem.answerType = 'multiple-choice';
   }
 
   // Extract correct answer


### PR DESCRIPTION
- Ensures screener frontend displays MC buttons instead of fill-in
- Previously problems had options but answerType was undefined