### PR TITLE
Fix: Prevent spacebar from activating voice when typing in input fields

### DIFF
--- a/public/js/voice-controller.js
+++ b/public/js/voice-controller.js
@@ -322,7 +322,8 @@ class VoiceController {
             }
 
             // Hold spacebar to talk (push-to-talk mode)
-            if (e.code === 'Space' && e.target.tagName !== 'INPUT' && e.target.tagName !== 'TEXTAREA') {
+            // Only activate if NOT typing in an input field
+            if (e.code === 'Space' && !this.isTypingInInputField(e.target)) {
                 if (!this.isListening && !e.repeat) {
                     e.preventDefault();
                     this.startListening();
@@ -331,11 +332,44 @@ class VoiceController {
         });
 
         document.addEventListener('keyup', (e) => {
-            if (e.code === 'Space' && this.isListening) {
+            // Only stop listening on space release if NOT typing in an input field
+            if (e.code === 'Space' && this.isListening && !this.isTypingInInputField(e.target)) {
                 e.preventDefault();
                 this.stopListening();
             }
         });
+    }
+
+    /**
+     * Check if user is currently typing in an input field
+     * Prevents spacebar from activating voice when typing
+     * @param {HTMLElement} target - The event target element
+     * @returns {boolean} True if user is typing in an input field
+     */
+    isTypingInInputField(target) {
+        // Check if target is an input, textarea, or contenteditable element
+        if (!target) return false;
+
+        const tagName = target.tagName;
+        const isContentEditable = target.isContentEditable || target.contentEditable === 'true';
+
+        // Check for standard input elements
+        if (tagName === 'INPUT' || tagName === 'TEXTAREA') {
+            return true;
+        }
+
+        // Check for contenteditable divs (like the chat input)
+        if (isContentEditable) {
+            return true;
+        }
+
+        // Check if user-input chat box has focus (additional safety check)
+        const userInput = document.getElementById('user-input');
+        if (userInput && (document.activeElement === userInput || userInput.contains(document.activeElement))) {
+            return true;
+        }
+
+        return false;
     }
 
     // ============================================


### PR DESCRIPTION
ISSUE:
Spacebar was triggering speech-to-text even when user was typing in the chat input box, causing errors:
- "Whisper transcription failed: audio file could not be decoded"
- Interrupted typing workflow
- Activated voice mode unintentionally

ROOT CAUSE:
The space bar event listeners only checked for INPUT and TEXTAREA tags, but the main chat input (#user-input) is a contenteditable div.

FIX:
1. Added isTypingInInputField() helper method that checks:
   - Standard INPUT and TEXTAREA elements
   - Contenteditable elements (isContentEditable property)
   - Specific check for #user-input chat box

2. Updated both keydown and keyup event listeners to use the new check:
   - keydown: Only activate voice if NOT typing
   - keyup: Only stop voice if NOT typing

RESULT:
- Spacebar now works normally when typing in chat
- Push-to-talk still works when focus is outside input fields
- No more spurious voice activation errors

FILES MODIFIED:
- public/js/voice-controller.js
  - Added isTypingInInputField() method
  - Updated keydown event listener (line 326)
  - Updated keyup event listener (line 336)