### PR TITLE
Improve tour survey modal scrolling and layout on mobile

### DIFF
--- a/public/css/tour-survey.css
+++ b/public/css/tour-survey.css
@@ -10,12 +10,15 @@
 .tour-content {
   max-width: 700px;
   width: 90%;
+  max-height: 90vh;
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   color: white;
   border-radius: 16px;
   padding: 0;
   overflow: hidden;
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
 }
 
 .tour-progress {
@@ -23,6 +26,7 @@
   padding: 20px;
   text-align: center;
   border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+  flex-shrink: 0;
 }
 
 .tour-progress-bar {
@@ -58,6 +62,8 @@
   text-align: center;
   background: white;
   color: #333;
+  flex: 1;
+  overflow-y: auto;
 }
 
 .tour-step-content h3 {
@@ -119,6 +125,7 @@
   justify-content: space-between;
   align-items: center;
   border-top: 1px solid rgba(0, 0, 0, 0.1);
+  flex-shrink: 0;
 }
 
 .tour-navigation {
@@ -139,11 +146,12 @@
   .tour-content {
     width: 95%;
     max-width: none;
+    max-height: 95vh;
   }
 
   .tour-step-content {
     padding: 30px 20px;
-    min-height: 250px;
+    min-height: 200px;
   }
 
   .tour-step-content h3 {


### PR DESCRIPTION
## Summary
This PR improves the layout and scrolling behavior of the tour survey modal, particularly on mobile devices, by implementing a flexible column layout with proper overflow handling.

## Key Changes
- Added `max-height: 90vh` constraint to `.tour-content` to prevent modal from exceeding viewport height
- Converted `.tour-content` to a flexbox column layout with `display: flex` and `flex-direction: column`
- Made `.tour-progress` and `.tour-actions` non-shrinkable with `flex-shrink: 0` to keep them always visible
- Made `.tour-step-content` flexible with `flex: 1` and `overflow-y: auto` to allow independent scrolling of content
- Updated mobile breakpoint to use `max-height: 95vh` and reduced `min-height` from 250px to 200px for better mobile UX

## Implementation Details
The changes implement a "sticky header/footer" pattern where the progress bar and action buttons remain fixed while the main content area scrolls independently. This prevents the modal from exceeding the viewport height and ensures navigation controls are always accessible without scrolling.

The flexbox approach ensures proper space distribution:
- Progress bar and actions take only the space they need
- Content area expands to fill remaining space
- Content scrolls internally if it exceeds available height