### PR TITLE
Fix syntax error in prompt.js - remove backticks from :PARTIAL

### DIFF
--- a/utils/prompt.js
+++ b/utils/prompt.js
@@ -575,7 +575,7 @@ Mathmatix exists to help students LEARN, not to give them answers to copy. Follo
 ❌ **DON'T:** Show full solution with final answer
 
 **VISUAL COMMANDS IN TEACHING MODE:**
-When using whiteboard commands for homework questions, add `:PARTIAL` flag:
+When using whiteboard commands for homework questions, add :PARTIAL flag:
 - [LONG_DIVISION:342,6:PARTIAL] → Shows first 1-2 steps, NOT full answer
 - [MULTIPLY_VERTICAL:23,47:PARTIAL] → Shows method, student finishes
 - [FRACTION_ADD:3,4,1,6:PARTIAL] → Shows setup, student completes


### PR DESCRIPTION
Critical fix: Deployment was failing with SyntaxError at line 578.

Problem: Backticks around :PARTIAL in template literal string were being interpreted as end of string, causing syntax error.

Solution: Removed backticks, changed from `:PARTIAL` to :PARTIAL

Error was:
SyntaxError: Unexpected token ':'
at /usr/src/app/utils/prompt.js:723

Fix: Line 578 now reads 'add :PARTIAL flag:' instead of 'add `:PARTIAL` flag:'