### PR TITLE
Implement in-chat CAT assessment with proper flow and context

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -2358,6 +2358,11 @@ document.addEventListener("DOMContentLoaded", () => {
             // Display AI response
             appendMessage(data.message, "ai");
 
+            // If rapport is complete, show assessment pitch
+            if (data.triggerAssessment) {
+                setTimeout(() => showAssessmentPitch(), 1000);
+            }
+
             showThinkingIndicator(false);
             return;
         }
@@ -2530,6 +2535,314 @@ document.addEventListener("DOMContentLoaded", () => {
     
     function showThinkingIndicator(show) {
         if (thinkingIndicator) thinkingIndicator.style.display = show ? "flex" : "none";
+    }
+
+    /**
+     * Show assessment pitch with explanation and skip option
+     */
+    function showAssessmentPitch() {
+        const pitchMessage = `**Quick Placement Assessment** 📊
+
+This helps me personalize your learning by understanding:
+• What you already know well
+• Where you might need support
+• The perfect starting point for you
+
+**What to expect:**
+• 5-30 adaptive questions (stops when I'm confident)
+• Questions adjust to your level as you go
+• Takes about 5-10 minutes
+
+Ready to start? Or would you rather skip for now and jump straight into general tutoring?`;
+
+        appendMessage(pitchMessage, "ai");
+
+        // Add action buttons
+        const buttonContainer = document.createElement('div');
+        buttonContainer.className = 'assessment-action-buttons';
+        buttonContainer.style.cssText = `
+            display: flex;
+            gap: 12px;
+            margin: 15px 0;
+            flex-wrap: wrap;
+        `;
+
+        const startBtn = document.createElement('button');
+        startBtn.textContent = "Let's do it!";
+        startBtn.className = 'btn-primary';
+        startBtn.style.cssText = `
+            padding: 12px 24px;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            border: none;
+            border-radius: 8px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: transform 0.2s;
+        `;
+        startBtn.onmouseover = () => startBtn.style.transform = 'scale(1.05)';
+        startBtn.onmouseout = () => startBtn.style.transform = 'scale(1)';
+        startBtn.onclick = () => {
+            buttonContainer.remove();
+            startInChatAssessment();
+        };
+
+        const skipBtn = document.createElement('button');
+        skipBtn.textContent = "Skip for now";
+        skipBtn.className = 'btn-secondary';
+        skipBtn.style.cssText = `
+            padding: 12px 24px;
+            background: #f3f4f6;
+            color: #6b7280;
+            border: 1px solid #d1d5db;
+            border-radius: 8px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.2s;
+        `;
+        skipBtn.onmouseover = () => {
+            skipBtn.style.background = '#e5e7eb';
+            skipBtn.style.color = '#4b5563';
+        };
+        skipBtn.onmouseout = () => {
+            skipBtn.style.background = '#f3f4f6';
+            skipBtn.style.color = '#6b7280';
+        };
+        skipBtn.onclick = async () => {
+            buttonContainer.remove();
+            appendMessage("No problem! I'll ask again next time. What would you like to work on today?", "ai");
+            // Mark that user skipped (will be offered again next login)
+            try {
+                await csrfFetch('/api/screener/skip', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' }
+                });
+            } catch (error) {
+                console.error('Failed to record skip:', error);
+            }
+        };
+
+        buttonContainer.appendChild(startBtn);
+        buttonContainer.appendChild(skipBtn);
+        chatBox.appendChild(buttonContainer);
+        chatBox.scrollTop = chatBox.scrollHeight;
+    }
+
+    /**
+     * Start in-chat CAT assessment
+     */
+    async function startInChatAssessment() {
+        try {
+            appendMessage("Great! Starting your placement assessment...", "ai");
+            showThinkingIndicator(true);
+
+            // Start screener session
+            const response = await csrfFetch('/api/screener/start', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' }
+            });
+
+            if (!response.ok) {
+                throw new Error('Failed to start assessment');
+            }
+
+            const data = await response.json();
+            console.log('[Assessment] Started:', data);
+
+            // Load first problem
+            await loadNextAssessmentProblem(data.sessionId);
+
+        } catch (error) {
+            console.error('[Assessment] Start error:', error);
+            appendMessage("Oops, something went wrong starting the assessment. Let's just chat instead - what would you like to work on?", "ai");
+            showThinkingIndicator(false);
+        }
+    }
+
+    /**
+     * Load next assessment problem
+     */
+    async function loadNextAssessmentProblem(sessionId) {
+        try {
+            const response = await csrfFetch(`/api/screener/next-problem?sessionId=${sessionId}`, {
+                credentials: 'include'
+            });
+
+            if (!response.ok) {
+                throw new Error('Failed to load problem');
+            }
+
+            const data = await response.json();
+            showThinkingIndicator(false);
+
+            if (data.complete) {
+                // Assessment finished - pass sessionId
+                data.sessionId = sessionId;
+                handleAssessmentComplete(data);
+                return;
+            }
+
+            // Display problem
+            const problemMessage = `**Question ${data.questionNumber} of ~${data.estimatedRemaining || '?'}**
+
+${data.problem.question}`;
+
+            appendMessage(problemMessage, "ai");
+
+            // Create answer input
+            createAssessmentAnswerInput(sessionId, data.problem);
+
+        } catch (error) {
+            console.error('[Assessment] Load problem error:', error);
+            appendMessage("Had trouble loading the next question. Let's continue with regular tutoring instead!", "ai");
+            showThinkingIndicator(false);
+        }
+    }
+
+    /**
+     * Create answer input for assessment
+     */
+    function createAssessmentAnswerInput(sessionId, problem) {
+        const inputContainer = document.createElement('div');
+        inputContainer.className = 'assessment-answer-input';
+        inputContainer.style.cssText = `
+            display: flex;
+            gap: 12px;
+            margin: 15px 0;
+            align-items: center;
+        `;
+
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.placeholder = 'Your answer...';
+        input.style.cssText = `
+            flex: 1;
+            padding: 12px;
+            border: 2px solid #e5e7eb;
+            border-radius: 8px;
+            font-size: 16px;
+        `;
+
+        const submitBtn = document.createElement('button');
+        submitBtn.textContent = 'Submit';
+        submitBtn.style.cssText = `
+            padding: 12px 24px;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            border: none;
+            border-radius: 8px;
+            font-weight: 600;
+            cursor: pointer;
+        `;
+
+        submitBtn.onclick = async () => {
+            const answer = input.value.trim();
+            if (!answer) return;
+
+            inputContainer.remove();
+            await submitAssessmentAnswer(sessionId, problem._id, answer);
+        };
+
+        input.onkeypress = (e) => {
+            if (e.key === 'Enter') submitBtn.click();
+        };
+
+        inputContainer.appendChild(input);
+        inputContainer.appendChild(submitBtn);
+        chatBox.appendChild(inputContainer);
+        chatBox.scrollTop = chatBox.scrollHeight;
+        input.focus();
+    }
+
+    /**
+     * Submit assessment answer
+     */
+    async function submitAssessmentAnswer(sessionId, problemId, answer) {
+        try {
+            appendMessage(answer, "user");
+            showThinkingIndicator(true);
+
+            const response = await csrfFetch('/api/screener/submit-answer', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    sessionId,
+                    problemId,
+                    answer,
+                    responseTime: 0 // Could track this if needed
+                })
+            });
+
+            if (!response.ok) {
+                throw new Error('Failed to submit answer');
+            }
+
+            const data = await response.json();
+
+            // Show feedback
+            if (data.feedback) {
+                appendMessage(data.feedback, "ai");
+            }
+
+            // Load next problem or finish
+            if (data.complete || data.converged) {
+                // Pass sessionId to completion handler
+                data.sessionId = sessionId;
+                handleAssessmentComplete(data);
+            } else {
+                await loadNextAssessmentProblem(sessionId);
+            }
+
+        } catch (error) {
+            console.error('[Assessment] Submit error:', error);
+            showThinkingIndicator(false);
+            appendMessage("Had trouble processing that. Let's move on to regular tutoring!", "ai");
+        }
+    }
+
+    /**
+     * Handle assessment completion
+     */
+    async function handleAssessmentComplete(data) {
+        showThinkingIndicator(false);
+
+        // Call the complete endpoint to save results
+        try {
+            const completeResponse = await csrfFetch('/api/screener/complete', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    sessionId: data.sessionId
+                })
+            });
+
+            if (completeResponse.ok) {
+                const completeData = await completeResponse.json();
+                const report = completeData.report;
+
+                const badgeInfo = report.earnedBadges && report.earnedBadges.length > 0
+                    ? `\n• **Badges Earned**: ${report.earnedBadges.length} 🎖️`
+                    : '';
+
+                const resultsMessage = `🎉 **Assessment Complete!**
+
+You did great! Here's what I learned:
+• **Level**: θ = ${report.theta.toFixed(2)} (${report.percentile}th percentile)
+• **Accuracy**: ${Math.round(report.accuracy * 100)}%
+• **Questions**: ${report.questionsAnswered}${badgeInfo}
+
+I now have a good understanding of where you are. I'll use this to personalize everything for you!
+
+What would you like to work on first?`;
+
+                appendMessage(resultsMessage, "ai");
+            } else {
+                throw new Error('Failed to complete assessment');
+            }
+        } catch (error) {
+            console.error('Failed to save assessment results:', error);
+            appendMessage("Assessment complete! What would you like to work on?", "ai");
+        }
     }
 
     async function playAudio(text, voiceId, messageId) {

--- a/routes/rapportBuilding.js
+++ b/routes/rapportBuilding.js
@@ -174,7 +174,8 @@ RESPOND IN JSON:
         res.json({
             message: result.nextMessage,
             rapportComplete: result.rapportComplete,
-            voiceId: currentTutor.voiceId
+            voiceId: currentTutor.voiceId,
+            triggerAssessment: result.rapportComplete // Signal frontend to show assessment pitch
         });
 
     } catch (error) {

--- a/routes/screener.js
+++ b/routes/screener.js
@@ -1315,4 +1315,38 @@ function thetaToPercentile(theta) {
   return Math.round(percentile);
 }
 
+/**
+ * POST /api/screener/skip
+ * Record that user skipped the assessment
+ * They'll be offered again on next login
+ */
+router.post('/skip', isAuthenticated, async (req, res) => {
+  try {
+    const user = await User.findById(req.user._id);
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    // Mark that user was offered but skipped
+    // Don't set assessmentCompleted, so they'll be offered again
+    if (!user.learningProfile) {
+      user.learningProfile = {};
+    }
+
+    user.learningProfile.assessmentOfferedAt = new Date();
+    user.learningProfile.assessmentSkipped = true;
+
+    await user.save();
+
+    res.json({
+      success: true,
+      message: 'Assessment skipped - will be offered again next time'
+    });
+
+  } catch (error) {
+    console.error('[Screener Skip] Error:', error);
+    res.status(500).json({ error: 'Failed to record skip' });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
This completely fixes the assessment not being offered or followed through.

Changes:
1. Assessment Pitch After Rapport
   - Explains WHAT assessment is (5-30 adaptive questions)
   - Explains WHY it matters (personalized learning)
   - Shows skip option (will be re-offered next login)
   - Clear visual with action buttons

2. In-Chat CAT Assessment Flow
   - Starts screener session via /api/screener/start
   - Loads adaptive problems via /api/screener/next-problem
   - Submits answers via /api/screener/submit-answer
   - Questions adapt based on grade level (uses gradeToTheta)
   - Shows progress (Question X of ~Y)
   - Maintains assessment context throughout

3. Assessment Completion
   - Calls /api/screener/complete to save results
   - Saves to user profile (assessmentCompleted, theta, badges)
   - Shows results summary with theta, percentile, accuracy
   - Lists earned badges if any

4. Skip Handling
   - New endpoint: POST /api/screener/skip
   - Records skip in user profile
   - Re-offers assessment on next login
   - No pressure, user can skip indefinitely

5. Context Preservation
   - CAT algorithm maintains difficulty throughout
   - No more "random questions" or "forgot it's an assessment"
   - Proper state management via ScreenerSession
   - Questions chosen based on grade level from start

Key Fixes:
- ✅ Assessment is actually offered to new users
- ✅ Questions are grade-appropriate (not random)
- ✅ AI doesn't forget it's giving an assessment
- ✅ Proper CAT algorithm (5-30 questions, adapts)
- ✅ Results saved to profile
- ✅ Can skip and be re-offered later