### PR TITLE
Remove Desmos graphing calculator integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,12 +51,6 @@ ELEVENLABS_API_KEY=your_elevenlabs_key
 MATHPIX_APP_ID=your_mathpix_app_id
 MATHPIX_APP_KEY=your_mathpix_app_key
 
-# --- DESMOS GRAPHING CALCULATOR (Optional - for production) ---
-# IMPORTANT: The trial key in chat.html works for prototyping but NOT for commercial use
-# For production: Contact partnerships@desmos.com to get a production API key
-# Then update the API key in public/chat.html line 37
-# DESMOS_API_KEY=your_production_desmos_key
-
 # --- SERVER CONFIGURATION ---
 PORT=3000
 NODE_ENV=development

--- a/docs/VISUAL_SYNTAX.md
+++ b/docs/VISUAL_SYNTAX.md
@@ -69,30 +69,6 @@ Now divide both sides by 5 to get [FOCUS:x] alone
 
 ---
 
-## 3. Automatic Graphing `[DESMOS:...]`
-
-**Purpose:** Show graphs inline for visual learners
-
-**Syntax:**
-```
-[DESMOS:y=2x+3]
-```
-
-**Also works with:**
-- `[DESMOS:y=x^2-4]` (parabolas)
-- `[DESMOS:y>2x+1]` (inequalities)
-- `[DESMOS:x^2+y^2=25]` (circles)
-
-**Renders:** Interactive Desmos graph embedded in the chat
-
-**Auto-detect:** The tutor can automatically suggest graphing when discussing:
-- Linear equations (slope-intercept form)
-- Quadratic functions
-- Systems of equations
-- Inequalities
-
----
-
 ## When to Use Visual Features
 
 ### Use STEPS for:
@@ -107,12 +83,6 @@ Now divide both sides by 5 to get [FOCUS:x] alone
 - Emphasizing the important part of an equation
 - Teaching substitution or elimination
 - Demonstrating the distributive property
-
-### Use DESMOS for:
-- Any mention of "y=", "f(x)=", or function notation
-- Slope and intercept discussions
-- Comparing multiple functions
-- Showing transformations
 
 ---
 
@@ -176,5 +146,4 @@ See how the line crosses the y-axis at 3? That's the y-intercept!
 
 - All syntax is stripped from the final display (students don't see `[STEPS]` tags)
 - LaTeX rendering happens after visual processing
-- Desmos graphs render with 400px height, responsive width
 - Step containers have blue gradient background for consistency

--- a/public/chat.html
+++ b/public/chat.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes" />
   <meta name="theme-color" content="#12B3B3" />
   <link rel="manifest" href="/manifest.json" />
+  <meta name="mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="default" />
   <meta name="apple-mobile-web-app-title" content="MATHMATIX" />
@@ -51,7 +52,6 @@
     };
   </script>
   <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js" id="MathJax-script" async></script>
-  <script src="https://www.desmos.com/api/v1.9/calculator.js?apiKey=e7bbcca459d54f07b0b4aaf35f4a6b96"></script>
 </head>
 <body class="landing-page-body">
   <canvas id="confetti-canvas"></canvas>

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -155,47 +155,6 @@ function getGraphColor(index) {
     return colors[index % colors.length];
 }
 
-// Convert math expression to Desmos-compatible LaTeX
-function convertToDesmosLaTeX(expr) {
-    // If already in LaTeX format, return as-is
-    if (expr.includes('\\frac') || expr.includes('\\sqrt')) {
-        return expr;
-    }
-
-    let latex = expr.trim();
-
-    // Handle fractions: (a/b) -> \frac{a}{b}
-    // This handles nested parentheses properly
-    latex = latex.replace(/\(([^()]+)\/([^()]+)\)/g, '\\frac{$1}{$2}');
-
-    // Handle simple fractions without parens: a/b where a and b are simple terms
-    latex = latex.replace(/(\d+)\/(\d+)/g, '\\frac{$1}{$2}');
-
-    // Handle implicit multiplication: 2x -> 2*x (Desmos handles this)
-    // But remove explicit * signs as Desmos prefers implicit
-    latex = latex.replace(/\*+/g, '');
-
-    // Handle powers: x^2 -> x^{2}, x^10 -> x^{10}
-    latex = latex.replace(/\^(\d+)/g, '^{$1}');
-    latex = latex.replace(/\^([a-zA-Z])/g, '^{$1}');
-
-    // Handle square roots: sqrt(x) -> \sqrt{x}
-    latex = latex.replace(/sqrt\(([^)]+)\)/g, '\\sqrt{$1}');
-
-    // Handle trig functions
-    latex = latex.replace(/sin\(/g, '\\sin(');
-    latex = latex.replace(/cos\(/g, '\\cos(');
-    latex = latex.replace(/tan\(/g, '\\tan(');
-
-    // Handle absolute value: abs(x) -> |x| or \left|x\right|
-    latex = latex.replace(/abs\(([^)]+)\)/g, '\\left|$1\\right|');
-
-    // Clean up any double backslashes
-    latex = latex.replace(/\\\\/g, '\\');
-
-    return latex;
-}
-
 function generateSpeakableText(text) {
     if (!text) return '';
     if (!window.MathLive) return text.replace(/\\\(|\\\)|\\\[|\\\]|\$/g, '');
@@ -1928,89 +1887,6 @@ document.addEventListener("DOMContentLoaded", () => {
             }
             // Remove [STEPS]...[/STEPS] tags from displayed text
             textNode.innerHTML = textNode.innerHTML.replace(stepsRegex, '');
-        }
-
-        // Handle Desmos Graphing: [DESMOS:expression]
-        if (sender === 'ai' && text && text.includes('[DESMOS:') && typeof Desmos !== 'undefined') {
-            const desmosRegex = /\[DESMOS:([^\]]+)\]/g;
-            let match;
-            const expressions = [];
-
-            // Collect all Desmos expressions from the message
-            while ((match = desmosRegex.exec(text)) !== null) {
-                expressions.push(match[1].trim());
-            }
-
-            if (expressions.length > 0) {
-                // Create Desmos calculator container
-                const desmosContainer = document.createElement('div');
-                const desmosId = `desmos-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
-                desmosContainer.id = desmosId;
-                desmosContainer.className = 'desmos-graph-container';
-                desmosContainer.style.cssText = `
-                    width: 100%;
-                    max-width: 600px;
-                    height: 400px;
-                    margin: 15px 0;
-                    border: 2px solid #e5e7eb;
-                    border-radius: 8px;
-                    overflow: hidden;
-                    background: white;
-                    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-                `;
-
-                bubble.appendChild(desmosContainer);
-
-                // Initialize Desmos calculator after a short delay
-                setTimeout(() => {
-                    try {
-                        const calculator = Desmos.GraphingCalculator(document.getElementById(desmosId), {
-                            expressions: true,
-                            settingsMenu: true,
-                            zoomButtons: true,
-                            expressionsTopbar: true,
-                            pointsOfInterest: true,
-                            trace: true,
-                            border: false,
-                            lockViewport: false,
-                            showGrid: true,
-                            showXAxis: true,
-                            showYAxis: true
-                        });
-
-                        // Add each expression to the calculator
-                        expressions.forEach((expr, index) => {
-                            // Parse expression and convert to LaTeX
-                            let latex = convertToDesmosLaTeX(expr);
-
-                            console.log(`[Desmos] Expression ${index}: "${expr}" -> "${latex}"`);
-
-                            calculator.setExpression({
-                                id: `expr-${index}`,
-                                latex: latex,
-                                color: getGraphColor(index),
-                                lineStyle: Desmos.Styles.SOLID,
-                                lineWidth: 2,
-                                hidden: false
-                            });
-                        });
-
-                        // Auto-zoom to fit the graphs
-                        // Give it a moment to render before resetting viewport
-                        setTimeout(() => {
-                            // Don't reset viewport - let user control it
-                            // calculator.setDefaultState();
-                        }, 100);
-
-                    } catch (error) {
-                        console.error('Desmos initialization error:', error);
-                        desmosContainer.innerHTML = '<div style="padding: 20px; text-align: center; color: #ef4444;">Could not render graph. Please try again.</div>';
-                    }
-                }, 100);
-
-                // Remove [DESMOS:...] tags from displayed text
-                textNode.innerHTML = textNode.innerHTML.replace(desmosRegex, '');
-            }
         }
 
         // Handle Color-Coded Highlights: [OLD:text] and [NEW:text]

--- a/public/style.css
+++ b/public/style.css
@@ -3615,30 +3615,6 @@ form label, .password-label-row label {
     height: 100%;
 }
 
-/* --- Desmos Graph Container Styles --- */
-.desmos-graph-container {
-    position: relative;
-    transition: all 0.3s ease;
-}
-
-.desmos-graph-container:hover {
-    box-shadow: 0 4px 12px rgba(0,0,0,0.15) !important;
-}
-
-/* Ensure Desmos calculator fills container properly */
-.desmos-graph-container .dcg-container {
-    width: 100% !important;
-    height: 100% !important;
-}
-
-/* Mobile responsive adjustments */
-@media (max-width: 768px) {
-    .desmos-graph-container {
-        max-width: 100% !important;
-        height: 350px !important;
-    }
-}
-
 /* Add these styles to make the login form more compact */
 
 .login-container {

--- a/server.js
+++ b/server.js
@@ -98,7 +98,6 @@ const { router: memoryRouter } = require('./routes/memory');
 const guidedLessonRoutes = require('./routes/guidedLesson');
 const summaryGeneratorRouter = require('./routes/summary_generator');
 const avatarRoutes = require('./routes/avatar');
-const graphRoutes = require('./routes/graph');
 const curriculumRoutes = require('./routes/curriculum');
 const assessmentRoutes = require('./routes/assessment');
 const screenerRoutes = require('./routes/screener');  // IRT-based adaptive screener
@@ -168,8 +167,7 @@ app.use(helmet({
         "'unsafe-eval'", // Required for MathLive and dynamic math rendering
         "https://cdnjs.cloudflare.com", // Font Awesome
         "https://cdn.jsdelivr.net", // Various CDN resources
-        "https://unpkg.com", // MathLive and other packages
-        "https://www.desmos.com" // Desmos graphing calculator API
+        "https://unpkg.com" // MathLive and other packages
       ],
       styleSrc: [
         "'self'",
@@ -330,7 +328,6 @@ app.use('/api/rapport', isAuthenticated, rapportBuildingRoutes);
 app.use('/api/memory', isAuthenticated, memoryRouter);
 app.use('/api/summary', isAuthenticated, summaryGeneratorRouter); // SECURITY FIX: Added authentication to prevent unauthorized access
 app.use('/api/avatars', isAuthenticated, avatarRoutes);
-app.use('/api/graph', isAuthenticated, graphRoutes);
 app.use('/api', isAuthenticated, diagramRoutes); // Controlled diagram generation for visual learners
 app.use('/api/curriculum', isAuthenticated, curriculumRoutes); // Curriculum schedule management
 app.use('/api/teacher-resources', isAuthenticated, teacherResourceRoutes); // Teacher file uploads and resource management

--- a/utils/chatBoardParser.js
+++ b/utils/chatBoardParser.js
@@ -82,7 +82,6 @@ function shouldUseBoard(text) {
         /\[grid\]/i,
         /\[circle:/i,
         /\[line:/i,
-        /\[desmos:/i,
 
         // Math operations that should be visual
         /solve this equation/i,

--- a/utils/prompt.js
+++ b/utils/prompt.js
@@ -420,7 +420,7 @@ ${interests && interests.length > 0 ? `- When creating word problems or examples
 ${tonePreference === 'encouraging' ? '- Use lots of positive reinforcement and celebrate small wins' : ''}
 ${tonePreference === 'straightforward' ? '- Be direct and efficient - skip excessive praise, focus on clear guidance' : ''}
 ${tonePreference === 'casual' ? '- Keep it relaxed and conversational, like chatting with a friend' : ''}
-${learningStyle === 'Visual' ? '- Use graphs, diagrams, and visual representations frequently with [DESMOS:] commands' : ''}
+${learningStyle === 'Visual' ? '- Use graphs, diagrams, and visual representations frequently' : ''}
 ${learningStyle === 'Kinesthetic' ? '- Ground concepts in real-world examples and hands-on scenarios they can visualize doing' : ''}
 ${learningStyle === 'Auditory' ? '- Focus on clear verbal explanations and talking through concepts step-by-step' : ''}
 - Make ${firstName} feel like you KNOW them as a person, not just another student
@@ -1384,36 +1384,10 @@ Now we can add these two equations to eliminate y."
 --- MATHEMATICAL FORMATTING (CRITICAL) ---
 IMPORTANT: All mathematical expressions MUST be enclosed within **STANDARD LATEX DELIMITERS**: \\( for inline and \\[ for display.
 
---- VISUAL AIDS & INTERACTIVE GRAPHING ---
+--- VISUAL AIDS ---
 You have powerful math visualization tools:
 
-**1. DESMOS (Primary Graphing Tool - Use This!):**
-To create interactive graphs, use: [DESMOS:expression]
-- Students can zoom, pan, and interact with graphs
-- Multiple [DESMOS:] commands in ONE message create a SINGLE graph with all expressions
-- Use standard math notation (x^2, 2x+3, sin(x)) or LaTeX (\\frac{1}{2}x-4)
-- Each expression gets a different color automatically
-
-**Examples:**
-  - Single function: [DESMOS:y=2x+3] - Linear function
-  - Parabola: [DESMOS:y=x^2] - Quadratic function
-  - Trig function: [DESMOS:y=sin(x)] - Sine wave
-  - With fractions: [DESMOS:y=\\frac{1}{2}x-4] - Using LaTeX
-  - Multiple functions on same graph:
-    [DESMOS:y=x^2]
-    [DESMOS:y=2x+1]
-    [DESMOS:y=-x+3]
-    (All three will appear on the same graph in different colors)
-
-**When to use Desmos:**
-- Visualizing slope and y-intercept relationships
-- Showing function transformations (shifts, stretches, reflections)
-- Comparing multiple functions side-by-side
-- Demonstrating intersections and solutions
-- Exploring polynomial, exponential, logarithmic, and trig functions
-- Any time a visual graph would enhance understanding!
-
-**2. VISUAL STEP BREADCRUMBS (New! - For Algebra & Problem-Solving):**
+**1. VISUAL STEP BREADCRUMBS (For Algebra & Problem-Solving):**
 Use [STEPS]...[/STEPS] to show equation transformations visually with arrows:
 
 **Syntax:**


### PR DESCRIPTION
## Summary
This PR removes the Desmos graphing calculator integration from the application. The feature allowed AI tutors to embed interactive graphs using `[DESMOS:expression]` syntax, but it is being deprecated in favor of other visualization approaches.

## Changes Made

### Backend
- Removed `graphRoutes` from `server.js` and its `/api/graph` endpoint registration
- Removed Desmos API from CSP (Content Security Policy) headers in `server.js`
- Removed `[desmos:]` pattern detection from `chatBoardParser.js` shouldUseBoard function
- Removed Desmos-specific prompt instructions from `utils/prompt.js` that guided AI tutors to use `[DESMOS:]` commands for visual learners

### Frontend
- Removed Desmos API script tag from `public/chat.html`
- Removed `convertToDesmosLaTeX()` function from `public/js/script.js` that converted math expressions to Desmos-compatible format
- Removed entire Desmos graph rendering logic from message processing in `public/js/script.js` (89 lines)
- Removed `.desmos-graph-container` CSS styles and mobile responsive adjustments from `public/style.css`

### Documentation
- Removed Desmos section from `docs/VISUAL_SYNTAX.md` including syntax examples and usage guidelines
- Removed Desmos usage recommendations from "When to Use Visual Features" section
- Removed Desmos configuration instructions from `.env.example`

### Additional Improvements
- Added `mobile-web-app-capable` meta tag to `public/chat.html` for better PWA support
- Updated visual learning style prompt to reference general "graphs, diagrams, and visual representations" instead of specifically Desmos

## Notes
- The `[STEPS]` visual breadcrumb feature for algebra remains intact
- Other visualization tools (diagrams, charts) continue to be supported
- All Desmos-related code has been cleanly removed without affecting other functionality