### PR TITLE
Fix: AI now answers direct questions about student information

### DIFF
--- a/utils/prompt.js
+++ b/utils/prompt.js
@@ -397,6 +397,19 @@ ${learningStyle ? `**Learning Style:** ${learningStyle}` : ''}
 ${tonePreference ? `**Communication Preference:** ${tonePreference}` : ''}
 ${preferredLanguage && preferredLanguage !== 'English' ? `**Preferred Language:** ${preferredLanguage}` : ''}
 
+**🔴 CRITICAL: ANSWER DIRECT QUESTIONS ABOUT STUDENT INFORMATION**
+When ${firstName} asks about themselves, ANSWER DIRECTLY. Do NOT deflect or change the subject.
+
+Examples of questions you MUST answer directly:
+- "What do you know about me?" → Tell them their grade level, interests, learning style, etc.
+- "What grade am I in?" → "${gradeLevel ? `You're in ${gradeLevel}` : 'I don\'t have your grade level on file yet'}"
+- "What are my interests?" → "${interests && interests.length > 0 ? `Your interests include ${interests.join(', ')}` : 'I don\'t have your interests listed yet'}"
+- "Do you remember me?" → "Of course! You're ${firstName}, ${gradeLevel ? `in ${gradeLevel}` : 'a student'} ${interests && interests.length > 0 ? `who's into ${interests[0]}` : ''}"
+
+❌ NEVER say: "What have you been working on lately?" when they ask what you know about them
+❌ NEVER deflect with: "What math topics are you interested in?" when they ask what grade they're in
+✅ ALWAYS answer their question directly, then optionally follow up with a math question
+
 **PERSONALIZATION RULES:**
 ${interests && interests.length > 0 ? `- When creating word problems or examples, USE ${firstName}'s interests: ${interests.join(', ')}. Make math relatable to what they care about!` : ''}
 ${tonePreference === 'encouraging' ? '- Use lots of positive reinforcement and celebrate small wins' : ''}


### PR DESCRIPTION
Problem: When students asked "what do you know about me?" or "what grade am I in?", the AI would deflect with generic questions like "What have you been working on lately?" This was extremely frustrating for students (see Nick's transcript with 4 deflections).

Root Cause: System prompt included all student information but had no explicit instruction that it's okay to share this information when the student asks. The AI was being overly cautious.

Solution: Added "ANSWER DIRECT QUESTIONS ABOUT STUDENT INFORMATION" section to system prompt with:
- Clear examples of questions that must be answered directly
- Specific response templates using actual student data
- Explicit prohibition of deflection patterns
- Examples of correct vs incorrect responses

Impact: Students can now ask about their profile and get straightforward answers instead of frustrating deflections.

Example:
Before: "what grade am I in?" → "What math topics have you been working on lately?" After: "what grade am I in?" → "You're in 10th grade"

https://claude.ai/code/session_01JQChRYte7hKKHFWuo9jCGh