### PR TITLE
Add: Resizable split-screen with draggable divider

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="/style.css" />
   <link rel="stylesheet" href="/css/whiteboard.css" />
   <link rel="stylesheet" href="/css/whiteboard-chat-layout.css" />
+  <link rel="stylesheet" href="/css/split-screen-resizer.css" />
   <link rel="stylesheet" href="/css/file-upload.css" />
   <link rel="stylesheet" href="/css/calculator.css" />
   <link rel="stylesheet" href="/css/responsive-resources.css" />
@@ -1326,6 +1327,7 @@
   <script src="/js/sidebar.js"></script>
   <script src="/js/engagement-widgets.js"></script>
   <script src="/js/visualTeachingHandler.js"></script>
+  <script src="/js/split-screen-resizer.js"></script>
   <script src="/js/whiteboard-chat-layout.js"></script>
   <!-- PDF.js library for PDF preview and rendering -->
   <script src="/pdfjs-viewer/build/pdf.mjs" type="module"></script>

--- a/public/css/algebra-tiles.css
+++ b/public/css/algebra-tiles.css
@@ -1354,7 +1354,7 @@ body.algebra-tiles-split-screen {
 }
 
 body.algebra-tiles-split-screen #chat-container {
-  width: 50%;
+  width: 50%; /* Default, will be overridden by resizer */
   max-width: none;
   margin: 0;
   padding: 0;
@@ -1362,17 +1362,17 @@ body.algebra-tiles-split-screen #chat-container {
   display: flex;
   flex-direction: column;
   border-right: 2px solid #e5e7eb;
-  transition: width 0.3s ease;
+  transition: width 0.1s ease; /* Faster transition for responsive resizing */
 }
 
 /* Tiles panel in split-screen - no modal overlay, docked to right */
 body.algebra-tiles-split-screen .algebra-tiles-modal {
   position: fixed !important;
-  left: 50% !important;
+  left: 50% !important; /* Default, will be overridden by resizer */
   right: 0 !important;
   top: 0 !important;
   bottom: 0 !important;
-  width: 50% !important;
+  width: 50% !important; /* Default, will be overridden by resizer */
   height: 100vh !important;
   background-color: transparent !important;
   backdrop-filter: none !important;
@@ -1381,6 +1381,7 @@ body.algebra-tiles-split-screen .algebra-tiles-modal {
   justify-content: flex-end !important;
   align-items: stretch !important;
   animation: none !important;
+  transition: left 0.1s ease, width 0.1s ease; /* Smooth resize */
 }
 
 body.algebra-tiles-split-screen .algebra-tiles-content {

--- a/public/css/split-screen-resizer.css
+++ b/public/css/split-screen-resizer.css
@@ -1,0 +1,99 @@
+/* ============================================
+   SPLIT-SCREEN RESIZER
+   Draggable divider for resizing chat/panel split
+   ============================================ */
+
+.split-screen-divider {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  width: 6px;
+  background: transparent;
+  cursor: col-resize;
+  z-index: 1100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease;
+}
+
+/* Hover state - show visual indicator */
+.split-screen-divider:hover {
+  background: rgba(18, 179, 179, 0.1);
+}
+
+/* Active/dragging state */
+.split-screen-divider.dragging {
+  background: rgba(18, 179, 179, 0.2);
+}
+
+/* Visual handle in the center */
+.divider-handle {
+  width: 100%;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(18, 179, 179, 0.15);
+  border-radius: 4px;
+  transition: all 0.2s ease;
+}
+
+.split-screen-divider:hover .divider-handle {
+  background: rgba(18, 179, 179, 0.3);
+  height: 80px;
+}
+
+.split-screen-divider.dragging .divider-handle {
+  background: rgba(18, 179, 179, 0.5);
+  height: 100px;
+}
+
+/* Grip dots */
+.divider-grip {
+  width: 4px;
+  height: 30px;
+  background-image: radial-gradient(circle, rgba(18, 179, 179, 0.6) 1px, transparent 1px);
+  background-size: 4px 6px;
+  background-position: center;
+  background-repeat: repeat-y;
+  transition: all 0.2s ease;
+}
+
+.split-screen-divider:hover .divider-grip {
+  background-image: radial-gradient(circle, rgba(18, 179, 179, 0.8) 1.5px, transparent 1.5px);
+  height: 40px;
+}
+
+.split-screen-divider.dragging .divider-grip {
+  background-image: radial-gradient(circle, rgba(18, 179, 179, 1) 2px, transparent 2px);
+  height: 50px;
+}
+
+/* Prevent text selection during drag */
+body.resizing-split {
+  user-select: none;
+  cursor: col-resize !important;
+}
+
+body.resizing-split * {
+  cursor: col-resize !important;
+}
+
+/* ============================================
+   RESPONSIVE BEHAVIOR
+   ============================================ */
+
+/* Hide divider on mobile (no split-screen on small screens) */
+@media (max-width: 768px) {
+  .split-screen-divider {
+    display: none;
+  }
+}
+
+/* Tablet - vertical divider still works */
+@media (max-width: 1024px) and (min-width: 769px) {
+  .split-screen-divider {
+    /* Keep divider functional on tablets */
+  }
+}

--- a/public/css/whiteboard-chat-layout.css
+++ b/public/css/whiteboard-chat-layout.css
@@ -101,7 +101,7 @@ body.whiteboard-split-screen #app-layout-wrapper {
 
 /* Chat side - left panel */
 body.whiteboard-split-screen #chat-container {
-    width: 50%;
+    width: 50%; /* Default, will be overridden by resizer */
     max-width: none;
     margin: 0;
     padding: 0;
@@ -109,23 +109,23 @@ body.whiteboard-split-screen #chat-container {
     display: flex;
     flex-direction: column;
     border-right: 2px solid #e5e7eb;
-    transition: width 0.3s ease;
+    transition: width 0.1s ease; /* Faster transition for responsive resizing */
 }
 
 /* Whiteboard side - right panel */
 body.whiteboard-split-screen #whiteboard-panel {
     position: fixed !important;
-    left: 50% !important;
+    left: 50% !important; /* Default, will be overridden by resizer */
     right: 0 !important;
     top: 60px !important; /* Below header */
     bottom: 0 !important;
-    width: 50% !important;
+    width: 50% !important; /* Default, will be overridden by resizer */
     height: calc(100vh - 60px) !important;
     max-width: none !important;
     transform: none !important;
     border-radius: 0 !important;
     box-shadow: -2px 0 8px rgba(0, 0, 0, 0.1) !important;
-    transition: all 0.3s ease;
+    transition: all 0.1s ease; /* Faster transition for responsive resizing */
 }
 
 /* Collapsed state - whiteboard minimized to thin bar */

--- a/public/js/algebra-tiles.js
+++ b/public/js/algebra-tiles.js
@@ -2111,6 +2111,12 @@ class AlgebraTiles {
       const isMobile = window.innerWidth < 768;
       if (!isMobile) {
         document.body.classList.add('algebra-tiles-split-screen');
+
+        // Enable resizable split divider
+        if (window.splitScreenResizer) {
+          window.splitScreenResizer.enableForTiles();
+        }
+
         console.log('📐 Algebra tiles opened in split-screen mode');
       } else {
         console.log('📐 Algebra tiles opened in modal mode (mobile)');
@@ -2125,6 +2131,11 @@ class AlgebraTiles {
 
       // Remove split-screen mode
       document.body.classList.remove('algebra-tiles-split-screen');
+
+      // Disable resizable split divider
+      if (window.splitScreenResizer) {
+        window.splitScreenResizer.disable();
+      }
 
       // Also remove collapsed state if it was set
       const chatContainer = document.getElementById('chat-container');

--- a/public/js/split-screen-resizer.js
+++ b/public/js/split-screen-resizer.js
@@ -1,0 +1,249 @@
+// ============================================
+// SPLIT-SCREEN RESIZER
+// Draggable divider for whiteboard/tiles split-screen
+// ============================================
+
+class SplitScreenResizer {
+  constructor() {
+    this.isDragging = false;
+    this.currentPosition = 50; // Default 50% split
+    this.minWidth = 30; // Minimum 30% for either side
+    this.maxWidth = 70; // Maximum 70% for either side
+
+    this.divider = null;
+    this.chatContainer = null;
+    this.activePanel = null; // 'whiteboard' or 'tiles'
+
+    console.log('📏 Split-Screen Resizer initialized');
+  }
+
+  /**
+   * Enable resizable split for whiteboard
+   */
+  enableForWhiteboard() {
+    this.activePanel = 'whiteboard';
+    this.chatContainer = document.getElementById('chat-container');
+
+    // Load saved position
+    const savedPosition = localStorage.getItem('whiteboardSplitPosition');
+    if (savedPosition) {
+      this.currentPosition = parseFloat(savedPosition);
+    }
+
+    this.createDivider();
+    this.applyLayout();
+
+    console.log('📏 Resizable split enabled for whiteboard');
+  }
+
+  /**
+   * Enable resizable split for algebra tiles
+   */
+  enableForTiles() {
+    this.activePanel = 'tiles';
+    this.chatContainer = document.getElementById('chat-container');
+
+    // Load saved position (separate from whiteboard)
+    const savedPosition = localStorage.getItem('tilesSplitPosition');
+    if (savedPosition) {
+      this.currentPosition = parseFloat(savedPosition);
+    }
+
+    this.createDivider();
+    this.applyLayout();
+
+    console.log('📏 Resizable split enabled for algebra tiles');
+  }
+
+  /**
+   * Create the draggable divider element
+   */
+  createDivider() {
+    // Remove existing divider if any
+    const existing = document.getElementById('split-screen-divider');
+    if (existing) {
+      existing.remove();
+    }
+
+    // Create divider
+    this.divider = document.createElement('div');
+    this.divider.id = 'split-screen-divider';
+    this.divider.className = 'split-screen-divider';
+    this.divider.innerHTML = `
+      <div class="divider-handle">
+        <div class="divider-grip"></div>
+      </div>
+    `;
+
+    // Add to body
+    document.body.appendChild(this.divider);
+
+    // Position divider
+    this.updateDividerPosition();
+
+    // Setup event listeners
+    this.setupEventListeners();
+  }
+
+  /**
+   * Setup drag event listeners
+   */
+  setupEventListeners() {
+    if (!this.divider) return;
+
+    // Mouse events
+    this.divider.addEventListener('mousedown', (e) => this.startDrag(e));
+    document.addEventListener('mousemove', (e) => this.onDrag(e));
+    document.addEventListener('mouseup', () => this.stopDrag());
+
+    // Touch events for mobile
+    this.divider.addEventListener('touchstart', (e) => this.startDrag(e), { passive: false });
+    document.addEventListener('touchmove', (e) => this.onDrag(e), { passive: false });
+    document.addEventListener('touchend', () => this.stopDrag());
+
+    // Double-click to reset to 50/50
+    this.divider.addEventListener('dblclick', () => this.resetPosition());
+  }
+
+  /**
+   * Start dragging
+   */
+  startDrag(e) {
+    this.isDragging = true;
+    this.divider.classList.add('dragging');
+    document.body.classList.add('resizing-split');
+
+    // Prevent text selection during drag
+    e.preventDefault();
+  }
+
+  /**
+   * Handle drag movement
+   */
+  onDrag(e) {
+    if (!this.isDragging) return;
+
+    e.preventDefault();
+
+    // Get mouse/touch position
+    const clientX = e.type.includes('touch') ? e.touches[0].clientX : e.clientX;
+
+    // Calculate percentage position
+    const windowWidth = window.innerWidth;
+    let newPosition = (clientX / windowWidth) * 100;
+
+    // Clamp to min/max
+    newPosition = Math.max(this.minWidth, Math.min(this.maxWidth, newPosition));
+
+    // Update position
+    this.currentPosition = newPosition;
+    this.updateDividerPosition();
+    this.applyLayout();
+  }
+
+  /**
+   * Stop dragging
+   */
+  stopDrag() {
+    if (!this.isDragging) return;
+
+    this.isDragging = false;
+    this.divider.classList.remove('dragging');
+    document.body.classList.remove('resizing-split');
+
+    // Save position to localStorage
+    const key = this.activePanel === 'whiteboard' ? 'whiteboardSplitPosition' : 'tilesSplitPosition';
+    localStorage.setItem(key, this.currentPosition.toString());
+
+    console.log(`📏 Split position saved: ${this.currentPosition.toFixed(1)}%`);
+  }
+
+  /**
+   * Reset to 50/50 split
+   */
+  resetPosition() {
+    this.currentPosition = 50;
+    this.updateDividerPosition();
+    this.applyLayout();
+
+    // Save reset position
+    const key = this.activePanel === 'whiteboard' ? 'whiteboardSplitPosition' : 'tilesSplitPosition';
+    localStorage.setItem(key, '50');
+
+    console.log('📏 Split reset to 50/50');
+  }
+
+  /**
+   * Update divider visual position
+   */
+  updateDividerPosition() {
+    if (!this.divider) return;
+
+    this.divider.style.left = `${this.currentPosition}%`;
+  }
+
+  /**
+   * Apply layout changes to chat and panel
+   */
+  applyLayout() {
+    if (!this.chatContainer) return;
+
+    // Update chat container width
+    this.chatContainer.style.width = `${this.currentPosition}%`;
+
+    // Update whiteboard or tiles panel
+    if (this.activePanel === 'whiteboard') {
+      const whiteboardPanel = document.getElementById('whiteboard-panel');
+      if (whiteboardPanel) {
+        whiteboardPanel.style.left = `${this.currentPosition}%`;
+        whiteboardPanel.style.width = `${100 - this.currentPosition}%`;
+      }
+    } else if (this.activePanel === 'tiles') {
+      const tilesModal = document.querySelector('.algebra-tiles-modal');
+      if (tilesModal) {
+        tilesModal.style.left = `${this.currentPosition}%`;
+        tilesModal.style.width = `${100 - this.currentPosition}%`;
+      }
+    }
+  }
+
+  /**
+   * Disable resizable split and cleanup
+   */
+  disable() {
+    if (this.divider) {
+      this.divider.remove();
+      this.divider = null;
+    }
+
+    // Reset chat container
+    if (this.chatContainer) {
+      this.chatContainer.style.width = '';
+    }
+
+    // Reset panel
+    if (this.activePanel === 'whiteboard') {
+      const whiteboardPanel = document.getElementById('whiteboard-panel');
+      if (whiteboardPanel) {
+        whiteboardPanel.style.left = '';
+        whiteboardPanel.style.width = '';
+      }
+    } else if (this.activePanel === 'tiles') {
+      const tilesModal = document.querySelector('.algebra-tiles-modal');
+      if (tilesModal) {
+        tilesModal.style.left = '';
+        tilesModal.style.width = '';
+      }
+    }
+
+    document.body.classList.remove('resizing-split');
+    this.activePanel = null;
+
+    console.log('📏 Resizable split disabled');
+  }
+}
+
+// Create global instance
+window.splitScreenResizer = new SplitScreenResizer();
+
+console.log('✅ Split-Screen Resizer loaded');

--- a/public/js/whiteboard-chat-layout.js
+++ b/public/js/whiteboard-chat-layout.js
@@ -290,12 +290,24 @@ class WhiteboardChatLayout {
     enableSplitScreen() {
         document.body.classList.add('whiteboard-split-screen');
         this.updateSplitScreenButton(true);
+
+        // Enable resizable split divider
+        if (window.splitScreenResizer) {
+            window.splitScreenResizer.enableForWhiteboard();
+        }
+
         console.log('[Layout] Split-screen mode enabled');
     }
 
     disableSplitScreen() {
         document.body.classList.remove('whiteboard-split-screen');
         this.updateSplitScreenButton(false);
+
+        // Disable resizable split divider
+        if (window.splitScreenResizer) {
+            window.splitScreenResizer.disable();
+        }
+
         console.log('[Layout] Split-screen mode disabled');
     }
 


### PR DESCRIPTION
Implemented a fully functional resizable split-screen system that allows users to drag the divider between chat and whiteboard/algebra tiles panels:

New Files:
- public/js/split-screen-resizer.js: Core resizer class with drag functionality
- public/css/split-screen-resizer.css: Visual styling for the draggable divider

Features:
- Mouse and touch drag support for divider
- 30%-70% width constraints to prevent panels from becoming too small
- Separate saved positions for whiteboard and algebra tiles (localStorage)
- Double-click divider to reset to 50/50 split
- Visual feedback on hover and drag (colored grip, cursor changes)
- Smooth transitions during resize

Integration:
- Updated whiteboard-chat-layout.js to enable/disable resizer for whiteboard
- Updated algebra-tiles.js to enable/disable resizer for tiles
- Updated chat.html to include new CSS and JS files
- Optimized CSS transitions (0.3s → 0.1s) for responsive feel
- Added comments indicating dynamic positioning by resizer

This addresses the user's request: "user should be able to drag the middle line left or right to make one or the other bigger"