### PR TITLE
Fix: Resources section connection to schedule and modal z-index

### DIFF
--- a/public/css/responsive-resources.css
+++ b/public/css/responsive-resources.css
@@ -1,5 +1,10 @@
 /* Responsive styles for student resources modal */
 
+/* Ensure resources modal appears above all elements including message input */
+#resources-modal {
+    z-index: 10000 !important;
+}
+
 /* Schedule iframe container */
 .schedule-iframe-container {
     position: relative;

--- a/public/js/student-resources.js
+++ b/public/js/student-resources.js
@@ -79,16 +79,19 @@ document.addEventListener('DOMContentLoaded', () => {
             }
 
             if (!data.hasResources) {
+                // Use teacher's actual Common Curriculum URL if available, otherwise use generic schedule
+                const scheduleUrl = data.scheduleUrl || 'https://www.commoncurriculum.com/sites/tentative-schedule';
+
                 resourcesContent.innerHTML = `
                     <div style="padding: 20px;">
                         <!-- Tentative Schedule Section -->
                         <div style="margin-bottom: 25px;">
                             <h3 style="margin: 0 0 15px 0; color: #333; display: flex; align-items: center; gap: 10px;">
                                 <i class="fas fa-calendar-alt" style="color: #12B3B3;"></i>
-                                Tentative Schedule
+                                ${data.scheduleUrl ? 'Your Class Schedule' : 'Tentative Schedule'}
                             </h3>
                             <div class="schedule-iframe-container">
-                                <iframe src="https://www.commoncurriculum.com/sites/tentative-schedule" title="Common Curriculum Tentative Schedule"></iframe>
+                                <iframe src="${scheduleUrl}" title="Common Curriculum Schedule"></iframe>
                             </div>
                             <p style="margin: 10px 0 0 0; font-size: 0.85em; color: #666; text-align: center;">
                                 <i class="fas fa-info-circle"></i> View the full curriculum schedule and click links to explore lesson resources
@@ -128,16 +131,19 @@ document.addEventListener('DOMContentLoaded', () => {
             });
 
             // Build HTML
+            // Use teacher's actual Common Curriculum URL if available, otherwise use generic schedule
+            const scheduleUrl = data.scheduleUrl || 'https://www.commoncurriculum.com/sites/tentative-schedule';
+
             let html = `
                 <div style="padding: 20px;">
                     <!-- Tentative Schedule Section -->
                     <div style="margin-bottom: 25px;">
                         <h3 style="margin: 0 0 15px 0; color: #333; display: flex; align-items: center; gap: 10px;">
                             <i class="fas fa-calendar-alt" style="color: #12B3B3;"></i>
-                            Tentative Schedule
+                            ${data.scheduleUrl ? 'Your Class Schedule' : 'Tentative Schedule'}
                         </h3>
                         <div class="schedule-iframe-container">
-                            <iframe src="https://www.commoncurriculum.com/sites/tentative-schedule" title="Common Curriculum Tentative Schedule"></iframe>
+                            <iframe src="${scheduleUrl}" title="Common Curriculum Schedule"></iframe>
                         </div>
                         <p style="margin: 10px 0 0 0; font-size: 0.85em; color: #666; text-align: center;">
                             <i class="fas fa-info-circle"></i> View the full curriculum schedule and click links to explore lesson resources

--- a/server.js
+++ b/server.js
@@ -197,7 +197,7 @@ app.use(helmet({
       ],
       mediaSrc: ["'self'", "blob:", "data:"], // Audio/video
       objectSrc: ["'none'"], // Disable plugins
-      frameSrc: ["'self'"], // Only allow same-origin iframes
+      frameSrc: ["'self'", "https://www.commoncurriculum.com"], // Allow Common Curriculum schedule iframes
       upgradeInsecureRequests: process.env.NODE_ENV === 'production' ? [] : null
     }
   },


### PR DESCRIPTION
This commit addresses multiple issues with the resources section and curriculum schedule integration:

1. **Fixed CSP Policy**: Added https://www.commoncurriculum.com to frameSrc to allow iframe embedding
   - Resolves "Content Security Policy directive: frame-src 'self'" blocking error
   - Files: server.js

2. **Fixed Resources Modal Z-Index**: Increased z-index to 10000 to appear above message input
   - Prevents modal from appearing behind chat input container
   - Files: public/css/responsive-resources.css

3. **Improved Date Parsing**: Enhanced extractDates() to handle multiple date formats
   - Now supports: "Nov 11 - Dec 12", "11/11 - 12/12", "2024-11-11 - 2024-12-12", "November 11 - December 12"
   - Handles year rollover (Dec to Jan transitions)
   - Automatically adds current year to dates without year specification
   - Files: routes/curriculum.js

4. **Enhanced parseDate()**: More robust date string parsing
   - Handles month abbreviations + day (e.g., "Nov 11")
   - Handles MM/DD format with automatic year addition
   - Files: routes/curriculum.js

5. **Added Fallback Logic to getCurrentLesson()**: Multi-tier fallback strategy
   - Primary: Find lesson by date range
   - Fallback 1: Estimate current week based on school year (Sept 1 start)
   - Fallback 2: Return lesson closest to current week
   - Fallback 3: Return first lesson with resources
   - Prevents empty resources when dates aren't set
   - Files: models/curriculum.js

6. **Dynamic Schedule URL Display**: Show teacher's actual Common Curriculum schedule
   - Added commonCurriculumUrl field to Curriculum model
   - API now returns teacher's specific schedule URL
   - Frontend displays teacher's actual schedule instead of generic template
   - Title changes from "Tentative Schedule" to "Your Class Schedule" when available
   - Files: models/curriculum.js, routes/curriculum.js, public/js/student-resources.js

These changes ensure students can view their teacher's curriculum schedule and access resources even when date parsing encounters edge cases or when lessons don't have explicit dates set.