### PR TITLE
Analyze user request logs and performance metrics

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -133,7 +133,7 @@ function handleLogout(req, res, next) {
 // SECURITY FIX: Per-user rate limiting for AI-powered endpoints to prevent API abuse
 const aiEndpointLimiter = rateLimit({
     windowMs: 60 * 60 * 1000, // 1 hour window
-    max: 100, // Limit each user to 100 requests per hour
+    max: 150, // Limit each user to 150 requests per hour (increased to accommodate 30s heartbeats = 120 req/hr)
     keyGenerator: (req) => {
         // Use user ID if authenticated, otherwise fall back to IP
         return req.user ? req.user._id.toString() : req.ip;

--- a/middleware/csrf.js
+++ b/middleware/csrf.js
@@ -17,8 +17,10 @@ function generateToken() {
  * (typically read-only endpoints or heartbeat/ping endpoints)
  */
 const CSRF_EXEMPT_ROUTES = [
-  '/api/session/heartbeat', // Session activity tracking (read-only)
-  '/api/chat/track-time'     // Time tracking heartbeat (read-only)
+  '/api/session/heartbeat',    // Session activity tracking (read-only)
+  '/api/chat/track-time',      // Time tracking heartbeat (read-only)
+  '/api/session/end',          // Session end via sendBeacon (can't send custom headers)
+  '/api/session/save-mastery'  // Mastery save via sendBeacon (can't send custom headers)
 ];
 
 /**


### PR DESCRIPTION
Fixed two issues identified from user request logs:

1. Rate Limit Fix (middleware/auth.js):
   - Increased aiEndpointLimiter from 100 to 150 requests/hour
   - 30-second heartbeat interval generates 120 req/hr, exceeding previous 100 limit
   - Users were receiving 429 errors on /api/chat/track-time

2. CSRF Token Fix (middleware/csrf.js):
   - Added /api/session/end and /api/session/save-mastery to CSRF_EXEMPT_ROUTES
   - navigator.sendBeacon() cannot send custom headers (X-CSRF-Token)
   - Users were receiving 403 errors on session end during page unload
   - These endpoints are safe to exempt (authenticated, non-destructive, unload-only)

Both issues prevented proper session tracking and data persistence.