### PR TITLE
Add minimize button and split screen to whiteboard

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -605,6 +605,9 @@
     <div class="whiteboard-header">
       <h2>Whiteboard</h2>
       <div class="whiteboard-header-controls">
+        <button class="whiteboard-control-btn" id="split-screen-btn" data-tooltip="Split Screen" title="Toggle Split Screen Mode">
+          <i class="fas fa-columns"></i>
+        </button>
         <button class="whiteboard-control-btn" id="minimize-whiteboard-btn" data-tooltip="Minimize" title="Minimize">
           <i class="fas fa-window-minimize"></i>
         </button>

--- a/public/css/whiteboard-chat-layout.css
+++ b/public/css/whiteboard-chat-layout.css
@@ -92,20 +92,44 @@ body.whiteboard-active #whiteboard-panel:not(.maximized) {
    ============================================ */
 
 body.whiteboard-split-screen {
-    /* Enable split mode */
+    /* Enable split mode - non-disruptive approach */
 }
 
+/* Chat container in split-screen mode - stays in place, just gets narrower */
 body.whiteboard-split-screen #chat-container {
     width: calc(50vw - 40px);
-    max-width: none;
-    margin-right: 20px;
+    max-width: calc(50vw - 40px);
+    margin-right: 0;
+    transition: width 0.3s ease, max-width 0.3s ease;
 }
 
+/* Main content area adjusts to accommodate split view */
+body.whiteboard-split-screen .main-content {
+    width: 50%;
+    transition: width 0.3s ease;
+}
+
+/* Whiteboard panel in split-screen mode - docks to right half */
 body.whiteboard-split-screen #whiteboard-panel:not(.maximized) {
+    position: fixed;
     left: auto;
-    right: 20px;
-    width: calc(50vw - 40px);
-    max-width: 800px;
+    right: 0;
+    top: 0;
+    width: calc(50vw - 20px);
+    height: 100vh;
+    max-width: none;
+    border-radius: 0;
+    transition: all 0.3s ease;
+    box-shadow: -4px 0 16px rgba(0, 0, 0, 0.1);
+}
+
+/* Ensure smooth transitions */
+#chat-container {
+    transition: width 0.3s ease, max-width 0.3s ease;
+}
+
+#whiteboard-panel {
+    transition: all 0.3s ease;
 }
 
 /* ============================================
@@ -203,19 +227,36 @@ body.whiteboard-active #chat-pip-widget {
         width: 500px;
         height: 600px;
     }
+
+    /* Adjust split-screen for medium screens - give more space to whiteboard */
+    body.whiteboard-split-screen #chat-container {
+        width: calc(45vw - 30px);
+        max-width: calc(45vw - 30px);
+    }
+
+    body.whiteboard-split-screen #whiteboard-panel:not(.maximized) {
+        width: calc(55vw - 20px);
+    }
 }
 
 @media (max-width: 1024px) {
-    /* Mobile: Whiteboard becomes modal overlay */
-    body.whiteboard-active #whiteboard-panel {
-        position: fixed;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-        width: 90vw;
-        height: 80vh;
-        max-width: 600px;
-        max-height: 700px;
+    /* Disable split-screen on smaller screens - revert to overlay mode */
+    body.whiteboard-split-screen #chat-container {
+        width: 100% !important;
+        max-width: 100% !important;
+    }
+
+    /* Mobile: Whiteboard becomes modal overlay even in split-screen mode */
+    body.whiteboard-active #whiteboard-panel,
+    body.whiteboard-split-screen #whiteboard-panel:not(.maximized) {
+        position: fixed !important;
+        top: 50% !important;
+        left: 50% !important;
+        transform: translate(-50%, -50%) !important;
+        width: 90vw !important;
+        height: 80vh !important;
+        max-width: 600px !important;
+        max-height: 700px !important;
     }
 
     /* Show backdrop */

--- a/public/js/whiteboard-chat-layout.js
+++ b/public/js/whiteboard-chat-layout.js
@@ -75,6 +75,14 @@ class WhiteboardChatLayout {
             };
         }
 
+        // Add split-screen toggle button listener
+        const splitScreenBtn = document.getElementById('split-screen-btn');
+        if (splitScreenBtn) {
+            splitScreenBtn.addEventListener('click', () => {
+                this.toggleSplitScreen();
+            });
+        }
+
         // Also listen for visual command execution
         document.addEventListener('visualCommandExecuted', (e) => {
             // Whiteboard was just used
@@ -119,8 +127,9 @@ class WhiteboardChatLayout {
     onWhiteboardClose() {
         this.isWhiteboardOpen = false;
         document.body.classList.remove('whiteboard-active');
-        document.body.classList.remove('whiteboard-split-screen');
 
+        // Clean up all modes
+        this.disableSplitScreen();
         this.hideMessageTicker();
         this.hidePIPWidget();
 
@@ -274,7 +283,37 @@ class WhiteboardChatLayout {
 
     enableSplitScreen() {
         document.body.classList.add('whiteboard-split-screen');
+        this.updateSplitScreenButton(true);
         console.log('[Layout] Split-screen mode enabled');
+    }
+
+    disableSplitScreen() {
+        document.body.classList.remove('whiteboard-split-screen');
+        this.updateSplitScreenButton(false);
+        console.log('[Layout] Split-screen mode disabled');
+    }
+
+    toggleSplitScreen() {
+        if (this.mode === 'split-screen') {
+            // Switch to message-ticker mode
+            this.setMode('message-ticker');
+        } else {
+            // Switch to split-screen mode
+            this.setMode('split-screen');
+        }
+    }
+
+    updateSplitScreenButton(isActive) {
+        const splitScreenBtn = document.getElementById('split-screen-btn');
+        if (splitScreenBtn) {
+            if (isActive) {
+                splitScreenBtn.style.background = 'rgba(255, 255, 255, 0.4)';
+                splitScreenBtn.style.transform = 'scale(1.05)';
+            } else {
+                splitScreenBtn.style.background = '';
+                splitScreenBtn.style.transform = '';
+            }
+        }
     }
 
     // ============================================
@@ -356,8 +395,8 @@ class WhiteboardChatLayout {
             // Medium screens: Message ticker
             this.mode = 'message-ticker';
         } else {
-            // Large screens: Split-screen
-            this.mode = 'message-ticker'; // Default to ticker (less disruptive)
+            // Large screens: Default to split-screen for better visibility
+            this.mode = 'split-screen';
         }
 
         // Check user preference from localStorage


### PR DESCRIPTION
Implemented a split-screen layout that displays the whiteboard and chat side-by-side, ensuring text remains visible while using the whiteboard.

Features:
- Added split-screen toggle button to whiteboard header (columns icon)
- Defaults to split-screen mode on screens >1400px wide
- Smooth transitions when entering/exiting split-screen
- Non-disruptive layout that preserves chat scroll position
- Responsive behavior: 50/50 split on large screens, 45/55 on medium, reverts to overlay on mobile
- Visual feedback on split-screen button when active
- Easy toggle between split-screen and message-ticker modes

The minimize button was already present in the header, so users now have both minimize and split-screen options available.