### PR TITLE
Fix: Replace generic data with real data in parent dashboard

### DIFF
--- a/public/js/logout.js
+++ b/public/js/logout.js
@@ -1,7 +1,7 @@
 // public/js/logout.js
 document.addEventListener('DOMContentLoaded', () => {
-  // Use querySelectorAll to select all buttons with the common class
-  const logoutButtons = document.querySelectorAll('.logout-button');
+  // Select all logout buttons (by class or by ID)
+  const logoutButtons = document.querySelectorAll('.logout-button, #logoutBtn');
 
   logoutButtons.forEach(logoutBtn => {
     if (logoutBtn) {

--- a/routes/parent.js
+++ b/routes/parent.js
@@ -132,7 +132,7 @@ router.get('/child/:childId/progress', isAuthenticated, isParent, async (req, re
         const recentSessions = await Conversation.find({ userId: childId })
             .sort({ lastActivity: -1 })
             .limit(5)
-            .select('summary date activeMinutes');
+            .select('summary lastActivity activeMinutes startDate');
         // --- MODIFICATION END ---
 
         // NEW: Fetch active conversation for live stats
@@ -170,7 +170,7 @@ router.get('/child/:childId/progress', isAuthenticated, isParent, async (req, re
             totalActiveTutoringMinutes: child.totalActiveTutoringMinutes,
             liveStats: liveStats, // NEW: Live activity stats
             recentSessions: recentSessions.map(session => ({
-                date: session.date,
+                date: session.lastActivity || session.startDate,
                 summary: session.summary,
                 duration: session.activeMinutes
             })),


### PR DESCRIPTION
Fixed three critical issues causing parent dashboard to show bad data:

1. **Invalid Date bug** (routes/parent.js:135,173)
   - Backend was selecting non-existent 'date' field from Conversation model
   - Changed to use 'lastActivity' (which actually exists)
   - Frontend was calling new Date() on undefined, causing "Invalid Date"

2. **Raw AI prompts displayed as summaries** (public/js/parent-dashboard.js:260-283)
   - Old sessions had broken summaries containing full AI instruction prompts
   - Added filtering to exclude sessions with prompt text like "--- End Session Transcript ---"
   - Added date validation to handle sessions with null/undefined dates
   - Now only shows real AI-generated summaries

3. **Logout button not working** (public/js/logout.js:4)
   - logout.js was only looking for `.logout-button` class
   - All dashboards use id="#logoutBtn" instead
   - Updated selector to: `.logout-button, #logoutBtn`
   - Fixes logout on parent, teacher, AND admin dashboards

Technical details:
- Conversation model has lastActivity/startDate, NOT 'date'
- Filter checks for prompt keywords to exclude malformed summaries
- Single logout.js fix applies to all 3 dashboards