### PR TITLE
Increase AI response token limits to prevent mid-sentence truncation

### DIFF
--- a/routes/chat.js
+++ b/routes/chat.js
@@ -253,7 +253,7 @@ if (!message) return res.status(400).json({ message: "Message is required." });
             res.flushHeaders();
 
             try {
-                const stream = await callLLMStream(PRIMARY_CHAT_MODEL, messagesForAI, { temperature: 0.7, max_tokens: 400 });
+                const stream = await callLLMStream(PRIMARY_CHAT_MODEL, messagesForAI, { temperature: 0.7, max_tokens: 1500 });
 
                 // Buffer to collect the complete response for database storage
                 let fullResponseBuffer = '';
@@ -305,13 +305,13 @@ if (!message) return res.status(400).json({ message: "Message is required." });
             } catch (streamError) {
                 console.error('ERROR: Streaming failed, falling back to non-streaming:', streamError.message);
                 // Fallback to non-streaming if streaming fails
-                const completion = await callLLM(PRIMARY_CHAT_MODEL, messagesForAI, { temperature: 0.7, max_tokens: 400 });
+                const completion = await callLLM(PRIMARY_CHAT_MODEL, messagesForAI, { temperature: 0.7, max_tokens: 1500 });
                 aiResponseText = completion.choices[0]?.message?.content?.trim() || "I'm not sure how to respond.";
                 res.write(`data: ${JSON.stringify({ type: 'chunk', content: aiResponseText })}\n\n`);
             }
         } else {
             // NON-STREAMING MODE: Original behavior
-            const completion = await callLLM(PRIMARY_CHAT_MODEL, messagesForAI, { system: systemPrompt, temperature: 0.7, max_tokens: 400 });
+            const completion = await callLLM(PRIMARY_CHAT_MODEL, messagesForAI, { system: systemPrompt, temperature: 0.7, max_tokens: 1500 });
             aiResponseText = completion.choices[0]?.message?.content?.trim() || "I'm not sure how to respond.";
         }
 
@@ -723,7 +723,7 @@ async function handleParentChat(req, res, parentId, childId, message) {
         const completion = await callLLM(PRIMARY_CHAT_MODEL, messagesForAI, {
             system: systemPrompt,
             temperature: 0.7,
-            max_tokens: 500
+            max_tokens: 800
         });
 
         let aiResponseText = completion.choices[0]?.message?.content?.trim() || "I apologize, I'm having trouble responding right now.";

--- a/utils/llmGateway.js
+++ b/utils/llmGateway.js
@@ -78,7 +78,7 @@ async function chat(context, options = {}) {
 
     const model = options.model || DEFAULT_MODELS.chat;
     const temperature = options.temperature || 0.7;
-    const maxTokens = options.maxTokens || 400;
+    const maxTokens = options.maxTokens || 1500;
 
     // Call LLM
     const completion = await callLLM(model, messagesForAI, {
@@ -129,7 +129,7 @@ async function chatStream(context, options = {}) {
 
     const model = options.model || DEFAULT_MODELS.chat;
     const temperature = options.temperature || 0.7;
-    const maxTokens = options.maxTokens || 400;
+    const maxTokens = options.maxTokens || 1500;
 
     // Call streaming LLM
     const stream = await callLLMStream(model, messagesForAI, {


### PR DESCRIPTION
Fixed issue where AI tutoring responses were being cut off mid-sentence due to restrictive token limits.

Changes:
- routes/chat.js: Increased main chat max_tokens from 400 to 1500
  - Streaming mode (line 256): 400 → 1500
  - Fallback mode (line 308): 400 → 1500
  - Non-streaming mode (line 314): 400 → 1500
  - Parent chat (line 726): 500 → 800

- utils/llmGateway.js: Increased default max_tokens from 400 to 1500
  - chat() method (line 81): 400 → 1500
  - chatStream() method (line 132): 400 → 1500

Impact:
- 400 tokens = ~600-800 characters (TOO SHORT for tutoring)
- 1500 tokens = ~2000-2400 characters (comprehensive explanations)
- Students will now receive complete, untruncated tutoring responses
- Math step-by-step solutions will no longer be cut off
- Visual teaching commands will render completely

This brings student chat in line with voice chat (1000 tokens) and provides adequate space for detailed mathematical explanations.