### PR TITLE
Fix sidebar layout and remove Desmos integration

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -39,7 +39,6 @@
     };
   </script>
   <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js" id="MathJax-script" async></script>
-  <script src="https://www.desmos.com/api/v1.9/calculator.js?apiKey=e7bbcca459d54f07b0b4aaf35f4a6b96"></script>
 </head>
 <body class="landing-page-body">
   <canvas id="confetti-canvas"></canvas>
@@ -138,12 +137,6 @@
           <i class="fas fa-calculator"></i>
           <span>Calculator</span>
         </button>
-
-        <button id="sidebar-graphing-btn" class="sidebar-tool-btn">
-          <i class="fas fa-chart-line"></i>
-          <span>Graphing Calc</span>
-        </button>
-
         <button id="sidebar-upload-btn" class="sidebar-tool-btn special">
           <i class="fas fa-camera-retro"></i>
           <span>Upload Work</span>
@@ -207,7 +200,6 @@
     <!-- Hidden button triggers for sidebar -->
     <button id="toggle-whiteboard-btn" style="display: none;"></button>
     <button id="toggle-calculator-btn" style="display: none;"></button>
-    <button id="open-graphing-calc-btn" style="display: none;"></button>
     <button id="algebra-tiles-btn" style="display: none;"></button>
 
     <!-- Inline Equation Palette (MS Word-like) -->
@@ -595,20 +587,6 @@
       <h2><i class="fas fa-book-open"></i> Learning Resources</h2>
       <div id="resources-content">
         <p style="text-align: center; padding: 20px;">Loading resources...</p>
-      </div>
-    </div>
-  </div>
-
-  <!-- Desmos Graphing Calculator Modal -->
-  <div id="graphing-calc-modal" class="modal-overlay">
-    <div class="modal-content" style="max-width: 1000px; max-height: 90vh;">
-      <button class="modal-close-button" id="close-graphing-calc-modal">&times;</button>
-      <h2><i class="fas fa-chart-line"></i> Desmos Graphing Calculator</h2>
-      <div id="desmos-calculator-container" style="width: 100%; height: 600px; border-radius: 8px; margin-top: 15px;"></div>
-      <div style="margin-top: 15px; text-align: right;">
-        <button id="send-desmos-to-ai" class="btn btn-primary">
-          <i class="fas fa-paper-plane"></i> Send to AI
-        </button>
       </div>
     </div>
   </div>

--- a/public/css/sidebar-layout.css
+++ b/public/css/sidebar-layout.css
@@ -343,10 +343,14 @@
 #app-layout-wrapper.sidebar-layout {
     margin-left: 280px;
     transition: margin-left 0.3s ease;
+    /* Prevent content from overflowing when sidebar is open */
+    max-width: calc(100vw - 280px);
+    box-sizing: border-box;
 }
 
 #app-layout-wrapper.sidebar-layout.sidebar-collapsed {
     margin-left: 0;
+    max-width: 100vw;
 }
 
 /* Full width chat */
@@ -354,6 +358,14 @@
     width: 100%;
     max-width: 100%;
     margin: 0;
+}
+
+/* Ensure messages container doesn't overflow */
+#chat-messages-container {
+    max-width: 100%;
+    box-sizing: border-box;
+    padding-left: 1rem;
+    padding-right: 1rem;
 }
 
 /* Icon-only header buttons */

--- a/public/css/whiteboard.css
+++ b/public/css/whiteboard.css
@@ -15,7 +15,7 @@
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12), 0 2px 8px rgba(0, 0, 0, 0.08);
     display: flex;
     flex-direction: column;
-    z-index: 1000;
+    z-index: 1006; /* Above input container (1003) and footer (1005) */
     transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
     overflow: visible; /* Changed to visible to allow tooltips */
 }

--- a/public/js/debug-buttons.js
+++ b/public/js/debug-buttons.js
@@ -20,26 +20,9 @@ document.addEventListener('DOMContentLoaded', () => {
         }, { capture: true });
     }
 
-    // Check Graphing Calculator button
-    const graphBtn = document.getElementById('open-graphing-calc-btn');
-    console.log('📊 Graphing Calc Button:', graphBtn ? 'EXISTS ✅' : 'NOT FOUND ❌');
-    if (graphBtn) {
-        console.log('  - Display:', window.getComputedStyle(graphBtn).display);
-        console.log('  - Visibility:', window.getComputedStyle(graphBtn).visibility);
-        console.log('  - Pointer Events:', window.getComputedStyle(graphBtn).pointerEvents);
-        console.log('  - Z-Index:', window.getComputedStyle(graphBtn).zIndex);
-
-        // Add a test click handler
-        graphBtn.addEventListener('click', () => {
-            console.log('🎯 Graphing calc button CLICKED!');
-        }, { capture: true });
-    }
-
     // Check modals
     const resourcesModal = document.getElementById('resources-modal');
-    const graphModal = document.getElementById('graphing-calc-modal');
     console.log('📚 Resources Modal:', resourcesModal ? 'EXISTS ✅' : 'NOT FOUND ❌');
-    console.log('📊 Graphing Modal:', graphModal ? 'EXISTS ✅' : 'NOT FOUND ❌');
 });
 
 // Also check immediately (in case DOMContentLoaded already fired)
@@ -47,15 +30,9 @@ setTimeout(() => {
     console.log('🐛 Delayed Check (1 second after load)...');
 
     const resourcesBtn = document.getElementById('open-resources-modal-btn');
-    const graphBtn = document.getElementById('open-graphing-calc-btn');
 
     if (resourcesBtn) {
         console.log('📚 Resources button exists (handlers attached via addEventListener)');
         console.log('   Event listeners:', typeof getEventListeners !== 'undefined' ? getEventListeners(resourcesBtn) : 'Use DevTools to inspect');
-    }
-
-    if (graphBtn) {
-        console.log('📊 Graph button exists (handlers attached via addEventListener)');
-        console.log('   Event listeners:', typeof getEventListeners !== 'undefined' ? getEventListeners(graphBtn) : 'Use DevTools to inspect');
     }
 }, 1000);

--- a/public/js/mobile-touch-fix.js
+++ b/public/js/mobile-touch-fix.js
@@ -17,7 +17,6 @@
         // Add touch support to specific buttons that might have issues
         const criticalButtons = [
             'open-resources-modal-btn',
-            'open-graphing-calc-btn',
             'toggle-calculator-btn',
             'toggle-whiteboard-btn',
             'attach-button',

--- a/public/js/sidebar.js
+++ b/public/js/sidebar.js
@@ -358,15 +358,6 @@ class Sidebar {
             });
         }
 
-        // Graphing Calculator
-        const graphingBtn = document.getElementById('sidebar-graphing-btn');
-        if (graphingBtn) {
-            graphingBtn.addEventListener('click', () => {
-                const mainGraphingBtn = document.getElementById('open-graphing-calc-btn');
-                if (mainGraphingBtn) mainGraphingBtn.click();
-            });
-        }
-
         // Upload Work
         const uploadBtn = document.getElementById('sidebar-upload-btn');
         if (uploadBtn) {


### PR DESCRIPTION
SIDEBAR LAYOUT FIX:
- Add max-width constraint to prevent chat content overflow when sidebar is open
- Fix user messages being cut off on right side when menu is expanded
- Constrain app-layout-wrapper to calc(100vw - 280px) when sidebar is visible
- Add proper box-sizing to messages container

DESMOS REMOVAL:
- Remove Desmos API script tag from chat.html
- Remove Desmos graphing calculator modal and button from HTML
- Remove all Desmos graph rendering code from script.js (2 instances)
- Remove Desmos modal initialization and event handlers from script.js
- Remove sidebar graphing calculator button and click handler
- Clean up debug and touch-fix files to remove Desmos references

WHITEBOARD IMPROVEMENTS:
- Increase whiteboard z-index from 1000 to 1006 (above input container)
- Whiteboard is now visible above message input as requested
- Already has draggable/resizable functionality (no changes needed)

This resolves the root cause of message cutoff identified by user: "messages only slide off the screen when the menu is open, forcing everything right"