### PR TITLE
fix: Update deprecated Claude model to claude-3-5-sonnet-20241022

### DIFF
--- a/routes/chat.js
+++ b/routes/chat.js
@@ -20,7 +20,7 @@ const { parseAIDrawingCommands } = require('../utils/aiDrawingTools');
 const { detectAndFetchResource } = require('../utils/resourceDetector');
 const { updateFluencyTracking, evaluateResponseTime, calculateAdaptiveTimeLimit } = require('../utils/adaptiveFluency');
 
-const PRIMARY_CHAT_MODEL = "claude-3-5-sonnet-20240620"; // Best teaching & reasoning (stable June 2024 - with GPT fallback)
+const PRIMARY_CHAT_MODEL = "claude-3-5-sonnet-20241022"; // Best teaching & reasoning (Sonnet 3.5 v2 - Oct 2024)
 const MAX_MESSAGE_LENGTH = 2000;
 const MAX_HISTORY_LENGTH_FOR_AI = 40;
 

--- a/routes/chatWithFile.js
+++ b/routes/chatWithFile.js
@@ -27,7 +27,7 @@ const upload = multer({
     }),
     limits: { fileSize: 10 * 1024 * 1024 } // 10MB per file
 });
-const PRIMARY_CHAT_MODEL = "claude-3-5-sonnet-20240620"; // Best teaching & reasoning (stable June 2024 - with GPT fallback)
+const PRIMARY_CHAT_MODEL = "claude-3-5-sonnet-20241022"; // Best teaching & reasoning (Sonnet 3.5 v2 - Oct 2024)
 
 router.post('/',
     isAuthenticated,

--- a/routes/masteryChat.js
+++ b/routes/masteryChat.js
@@ -10,7 +10,7 @@ const { generateSystemPrompt } = require('../utils/prompt');
 const { callLLM, callLLMStream } = require("../utils/llmGateway");
 const TUTOR_CONFIG = require('../utils/tutorConfig');
 
-const PRIMARY_CHAT_MODEL = "claude-3-5-sonnet-20240620"; // Best teaching & reasoning (stable June 2024 - with GPT fallback)
+const PRIMARY_CHAT_MODEL = "claude-3-5-sonnet-20241022"; // Best teaching & reasoning (Sonnet 3.5 v2 - Oct 2024)
 const MAX_MESSAGE_LENGTH = 2000;
 const MAX_HISTORY_LENGTH_FOR_AI = 40;
 

--- a/routes/upload.js
+++ b/routes/upload.js
@@ -11,7 +11,7 @@ const ocr = require("../utils/ocr");
 const pdfOcr = require("../utils/pdfOcr");
 const TUTOR_CONFIG = require('../utils/tutorConfig');
 
-const PRIMARY_UPLOAD_AI_MODEL = "claude-3-5-sonnet-20240620"; // Best for analyzing student work (stable June 2024)
+const PRIMARY_UPLOAD_AI_MODEL = "claude-3-5-sonnet-20241022"; // Best for analyzing student work (Sonnet 3.5 v2 - Oct 2024)
 
 // CTO REVIEW FIX: Use diskStorage instead of memoryStorage to prevent server crashes
 const upload = multer({

--- a/utils/llmGateway.js
+++ b/utils/llmGateway.js
@@ -25,9 +25,9 @@ const { generateSystemPrompt } = require('./prompt');
 // ============================================================================
 
 const DEFAULT_MODELS = {
-    chat: 'claude-3-5-sonnet-20240620',      // Best teaching & reasoning model (stable June 2024 version)
-    grading: 'claude-3-5-sonnet-20240620',   // Vision-capable, superior analysis
-    reasoning: 'claude-3-5-sonnet-20240620', // Top-tier complex problem solving
+    chat: 'claude-3-5-sonnet-20241022',      // Best teaching & reasoning model (Sonnet 3.5 v2 - Oct 2024)
+    grading: 'claude-3-5-sonnet-20241022',   // Vision-capable, superior analysis
+    reasoning: 'claude-3-5-sonnet-20241022', // Top-tier complex problem solving
     embedding: 'text-embedding-3-small'      // Keep OpenAI for embeddings (specialized task)
 };
 

--- a/utils/openaiClient.js
+++ b/utils/openaiClient.js
@@ -49,7 +49,7 @@ async function retryWithExponentialBackoff(fn, retries = 5, delay = 1000) {
  * Centralized function to call the LLM with intelligent routing.
  * PRIMARY: Claude Sonnet 3.5 (best teaching & reasoning)
  * FALLBACK: GPT-4o-mini (fast & cheap backup)
- * @param {string} model - The model name (e.g., "claude-3-5-sonnet-20240620", "gpt-4o-mini")
+ * @param {string} model - The model name (e.g., "claude-3-5-sonnet-20241022", "gpt-4o-mini")
  * @param {Array<Object>} messages - Array of message objects for the AI.
  * @param {Object} options - Additional options like temperature, max_tokens.
  * @returns {Promise<Object>} The completion object from the AI.
@@ -140,7 +140,7 @@ async function callLLM(model, messages, options = {}) {
 /**
  * Streaming version of callLLM - returns a stream object for real-time responses
  * Supports both Claude and OpenAI streaming
- * @param {string} model - The model name (e.g., "claude-3-5-sonnet-20240620", "gpt-4o-mini")
+ * @param {string} model - The model name (e.g., "claude-3-5-sonnet-20241022", "gpt-4o-mini")
  * @param {Array<Object>} messages - Array of message objects for the AI
  * @param {Object} options - Additional options like temperature, max_tokens
  * @returns {Promise<Stream>} The stream object


### PR DESCRIPTION
PROBLEM: Application was using claude-3-5-sonnet-20240620 which is deprecated
- Returning 404 errors from Anthropic API
- Causing fallback to GPT-4o-mini instead of using Claude
- Warning logs: "model: claude-3-5-sonnet-20240620 not_found_error"

SOLUTION: Update to current Sonnet 3.5 v2 (October 2024 release)
- Updated DEFAULT_MODELS in utils/llmGateway.js
- Updated PRIMARY_CHAT_MODEL in routes/chat.js
- Updated PRIMARY_CHAT_MODEL in routes/chatWithFile.js
- Updated PRIMARY_CHAT_MODEL in routes/masteryChat.js
- Updated PRIMARY_UPLOAD_AI_MODEL in routes/upload.js
- Updated JSDoc comments in utils/openaiClient.js

BENEFITS:
✅ Claude API will work without 404 errors
✅ No more unwanted fallback to GPT-4o-mini
✅ Access to Sonnet 3.5 v2 improvements (better reasoning, faster) ✅ Consistent model across all chat, grading, and upload endpoints

Model changed: claude-3-5-sonnet-20240620 → claude-3-5-sonnet-20241022