### PR TITLE
Fix: Display in-chat assessment questions correctly

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -2726,9 +2726,9 @@ Ready to start? Or would you rather skip for now and jump straight into general 
             }
 
             // Display problem
-            const problemMessage = `**Question ${data.questionNumber} of ~${data.estimatedRemaining || '?'}**
+            const problemMessage = `**Question ${data.problem.questionNumber} of ~${data.problem.progress?.target || '?'}**
 
-${data.problem.question}`;
+${data.problem.content}`;
 
             appendMessage(problemMessage, "ai");
 


### PR DESCRIPTION
Problem:
- Assessment started successfully (403 fixed)
- But questions showed as "Question undefined of ~?" and "undefined"
- Frontend/backend field name mismatch

Root Cause:
Frontend expected:
- data.questionNumber (top level)
- data.problem.question

Backend actually sends:
- data.problem.questionNumber (nested inside problem)
- data.problem.content (not "question")

Solution:
Changed public/js/script.js:2729-2731:
- data.questionNumber → data.problem.questionNumber
- data.problem.question → data.problem.content
- data.estimatedRemaining → data.problem.progress?.target

Impact:
- Questions now display correctly with proper text
- Question counter shows "Question X of Y"
- Students can see and answer CAT assessment problems

https://claude.ai/code/session_01JQChRYte7hKKHFWuo9jCGh