### PR TITLE
Implement split-screen whiteboard layout for better learning

### DIFF
--- a/public/css/whiteboard-chat-layout.css
+++ b/public/css/whiteboard-chat-layout.css
@@ -87,25 +87,79 @@ body.whiteboard-active #whiteboard-panel:not(.maximized) {
 }
 
 /* ============================================
-   SOLUTION 2: SPLIT-SCREEN MODE
+   SOLUTION 2: SPLIT-SCREEN MODE (ENHANCED)
    Side-by-side layout when whiteboard is open
    ============================================ */
 
-body.whiteboard-split-screen {
-    /* Enable split mode */
+/* Main layout container adjustments */
+body.whiteboard-split-screen #app-layout-wrapper {
+    display: flex;
+    gap: 0;
+    height: 100vh;
+    overflow: hidden;
 }
 
+/* Chat side - left panel */
 body.whiteboard-split-screen #chat-container {
-    width: calc(50vw - 40px);
+    width: 50%;
     max-width: none;
-    margin-right: 20px;
+    margin: 0;
+    padding: 0;
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: column;
+    border-right: 2px solid #e5e7eb;
+    transition: width 0.3s ease;
 }
 
-body.whiteboard-split-screen #whiteboard-panel:not(.maximized) {
-    left: auto;
-    right: 20px;
-    width: calc(50vw - 40px);
-    max-width: 800px;
+/* Whiteboard side - right panel */
+body.whiteboard-split-screen #whiteboard-panel {
+    position: fixed !important;
+    left: 50% !important;
+    right: 0 !important;
+    top: 60px !important; /* Below header */
+    bottom: 0 !important;
+    width: 50% !important;
+    height: calc(100vh - 60px) !important;
+    max-width: none !important;
+    transform: none !important;
+    border-radius: 0 !important;
+    box-shadow: -2px 0 8px rgba(0, 0, 0, 0.1) !important;
+    transition: all 0.3s ease;
+}
+
+/* Collapsed state - whiteboard minimized to thin bar */
+body.whiteboard-split-screen #whiteboard-panel.collapsed {
+    width: 48px !important;
+    left: calc(100% - 48px) !important;
+}
+
+body.whiteboard-split-screen #whiteboard-panel.collapsed .whiteboard-header h2,
+body.whiteboard-split-screen #whiteboard-panel.collapsed .whiteboard-toolbar,
+body.whiteboard-split-screen #whiteboard-panel.collapsed .whiteboard-canvas-container {
+    display: none;
+}
+
+body.whiteboard-split-screen #whiteboard-panel.collapsed .whiteboard-header {
+    flex-direction: column;
+    padding: 8px 4px;
+    height: 100%;
+}
+
+body.whiteboard-split-screen #whiteboard-panel.collapsed .whiteboard-header-controls {
+    flex-direction: column;
+    gap: 12px;
+}
+
+/* Expand chat when whiteboard is collapsed */
+body.whiteboard-split-screen #chat-container.whiteboard-collapsed {
+    width: calc(100% - 48px);
+}
+
+/* Smooth transitions */
+body.whiteboard-split-screen #chat-container,
+body.whiteboard-split-screen #whiteboard-panel {
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 /* ============================================
@@ -193,7 +247,103 @@ body.whiteboard-active #chat-pip-widget {
    RESPONSIVE BEHAVIOR
    ============================================ */
 
-/* On smaller screens, auto-use compact mode */
+/* Tablet/small laptop - adjust split to 40/60 */
+@media (max-width: 1400px) {
+    body.whiteboard-split-screen #chat-container {
+        width: 40%;
+    }
+
+    body.whiteboard-split-screen #whiteboard-panel {
+        left: 40% !important;
+        width: 60% !important;
+    }
+
+    body.whiteboard-split-screen #whiteboard-panel.collapsed {
+        left: calc(100% - 48px) !important;
+    }
+
+    body.whiteboard-split-screen #chat-container.whiteboard-collapsed {
+        width: calc(100% - 48px);
+    }
+}
+
+/* Tablet - stack vertically on medium screens */
+@media (max-width: 1024px) {
+    body.whiteboard-split-screen #app-layout-wrapper {
+        flex-direction: column;
+    }
+
+    body.whiteboard-split-screen #chat-container {
+        width: 100% !important;
+        height: 50%;
+        border-right: none;
+        border-bottom: 2px solid #e5e7eb;
+    }
+
+    body.whiteboard-split-screen #whiteboard-panel {
+        position: fixed !important;
+        left: 0 !important;
+        right: 0 !important;
+        top: 50% !important;
+        bottom: 0 !important;
+        width: 100% !important;
+        height: 50% !important;
+    }
+
+    body.whiteboard-split-screen #whiteboard-panel.collapsed {
+        height: 48px !important;
+        top: calc(100% - 48px) !important;
+        left: 0 !important;
+    }
+
+    body.whiteboard-split-screen #chat-container.whiteboard-collapsed {
+        height: calc(100% - 48px);
+        width: 100%;
+    }
+}
+
+/* Mobile - full overlay mode (disable split-screen) */
+@media (max-width: 768px) {
+    body.whiteboard-split-screen #app-layout-wrapper {
+        flex-direction: column;
+    }
+
+    body.whiteboard-split-screen #chat-container {
+        width: 100% !important;
+        height: 100%;
+        border: none;
+    }
+
+    body.whiteboard-split-screen #whiteboard-panel {
+        position: fixed !important;
+        left: 0 !important;
+        right: 0 !important;
+        top: 0 !important;
+        bottom: 0 !important;
+        width: 100% !important;
+        height: 100% !important;
+        z-index: 1050;
+    }
+
+    body.whiteboard-split-screen #whiteboard-panel.collapsed {
+        display: none;
+    }
+
+    /* Show backdrop on mobile */
+    body.whiteboard-split-screen::before {
+        content: '';
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: rgba(0, 0, 0, 0.5);
+        z-index: 1040;
+        pointer-events: none;
+    }
+}
+
+/* Legacy responsive styles for non-split-screen mode */
 @media (max-width: 1400px) {
     body.whiteboard-active #chat-container {
         max-width: calc(100vw - 550px);

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -409,9 +409,30 @@ document.addEventListener("DOMContentLoaded", () => {
 
             if (toggleBtn && whiteboardPanel) {
                 toggleBtn.addEventListener('click', () => {
-                    whiteboardPanel.classList.toggle('is-hidden');
-                    if (openWhiteboardBtn) {
-                        openWhiteboardBtn.classList.toggle('hidden');
+                    const isHidden = whiteboardPanel.classList.contains('is-hidden');
+
+                    if (isHidden) {
+                        // Open whiteboard in split-screen mode
+                        whiteboardPanel.classList.remove('is-hidden');
+                        document.body.classList.add('whiteboard-split-screen');
+                        const chatContainer = document.getElementById('chat-container');
+                        if (chatContainer) {
+                            chatContainer.classList.remove('whiteboard-collapsed');
+                        }
+                        if (openWhiteboardBtn) {
+                            openWhiteboardBtn.classList.add('hidden');
+                        }
+                    } else {
+                        // Close whiteboard
+                        whiteboardPanel.classList.add('is-hidden');
+                        document.body.classList.remove('whiteboard-split-screen');
+                        const chatContainer = document.getElementById('chat-container');
+                        if (chatContainer) {
+                            chatContainer.classList.remove('whiteboard-collapsed');
+                        }
+                        if (openWhiteboardBtn) {
+                            openWhiteboardBtn.classList.remove('hidden');
+                        }
                     }
                 });
             }
@@ -419,7 +440,12 @@ document.addEventListener("DOMContentLoaded", () => {
             if (openWhiteboardBtn && whiteboardPanel) {
                 openWhiteboardBtn.addEventListener('click', () => {
                     whiteboardPanel.classList.remove('is-hidden');
+                    document.body.classList.add('whiteboard-split-screen');
                     openWhiteboardBtn.classList.add('hidden');
+                    const chatContainer = document.getElementById('chat-container');
+                    if (chatContainer) {
+                        chatContainer.classList.remove('whiteboard-collapsed');
+                    }
                 });
             }
 
@@ -3098,10 +3124,51 @@ document.addEventListener("DOMContentLoaded", () => {
     
     if (closeWhiteboardBtn) {
         closeWhiteboardBtn.addEventListener('click', () => {
-            if (whiteboard) {
-                whiteboard.hide();
+            const whiteboardPanel = document.getElementById('whiteboard-panel');
+            if (whiteboardPanel) {
+                whiteboardPanel.classList.add('is-hidden');
+                whiteboardPanel.classList.remove('collapsed');
+                document.body.classList.remove('whiteboard-split-screen');
+                const chatContainer = document.getElementById('chat-container');
+                if (chatContainer) {
+                    chatContainer.classList.remove('whiteboard-collapsed');
+                }
                 const openBtn = document.getElementById('open-whiteboard-btn');
                 if (openBtn) openBtn.classList.remove('hidden');
+            }
+        });
+    }
+
+    // Handle minimize button - collapse to thin bar
+    const minimizeWhiteboardBtn = document.getElementById('minimize-whiteboard-btn');
+    if (minimizeWhiteboardBtn) {
+        minimizeWhiteboardBtn.addEventListener('click', () => {
+            const whiteboardPanel = document.getElementById('whiteboard-panel');
+            const chatContainer = document.getElementById('chat-container');
+            const icon = minimizeWhiteboardBtn.querySelector('i');
+
+            if (whiteboardPanel && chatContainer) {
+                const isCollapsed = whiteboardPanel.classList.contains('collapsed');
+
+                if (isCollapsed) {
+                    // Expand whiteboard
+                    whiteboardPanel.classList.remove('collapsed');
+                    chatContainer.classList.remove('whiteboard-collapsed');
+                    if (icon) {
+                        icon.className = 'fas fa-window-minimize';
+                    }
+                    minimizeWhiteboardBtn.setAttribute('title', 'Minimize');
+                    minimizeWhiteboardBtn.setAttribute('data-tooltip', 'Minimize');
+                } else {
+                    // Collapse whiteboard to thin bar
+                    whiteboardPanel.classList.add('collapsed');
+                    chatContainer.classList.add('whiteboard-collapsed');
+                    if (icon) {
+                        icon.className = 'fas fa-window-maximize';
+                    }
+                    minimizeWhiteboardBtn.setAttribute('title', 'Expand');
+                    minimizeWhiteboardBtn.setAttribute('data-tooltip', 'Expand');
+                }
             }
         });
     }


### PR DESCRIPTION
Major UX Improvement:
- Whiteboard now opens in split-screen mode automatically
- Students can see both chat instructions and whiteboard simultaneously
- No more switching between chat and whiteboard views

Split-Screen Layout:
- Chat takes left 50%, whiteboard takes right 50% (desktop)
- Clean vertical divider between panels
- Smooth transitions when opening/closing/collapsing

Collapse/Expand Feature:
- Minimize button now collapses whiteboard to 48px thin bar
- Chat automatically expands to fill available space when collapsed
- Icon changes: minimize (−) ↔ expand (□)
- Click minimize again to restore full whiteboard view

Responsive Behavior:
- Desktop (>1400px): 50/50 split
- Laptop (≤1400px): 40/60 split (more room for whiteboard)
- Tablet (≤1024px): Vertical stack (chat top, whiteboard bottom)
- Mobile (≤768px): Full overlay mode with backdrop

Implementation Details:
- Added 'whiteboard-split-screen' body class when whiteboard opens
- Updated toggle, open, and close handlers to manage split-screen state
- Collapse state tracked with 'collapsed' class on whiteboard panel
- Chat container gets 'whiteboard-collapsed' class when minimized

Benefits:
✅ Students can read AI instructions while seeing visual demonstrations ✅ No more "wait, what did they say?" moments
✅ Better learning flow - visual + text together
✅ Minimize option for when students only need chat temporarily ✅ Fully responsive across all device sizes

This dramatically improves the teaching experience for visual learners and makes step-by-step instructions much easier to follow.