### PR TITLE
CRITICAL FIX: gpt-5-nano temperature parameter + user scoping error

### DIFF
--- a/routes/welcome.js
+++ b/routes/welcome.js
@@ -14,8 +14,10 @@ router.get('/', async (req, res) => {
         return res.status(400).json({ error: "Not authenticated." });
     }
 
+    let user = null; // CRITICAL FIX: Declare outside try block for catch block access
+
     try {
-        const user = await User.findById(userId).lean();
+        user = await User.findById(userId).lean();
         if (!user) {
             return res.status(404).json({ error: "User not found." });
         }

--- a/utils/openaiClient.js
+++ b/utils/openaiClient.js
@@ -160,11 +160,17 @@ async function callLLM(model, messages, options = {}) {
                     { max_tokens: options.max_tokens })
                 : {};
 
+            // CRITICAL FIX: Some models (like gpt-5-nano) only support default temperature
+            // Don't pass temperature for these models
+            const temperatureParam = model.includes('nano') ?
+                {} :
+                { temperature: options.temperature || 0.7 };
+
             const completion = await retryWithExponentialBackoff(() =>
                 openai.chat.completions.create({
                     model: model,
                     messages: messages,
-                    temperature: options.temperature || 0.7,
+                    ...temperatureParam,
                     ...tokenParam,
                     stream: options.stream || false,
                 })
@@ -227,10 +233,15 @@ async function callLLMStream(model, messages, options = {}) {
                     { max_tokens: options.max_tokens })
                 : {};
 
+            // CRITICAL FIX: Some models (like gpt-5-nano) only support default temperature
+            const temperatureParam = model.includes('nano') ?
+                {} :
+                { temperature: options.temperature || 0.7 };
+
             const stream = await openai.chat.completions.create({
                 model: model,
                 messages: messages,
-                temperature: options.temperature || 0.7,
+                ...temperatureParam,
                 ...tokenParam,
                 stream: true,
             });


### PR DESCRIPTION
- Fixed ReferenceError: user is not defined in welcome.js catch block
- Fixed OpenAI temperature error for gpt-5-nano (only supports default=1)
- Added temperature parameter handling for 'nano' models
- Applied fix to both streaming and non-streaming API calls