### PR TITLE
Fix: Whiteboard split-screen mode and close button functionality

### DIFF
--- a/public/css/split-screen-resizer.css
+++ b/public/css/split-screen-resizer.css
@@ -10,11 +10,12 @@
   width: 6px;
   background: transparent;
   cursor: col-resize;
-  z-index: 1100;
+  z-index: 999; /* Below whiteboard (1006) and tiles (1000) to not block interactive elements */
   display: flex;
   align-items: center;
   justify-content: center;
   transition: background 0.2s ease;
+  pointer-events: auto; /* Only the divider itself should be interactive */
 }
 
 /* Hover state - show visual indicator */

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -457,23 +457,23 @@ document.addEventListener("DOMContentLoaded", () => {
                     const isHidden = whiteboardPanel.classList.contains('is-hidden');
 
                     if (isHidden) {
-                        // Open whiteboard in split-screen mode
-                        whiteboardPanel.classList.remove('is-hidden');
-                        document.body.classList.add('whiteboard-split-screen');
-                        const chatContainer = document.getElementById('chat-container');
-                        if (chatContainer) {
-                            chatContainer.classList.remove('whiteboard-collapsed');
+                        // Open whiteboard using proper method to trigger layout manager
+                        if (window.whiteboard && typeof window.whiteboard.show === 'function') {
+                            window.whiteboard.show();
+                        } else {
+                            // Fallback if whiteboard not fully initialized
+                            whiteboardPanel.classList.remove('is-hidden');
                         }
                         if (openWhiteboardBtn) {
                             openWhiteboardBtn.classList.add('hidden');
                         }
                     } else {
-                        // Close whiteboard
-                        whiteboardPanel.classList.add('is-hidden');
-                        document.body.classList.remove('whiteboard-split-screen');
-                        const chatContainer = document.getElementById('chat-container');
-                        if (chatContainer) {
-                            chatContainer.classList.remove('whiteboard-collapsed');
+                        // Close whiteboard using proper method to trigger layout manager
+                        if (window.whiteboard && typeof window.whiteboard.hide === 'function') {
+                            window.whiteboard.hide();
+                        } else {
+                            // Fallback if whiteboard not fully initialized
+                            whiteboardPanel.classList.add('is-hidden');
                         }
                         if (openWhiteboardBtn) {
                             openWhiteboardBtn.classList.remove('hidden');
@@ -484,13 +484,14 @@ document.addEventListener("DOMContentLoaded", () => {
 
             if (openWhiteboardBtn && whiteboardPanel) {
                 openWhiteboardBtn.addEventListener('click', () => {
-                    whiteboardPanel.classList.remove('is-hidden');
-                    document.body.classList.add('whiteboard-split-screen');
-                    openWhiteboardBtn.classList.add('hidden');
-                    const chatContainer = document.getElementById('chat-container');
-                    if (chatContainer) {
-                        chatContainer.classList.remove('whiteboard-collapsed');
+                    // Open whiteboard using proper method to trigger layout manager
+                    if (window.whiteboard && typeof window.whiteboard.show === 'function') {
+                        window.whiteboard.show();
+                    } else {
+                        // Fallback if whiteboard not fully initialized
+                        whiteboardPanel.classList.remove('is-hidden');
                     }
+                    openWhiteboardBtn.classList.add('hidden');
                 });
             }
 


### PR DESCRIPTION
Critical fixes for split-screen mode activation and z-index layering:

Root Cause #1 - Split-screen not activating:
The toggle-whiteboard-btn click handler in script.js was manually manipulating DOM classes (adding/removing 'whiteboard-split-screen') instead of calling window.whiteboard.show()/hide(). This bypassed the whiteboard-chat-layout manager's hooks, preventing split-screen mode and the resizer from being properly initialized.

Root Cause #2 - Close button not working:
The split-screen divider had z-index: 1100, which was higher than both the whiteboard panel (z-index: 1006) and algebra tiles modal (z-index: 1000). This caused the divider to block interactive elements like the close button.

Changes:
- script.js: Updated toggle button handlers to call whiteboard.show()/hide() methods instead of directly manipulating classes, ensuring layout manager hooks are triggered
- split-screen-resizer.css: Lowered divider z-index from 1100 to 999 to prevent blocking panel controls, added pointer-events clarification

Result:
- Split-screen mode now activates correctly when whiteboard opens
- Resizer divider is properly positioned and functional
- Close button and other controls work as expected
- Layout manager hooks are properly invoked for all open/close operations