### PR TITLE
claude/fix-algebra-tiles-drag-MHEkr

### DIFF
--- a/public/css/algebra-tiles.css
+++ b/public/css/algebra-tiles.css
@@ -312,6 +312,123 @@
   font-size: 16px;
 }
 
+/* ===== RIGHT SIDEBAR (Control Buttons) ===== */
+.algebra-tiles-controls-right {
+  width: 160px;
+  background: linear-gradient(180deg, #f8f9fa 0%, #e9ecef 100%);
+  border-left: 3px solid #dee2e6;
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+  padding: 15px;
+  overflow-y: auto;
+}
+
+.control-button-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: rgba(255, 255, 255, 0.7);
+  padding: 12px;
+  border-radius: 10px;
+  border: 2px solid #dee2e6;
+}
+
+.control-label {
+  font-weight: 700;
+  color: #495057;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  text-align: center;
+  margin-bottom: 4px;
+}
+
+.control-btn {
+  background: white;
+  border: 2px solid #cbd5e0;
+  border-radius: 8px;
+  padding: 12px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #495057;
+}
+
+.control-btn i {
+  font-size: 20px;
+  color: #667eea;
+}
+
+.control-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  border-color: #667eea;
+  background: #f7fafc;
+}
+
+.control-btn:active {
+  transform: translateY(0);
+}
+
+/* Trash zone on right sidebar */
+.trash-zone-right {
+  padding: 20px 16px;
+  background: linear-gradient(135deg, #fee2e2 0%, #fecaca 100%);
+  border: 3px dashed #ef4444;
+  border-radius: 10px;
+  text-align: center;
+  color: #991b1b;
+  font-weight: 700;
+  transition: all 0.3s;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  margin-top: auto; /* Push to bottom */
+  min-height: 120px;
+  justify-content: center;
+}
+
+.trash-zone-right i {
+  font-size: 32px;
+}
+
+.trash-zone-right span {
+  font-size: 12px;
+  line-height: 1.3;
+}
+
+.trash-zone-right:hover {
+  background: linear-gradient(135deg, #fecaca 0%, #fca5a5 100%);
+  border-color: #dc2626;
+  transform: scale(1.02);
+}
+
+.trash-zone-right.drag-over {
+  background: linear-gradient(135deg, #fca5a5 0%, #f87171 100%);
+  border-color: #b91c1c;
+  transform: scale(1.08);
+  box-shadow: 0 4px 16px rgba(239, 68, 68, 0.4);
+  animation: trashPulse 0.5s ease-in-out infinite;
+}
+
+@keyframes trashPulse {
+  0%, 100% {
+    transform: scale(1.08);
+  }
+  50% {
+    transform: scale(1.12);
+  }
+}
+
 /* ===== WORKSPACE ===== */
 .algebra-tiles-workspace {
   flex: 1;
@@ -706,9 +823,30 @@
   .algebra-tiles-sidebar {
     width: 100%;
     height: auto;
-    max-height: 35vh;
+    max-height: 30vh;
     border-right: none;
     border-bottom: 3px solid #dee2e6;
+  }
+
+  .algebra-tiles-controls-right {
+    width: 100%;
+    height: auto;
+    max-height: 25vh;
+    border-left: none;
+    border-top: 3px solid #dee2e6;
+    flex-direction: row;
+    overflow-x: auto;
+    padding: 10px;
+  }
+
+  .control-button-section {
+    flex-direction: row;
+    min-width: 200px;
+  }
+
+  .trash-zone-right {
+    min-width: 120px;
+    min-height: 80px;
   }
 
   .equation-input-section {


### PR DESCRIPTION
Major fixes:
- Fix drag-and-drop: Tiles now stay where dropped instead of snapping back
  - Rewrote onMouseUp to use mouse delta instead of parsing transform
  - Properly handles tiles with rotation applied

- Fix Delete key: Corrected modal ID check (algebraTilesModal vs algebra-tiles-modal)

- Add x^2 notation support: Parser now converts x^2 to x² (x squared)

UI improvements:
- Renamed "Build It" button to "Insert" for clarity
- Added Escape key to clear/unfocus equation input
- Updated placeholder to show x^2 support
- Added right sidebar with control buttons:
  - Rotate button (rotates selected tiles)
  - Clear All button (clears workspace with confirmation)
  - Drag-to-delete zone (moved from left to right side)
- Improved trash zone with visual feedback and animations
- Added responsive design for mobile devices

All features tested and working correctly.