### PR TITLE
Fix: Add CSRF token to diagram generation API request

### DIFF
--- a/public/js/diagram-display.js
+++ b/public/js/diagram-display.js
@@ -157,11 +157,23 @@ class DiagramDisplay {
         try {
             console.log(`[DiagramDisplay] Generating ${type} diagram with params:`, params);
 
+            // Get CSRF token (from global csrf.js)
+            const csrfToken = typeof getCsrfToken === 'function' ? getCsrfToken() : null;
+
+            const headers = {
+                'Content-Type': 'application/json'
+            };
+
+            // Add CSRF token if available
+            if (csrfToken) {
+                headers['X-CSRF-Token'] = csrfToken;
+            } else {
+                console.warn('[DiagramDisplay] No CSRF token found. Request may be rejected.');
+            }
+
             const response = await fetch('/api/generate-diagram', {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
+                headers: headers,
                 credentials: 'include',
                 body: JSON.stringify({ type, params })
             });


### PR DESCRIPTION
This commit resolves the CSRF protection issue causing diagram generation to fail with "Missing CSRF token" error.

**Problem:**
Server logs showed diagram generation requests being rejected: [CSRF] Missing CSRF token: {
  method: 'POST',
  url: '/api/generate-diagram',
  hasCookie: true,
  hasHeader: false
}

**Solution:**
Updated the diagram generation fetch request to include the CSRF token in the X-CSRF-Token header using the global getCsrfToken() function from csrf.js.

**Changes:**
- public/js/diagram-display.js:
  * Added CSRF token retrieval using getCsrfToken()
  * Added X-CSRF-Token header to fetch request
  * Added warning if CSRF token is not available

**Testing:**
With this fix, diagram generation requests will now include the required CSRF token and should no longer be rejected by the server.

https://claude.ai/code/session_01AQqR5mEpHQpBVoNXnFK5PL