### PR TITLE
Fix: Prevent TypeError when accessing whiteboard.panel

### DIFF
--- a/public/js/whiteboard-chat-layout.js
+++ b/public/js/whiteboard-chat-layout.js
@@ -523,7 +523,7 @@ class WhiteboardChatLayout {
         this.mode = mode;
 
         // Apply new mode if whiteboard is open
-        if (this.isWhiteboardOpen || !window.whiteboard.panel.classList.contains('is-hidden')) {
+        if (this.isWhiteboardOpen || (window.whiteboard && window.whiteboard.panel && !window.whiteboard.panel.classList.contains('is-hidden'))) {
             this.onWhiteboardOpen();
         }
 


### PR DESCRIPTION
Fixed a null reference error that occurred when layout mode buttons were clicked before the whiteboard was fully initialized.

Error:
  "Cannot read properties of undefined (reading 'panel')"
  at whiteboard-chat-layout.js:526

Root Cause:
  setLayoutMode() was checking window.whiteboard.panel.classList without first verifying that window.whiteboard and window.whiteboard.panel exist.

Fix:
  Added proper null checks before accessing nested properties:
  - Check window.whiteboard exists
  - Check window.whiteboard.panel exists
  - Then check classList.contains('is-hidden')

This prevents the TypeError when users click layout mode buttons during initialization.