### PR TITLE
Fix hamburger menu overlay issue on mobile

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -2365,7 +2365,7 @@ form label, .password-label-row label {
     background: var(--clr-bg-light);
     box-shadow: var(--shadow-lg);
     transition: transform 0.3s ease;
-    z-index: 900;
+    z-index: 1000; /* Increased from 900 to ensure it's above sticky header (z-index: 100) */
     padding: 20px;
     display: flex;
     flex-direction: column;
@@ -2453,6 +2453,18 @@ form label, .password-label-row label {
 @media (max-width: 767px) {
     .drawer-toggle-btn {
         display: flex;
+    }
+
+    /* Hide toggle buttons when their respective drawers are open */
+    .drawer.left.open ~ header #left-drawer-toggle,
+    body:has(.drawer.left.open) #left-drawer-toggle {
+        opacity: 0;
+        pointer-events: none;
+    }
+
+    body:has(.drawer.right.open) #right-drawer-toggle {
+        opacity: 0;
+        pointer-events: none;
     }
 }
 


### PR DESCRIPTION
PROBLEM:
Hamburger menu button was appearing over chat messages and drawer content due to sticky header positioning and z-index stacking context issues.

FIXES:
1. Increased drawer z-index from 900 to 1000 to ensure it's above the sticky header (z-index: 100) and all its children including the hamburger button

2. Hide hamburger toggle buttons when their respective drawers are open:
   - Uses :has() selector for modern browser support
   - Sets opacity: 0 and pointer-events: none when drawer.open
   - Prevents visual clutter and accidental clicks

IMPACT:
✅ Hamburger button no longer overlays chat messages ✅ Hamburger button disappears when drawer is open (cleaner UX) ✅ Drawer properly covers header area when opened
✅ No more confusing floating menu button