### PR TITLE
Fix upload cleanup error: use correct StudentUpload field names

### DIFF
--- a/middleware/uploadSecurity.js
+++ b/middleware/uploadSecurity.js
@@ -24,7 +24,7 @@ async function verifyUploadAccess(req, res, next) {
         }
 
         // Find the upload record
-        const upload = await StudentUpload.findOne({ filename });
+        const upload = await StudentUpload.findOne({ storedFilename: filename });
 
         if (!upload) {
             return res.status(404).json({
@@ -185,11 +185,11 @@ async function cleanupOldUploads() {
 
         for (const upload of uploadsToDelete) {
             try {
-                // Delete file from disk
-                const filePath = path.join(__dirname, '..', 'uploads', upload.filename);
+                // Delete file from disk using the stored filePath or construct from storedFilename
+                const filePath = upload.filePath || path.join(__dirname, '..', 'uploads', upload.storedFilename);
                 if (fs.existsSync(filePath)) {
                     fs.unlinkSync(filePath);
-                    console.log(`[Upload Cleanup] Deleted file: ${upload.filename}`);
+                    console.log(`[Upload Cleanup] Deleted file: ${upload.storedFilename}`);
                 }
 
                 // Delete from database


### PR DESCRIPTION
The cleanup job was failing with "path must be of type string. Received undefined" because it was trying to access upload.filename which doesn't exist in the StudentUpload model.

Fixes:
1. Line 27: Changed findOne({ filename }) to findOne({ storedFilename: filename })
2. Line 189: Changed upload.filename to upload.filePath (with storedFilename fallback)

The StudentUpload model uses:
- storedFilename: unique filename on disk
- filePath: full path to the file
- originalFilename: user's original filename

This fixes the TypeError that was preventing old uploads from being deleted.