### PR TITLE
Fix: Detect explicit assessment requests and trigger placement test

### DIFF
--- a/routes/chat.js
+++ b/routes/chat.js
@@ -69,6 +69,53 @@ if (!message) return res.status(400).json({ message: "Message is required." });
         });
     }
 
+    // ASSESSMENT REQUEST DETECTION: Catch explicit requests for placement tests
+    const assessmentKeywords = [
+        /\b(placement|skills?)\s+(test|assessment|exam)\b/i,
+        /\btake\s+(a|an|the)?\s*(placement|skills?|initial)?\s*(test|assessment)\b/i,
+        /\b(teacher|instructor)\s+(said|told|wants?)\b.*\b(test|assessment|placement)\b/i,
+        /\bsupposed to (give|take)\b.*\b(test|assessment|placement|one)\b/i,
+        /\bneed to take\b.*\b(test|assessment|placement)\b/i,
+        /\b(give|take) me (a|an|the)?\s*(test|assessment|placement|one)\b/i,
+        /\b(teacher|instructor|she|he)\s+(said|told).*\bgive me (one|it)\b/i
+    ];
+
+    const isAssessmentRequest = assessmentKeywords.some(pattern => pattern.test(messageClean));
+
+    if (isAssessmentRequest) {
+        console.log(`📋 ASSESSMENT REQUEST DETECTED - User ${userId} - Message: "${message.substring(0, 100)}..."`);
+
+        // Check if user already has skill mastery data (already took assessment)
+        const user = await User.findById(userId);
+        if (user && user.skillMastery && user.skillMastery instanceof Map && user.skillMastery.size > 0) {
+            // User already took assessment, just acknowledge
+            return res.json({
+                text: "I see you've already completed your skills assessment! Your learning profile is all set up. What would you like to work on today?",
+                userXp: 0,
+                userLevel: user.level || 1,
+                xpNeeded: (user.level || 1) * BRAND_CONFIG.xpPerLevel,
+                specialXpAwarded: "",
+                voiceId: TUTOR_CONFIG[user.selectedTutorId || "default"].voiceId,
+                newlyUnlockedTutors: [],
+                drawingSequence: null,
+                triggerAssessment: false
+            });
+        }
+
+        // User needs assessment - trigger it
+        return res.json({
+            text: "You're absolutely right! Let's get you started with your placement test. This will help me understand exactly where you are so I can give you the best help possible. Ready?",
+            userXp: 0,
+            userLevel: user ? (user.level || 1) : 1,
+            xpNeeded: user ? ((user.level || 1) * BRAND_CONFIG.xpPerLevel) : 200,
+            specialXpAwarded: "",
+            voiceId: user && user.selectedTutorId ? TUTOR_CONFIG[user.selectedTutorId].voiceId : "default",
+            newlyUnlockedTutors: [],
+            drawingSequence: null,
+            triggerAssessment: true
+        });
+    }
+
     try {
         const user = await User.findById(userId);
         if (!user) return res.status(404).json({ message: "User not found." });

--- a/utils/prompt.js
+++ b/utils/prompt.js
@@ -20,8 +20,10 @@ function buildSkillMasteryContext(userProfile, filterToSkill = null) {
       userProfile.skillMastery.size === 0) {
     return `--- SKILL PROGRESSION & LEARNING PATH ---
 **ASSESSMENT NEEDED:** This student hasn't completed their initial skills assessment yet.
-- If they ask what to learn or seem ready for structured learning, suggest they take the assessment
-- For now, provide tutoring help on whatever they ask about
+- **IMPORTANT:** If they explicitly request a "placement test," "assessment," or say "my teacher said to take a test," IMMEDIATELY tell them you'll start their assessment and ask if they're ready
+- Do NOT give practice problems when they ask for the actual placement test
+- If they seem ready for structured learning or ask what to learn, proactively suggest they take the assessment
+- For general questions, provide tutoring help on whatever they ask about
 `;
   }
 


### PR DESCRIPTION
Problem:
- When students explicitly said "my teacher wants me to take a placement test" and "she said you were supposed to give me one", the chatbot failed to recognize this as a request for the formal CAT assessment
- Instead, it gave practice problems, leaving the student without their required placement test

Root Cause:
- System relied on passive AI interpretation ("suggest if they ask") rather than active keyword detection
- No logic in chat route to intercept explicit assessment requests
- Assessment only triggered via rapport building or manual selection

Solution:
1. Added keyword detection in chat route (routes/chat.js:72-117) that catches:
   - "placement test", "skills test", "take a test"
   - "teacher/instructor said/told/wants" + "test/assessment"
   - "supposed to give me one/it" (contextual follow-ups)
   - "give me a test"

2. Returns triggerAssessment: true when detected, same as rapport building flow

3. Updated system prompt (utils/prompt.js:23-26) to be more directive:
   - Explicitly tells AI to IMMEDIATELY offer assessment when requested
   - Warns NOT to give practice problems instead of real assessment
   - Maintains fallback for natural language understanding

Testing:
- Verified patterns match both transcript phrases: ✓ "My teacher wants me to take a placement test" ✓ "no. she said you were supposed to give me one"
- Verified non-assessment phrases don't trigger false positives

https://claude.ai/code/session_01JQChRYte7hKKHFWuo9jCGh