### PR TITLE
fix: Math Blast game screen not showing when clicking fact cards

### DIFF
--- a/public/js/factFluencyBlaster.js
+++ b/public/js/factFluencyBlaster.js
@@ -576,6 +576,9 @@ function showPlacementResults() {
 // ===== PRACTICE SESSION =====
 
 async function startPracticeSession(operation, familyName) {
+    // Switch to game screen
+    showScreen('game');
+
     // Get family config
     const family = gameState.families[operation].find(f => f.familyName === familyName);
     if (!family) {


### PR DESCRIPTION
Same issue as Math Race - the startPracticeSession() function was starting the game logic but never switching to the game screen. Added showScreen('game') call at the start of startPracticeSession() so clicking any fact card now properly shows the shooter game.

This fixes the issue where clicking a fact family on the mastery grid would start the game in the background but remain invisible.