### PR TITLE
Fix: CSRF token missing on cross-site navigation

### DIFF
--- a/middleware/csrf.js
+++ b/middleware/csrf.js
@@ -42,7 +42,7 @@ function csrfProtection(req, res, next) {
     res.cookie('_csrf', token, {
       httpOnly: false, // MUST be false so JavaScript can read it and send in header
       secure: process.env.NODE_ENV === 'production', // HTTPS only in production
-      sameSite: 'strict', // Prevents CSRF attacks
+      sameSite: 'lax', // 'lax' allows cookie on top-level navigations (links), 'strict' blocks them
       maxAge: 3600000 // 1 hour
     });
 

--- a/public/login.html
+++ b/public/login.html
@@ -6,6 +6,7 @@
   <title>Login - M∆THM∆TIΧ AI</title>
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" referrerpolicy="no-referrer" />
+  <script src="/js/csrf.js"></script>
   </head>
 <body class="landing-page-body">
   <header class="landing-header">
@@ -76,6 +77,15 @@
 
       loginMessage.style.display = 'none';
 
+      // Check if CSRF token exists before attempting login
+      const csrfToken = getCsrfToken();
+      if (!csrfToken) {
+        console.error('[Login] CSRF token not found. Cookies may be disabled or blocked.');
+        loginMessage.textContent = 'Session error. Please refresh the page or check that cookies are enabled.';
+        loginMessage.style.display = 'block';
+        return;
+      }
+
       try {
         const response = await csrfFetch('/login', {
           method: 'POST',
@@ -105,6 +115,5 @@
       }
     });
   </script>
-<script src="/js/csrf.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Two issues fixed:
1. Changed CSRF cookie sameSite from 'strict' to 'lax' - strict was blocking cookies when users clicked links from emails or other sites to reach the login page
2. Moved csrf.js to load in head of login.html and added validation to show user-friendly error if CSRF token is missing