### PR TITLE
fix: Critical mastery mode UX and API bugs

### DIFF
--- a/public/badge-map.html
+++ b/public/badge-map.html
@@ -1162,23 +1162,29 @@
         'accumulation': 'fa-layer-group'
       };
 
-      container.innerHTML = patterns.map(pattern => `
-        <div class="pattern-badge" onclick="selectPattern('${pattern.patternId}')">
-          <div class="pattern-badge-circle pattern-${pattern.patternId}">
-            <i class="fas ${iconMap[pattern.patternId] || 'fa-star'} pattern-badge-icon"></i>
-          </div>
-          <div class="pattern-badge-name">${pattern.name}</div>
-          <div class="pattern-badge-tier">Tier ${pattern.currentTier || 0}</div>
-          ${pattern.progress !== undefined ? `
-            <div class="pattern-badge-progress">
-              <div class="pattern-badge-progress-fill" style="width: ${pattern.progress}%"></div>
+      container.innerHTML = patterns.map(pattern => {
+        const isLocked = !pattern.currentTier || pattern.currentTier === 0;
+        const clickHandler = isLocked ? '' : `onclick="selectPattern('${pattern.patternId}')"`;
+        const cursorStyle = isLocked ? 'cursor: not-allowed; opacity: 0.5;' : 'cursor: pointer;';
+
+        return `
+          <div class="pattern-badge" ${clickHandler} style="${cursorStyle}">
+            <div class="pattern-badge-circle pattern-${pattern.patternId}">
+              <i class="fas ${iconMap[pattern.patternId] || 'fa-star'} pattern-badge-icon"></i>
             </div>
-          ` : ''}
-          <div class="pattern-badge-status ${pattern.status || 'locked'}">
-            ${getPatternStatusText(pattern.status, pattern.currentTier)}
+            <div class="pattern-badge-name">${pattern.name}</div>
+            <div class="pattern-badge-tier">Tier ${pattern.currentTier || 0}</div>
+            ${pattern.progress !== undefined && !isLocked ? `
+              <div class="pattern-badge-progress">
+                <div class="pattern-badge-progress-fill" style="width: ${pattern.progress}%"></div>
+              </div>
+            ` : ''}
+            <div class="pattern-badge-status ${pattern.status || 'locked'}">
+              ${getPatternStatusText(pattern.status, pattern.currentTier)}
+            </div>
           </div>
-        </div>
-      `).join('');
+        `;
+      }).join('');
     }
 
     function getPatternStatusText(status, tier) {

--- a/public/mastery-chat.html
+++ b/public/mastery-chat.html
@@ -757,16 +757,10 @@
         // Load next problem from backend
         async function loadNextProblem() {
             try {
-                const badge = currentUser.masteryProgress.activeBadge;
                 const response = await fetch('/api/mastery/next-phase-problem', {
-                    method: 'POST',
+                    method: 'GET',
                     headers: { 'Content-Type': 'application/json' },
-                    credentials: 'include',
-                    body: JSON.stringify({
-                        skillId: badge.skillId,
-                        currentPhase: currentPhase,
-                        tier: badge.tier || 1
-                    })
+                    credentials: 'include'
                 });
 
                 if (!response.ok) {


### PR DESCRIPTION
MASTERY-CHAT FIXES:
- Change loadNextProblem() from POST to GET (was causing 404)
- Backend endpoint is GET /api/mastery/next-phase-problem
- Remove unnecessary request body (GET doesn't need body)

BADGE-MAP FIXES:
- Disable clicking on locked pattern badges (Tier 0)
- Add visual indicators: opacity 0.5 + cursor not-allowed for locked
- Prevents 400 error: 'No available milestones for this pattern'
- Only show progress bars on unlocked patterns

USER IMPACT:
Before: Clicking pattern badges triggered errors and failed redirects After: Locked badges are visually disabled and not clickable

Related errors fixed:
- POST /api/mastery/next-phase-problem 404 → now GET
- POST /api/mastery/select-pattern 400 → prevented by disabling locked badges