### PR TITLE
Fix: Add --break-system-packages to pip3 install in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # 3. Install Python dependencies for diagram generation
-RUN pip3 install --no-cache-dir \
+RUN pip3 install --no-cache-dir --break-system-packages \
     matplotlib \
     numpy
 


### PR DESCRIPTION
Problem:
- Docker build failing with "externally-managed-environment" error
- Python 3.11 in Debian 12 (node:20-slim) blocks pip installs per PEP 668
- Build error at line 14: pip3 install matplotlib numpy

Solution:
- Added --break-system-packages flag to pip3 install command
- This is safe in Docker containers (isolated environment)
- Python packages won't conflict with system packages

Impact:
- Docker builds will succeed
- matplotlib and numpy will install correctly for diagram generation

https://claude.ai/code/session_01JQChRYte7hKKHFWuo9jCGh