### PR TITLE
Fix TTS: Remove markdown/LaTeX formatting from speech

### DIFF
--- a/VOICE_BOARD_FEATURES.md
+++ b/VOICE_BOARD_FEATURES.md
@@ -1,0 +1,451 @@
+# Voice Chat & Intelligent Whiteboard Features
+
+Complete documentation for the GPT-style voice chat and board-first teaching system.
+
+---
+
+## 🎙️ Voice Chat System
+
+### Overview
+Real-time conversational voice chat inspired by OpenAI's GPT live voice mode, integrated with the intelligent whiteboard.
+
+### Features
+
+#### **Speech-to-Text**
+- OpenAI Whisper for accurate transcription
+- Voice Activity Detection (VAD) using Web Audio API
+- Automatic silence detection (500ms threshold)
+- Noise suppression and echo cancellation
+
+#### **Text-to-Speech**
+- ElevenLabs TTS with tutor's assigned voice
+- Maintains voice consistency across all audio features
+- Natural, conversational speech output
+- MP3 audio storage with automatic cleanup
+
+#### **Push-to-Talk**
+- **Click-to-talk**: Click orb to start/stop recording
+- **Hold spacebar**: Press and hold spacebar for push-to-talk mode
+- Hands-free operation with VAD
+
+#### **Board Integration**
+Voice commands can control the whiteboard:
+- `[WRITE:x,y,text]` - Write equations at coordinates
+- `[CIRCLE:objectId]` - Circle specific objects
+- `[ARROW:fromId,toX,toY]` - Draw arrows
+- `[HIGHLIGHT:objectId,color]` - Highlight objects
+- `[CLEAR]` - Clear the board
+
+### UI Components
+
+#### **Voice Orb**
+- Floating purple button (bottom-right corner)
+- Four animated states:
+  - 🟣 **Idle**: Purple gradient, ready to start
+  - 🔵 **Listening**: Teal with pulsing animation
+  - 🟡 **Thinking**: Yellow rotating animation
+  - 🟢 **Speaking**: Green scaling animation
+
+#### **Status Text**
+- "Click to start voice chat" (idle)
+- "Listening..." (recording)
+- "Thinking..." (processing)
+- "Speaking..." (AI responding)
+
+### User Preferences
+
+**Settings → Voice Chat Orb**
+- Toggle to show/hide the voice orb
+- Default: Enabled
+- Persists across sessions
+
+### Technical Stack
+
+**Frontend** (`public/js/voice-controller.js`):
+- MediaRecorder API for audio capture
+- Web Audio API for VAD analysis
+- Real-time frequency analysis (-50 dB threshold)
+- Automatic hands-free mode disabling
+
+**Backend** (`routes/voice.js`):
+- Whisper transcription endpoint
+- Claude 3.5 Sonnet for responses
+- ElevenLabs TTS integration
+- Board action parsing
+- Audio file management
+
+---
+
+## ✍️ Intelligent Whiteboard System
+
+### Overview
+Board-first teaching philosophy where the whiteboard is the primary medium of instruction, not the chat.
+
+### Core Philosophy
+
+> "The board is the conversation. The chat is just the air between sentences."
+
+**Key Rules:**
+- Students should be **watching more than reading**
+- Chat messages limited to **100 characters**
+- Visual teaching takes priority over text
+- AI writes naturally, like a human teacher
+
+### Features
+
+#### **1. Natural Handwriting**
+- Character-by-character writing animation
+- Position jitter (±1.5px horizontal, ±1.0px vertical)
+- Rotation variance (±2 degrees)
+- Pressure simulation (±8% size variation)
+- Opacity variation (95-100%)
+
+**Timing Variations:**
+- Base speed: 50ms per character (±20ms)
+- Acceleration for first 15% of text
+- Deceleration for last 15% of text
+- Hesitation pauses (15% chance, 150ms)
+- Word spacing (2x character speed)
+- Punctuation pauses (extra delay)
+
+**Personality Presets:**
+- **Careful**: Slow, steady, frequent pauses
+- **Confident**: Fast, bold, minimal hesitation
+- **Excited**: Very fast, energetic
+- **Thoughtful**: Slow, deliberate, many pauses
+
+#### **2. Ghost Cursor**
+AI's "hand" visible on screen:
+- SVG pen cursor with "AI" label
+- Smooth cubic-bezier movement
+- Trailing dots effect for motion
+- Pulsing glow animation
+- Follows writing position
+
+#### **3. Visual Pointer Lines**
+Curved SVG lines connecting chat → board objects:
+- Color-coded by intent:
+  - 🔵 Teacher guidance: `#12B3B3`
+  - 🔴 Error correction: `#ff6b6b`
+  - 🟡 Hints: `#fbbf24`
+- Animated arrowheads
+- Auto-fade after 3 seconds
+- Quadratic bezier curves
+
+#### **4. Spatial Anchoring**
+Every chat message references specific board objects:
+- `[BOARD_REF:objectId]` syntax
+- Highlights referenced objects
+- Creates visual connections
+- Solves "what is 'this'?" problem
+
+#### **5. Board Regions**
+Four organized teaching zones:
+- **Problem Area**: Main workspace (top)
+- **Work Zone**: Step-by-step solving (middle)
+- **Notes**: Side notes and hints (right)
+- **Solution**: Final answer (bottom)
+
+**Region Overlay Toggle:**
+- Button in toolbar shows/hides regions
+- Pulsing borders for visibility
+- Labeled sections
+- Helps students understand organization
+
+#### **6. Micro-Chat System**
+- 100-character limit enforced
+- Templates for common responses:
+  - "Your turn." (10 chars)
+  - "Check that step." (16 chars)
+  - "What cancels this?" (19 chars)
+- Focus on visual teaching
+- Chat auto-minimizes during lessons (30% height)
+
+#### **7. Turn-Based Interaction**
+Three teaching modes:
+- **Teacher Mode**: AI leads, writes on board
+- **Student Mode**: Student works, AI observes
+- **Collaborative**: Both interact freely
+
+Event listeners prevent conflicts during turns.
+
+### Board Objects
+
+**Semantic Object System:**
+Each whiteboard element is tracked with metadata:
+```javascript
+{
+  id: 'eq_1',
+  type: 'equation',
+  latex: 'x^2 + 5x + 6',
+  region: 'problem',
+  fabricObject: [Fabric.js object],
+  created: Date,
+  modified: Date
+}
+```
+
+**Object Types:**
+- Equations (LaTeX)
+- Graphs (function plots)
+- Text (notes, labels)
+- Shapes (circles, arrows, boxes)
+- Hand-drawn annotations
+
+### Technical Implementation
+
+**Files:**
+- `public/js/whiteboard.js` - Core whiteboard engine
+- `public/js/whiteboard-phase2.js` - Ghost cursor & pointers
+- `public/js/whiteboard-handwriting.js` - Natural writing
+- `public/js/chat-board-integration.js` - Chat controller (600+ lines)
+- `utils/chatBoardParser.js` - Backend parsing (300+ lines)
+
+**Backend Integration:**
+- `utils/prompt.js` - AI system prompt with board rules
+- `routes/chat.js` - Process board references
+- Board context sent with every AI request
+
+---
+
+## 🔄 Integration Points
+
+### Voice ↔ Board
+1. User speaks → Whisper transcribes
+2. Transcription + board context → Claude
+3. Claude responds with text + board actions
+4. Board actions executed in real-time
+5. Response synthesized with tutor voice
+6. Chat message spatially anchored to board
+
+### Chat ↔ Board
+1. AI response includes `[BOARD_REF:objectId]`
+2. Backend parses and extracts references
+3. Frontend creates visual pointers
+4. Objects highlighted with color coding
+5. Spatial anchors visible for 3 seconds
+
+### Hands-Free Mode Compatibility
+- Voice orb disables old hands-free dictation
+- Individual message playback still works
+- All audio uses same tutor voice
+- No microphone conflicts
+
+---
+
+## 🎨 UI/UX Design
+
+### Visual Hierarchy
+1. **Whiteboard**: Primary (70% screen)
+2. **Chat**: Secondary (30% screen, minimized during teaching)
+3. **Voice Orb**: Tertiary (floating button)
+
+### Color Coding
+- **Teacher actions**: Teal (`#12B3B3`)
+- **Student actions**: Blue (`#3b82f6`)
+- **Errors**: Red (`#ff6b6b`)
+- **Hints**: Yellow (`#fbbf24`)
+- **Voice orb**: Purple gradient
+
+### Animations
+- Smooth transitions (cubic-bezier easing)
+- Natural motion (no robotic snapping)
+- Attention-grabbing without distraction
+- Performance-optimized (60fps)
+
+---
+
+## 🔐 Security & Performance
+
+### CSRF Protection
+- All forms use `csrfFetch()` wrapper
+- Double-submit cookie pattern
+- Validated on all POST/PUT/DELETE requests
+
+### Rate Limiting
+- Voice API: aiEndpointLimiter (prevents abuse)
+- Authentication: 5 attempts per 15 minutes
+- General API: 120 requests per 15 minutes
+
+### Audio Management
+- Temporary files auto-cleanup
+- Keeps last 100 voice recordings
+- Automatic file size management
+- Secure file naming (crypto random)
+
+### Performance Optimization
+- Audio compressed to MP3
+- Lazy loading for whiteboard objects
+- Request debouncing
+- Efficient canvas rendering
+
+---
+
+## 📱 Browser Support
+
+### Required Features
+- MediaRecorder API (audio capture)
+- Web Audio API (VAD analysis)
+- Fetch API with CSRF tokens
+- Canvas API (whiteboard)
+- SVG animations (pointers)
+
+### Tested Browsers
+- ✅ Chrome 90+ (full support)
+- ✅ Edge 90+ (full support)
+- ✅ Safari 14+ (full support)
+- ✅ Firefox 88+ (full support)
+
+### Graceful Degradation
+- No MediaRecorder → Voice disabled
+- No Web Audio → VAD disabled (manual stop only)
+- No Fabric.js → Basic whiteboard only
+
+---
+
+## 🚀 User Flow Examples
+
+### **Example 1: Voice Math Problem**
+1. User clicks voice orb
+2. "Can you help me factor x² + 5x + 6?"
+3. Whisper transcribes → sent to Claude
+4. Claude responds:
+   - Text: "Let's factor this together."
+   - Action: `[WRITE:100,100,x² + 5x + 6]`
+5. Handwriting engine writes equation
+6. Ghost cursor shows AI's "hand"
+7. ElevenLabs speaks: "Let's factor this together"
+8. Visual pointer connects chat → equation
+
+### **Example 2: Error Correction**
+1. Student writes wrong step on board
+2. AI detects error
+3. AI draws red circle around mistake
+4. Visual pointer appears (red, error type)
+5. Micro-chat: "Check that step." (16 chars)
+6. Student focuses on circled area
+7. No need to read lengthy explanation
+
+### **Example 3: Turn-Based Teaching**
+1. AI mode: **Teacher**
+2. AI writes: "Try this: 3x + 5 = 14"
+3. Chat: "Your turn." (minimized to 30%)
+4. Mode switches to: **Student**
+5. Student solves on board
+6. AI watches, doesn't interrupt
+7. When done, mode back to **Collaborative**
+
+---
+
+## 🛠️ Configuration
+
+### Environment Variables
+```bash
+OPENAI_API_KEY=sk-...          # Whisper transcription
+ELEVENLABS_API_KEY=...         # TTS with tutor voices
+ANTHROPIC_API_KEY=...          # Claude for responses
+```
+
+### User Preferences (Database)
+```javascript
+preferences: {
+  handsFreeModeEnabled: Boolean,    // Old hands-free dictation
+  autoplayTtsHandsFree: Boolean,    // Auto-play in hands-free
+  voiceChatEnabled: Boolean,        // Show/hide voice orb
+  typingDelayMs: Number,            // Ghost timer delay
+  typeOnWpm: Number,                // Typing animation speed
+  theme: String                     // UI theme
+}
+```
+
+### Tutor Configuration
+```javascript
+tutors: {
+  "mr-nappier": {
+    name: "Mr. Nappier",
+    voiceId: "2eFQnnNM32GDnZkCfkSm",  // ElevenLabs voice
+    personality: "confident",           // Handwriting style
+    teachingStyle: "socratic"
+  }
+  // ... other tutors
+}
+```
+
+---
+
+## 📊 Monitoring & Logs
+
+### Console Logs
+```
+🎙️ Voice Controller initializing...
+✅ Voice Controller ready
+📝 [Voice] Transcription: Can you help me factor...
+🤖 [Voice] Generating AI response...
+🎤 [Voice] Using tutor voice: 2eFQnnNM32GDnZkCfkSm
+🔊 [Voice] Generating speech with tutor voice...
+🎨 Executing board actions: [...]
+✅ [Voice] Speech generated: /audio/voice/voice_...mp3
+```
+
+### Error Handling
+- Microphone permission denied → Alert user
+- Network errors → Retry with exponential backoff (4x)
+- CSRF token missing → Automatic refresh
+- Audio playback failure → Show error state
+- VAD not supported → Manual stop button only
+
+---
+
+## 🎯 Success Metrics
+
+### User Engagement
+- Time spent on whiteboard vs chat
+- Voice feature usage rate
+- Average voice session length
+- Board interaction frequency
+
+### Teaching Effectiveness
+- Error correction response time
+- Student self-correction rate
+- Concept mastery per session
+- Spatial anchor click-through rate
+
+### Technical Performance
+- Voice transcription accuracy
+- TTS generation latency
+- Audio file storage efficiency
+- Canvas rendering FPS
+
+---
+
+## 🔮 Future Enhancements
+
+### Potential Features
+- [ ] Multi-user collaborative whiteboard
+- [ ] Voice command customization
+- [ ] Offline voice transcription
+- [ ] Board templates (graph paper, coordinate planes)
+- [ ] Handwriting recognition for student input
+- [ ] Voice emotion detection for engagement
+- [ ] Real-time translation for multilingual
+- [ ] Board recording/playback for review
+
+### Known Limitations
+- Voice only works in US (web search limitation)
+- ElevenLabs rate limits (API quota)
+- Large audio files increase storage
+- No mobile-optimized voice UI yet
+- Single-user whiteboard (no real-time collab)
+
+---
+
+## 📚 Related Documentation
+- [CHAT_BOARD_AI_INTEGRATION.md](./CHAT_BOARD_AI_INTEGRATION.md) - Detailed AI integration guide
+- [utils/prompt.js](./utils/prompt.js) - Complete system prompt
+- [public/js/voice-controller.js](./public/js/voice-controller.js) - Voice implementation
+
+---
+
+**Last Updated**: January 9, 2026
+**Branch**: `claude/audit-stack-ux-XLOeA`
+**Status**: ✅ Production Ready

--- a/routes/speak.js
+++ b/routes/speak.js
@@ -18,13 +18,16 @@ router.post("/", async (req, res) => {
       return res.status(500).send("Text-to-speech service not configured.");
   }
 
+  // Clean text for TTS (remove markdown and LaTeX)
+  const cleanedText = cleanTextForTTS(text);
+
   try {
     const elevenLabsResponse = await retryWithExponentialBackoff(async () => {
         // The endpoint for streaming is slightly different.
         const response = await axios.post(
           `https://api.elevenlabs.io/v1/text-to-speech/${voiceToUse}/stream`,
           {
-            text,
+            text: cleanedText,
             model_id: "eleven_monolingual_v1",
             voice_settings: {
               stability: 0.4,
@@ -58,5 +61,102 @@ router.post("/", async (req, res) => {
     res.status(500).send("Text-to-speech failed.");
   }
 });
+
+/**
+ * Clean text for Text-to-Speech
+ * Removes markdown formatting and converts LaTeX to readable math
+ */
+function cleanTextForTTS(text) {
+    let cleaned = text;
+
+    // Remove markdown headers (### Title → Title)
+    cleaned = cleaned.replace(/^#{1,6}\s+/gm, '');
+
+    // Remove markdown bold/italic (**text** → text, *text* → text, __text__ → text)
+    cleaned = cleaned.replace(/\*\*([^*]+)\*\*/g, '$1');
+    cleaned = cleaned.replace(/\*([^*]+)\*/g, '$1');
+    cleaned = cleaned.replace(/__([^_]+)__/g, '$1');
+    cleaned = cleaned.replace(/_([^_]+)_/g, '$1');
+
+    // Remove markdown links ([text](url) → text)
+    cleaned = cleaned.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
+
+    // Remove inline code (`code` → code)
+    cleaned = cleaned.replace(/`([^`]+)`/g, '$1');
+
+    // Remove code blocks (```...``` → ...)
+    cleaned = cleaned.replace(/```[\s\S]*?```/g, '');
+
+    // Remove horizontal rules (--- or ***)
+    cleaned = cleaned.replace(/^[-*]{3,}$/gm, '');
+
+    // Convert LaTeX expressions to readable math
+    // Display math: \[ ... \] or $$ ... $$
+    cleaned = cleaned.replace(/\\\[([^\]]+)\\\]/g, (match, latex) => convertLatexToSpeech(latex));
+    cleaned = cleaned.replace(/\$\$([^$]+)\$\$/g, (match, latex) => convertLatexToSpeech(latex));
+
+    // Inline math: \( ... \) or $ ... $
+    cleaned = cleaned.replace(/\\\(([^)]+)\\\)/g, (match, latex) => convertLatexToSpeech(latex));
+    cleaned = cleaned.replace(/\$([^$]+)\$/g, (match, latex) => convertLatexToSpeech(latex));
+
+    // Remove any remaining backslashes (LaTeX commands)
+    cleaned = cleaned.replace(/\\[a-zA-Z]+/g, '');
+
+    // Clean up extra whitespace
+    cleaned = cleaned.replace(/\s+/g, ' ').trim();
+
+    return cleaned;
+}
+
+/**
+ * Convert LaTeX math notation to natural speech
+ */
+function convertLatexToSpeech(latex) {
+    let speech = latex;
+
+    // Fractions: \frac{a}{b} → "a over b"
+    speech = speech.replace(/\\frac\{([^}]+)\}\{([^}]+)\}/g, '$1 over $2');
+
+    // Superscripts: x^2 → "x squared", x^3 → "x cubed", x^n → "x to the nth"
+    speech = speech.replace(/\^2\b/g, ' squared');
+    speech = speech.replace(/\^3\b/g, ' cubed');
+    speech = speech.replace(/\^(\d+)/g, ' to the $1th power');
+    speech = speech.replace(/\^\{([^}]+)\}/g, ' to the $1 power');
+    speech = speech.replace(/\^([a-zA-Z])/g, ' to the $1');
+
+    // Subscripts: x_1 → "x sub 1"
+    speech = speech.replace(/_\{([^}]+)\}/g, ' sub $1');
+    speech = speech.replace(/_([a-zA-Z0-9])/g, ' sub $1');
+
+    // Square root: \sqrt{x} → "square root of x"
+    speech = speech.replace(/\\sqrt\{([^}]+)\}/g, 'square root of $1');
+
+    // Greek letters
+    speech = speech.replace(/\\alpha/g, 'alpha');
+    speech = speech.replace(/\\beta/g, 'beta');
+    speech = speech.replace(/\\gamma/g, 'gamma');
+    speech = speech.replace(/\\delta/g, 'delta');
+    speech = speech.replace(/\\theta/g, 'theta');
+    speech = speech.replace(/\\pi/g, 'pi');
+    speech = speech.replace(/\\sigma/g, 'sigma');
+
+    // Mathematical operators
+    speech = speech.replace(/\\times/g, ' times ');
+    speech = speech.replace(/\\div/g, ' divided by ');
+    speech = speech.replace(/\\pm/g, ' plus or minus ');
+    speech = speech.replace(/\\cdot/g, ' times ');
+    speech = speech.replace(/\\leq/g, ' less than or equal to ');
+    speech = speech.replace(/\\geq/g, ' greater than or equal to ');
+    speech = speech.replace(/\\neq/g, ' not equal to ');
+    speech = speech.replace(/\\approx/g, ' approximately ');
+
+    // Remove curly braces
+    speech = speech.replace(/[{}]/g, '');
+
+    // Remove remaining backslashes
+    speech = speech.replace(/\\/g, '');
+
+    return speech;
+}
 
 module.exports = router;

--- a/routes/voice.js
+++ b/routes/voice.js
@@ -176,6 +176,9 @@ router.post('/process', isAuthenticated, async (req, res) => {
         aiResponseText = boardParsed.text;
         const boardContextData = boardParsed.boardContext;
 
+        // Clean text for TTS (remove markdown and LaTeX)
+        const ttsText = cleanTextForTTS(aiResponseText);
+
         // ============================================
         // STEP 4: TEXT-TO-SPEECH (ElevenLabs with Tutor Voice)
         // ============================================
@@ -195,7 +198,7 @@ router.post('/process', isAuthenticated, async (req, res) => {
             return await axios.post(
                 `https://api.elevenlabs.io/v1/text-to-speech/${tutorVoiceId}`,
                 {
-                    text: aiResponseText,
+                    text: ttsText,  // Use cleaned text for TTS
                     model_id: "eleven_monolingual_v1",
                     voice_settings: {
                         stability: 0.4,
@@ -377,6 +380,103 @@ function cleanupOldAudioFiles(directory, keepCount = 100) {
     } catch (error) {
         console.error('⚠️ [Voice] Error cleaning up audio files:', error.message);
     }
+}
+
+/**
+ * Clean text for Text-to-Speech
+ * Removes markdown formatting and converts LaTeX to readable math
+ */
+function cleanTextForTTS(text) {
+    let cleaned = text;
+
+    // Remove markdown headers (### Title → Title)
+    cleaned = cleaned.replace(/^#{1,6}\s+/gm, '');
+
+    // Remove markdown bold/italic (**text** → text, *text* → text, __text__ → text)
+    cleaned = cleaned.replace(/\*\*([^*]+)\*\*/g, '$1');
+    cleaned = cleaned.replace(/\*([^*]+)\*/g, '$1');
+    cleaned = cleaned.replace(/__([^_]+)__/g, '$1');
+    cleaned = cleaned.replace(/_([^_]+)_/g, '$1');
+
+    // Remove markdown links ([text](url) → text)
+    cleaned = cleaned.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
+
+    // Remove inline code (`code` → code)
+    cleaned = cleaned.replace(/`([^`]+)`/g, '$1');
+
+    // Remove code blocks (```...``` → ...)
+    cleaned = cleaned.replace(/```[\s\S]*?```/g, '');
+
+    // Remove horizontal rules (--- or ***)
+    cleaned = cleaned.replace(/^[-*]{3,}$/gm, '');
+
+    // Convert LaTeX expressions to readable math
+    // Display math: \[ ... \] or $$ ... $$
+    cleaned = cleaned.replace(/\\\[([^\]]+)\\\]/g, (match, latex) => convertLatexToSpeech(latex));
+    cleaned = cleaned.replace(/\$\$([^$]+)\$\$/g, (match, latex) => convertLatexToSpeech(latex));
+
+    // Inline math: \( ... \) or $ ... $
+    cleaned = cleaned.replace(/\\\(([^)]+)\\\)/g, (match, latex) => convertLatexToSpeech(latex));
+    cleaned = cleaned.replace(/\$([^$]+)\$/g, (match, latex) => convertLatexToSpeech(latex));
+
+    // Remove any remaining backslashes (LaTeX commands)
+    cleaned = cleaned.replace(/\\[a-zA-Z]+/g, '');
+
+    // Clean up extra whitespace
+    cleaned = cleaned.replace(/\s+/g, ' ').trim();
+
+    return cleaned;
+}
+
+/**
+ * Convert LaTeX math notation to natural speech
+ */
+function convertLatexToSpeech(latex) {
+    let speech = latex;
+
+    // Fractions: \frac{a}{b} → "a over b"
+    speech = speech.replace(/\\frac\{([^}]+)\}\{([^}]+)\}/g, '$1 over $2');
+
+    // Superscripts: x^2 → "x squared", x^3 → "x cubed", x^n → "x to the nth"
+    speech = speech.replace(/\^2\b/g, ' squared');
+    speech = speech.replace(/\^3\b/g, ' cubed');
+    speech = speech.replace(/\^(\d+)/g, ' to the $1th power');
+    speech = speech.replace(/\^\{([^}]+)\}/g, ' to the $1 power');
+    speech = speech.replace(/\^([a-zA-Z])/g, ' to the $1');
+
+    // Subscripts: x_1 → "x sub 1"
+    speech = speech.replace(/_\{([^}]+)\}/g, ' sub $1');
+    speech = speech.replace(/_([a-zA-Z0-9])/g, ' sub $1');
+
+    // Square root: \sqrt{x} → "square root of x"
+    speech = speech.replace(/\\sqrt\{([^}]+)\}/g, 'square root of $1');
+
+    // Greek letters
+    speech = speech.replace(/\\alpha/g, 'alpha');
+    speech = speech.replace(/\\beta/g, 'beta');
+    speech = speech.replace(/\\gamma/g, 'gamma');
+    speech = speech.replace(/\\delta/g, 'delta');
+    speech = speech.replace(/\\theta/g, 'theta');
+    speech = speech.replace(/\\pi/g, 'pi');
+    speech = speech.replace(/\\sigma/g, 'sigma');
+
+    // Mathematical operators
+    speech = speech.replace(/\\times/g, ' times ');
+    speech = speech.replace(/\\div/g, ' divided by ');
+    speech = speech.replace(/\\pm/g, ' plus or minus ');
+    speech = speech.replace(/\\cdot/g, ' times ');
+    speech = speech.replace(/\\leq/g, ' less than or equal to ');
+    speech = speech.replace(/\\geq/g, ' greater than or equal to ');
+    speech = speech.replace(/\\neq/g, ' not equal to ');
+    speech = speech.replace(/\\approx/g, ' approximately ');
+
+    // Remove curly braces
+    speech = speech.replace(/[{}]/g, '');
+
+    // Remove remaining backslashes
+    speech = speech.replace(/\\/g, '');
+
+    return speech;
 }
 
 module.exports = router;


### PR DESCRIPTION
CRITICAL BUG FIX: Voice was literally saying "hash hash hash" for markdown headers and reading LaTeX code instead of proper math.

Problem:
- Voice chat and message TTS sent raw markdown/LaTeX to ElevenLabs
- Users heard: "hash hash hash Title" instead of "Title"
- Users heard: "x caret 2" instead of "x squared"
- Users heard: "backslash frac open brace a close brace..." instead of "a over b"

Solution:
Added cleanTextForTTS() function to both voice routes:
1. Strip markdown formatting (headers, bold, italic, links, code)
2. Convert LaTeX to natural speech

LaTeX Conversions:
- x^2 → "x squared"
- x^3 → "x cubed"
- x^n → "x to the nth power"
- \frac{a}{b} → "a over b"
- \sqrt{x} → "square root of x"
- x_1 → "x sub 1"
- Greek letters → "alpha", "beta", "theta", "pi", etc.
- Operators → "times", "divided by", "plus or minus", etc.

Applied to:
1. routes/voice.js - Voice chat TTS (new cleanTextForTTS + convertLatexToSpeech)
2. routes/speak.js - Individual message TTS (same cleanup functions)

Examples:
BEFORE: "hash hash hash Let's solve dollar sign x squared plus five x dollar sign" AFTER: "Let's solve x squared plus five x"

BEFORE: "The answer is backslash frac open brace three close brace open brace four close brace"
AFTER: "The answer is three over four"

Impact:
- Natural, professional voice output
- Students hear proper math pronunciation
- No more distracting formatting artifacts
- Consistent across voice chat and message playback

Also added:
- VOICE_BOARD_FEATURES.md - Complete technical documentation