### PR TITLE
fix: Replace broken /dashboard.html links with /badge-map.html

### DIFF
--- a/public/fact-fluency-blaster.html
+++ b/public/fact-fluency-blaster.html
@@ -14,7 +14,7 @@
         <div class="main-header-content">
             <div class="brand-section">
                 <div class="logo-container">
-                    <a href="/dashboard.html">
+                    <a href="/badge-map.html">
                         <img src="/images/mathmatix-ai-logo.png" alt="MATHMATIX AI Logo" class="main-logo" />
                     </a>
                 </div>

--- a/public/number-run.html
+++ b/public/number-run.html
@@ -14,7 +14,7 @@
         <div class="main-header-content">
             <div class="brand-section">
                 <div class="logo-container">
-                    <a href="/dashboard.html">
+                    <a href="/badge-map.html">
                         <img src="/images/mathmatix-ai-logo.png" alt="MATHMATIX AI Logo" class="main-logo" />
                     </a>
                 </div>


### PR DESCRIPTION
ISSUE:
- Both arcade games had header logo links to /dashboard.html
- This file doesn't exist, causing 404 errors
- Users clicking logo would see error instead of navigation

FIX:
- Changed header logo links from /dashboard.html to /badge-map.html
- Applies to:
  - fact-fluency-blaster.html (M∆THBL∆ST game)
  - number-run.html (NUMBER RUN game)

NOW:
- Clicking logo returns users to badge map
- Consistent navigation across all mastery mode pages
- No more 404 errors on logo click