### PR TITLE
Fix: Add credentials to diagram generation API call

### DIFF
--- a/public/js/diagram-display.js
+++ b/public/js/diagram-display.js
@@ -57,6 +57,7 @@ class DiagramDisplay {
                 headers: {
                     'Content-Type': 'application/json'
                 },
+                credentials: 'include',
                 body: JSON.stringify({ type, params })
             });
 


### PR DESCRIPTION
Added credentials: 'include' to the fetch call in diagram-display.js to properly authenticate diagram generation requests. This fixes the 403 error when generating diagrams.

https://claude.ai/code/session_01M7weywZnvD6XKBJN2Zy8bY