### PR TITLE
Add: Include assessment results in session summaries

### DIFF
--- a/routes/assessment.js
+++ b/routes/assessment.js
@@ -339,8 +339,9 @@ async function completeAssessment(user, conversation, aiResponse) {
 
     await user.save();
 
-    // Update conversation
+    // Update conversation and mark inactive so it gets properly summarized
     conversation.isAssessmentComplete = true;
+    conversation.isActive = false;
     await conversation.save();
 
   } catch (error) {

--- a/services/assessmentService.js
+++ b/services/assessmentService.js
@@ -414,9 +414,10 @@ async function calculateAssessmentResults(conversation) {
     totalQuestions
   };
 
-  // Save results to conversation
+  // Save results to conversation and mark as inactive
   conversation.assessmentResults = results;
   conversation.isAssessmentComplete = true;
+  conversation.isActive = false; // Mark inactive so it gets properly summarized
   await conversation.save();
 
   logger.info('Assessment completed', {

--- a/utils/activitySummarizer.js
+++ b/utils/activitySummarizer.js
@@ -158,6 +158,23 @@ async function generateSessionSummary(conversation, studentName) {
         const stats = calculateProblemStats(messages);
         const topic = detectTopic(messages);
 
+        // Check if this is an assessment session with results
+        if (conversation.isAssessment && conversation.assessmentResults) {
+            const results = conversation.assessmentResults;
+
+            // Create structured assessment summary
+            const assessmentSummary = `${studentName} completed a placement assessment. Results:
+- Estimated Grade Level: ${results.estimatedGrade || 'Not determined'}
+- Skill Level: ${results.skillLevel || 'Not scored'}/100
+- Questions: ${results.correctCount || stats.correct}/${results.totalQuestions || stats.attempted} correct
+- Strengths: ${results.strengths?.join(', ') || 'None identified'}
+- Weaknesses: ${results.weaknesses?.join(', ') || 'None identified'}
+- Recommended Starting Point: ${results.recommendedStartingPoint || 'To be determined'}`;
+
+            return assessmentSummary;
+        }
+
+        // Regular session summary for non-assessment sessions
         const summaryPrompt = `Summarize this math tutoring session in 2-3 sentences for a teacher. Focus on:
 - Main topic covered
 - Number of problems attempted and success rate


### PR DESCRIPTION
Problem:
- When students completed placement assessments, session summaries were generated from message content only
- Structured assessment results (grade level, strengths/weaknesses, skill level) were stored but NOT included in summaries
- Teachers, parents, and future AI sessions couldn't easily see what was learned from the assessment

Solution:
1. Modified generateSessionSummary() (utils/activitySummarizer.js:161-174)
   - Checks if conversation.isAssessment && conversation.assessmentResults exist
   - Creates structured summary including:
     * Estimated grade level
     * Skill level (0-100) * Questions correct/total * Strengths and weaknesses * Recommended starting point
   - Falls back to AI-generated summary for regular sessions

2. Mark assessment conversations inactive immediately after completion
   - services/assessmentService.js:420 - Added isActive = false
   - routes/assessment.js:344 - Added isActive = false
   - Ensures assessment conversations get properly summarized at session end

Benefits:
- Teachers can see "Jason tested at 7th grade, strong in fractions, needs work on solving equations" instead of "Student worked on questions"
- Parents get actionable insights about student's skill level
- Future AI sessions can reference "student's placement showed strength in X, weakness in Y" for better personalization
- Structured data preserved and accessible in summaries

Testing:
- Validated assessment summary includes all result fields
- Confirmed regular sessions still get AI-generated summaries
- Verified conversations marked inactive after assessment completion

https://claude.ai/code/session_01JQChRYte7hKKHFWuo9jCGh