### PR TITLE
Fix playTextToSpeech is not defined error

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -2358,11 +2358,6 @@ document.addEventListener("DOMContentLoaded", () => {
             // Display AI response
             appendMessage(data.message, "ai");
 
-            // TTS if enabled
-            if (data.voiceId) {
-                playTextToSpeech(data.message, data.voiceId);
-            }
-
             showThinkingIndicator(false);
             return;
         }


### PR DESCRIPTION
- Remove call to undefined playTextToSpeech function in rapport building handler
- AI messages already get play buttons via appendMessage()
- Users can click play button if they want to hear the message
- No auto-play needed for rapport building responses