### PR TITLE
Add course progression guide for structured curriculum learning

### DIFF
--- a/public/resources/act-prep-pathway.json
+++ b/public/resources/act-prep-pathway.json
@@ -1,0 +1,518 @@
+{
+  "courseId": "act-prep",
+  "track": "ACT Math Prep",
+  "overview": "Targeted preparation for the ACT Mathematics section covering pre-algebra through trigonometry with test-taking strategies.",
+  "prerequisites": ["algebra-2"],
+  "naturalProgression": [
+    "Review foundational arithmetic and algebra skills",
+    "Master coordinate geometry and functions",
+    "Strengthen geometry knowledge",
+    "Learn trigonometry essentials",
+    "Practice timing and test strategies"
+  ],
+  "testInfo": {
+    "totalQuestions": 60,
+    "timeLimit": "60 minutes",
+    "contentBreakdown": {
+      "preAlgebraElementaryAlgebra": "20-25%",
+      "intermediateAlgebraCoordinateGeometry": "25-30%",
+      "planeGeometry": "20-25%",
+      "trigonometry": "5-10%"
+    },
+    "calculatorPolicy": "Calculator allowed for entire test"
+  },
+  "modules": [
+    {
+      "moduleId": "pre_algebra_foundations",
+      "title": "Pre-Algebra & Number Properties",
+      "preview": "Fractions, decimals, percents, and number properties",
+      "actPercentage": "10-15%",
+      "lessons": [
+        {
+          "lessonId": "number-operations",
+          "title": "Number Operations",
+          "order": 1,
+          "concepts": [
+            "Order of operations (PEMDAS)",
+            "Absolute value",
+            "Factors and multiples",
+            "GCF and LCM"
+          ],
+          "actTips": "These are often the 'easy' questions at the beginning. Don't rush - careless errors cost points."
+        },
+        {
+          "lessonId": "fractions-decimals",
+          "title": "Fractions and Decimals",
+          "order": 2,
+          "concepts": [
+            "Converting between fractions and decimals",
+            "Operations with fractions",
+            "Comparing fractions"
+          ]
+        },
+        {
+          "lessonId": "percents-ratios",
+          "title": "Percents and Ratios",
+          "order": 3,
+          "concepts": [
+            "Percent calculations (of, is, what)",
+            "Percent increase/decrease",
+            "Ratios and proportions",
+            "Unit rates"
+          ],
+          "actTips": "Percent change formula: (new - old)/old × 100"
+        },
+        {
+          "lessonId": "exponents-roots",
+          "title": "Exponents and Roots",
+          "order": 4,
+          "concepts": [
+            "Exponent rules",
+            "Square roots and cube roots",
+            "Rational exponents",
+            "Scientific notation"
+          ]
+        },
+        {
+          "lessonId": "mean-median-mode",
+          "title": "Statistics Basics",
+          "order": 5,
+          "concepts": [
+            "Mean, median, mode",
+            "Range",
+            "Weighted averages",
+            "Probability basics"
+          ],
+          "actTips": "ACT loves weighted average problems. Know the formula: total = sum/count."
+        }
+      ]
+    },
+    {
+      "moduleId": "elementary_algebra",
+      "title": "Elementary Algebra",
+      "preview": "Equations, inequalities, and basic algebraic manipulation",
+      "actPercentage": "10-15%",
+      "lessons": [
+        {
+          "lessonId": "linear-equations-act",
+          "title": "Linear Equations",
+          "order": 1,
+          "concepts": [
+            "Solving one and two-step equations",
+            "Equations with fractions",
+            "Word problems to equations"
+          ],
+          "actTips": "Plug in answer choices (backsolving) when algebra seems messy."
+        },
+        {
+          "lessonId": "inequalities-act",
+          "title": "Inequalities",
+          "order": 2,
+          "concepts": [
+            "Solving linear inequalities",
+            "Compound inequalities",
+            "Inequality word problems"
+          ]
+        },
+        {
+          "lessonId": "absolute-value-equations",
+          "title": "Absolute Value",
+          "order": 3,
+          "concepts": [
+            "Absolute value equations",
+            "Absolute value inequalities",
+            "Graphing absolute value"
+          ]
+        },
+        {
+          "lessonId": "substitution-evaluation",
+          "title": "Substitution and Evaluation",
+          "order": 4,
+          "concepts": [
+            "Evaluating expressions",
+            "Substituting values",
+            "Working with formulas"
+          ]
+        }
+      ]
+    },
+    {
+      "moduleId": "intermediate_algebra",
+      "title": "Intermediate Algebra",
+      "preview": "Quadratics, systems, functions, and polynomials",
+      "actPercentage": "15-20%",
+      "lessons": [
+        {
+          "lessonId": "systems-act",
+          "title": "Systems of Equations",
+          "order": 1,
+          "concepts": [
+            "Substitution method",
+            "Elimination method",
+            "Word problems with systems"
+          ],
+          "actTips": "ACT systems often have nice numbers - look for quick elimination opportunities."
+        },
+        {
+          "lessonId": "quadratics-act",
+          "title": "Quadratic Equations",
+          "order": 2,
+          "concepts": [
+            "Factoring quadratics",
+            "Quadratic formula",
+            "Completing the square",
+            "Discriminant"
+          ],
+          "keyFormulas": ["x = (-b ± √(b²-4ac))/(2a)"]
+        },
+        {
+          "lessonId": "polynomials-act",
+          "title": "Polynomials",
+          "order": 3,
+          "concepts": [
+            "Adding and subtracting polynomials",
+            "Multiplying polynomials (FOIL)",
+            "Factoring techniques"
+          ]
+        },
+        {
+          "lessonId": "functions-act",
+          "title": "Functions",
+          "order": 4,
+          "concepts": [
+            "Function notation f(x)",
+            "Domain and range",
+            "Composite functions",
+            "Inverse functions"
+          ],
+          "actTips": "f(g(x)) means do g first, then f. Work inside out."
+        },
+        {
+          "lessonId": "radicals-act",
+          "title": "Radicals and Rational Expressions",
+          "order": 5,
+          "concepts": [
+            "Simplifying radicals",
+            "Rationalizing denominators",
+            "Operations with radicals"
+          ]
+        },
+        {
+          "lessonId": "complex-numbers",
+          "title": "Complex Numbers",
+          "order": 6,
+          "concepts": [
+            "i = √(-1), i² = -1",
+            "Adding and multiplying complex numbers",
+            "Powers of i pattern"
+          ],
+          "actTips": "Powers of i cycle: i, -1, -i, 1, i, -1, ... Use remainder when dividing exponent by 4."
+        }
+      ]
+    },
+    {
+      "moduleId": "coordinate_geometry",
+      "title": "Coordinate Geometry",
+      "preview": "Graphing, lines, circles, and conic sections",
+      "actPercentage": "15-20%",
+      "lessons": [
+        {
+          "lessonId": "coordinate-plane-act",
+          "title": "The Coordinate Plane",
+          "order": 1,
+          "concepts": [
+            "Plotting points",
+            "Quadrants",
+            "Distance formula",
+            "Midpoint formula"
+          ],
+          "keyFormulas": [
+            "Distance: d = √[(x₂-x₁)² + (y₂-y₁)²]",
+            "Midpoint: ((x₁+x₂)/2, (y₁+y₂)/2)"
+          ]
+        },
+        {
+          "lessonId": "linear-graphs-act",
+          "title": "Graphing Linear Equations",
+          "order": 2,
+          "concepts": [
+            "Slope-intercept form (y = mx + b)",
+            "Point-slope form",
+            "Standard form",
+            "Finding slope from two points"
+          ],
+          "actTips": "Know slope formula cold: m = (y₂-y₁)/(x₂-x₁)"
+        },
+        {
+          "lessonId": "parallel-perpendicular-act",
+          "title": "Parallel and Perpendicular Lines",
+          "order": 3,
+          "concepts": [
+            "Parallel lines: same slope",
+            "Perpendicular lines: negative reciprocal slopes",
+            "Writing equations given conditions"
+          ]
+        },
+        {
+          "lessonId": "parabolas-act",
+          "title": "Parabolas",
+          "order": 4,
+          "concepts": [
+            "Standard form y = ax² + bx + c",
+            "Vertex form y = a(x-h)² + k",
+            "Finding vertex: x = -b/(2a)",
+            "Direction of opening"
+          ]
+        },
+        {
+          "lessonId": "circles-act",
+          "title": "Circles",
+          "order": 5,
+          "concepts": [
+            "Standard form: (x-h)² + (y-k)² = r²",
+            "Center (h, k) and radius r",
+            "Converting from general form"
+          ],
+          "keyFormulas": ["(x-h)² + (y-k)² = r²"]
+        },
+        {
+          "lessonId": "transformations-act",
+          "title": "Transformations",
+          "order": 6,
+          "concepts": [
+            "Translations",
+            "Reflections",
+            "Stretches and shrinks"
+          ]
+        }
+      ]
+    },
+    {
+      "moduleId": "plane_geometry",
+      "title": "Plane Geometry",
+      "preview": "Angles, triangles, polygons, circles, and area/volume",
+      "actPercentage": "20-25%",
+      "lessons": [
+        {
+          "lessonId": "angles-lines-act",
+          "title": "Angles and Lines",
+          "order": 1,
+          "concepts": [
+            "Complementary (90°) and supplementary (180°)",
+            "Vertical angles (equal)",
+            "Parallel lines cut by transversal",
+            "Corresponding, alternate interior/exterior angles"
+          ]
+        },
+        {
+          "lessonId": "triangles-act",
+          "title": "Triangles",
+          "order": 2,
+          "concepts": [
+            "Angle sum = 180°",
+            "Types: equilateral, isosceles, scalene, right",
+            "Triangle inequality",
+            "Similar triangles (AA, SAS, SSS)"
+          ],
+          "actTips": "Look for similar triangles in complex figures. Ratios are your friend."
+        },
+        {
+          "lessonId": "pythagorean-act",
+          "title": "Pythagorean Theorem",
+          "order": 3,
+          "concepts": [
+            "a² + b² = c²",
+            "Common triples: 3-4-5, 5-12-13, 8-15-17",
+            "Special right triangles: 45-45-90, 30-60-90"
+          ],
+          "keyFormulas": [
+            "a² + b² = c²",
+            "45-45-90: x, x, x√2",
+            "30-60-90: x, x√3, 2x"
+          ],
+          "actTips": "Memorize the special triangles! They appear constantly."
+        },
+        {
+          "lessonId": "polygons-act",
+          "title": "Polygons",
+          "order": 4,
+          "concepts": [
+            "Sum of interior angles: (n-2)·180°",
+            "Regular polygon properties",
+            "Quadrilateral properties"
+          ]
+        },
+        {
+          "lessonId": "circles-geometry-act",
+          "title": "Circle Properties",
+          "order": 5,
+          "concepts": [
+            "Circumference: C = 2πr = πd",
+            "Area: A = πr²",
+            "Arc length and sector area",
+            "Central and inscribed angles"
+          ],
+          "keyFormulas": [
+            "C = 2πr",
+            "A = πr²",
+            "Arc = (θ/360)·2πr",
+            "Sector = (θ/360)·πr²"
+          ]
+        },
+        {
+          "lessonId": "area-volume-act",
+          "title": "Area and Volume",
+          "order": 6,
+          "concepts": [
+            "Rectangle, triangle, parallelogram, trapezoid areas",
+            "Surface area and volume of prisms, cylinders",
+            "Cones, spheres, pyramids"
+          ],
+          "keyFormulas": [
+            "Triangle: A = (1/2)bh",
+            "Trapezoid: A = (1/2)(b₁+b₂)h",
+            "Cylinder: V = πr²h",
+            "Sphere: V = (4/3)πr³"
+          ]
+        }
+      ]
+    },
+    {
+      "moduleId": "trigonometry",
+      "title": "Trigonometry",
+      "preview": "Right triangle trig and unit circle basics",
+      "actPercentage": "5-10%",
+      "lessons": [
+        {
+          "lessonId": "sohcahtoa",
+          "title": "Right Triangle Trigonometry",
+          "order": 1,
+          "concepts": [
+            "SOH-CAH-TOA",
+            "Finding sides and angles",
+            "Setting up trig equations"
+          ],
+          "keyFormulas": [
+            "sin θ = opposite/hypotenuse",
+            "cos θ = adjacent/hypotenuse",
+            "tan θ = opposite/adjacent"
+          ]
+        },
+        {
+          "lessonId": "trig-identities-act",
+          "title": "Basic Trig Identities",
+          "order": 2,
+          "concepts": [
+            "sin²θ + cos²θ = 1",
+            "tan θ = sin θ/cos θ",
+            "Reciprocal functions: csc, sec, cot"
+          ]
+        },
+        {
+          "lessonId": "unit-circle-act",
+          "title": "Unit Circle Basics",
+          "order": 3,
+          "concepts": [
+            "Angles in radians",
+            "Key angles: 0, π/6, π/4, π/3, π/2",
+            "Signs in quadrants"
+          ],
+          "actTips": "ACT rarely goes deep on unit circle. Know the quadrant signs: All Students Take Calculus."
+        },
+        {
+          "lessonId": "law-of-sines-cosines",
+          "title": "Laws of Sines and Cosines",
+          "order": 4,
+          "concepts": [
+            "Law of Sines: a/sin A = b/sin B = c/sin C",
+            "Law of Cosines: c² = a² + b² - 2ab·cos C",
+            "When to use each"
+          ],
+          "keyFormulas": [
+            "Law of Sines: a/sin A = b/sin B",
+            "Law of Cosines: c² = a² + b² - 2ab·cos C"
+          ]
+        },
+        {
+          "lessonId": "trig-graphs-act",
+          "title": "Graphing Trig Functions",
+          "order": 5,
+          "concepts": [
+            "Amplitude, period, phase shift",
+            "y = A sin(Bx + C) + D form",
+            "Reading graphs"
+          ],
+          "optional": true
+        }
+      ]
+    },
+    {
+      "moduleId": "test_strategies",
+      "title": "ACT Test Strategies",
+      "preview": "Time management, question types, and scoring strategies",
+      "lessons": [
+        {
+          "lessonId": "timing-strategy",
+          "title": "Time Management",
+          "order": 1,
+          "concepts": [
+            "60 questions in 60 minutes = 1 min/question average",
+            "Questions get harder as you go",
+            "Don't spend more than 2 minutes on any question",
+            "Skip and return strategy"
+          ],
+          "actTips": "Mark questions you skip. Answer every question - no penalty for guessing!"
+        },
+        {
+          "lessonId": "backsolving",
+          "title": "Backsolving (Plugging In Answers)",
+          "order": 2,
+          "concepts": [
+            "When algebra is messy, try answer choices",
+            "Start with middle answer (B or C) for efficiency",
+            "Works great for word problems"
+          ]
+        },
+        {
+          "lessonId": "picking-numbers",
+          "title": "Picking Numbers",
+          "order": 3,
+          "concepts": [
+            "Replace variables with easy numbers",
+            "Good for 'which expression equals...' questions",
+            "Avoid 0, 1, and numbers in the problem"
+          ]
+        },
+        {
+          "lessonId": "estimation",
+          "title": "Estimation and Elimination",
+          "order": 4,
+          "concepts": [
+            "Round numbers to estimate quickly",
+            "Eliminate obviously wrong answers",
+            "Use approximations for π, √2, √3"
+          ]
+        },
+        {
+          "lessonId": "common-traps",
+          "title": "Common Traps and Mistakes",
+          "order": 5,
+          "concepts": [
+            "Not reading the question fully (asks for x+1, not x)",
+            "Forgetting negative solutions",
+            "Unit conversions",
+            "Misreading graphs"
+          ]
+        }
+      ]
+    },
+    {
+      "moduleId": "practice_tests",
+      "title": "Practice and Assessment",
+      "preview": "Full-length practice and targeted review",
+      "isCheckpoint": true,
+      "isFinal": true
+    }
+  ],
+  "aiGuidanceNotes": "For ACT prep, focus on efficiency and strategy alongside content review. Many students know the math but lose points to timing or careless errors. Practice identifying question types quickly and knowing which strategy to use. The test is predictable - certain question types appear every time."
+}

--- a/public/resources/algebra-1-pathway.json
+++ b/public/resources/algebra-1-pathway.json
@@ -1,73 +1,621 @@
 {
+  "courseId": "algebra-1",
   "track": "Algebra 1",
   "overview": "Build algebraic thinking through equations, functions, and data analysis. Master linear and quadratic relationships.",
+  "prerequisites": ["grade-8", "pre-algebra"],
+  "naturalProgression": [
+    "Start with solving equations - the core skill of algebra",
+    "Move to linear functions and graphing",
+    "Learn systems of equations for multiple unknowns",
+    "Build polynomial skills and factoring",
+    "Culminate with quadratic functions and exponentials"
+  ],
   "modules": [
     {
       "moduleId": "foundations_equations",
       "quarter": 1,
       "title": "Foundations & Linear Equations",
-      "preview": "Solve equations systematically and understand equality.",
-      "skills": ["solving-one-step-equations", "solving-two-step-equations", "solving-multi-step-equations", "solving-equations-with-variables-both-sides"]
+      "preview": "Solve equations systematically and understand equality",
+      "skills": ["solving-one-step-equations", "solving-two-step-equations", "solving-multi-step-equations", "solving-equations-with-variables-both-sides"],
+      "lessons": [
+        {
+          "lessonId": "variables-expressions",
+          "title": "Variables and Expressions",
+          "order": 1,
+          "concepts": [
+            "Variables represent unknown quantities",
+            "Writing expressions from words",
+            "Evaluating expressions"
+          ],
+          "teachingNotes": "Review and solidify understanding of what a variable means."
+        },
+        {
+          "lessonId": "equations-intro",
+          "title": "What is an Equation?",
+          "order": 2,
+          "concepts": [
+            "Equations show equality",
+            "Solutions make equations true",
+            "Checking solutions by substitution"
+          ]
+        },
+        {
+          "lessonId": "one-step-equations",
+          "title": "One-Step Equations",
+          "order": 3,
+          "concepts": [
+            "Inverse operations",
+            "Addition/subtraction equations",
+            "Multiplication/division equations",
+            "Keeping equations balanced"
+          ],
+          "keyFormulas": ["Whatever you do to one side, do to the other"],
+          "teachingNotes": "Use balance scale analogy. Stress the 'why' behind inverse operations."
+        },
+        {
+          "lessonId": "two-step-equations",
+          "title": "Two-Step Equations",
+          "order": 4,
+          "concepts": [
+            "Order of operations in reverse",
+            "Undo addition/subtraction first, then multiplication/division",
+            "ax + b = c form"
+          ],
+          "teachingNotes": "Box the variable term, then work 'outside the box' first."
+        },
+        {
+          "lessonId": "multi-step-equations",
+          "title": "Multi-Step Equations",
+          "order": 5,
+          "concepts": [
+            "Combining like terms first",
+            "Distributive property",
+            "Simplifying before solving"
+          ]
+        },
+        {
+          "lessonId": "variables-both-sides",
+          "title": "Variables on Both Sides",
+          "order": 6,
+          "concepts": [
+            "Move all variables to one side",
+            "Move all constants to other side",
+            "Special cases: no solution, infinite solutions"
+          ],
+          "commonMistakes": ["Forgetting to distribute negative signs", "Not collecting all variable terms"]
+        },
+        {
+          "lessonId": "literal-equations",
+          "title": "Literal Equations and Formulas",
+          "order": 7,
+          "concepts": [
+            "Solving for a specific variable",
+            "Rearranging formulas",
+            "Applications with geometry and science formulas"
+          ]
+        },
+        {
+          "lessonId": "inequalities-intro",
+          "title": "Solving Inequalities",
+          "order": 8,
+          "concepts": [
+            "Inequality symbols: <, >, ≤, ≥",
+            "Solving like equations (mostly)",
+            "FLIP the sign when multiplying/dividing by negative",
+            "Graphing on number lines"
+          ],
+          "commonMistakes": ["Forgetting to flip inequality when multiplying by negative"]
+        }
+      ]
     },
     {
       "moduleId": "linear_functions",
       "quarter": 2,
       "title": "Linear Functions & Graphing",
-      "preview": "Graph linear relationships and write equations from multiple representations.",
-      "skills": ["graphing-linear-equations-slope-intercept", "writing-linear-equations-slope-intercept", "slope-from-points", "parallel-perpendicular-lines"]
+      "preview": "Graph linear relationships and write equations from multiple representations",
+      "skills": ["graphing-linear-equations-slope-intercept", "writing-linear-equations-slope-intercept", "slope-from-points", "parallel-perpendicular-lines"],
+      "lessons": [
+        {
+          "lessonId": "coordinate-plane",
+          "title": "The Coordinate Plane",
+          "order": 1,
+          "concepts": [
+            "x-axis, y-axis, origin",
+            "Ordered pairs (x, y)",
+            "Plotting and reading points"
+          ]
+        },
+        {
+          "lessonId": "relations-functions",
+          "title": "Relations and Functions",
+          "order": 2,
+          "concepts": [
+            "Domain and range",
+            "Function definition: each input has exactly one output",
+            "Vertical line test",
+            "Function notation f(x)"
+          ]
+        },
+        {
+          "lessonId": "slope-intro",
+          "title": "Understanding Slope",
+          "order": 3,
+          "concepts": [
+            "Slope as rate of change",
+            "Rise over run",
+            "Positive, negative, zero, undefined slopes",
+            "Slope from a graph"
+          ],
+          "keyFormulas": ["m = (y₂ - y₁)/(x₂ - x₁) = rise/run"]
+        },
+        {
+          "lessonId": "slope-intercept",
+          "title": "Slope-Intercept Form",
+          "order": 4,
+          "concepts": [
+            "y = mx + b",
+            "m is slope, b is y-intercept",
+            "Graphing from slope-intercept form",
+            "Writing equations from graphs"
+          ],
+          "keyFormulas": ["y = mx + b"]
+        },
+        {
+          "lessonId": "point-slope",
+          "title": "Point-Slope Form",
+          "order": 5,
+          "concepts": [
+            "y - y₁ = m(x - x₁)",
+            "When to use point-slope",
+            "Converting between forms"
+          ],
+          "keyFormulas": ["y - y₁ = m(x - x₁)"]
+        },
+        {
+          "lessonId": "standard-form",
+          "title": "Standard Form",
+          "order": 6,
+          "concepts": [
+            "Ax + By = C",
+            "Finding intercepts",
+            "Converting to slope-intercept"
+          ],
+          "keyFormulas": ["Ax + By = C"]
+        },
+        {
+          "lessonId": "parallel-perpendicular",
+          "title": "Parallel and Perpendicular Lines",
+          "order": 7,
+          "concepts": [
+            "Parallel lines: same slope",
+            "Perpendicular lines: negative reciprocal slopes",
+            "Writing equations of parallel/perpendicular lines"
+          ],
+          "keyFormulas": ["Parallel: m₁ = m₂", "Perpendicular: m₁ × m₂ = -1"]
+        },
+        {
+          "lessonId": "linear-inequalities-2var",
+          "title": "Graphing Linear Inequalities",
+          "order": 8,
+          "concepts": [
+            "Boundary line (solid vs dashed)",
+            "Shading above or below",
+            "Testing points to verify"
+          ]
+        }
+      ]
     },
     {
       "moduleId": "systems_equations",
       "quarter": 2,
       "title": "Systems of Equations",
-      "preview": "Solve systems using graphing, substitution, and elimination methods.",
-      "skills": ["systems-of-equations-graphing", "systems-of-equations-substitution", "systems-of-equations-elimination", "systems-word-problems"]
+      "preview": "Solve systems using graphing, substitution, and elimination methods",
+      "skills": ["systems-of-equations-graphing", "systems-of-equations-substitution", "systems-of-equations-elimination", "systems-word-problems"],
+      "lessons": [
+        {
+          "lessonId": "systems-intro",
+          "title": "Introduction to Systems",
+          "order": 1,
+          "concepts": [
+            "Two equations, two unknowns",
+            "Solution as intersection point",
+            "Checking solutions in both equations"
+          ]
+        },
+        {
+          "lessonId": "systems-graphing",
+          "title": "Solving by Graphing",
+          "order": 2,
+          "concepts": [
+            "Graph both lines",
+            "Find intersection point",
+            "Limitations (imprecise for non-integer solutions)"
+          ]
+        },
+        {
+          "lessonId": "systems-substitution",
+          "title": "Solving by Substitution",
+          "order": 3,
+          "concepts": [
+            "Solve one equation for one variable",
+            "Substitute into other equation",
+            "Solve and back-substitute"
+          ],
+          "teachingNotes": "Best when one equation is already solved for a variable."
+        },
+        {
+          "lessonId": "systems-elimination",
+          "title": "Solving by Elimination",
+          "order": 4,
+          "concepts": [
+            "Add/subtract equations to eliminate a variable",
+            "Multiplying to create opposites",
+            "Choosing which variable to eliminate"
+          ],
+          "teachingNotes": "Best when coefficients are already opposites or easy to make opposites."
+        },
+        {
+          "lessonId": "systems-special-cases",
+          "title": "Special Cases",
+          "order": 5,
+          "concepts": [
+            "No solution (parallel lines)",
+            "Infinite solutions (same line)",
+            "Recognizing from algebraic solution"
+          ]
+        },
+        {
+          "lessonId": "systems-word-problems",
+          "title": "Systems Word Problems",
+          "order": 6,
+          "concepts": [
+            "Define variables",
+            "Write two equations from context",
+            "Solve and interpret"
+          ],
+          "teachingNotes": "Common types: mixture, distance-rate-time, cost problems."
+        }
+      ]
     },
     {
       "moduleId": "checkpoint_q2",
       "quarter": 2,
       "title": "Q2 Checkpoint",
-      "preview": "Cumulative assessment: Linear functions and systems"
+      "preview": "Cumulative assessment: Linear functions and systems",
+      "isCheckpoint": true
     },
     {
       "moduleId": "exponents_polynomials",
       "quarter": 3,
       "title": "Exponents & Polynomials",
-      "preview": "Master exponent rules and polynomial operations.",
-      "skills": ["exponent-rules-multiplication", "exponent-rules-division", "exponent-rules-power-of-power", "polynomial-addition-subtraction", "polynomial-multiplication-monomial"]
+      "preview": "Master exponent rules and polynomial operations",
+      "skills": ["exponent-rules-multiplication", "exponent-rules-division", "exponent-rules-power-of-power", "polynomial-addition-subtraction", "polynomial-multiplication-monomial"],
+      "lessons": [
+        {
+          "lessonId": "exponents-review",
+          "title": "Exponent Basics",
+          "order": 1,
+          "concepts": [
+            "Base and exponent",
+            "Expanded form",
+            "Negative exponents as reciprocals",
+            "Zero exponent rule"
+          ],
+          "keyFormulas": ["a⁰ = 1", "a⁻ⁿ = 1/aⁿ"]
+        },
+        {
+          "lessonId": "exponents-multiply",
+          "title": "Multiplying with Exponents",
+          "order": 2,
+          "concepts": [
+            "Product rule: aᵐ × aⁿ = aᵐ⁺ⁿ",
+            "Same base required",
+            "Power of a product"
+          ],
+          "keyFormulas": ["aᵐ × aⁿ = aᵐ⁺ⁿ", "(ab)ⁿ = aⁿbⁿ"]
+        },
+        {
+          "lessonId": "exponents-divide",
+          "title": "Dividing with Exponents",
+          "order": 3,
+          "concepts": [
+            "Quotient rule: aᵐ ÷ aⁿ = aᵐ⁻ⁿ",
+            "Power of a quotient"
+          ],
+          "keyFormulas": ["aᵐ ÷ aⁿ = aᵐ⁻ⁿ", "(a/b)ⁿ = aⁿ/bⁿ"]
+        },
+        {
+          "lessonId": "exponents-power",
+          "title": "Power of a Power",
+          "order": 4,
+          "concepts": [
+            "(aᵐ)ⁿ = aᵐⁿ",
+            "Combining exponent rules"
+          ],
+          "keyFormulas": ["(aᵐ)ⁿ = aᵐⁿ"]
+        },
+        {
+          "lessonId": "polynomials-intro",
+          "title": "Introduction to Polynomials",
+          "order": 5,
+          "concepts": [
+            "Terms, coefficients, degrees",
+            "Monomials, binomials, trinomials",
+            "Standard form",
+            "Classifying polynomials"
+          ]
+        },
+        {
+          "lessonId": "polynomials-add-sub",
+          "title": "Adding and Subtracting Polynomials",
+          "order": 6,
+          "concepts": [
+            "Combining like terms",
+            "Distributing the negative",
+            "Horizontal and vertical methods"
+          ]
+        },
+        {
+          "lessonId": "polynomials-multiply",
+          "title": "Multiplying Polynomials",
+          "order": 7,
+          "concepts": [
+            "Monomial × polynomial (distribute)",
+            "Binomial × binomial (FOIL)",
+            "Polynomial × polynomial (distribute each term)"
+          ],
+          "teachingNotes": "FOIL is a special case of distribution, not a separate method."
+        },
+        {
+          "lessonId": "special-products",
+          "title": "Special Products",
+          "order": 8,
+          "concepts": [
+            "Square of a binomial: (a+b)² = a² + 2ab + b²",
+            "Difference of squares: (a+b)(a-b) = a² - b²"
+          ],
+          "keyFormulas": ["(a+b)² = a² + 2ab + b²", "(a-b)² = a² - 2ab + b²", "(a+b)(a-b) = a² - b²"]
+        }
+      ]
     },
     {
       "moduleId": "factoring",
       "quarter": 3,
       "title": "Factoring",
-      "preview": "Factor polynomials using GCF, grouping, and special patterns.",
-      "skills": ["factoring-gcf", "factoring-trinomials", "factoring-difference-of-squares", "factoring-perfect-square-trinomials"]
+      "preview": "Factor polynomials using GCF, grouping, and special patterns",
+      "skills": ["factoring-gcf", "factoring-trinomials", "factoring-difference-of-squares", "factoring-perfect-square-trinomials"],
+      "lessons": [
+        {
+          "lessonId": "factoring-gcf",
+          "title": "Factoring Out the GCF",
+          "order": 1,
+          "concepts": [
+            "Finding greatest common factor",
+            "Factoring out GCF from all terms",
+            "Always factor GCF first!"
+          ],
+          "teachingNotes": "This should always be the first step in any factoring problem."
+        },
+        {
+          "lessonId": "factoring-x2-bx-c",
+          "title": "Factoring x² + bx + c",
+          "order": 2,
+          "concepts": [
+            "Find two numbers that multiply to c and add to b",
+            "(x + p)(x + q) where pq = c and p + q = b",
+            "Signs: both positive, both negative, or opposite"
+          ],
+          "teachingNotes": "Lots of practice with the 'sum and product' thinking."
+        },
+        {
+          "lessonId": "factoring-ax2-bx-c",
+          "title": "Factoring ax² + bx + c",
+          "order": 3,
+          "concepts": [
+            "When a ≠ 1",
+            "AC method (grouping)",
+            "Trial and error method"
+          ],
+          "teachingNotes": "AC method: find numbers that multiply to ac and add to b, then factor by grouping."
+        },
+        {
+          "lessonId": "factoring-special",
+          "title": "Factoring Special Patterns",
+          "order": 4,
+          "concepts": [
+            "Difference of squares: a² - b² = (a+b)(a-b)",
+            "Perfect square trinomials",
+            "Recognizing the patterns"
+          ],
+          "keyFormulas": ["a² - b² = (a+b)(a-b)", "a² + 2ab + b² = (a+b)²"]
+        },
+        {
+          "lessonId": "factoring-grouping",
+          "title": "Factoring by Grouping",
+          "order": 5,
+          "concepts": [
+            "Four-term polynomials",
+            "Group first two and last two",
+            "Factor out common binomial"
+          ]
+        },
+        {
+          "lessonId": "factoring-completely",
+          "title": "Factoring Completely",
+          "order": 6,
+          "concepts": [
+            "Multiple factoring steps",
+            "Check for GCF first, then other methods",
+            "Factor until prime"
+          ]
+        }
+      ]
     },
     {
       "moduleId": "checkpoint_q3",
       "quarter": 3,
       "title": "Q3 Checkpoint",
-      "preview": "Cumulative assessment: Exponents, polynomials, and factoring"
+      "preview": "Cumulative assessment: Exponents, polynomials, and factoring",
+      "isCheckpoint": true
     },
     {
       "moduleId": "quadratic_functions",
       "quarter": 4,
       "title": "Quadratic Functions",
-      "preview": "Graph parabolas and solve quadratic equations using multiple methods.",
-      "skills": ["quadratic-equations-graphing", "solving-quadratics-factoring", "solving-quadratics-square-roots", "quadratic-formula", "discriminant"]
+      "preview": "Graph parabolas and solve quadratic equations using multiple methods",
+      "skills": ["quadratic-equations-graphing", "solving-quadratics-factoring", "solving-quadratics-square-roots", "quadratic-formula", "discriminant"],
+      "lessons": [
+        {
+          "lessonId": "quadratics-intro",
+          "title": "Introduction to Quadratics",
+          "order": 1,
+          "concepts": [
+            "f(x) = ax² + bx + c",
+            "Parabola shape",
+            "Real-world applications (projectile motion)"
+          ]
+        },
+        {
+          "lessonId": "quadratics-graphing",
+          "title": "Graphing Quadratic Functions",
+          "order": 2,
+          "concepts": [
+            "Vertex and axis of symmetry",
+            "Direction of opening (a > 0 vs a < 0)",
+            "x-intercepts (zeros/roots)",
+            "y-intercept"
+          ],
+          "keyFormulas": ["Axis of symmetry: x = -b/(2a)"]
+        },
+        {
+          "lessonId": "vertex-form",
+          "title": "Vertex Form",
+          "order": 3,
+          "concepts": [
+            "f(x) = a(x-h)² + k",
+            "Vertex at (h, k)",
+            "Transformations from parent function",
+            "Converting to/from standard form"
+          ],
+          "keyFormulas": ["f(x) = a(x-h)² + k, vertex at (h,k)"]
+        },
+        {
+          "lessonId": "solving-factoring",
+          "title": "Solving by Factoring",
+          "order": 4,
+          "concepts": [
+            "Zero product property",
+            "Set each factor = 0",
+            "Factor, then solve"
+          ],
+          "keyFormulas": ["If ab = 0, then a = 0 or b = 0"]
+        },
+        {
+          "lessonId": "solving-square-roots",
+          "title": "Solving by Square Roots",
+          "order": 5,
+          "concepts": [
+            "When there's no x-term",
+            "Isolate x², take square root",
+            "Don't forget ± for two solutions"
+          ]
+        },
+        {
+          "lessonId": "completing-square",
+          "title": "Completing the Square",
+          "order": 6,
+          "concepts": [
+            "Creating a perfect square trinomial",
+            "Adding (b/2)² to both sides",
+            "Solving and converting to vertex form"
+          ]
+        },
+        {
+          "lessonId": "quadratic-formula",
+          "title": "The Quadratic Formula",
+          "order": 7,
+          "concepts": [
+            "x = (-b ± √(b²-4ac))/(2a)",
+            "Works for any quadratic",
+            "Derivation from completing the square"
+          ],
+          "keyFormulas": ["x = (-b ± √(b²-4ac))/(2a)"]
+        },
+        {
+          "lessonId": "discriminant",
+          "title": "The Discriminant",
+          "order": 8,
+          "concepts": [
+            "b² - 4ac determines number of solutions",
+            "Positive: 2 real solutions",
+            "Zero: 1 real solution (double root)",
+            "Negative: no real solutions"
+          ],
+          "keyFormulas": ["Discriminant = b² - 4ac"]
+        }
+      ]
     },
     {
       "moduleId": "exponential_functions",
       "quarter": 4,
       "title": "Exponential Functions",
-      "preview": "Model growth and decay with exponential relationships.",
-      "skills": ["exponential-functions-basics", "exponential-growth-decay", "exponential-equations"]
+      "preview": "Model growth and decay with exponential relationships",
+      "skills": ["exponential-functions-basics", "exponential-growth-decay", "exponential-equations"],
+      "lessons": [
+        {
+          "lessonId": "exponential-intro",
+          "title": "Exponential Functions",
+          "order": 1,
+          "concepts": [
+            "f(x) = a·bˣ",
+            "Base b determines growth or decay",
+            "Exponential vs linear growth"
+          ]
+        },
+        {
+          "lessonId": "exponential-growth",
+          "title": "Exponential Growth",
+          "order": 2,
+          "concepts": [
+            "When b > 1",
+            "Doubling, tripling",
+            "Growth rate and factor",
+            "Applications: population, compound interest"
+          ],
+          "keyFormulas": ["A = P(1 + r)ᵗ"]
+        },
+        {
+          "lessonId": "exponential-decay",
+          "title": "Exponential Decay",
+          "order": 3,
+          "concepts": [
+            "When 0 < b < 1",
+            "Half-life",
+            "Depreciation",
+            "Decay rate"
+          ],
+          "keyFormulas": ["A = P(1 - r)ᵗ"]
+        },
+        {
+          "lessonId": "exponential-graphing",
+          "title": "Graphing Exponential Functions",
+          "order": 4,
+          "concepts": [
+            "Horizontal asymptote",
+            "Domain and range",
+            "Transformations"
+          ]
+        }
+      ]
     },
     {
       "moduleId": "final_mastery_assessment",
       "quarter": 4,
       "title": "Final Mastery Assessment",
-      "preview": "Comprehensive assessment covering all Algebra 1 content"
+      "preview": "Comprehensive assessment covering all Algebra 1 content",
+      "isCheckpoint": true,
+      "isFinal": true
     }
-  ]
+  ],
+  "aiGuidanceNotes": "Algebra 1 is the foundation for all higher math. Focus on equation-solving fluency first. Linear functions connect algebra to graphing - use multiple representations. Factoring requires lots of practice. The quadratic formula is a safety net but encourage understanding other methods first."
 }

--- a/public/resources/calculus-1-pathway.json
+++ b/public/resources/calculus-1-pathway.json
@@ -1,18 +1,681 @@
 {
+  "courseId": "calculus-1",
   "track": "Calculus 1",
-  "overview": "Introduction to differential and integral calculus. Limits, derivatives, integrals, and applications.",
+  "overview": "Introduction to differential and integral calculus covering limits, derivatives, integrals, and their applications. Equivalent to AP Calculus AB.",
+  "prerequisites": ["algebra-2", "precalculus", "trigonometry"],
+  "naturalProgression": [
+    "Start with limits - the foundation of calculus",
+    "Move to derivatives - rates of change",
+    "Apply derivatives to real problems",
+    "Learn integration - the reverse of differentiation",
+    "Apply integrals to area and volume problems"
+  ],
   "modules": [
-    {"moduleId": "limits_continuity", "quarter": 1, "title": "Limits & Continuity", "preview": "Evaluate limits, determine continuity", "skills": ["limits-algebraic", "continuity", "intermediate-value-theorem"]},
-    {"moduleId": "derivatives_definition", "quarter": 1, "title": "Derivative Concept", "preview": "Definition of derivative, interpretations", "skills": ["derivatives-definition", "tangent-lines", "differentiability"]},
-    {"moduleId": "differentiation_rules", "quarter": 1, "title": "Differentiation Rules", "preview": "Power, product, quotient, chain rules", "skills": ["power-rule", "product-rule", "quotient-rule", "trig-derivatives"]},
-    {"moduleId": "checkpoint_q1", "quarter": 1, "title": "Q1 Checkpoint", "preview": "Limits and basic differentiation"},
-    {"moduleId": "advanced_differentiation", "quarter": 2, "title": "Advanced Differentiation", "preview": "Chain rule, implicit, exponential, logarithmic", "skills": ["chain-rule", "implicit-differentiation", "exponential-log-derivatives"]},
-    {"moduleId": "applications_derivatives", "quarter": 2, "title": "Applications of Derivatives", "preview": "Related rates, optimization, curve sketching", "skills": ["related-rates", "optimization", "first-derivative-test", "second-derivative-test", "curve-sketching"]},
-    {"moduleId": "checkpoint_q2", "quarter": 2, "title": "Q2 Checkpoint", "preview": "Differentiation mastery"},
-    {"moduleId": "antiderivatives_indefinite", "quarter": 3, "title": "Antiderivatives", "preview": "Indefinite integrals, basic integration", "skills": ["indefinite-integrals", "u-substitution", "integration-trig"]},
-    {"moduleId": "definite_integrals", "quarter": 3, "title": "Definite Integrals", "preview": "FTC, Riemann sums, accumulation", "skills": ["riemann-sums", "definite-integrals-ftc", "accumulation-functions"]},
-    {"moduleId": "checkpoint_q3", "quarter": 3, "title": "Q3 Checkpoint", "preview": "Integration fundamentals"},
-    {"moduleId": "applications_integrals", "quarter": 4, "title": "Applications of Integration", "preview": "Area, volume, average value", "skills": ["area-under-curve", "area-between-curves", "volume-disks-washers", "volume-shells"]},
-    {"moduleId": "final_mastery_assessment", "quarter": 4, "title": "Final Mastery Assessment / AP Exam Prep", "preview": "Comprehensive Calculus 1 (AP Calc AB level)"}
-  ]
+    {
+      "moduleId": "limits_continuity",
+      "quarter": 1,
+      "title": "Limits & Continuity",
+      "preview": "The foundation of calculus - understanding how functions behave as they approach values",
+      "skills": ["limits-algebraic", "continuity", "intermediate-value-theorem"],
+      "lessons": [
+        {
+          "lessonId": "limits-intro",
+          "title": "Introduction to Limits",
+          "order": 1,
+          "concepts": [
+            "What is a limit? Understanding function behavior near a point",
+            "Limit notation: lim(x→a) f(x)",
+            "One-sided limits (left and right)",
+            "When limits exist vs don't exist"
+          ],
+          "keyFormulas": [],
+          "teachingNotes": "Start with intuitive examples - what value does f(x) approach as x gets close to a? Use tables of values and graphs before formal notation.",
+          "commonMistakes": ["Confusing f(a) with lim(x→a) f(x)", "Forgetting that x never actually equals a in a limit"]
+        },
+        {
+          "lessonId": "limits-direct-sub",
+          "title": "Direct Substitution",
+          "order": 2,
+          "concepts": [
+            "When direct substitution works",
+            "Continuous functions and limits",
+            "Evaluating limits by plugging in"
+          ],
+          "keyFormulas": ["If f is continuous at a, then lim(x→a) f(x) = f(a)"],
+          "teachingNotes": "This is the easiest case - try it first, then use other techniques if it fails."
+        },
+        {
+          "lessonId": "limits-algebraic",
+          "title": "Algebraic Limit Techniques",
+          "order": 3,
+          "concepts": [
+            "Factoring to cancel common factors (0/0 indeterminate forms)",
+            "Rationalizing with conjugates",
+            "Expanding and simplifying"
+          ],
+          "keyFormulas": [
+            "Difference of squares: a² - b² = (a+b)(a-b)",
+            "Conjugate: (√a - √b)(√a + √b) = a - b"
+          ],
+          "teachingNotes": "When direct substitution gives 0/0, that's a signal to factor or simplify first.",
+          "commonMistakes": ["Canceling terms that don't share a common factor", "Forgetting to evaluate the limit after simplifying"]
+        },
+        {
+          "lessonId": "limits-infinity",
+          "title": "Limits at Infinity",
+          "order": 4,
+          "concepts": [
+            "Horizontal asymptotes",
+            "End behavior of polynomials and rational functions",
+            "Comparing degrees of numerator and denominator"
+          ],
+          "keyFormulas": [
+            "Same degree: limit = ratio of leading coefficients",
+            "Numerator degree higher: limit = ±∞",
+            "Denominator degree higher: limit = 0"
+          ],
+          "teachingNotes": "Focus on leading terms - everything else becomes negligible as x → ∞"
+        },
+        {
+          "lessonId": "limits-trig",
+          "title": "Trigonometric Limits",
+          "order": 5,
+          "concepts": [
+            "The fundamental limit: lim(x→0) sin(x)/x = 1",
+            "Related limits with cos and tan",
+            "L'Hôpital's Rule preview (optional)"
+          ],
+          "keyFormulas": [
+            "lim(x→0) sin(x)/x = 1",
+            "lim(x→0) (1-cos(x))/x = 0",
+            "lim(x→0) tan(x)/x = 1"
+          ],
+          "teachingNotes": "These special limits must be memorized. Show why sin(x)/x → 1 using the squeeze theorem or unit circle."
+        },
+        {
+          "lessonId": "limits-lhopital",
+          "title": "L'Hôpital's Rule",
+          "order": 6,
+          "concepts": [
+            "When to use L'Hôpital's Rule (0/0 or ∞/∞ forms)",
+            "Taking derivatives of numerator and denominator separately",
+            "Applying the rule multiple times if needed"
+          ],
+          "keyFormulas": ["If lim f(x)/g(x) gives 0/0 or ∞/∞, then lim f(x)/g(x) = lim f'(x)/g'(x)"],
+          "teachingNotes": "Only use when you have an indeterminate form! Verify the form first.",
+          "commonMistakes": ["Using L'Hôpital when not in indeterminate form", "Taking derivative of the whole fraction instead of separately"]
+        },
+        {
+          "lessonId": "continuity",
+          "title": "Continuity",
+          "order": 7,
+          "concepts": [
+            "Definition of continuity at a point",
+            "Three conditions: f(a) exists, limit exists, they're equal",
+            "Types of discontinuities (removable, jump, infinite)",
+            "Continuity on an interval"
+          ],
+          "keyFormulas": ["f is continuous at a if: lim(x→a) f(x) = f(a)"],
+          "teachingNotes": "Connect to intuition: can you draw the graph without lifting your pencil?"
+        },
+        {
+          "lessonId": "ivt",
+          "title": "Intermediate Value Theorem",
+          "order": 8,
+          "concepts": [
+            "Statement of IVT",
+            "Using IVT to show solutions exist",
+            "Applications to root finding"
+          ],
+          "keyFormulas": ["If f is continuous on [a,b] and k is between f(a) and f(b), then f(c)=k for some c in (a,b)"],
+          "teachingNotes": "Intuitive: a continuous function can't skip values."
+        }
+      ]
+    },
+    {
+      "moduleId": "derivatives_definition",
+      "quarter": 1,
+      "title": "Derivative Concept",
+      "preview": "Understanding derivatives as rates of change and slopes of tangent lines",
+      "skills": ["derivatives-definition", "tangent-lines", "differentiability"],
+      "lessons": [
+        {
+          "lessonId": "derivative-concept",
+          "title": "What is a Derivative?",
+          "order": 1,
+          "concepts": [
+            "Average rate of change vs instantaneous rate of change",
+            "Secant lines approaching tangent lines",
+            "Derivative as slope of tangent line"
+          ],
+          "teachingNotes": "Build intuition with real examples: velocity, growth rates, marginal cost."
+        },
+        {
+          "lessonId": "derivative-definition",
+          "title": "Limit Definition of Derivative",
+          "order": 2,
+          "concepts": [
+            "f'(x) = lim(h→0) [f(x+h) - f(x)]/h",
+            "Computing derivatives from the definition",
+            "Alternative form: lim(x→a) [f(x) - f(a)]/(x-a)"
+          ],
+          "keyFormulas": ["f'(x) = lim(h→0) [f(x+h) - f(x)]/h"],
+          "teachingNotes": "Work through several examples by hand before introducing shortcut rules."
+        },
+        {
+          "lessonId": "derivative-notation",
+          "title": "Derivative Notation",
+          "order": 3,
+          "concepts": [
+            "Lagrange notation: f'(x), y'",
+            "Leibniz notation: dy/dx, df/dx",
+            "Newton notation: ẏ (physics)",
+            "When to use each notation"
+          ],
+          "teachingNotes": "Leibniz notation is helpful for chain rule and related rates later."
+        },
+        {
+          "lessonId": "differentiability",
+          "title": "Differentiability",
+          "order": 4,
+          "concepts": [
+            "When derivatives don't exist (corners, cusps, vertical tangents)",
+            "Differentiability implies continuity",
+            "Continuity does NOT imply differentiability"
+          ],
+          "teachingNotes": "Show examples like |x| at x=0 - continuous but not differentiable."
+        }
+      ]
+    },
+    {
+      "moduleId": "differentiation_rules",
+      "quarter": 1,
+      "title": "Differentiation Rules",
+      "preview": "The shortcuts for finding derivatives quickly",
+      "skills": ["power-rule", "product-rule", "quotient-rule", "trig-derivatives"],
+      "lessons": [
+        {
+          "lessonId": "power-rule",
+          "title": "Power Rule",
+          "order": 1,
+          "concepts": [
+            "d/dx[xⁿ] = nxⁿ⁻¹",
+            "Constants: d/dx[c] = 0",
+            "Constant multiple rule",
+            "Sum/difference rule"
+          ],
+          "keyFormulas": [
+            "d/dx[xⁿ] = nxⁿ⁻¹",
+            "d/dx[cf(x)] = c·f'(x)",
+            "d/dx[f(x) ± g(x)] = f'(x) ± g'(x)"
+          ],
+          "teachingNotes": "This handles polynomials completely. Practice until automatic."
+        },
+        {
+          "lessonId": "product-rule",
+          "title": "Product Rule",
+          "order": 2,
+          "concepts": [
+            "When two functions are multiplied",
+            "d/dx[f·g] = f'g + fg'",
+            "Mnemonic: 'first times derivative of second plus second times derivative of first'"
+          ],
+          "keyFormulas": ["d/dx[f(x)·g(x)] = f'(x)·g(x) + f(x)·g'(x)"],
+          "commonMistakes": ["Thinking d/dx[fg] = f'g' (it's not!)"]
+        },
+        {
+          "lessonId": "quotient-rule",
+          "title": "Quotient Rule",
+          "order": 3,
+          "concepts": [
+            "When one function is divided by another",
+            "d/dx[f/g] = (f'g - fg')/g²",
+            "Mnemonic: 'low d-high minus high d-low, over low squared'"
+          ],
+          "keyFormulas": ["d/dx[f(x)/g(x)] = [f'(x)·g(x) - f(x)·g'(x)]/[g(x)]²"],
+          "teachingNotes": "Can also use product rule with negative exponents, but quotient rule is often easier."
+        },
+        {
+          "lessonId": "trig-derivatives",
+          "title": "Trigonometric Derivatives",
+          "order": 4,
+          "concepts": [
+            "Derivatives of sin, cos, tan, cot, sec, csc",
+            "Patterns and memorization tips"
+          ],
+          "keyFormulas": [
+            "d/dx[sin(x)] = cos(x)",
+            "d/dx[cos(x)] = -sin(x)",
+            "d/dx[tan(x)] = sec²(x)",
+            "d/dx[sec(x)] = sec(x)tan(x)",
+            "d/dx[cot(x)] = -csc²(x)",
+            "d/dx[csc(x)] = -csc(x)cot(x)"
+          ],
+          "teachingNotes": "Derive sin and cos from definition, then use quotient rule for the rest."
+        }
+      ]
+    },
+    {
+      "moduleId": "checkpoint_q1",
+      "quarter": 1,
+      "title": "Q1 Checkpoint",
+      "preview": "Assessment of limits and basic differentiation",
+      "isCheckpoint": true
+    },
+    {
+      "moduleId": "advanced_differentiation",
+      "quarter": 2,
+      "title": "Advanced Differentiation",
+      "preview": "Chain rule and special function derivatives",
+      "skills": ["chain-rule", "implicit-differentiation", "exponential-log-derivatives"],
+      "lessons": [
+        {
+          "lessonId": "chain-rule",
+          "title": "Chain Rule",
+          "order": 1,
+          "concepts": [
+            "Composition of functions",
+            "d/dx[f(g(x))] = f'(g(x))·g'(x)",
+            "Identifying 'inner' and 'outer' functions",
+            "Multiple applications of chain rule"
+          ],
+          "keyFormulas": ["d/dx[f(g(x))] = f'(g(x))·g'(x)"],
+          "teachingNotes": "Think of it as 'derivative of outside times derivative of inside'. Practice identifying composite functions."
+        },
+        {
+          "lessonId": "exp-log-derivatives",
+          "title": "Exponential and Logarithmic Derivatives",
+          "order": 2,
+          "concepts": [
+            "d/dx[eˣ] = eˣ (the magic of e!)",
+            "d/dx[aˣ] = aˣ·ln(a)",
+            "d/dx[ln(x)] = 1/x",
+            "d/dx[logₐ(x)] = 1/(x·ln(a))"
+          ],
+          "keyFormulas": [
+            "d/dx[eˣ] = eˣ",
+            "d/dx[aˣ] = aˣ·ln(a)",
+            "d/dx[ln(x)] = 1/x"
+          ],
+          "teachingNotes": "e is special because it's its own derivative. Explain why e ≈ 2.718."
+        },
+        {
+          "lessonId": "implicit-diff",
+          "title": "Implicit Differentiation",
+          "order": 3,
+          "concepts": [
+            "When y is not explicitly solved for",
+            "Treating y as a function of x",
+            "Using chain rule on y terms",
+            "Solving for dy/dx"
+          ],
+          "teachingNotes": "Whenever you differentiate y, multiply by dy/dx (chain rule!)."
+        },
+        {
+          "lessonId": "inverse-trig-derivatives",
+          "title": "Inverse Trigonometric Derivatives",
+          "order": 4,
+          "concepts": [
+            "Derivatives of arcsin, arccos, arctan",
+            "Using implicit differentiation to derive them"
+          ],
+          "keyFormulas": [
+            "d/dx[arcsin(x)] = 1/√(1-x²)",
+            "d/dx[arccos(x)] = -1/√(1-x²)",
+            "d/dx[arctan(x)] = 1/(1+x²)"
+          ]
+        },
+        {
+          "lessonId": "logarithmic-diff",
+          "title": "Logarithmic Differentiation",
+          "order": 5,
+          "concepts": [
+            "Taking ln of both sides",
+            "Useful for products/quotients of many terms",
+            "Necessary for xˣ type functions"
+          ],
+          "teachingNotes": "Most useful when exponent is also a function of x."
+        }
+      ]
+    },
+    {
+      "moduleId": "applications_derivatives",
+      "quarter": 2,
+      "title": "Applications of Derivatives",
+      "preview": "Using derivatives to solve real problems",
+      "skills": ["related-rates", "optimization", "first-derivative-test", "second-derivative-test", "curve-sketching"],
+      "lessons": [
+        {
+          "lessonId": "related-rates",
+          "title": "Related Rates",
+          "order": 1,
+          "concepts": [
+            "Variables changing with respect to time",
+            "Setting up equations from word problems",
+            "Implicit differentiation with respect to t",
+            "Classic problems: ladder, balloon, cone"
+          ],
+          "teachingNotes": "Draw a picture, identify what's changing, write an equation relating quantities, differentiate with respect to t."
+        },
+        {
+          "lessonId": "linearization",
+          "title": "Linear Approximation",
+          "order": 2,
+          "concepts": [
+            "Tangent line as approximation",
+            "L(x) = f(a) + f'(a)(x-a)",
+            "Differentials: dy = f'(x)dx"
+          ],
+          "keyFormulas": ["L(x) = f(a) + f'(a)(x-a)"]
+        },
+        {
+          "lessonId": "extrema",
+          "title": "Finding Extrema",
+          "order": 3,
+          "concepts": [
+            "Critical points where f'(x) = 0 or undefined",
+            "Local vs absolute extrema",
+            "Closed interval method"
+          ],
+          "teachingNotes": "Extrema can only occur at critical points or endpoints (on closed intervals)."
+        },
+        {
+          "lessonId": "first-derivative-test",
+          "title": "First Derivative Test",
+          "order": 4,
+          "concepts": [
+            "Sign of f' tells increasing/decreasing",
+            "Sign change at critical point → local extremum",
+            "+ to - means local max, - to + means local min"
+          ]
+        },
+        {
+          "lessonId": "second-derivative-test",
+          "title": "Second Derivative Test",
+          "order": 5,
+          "concepts": [
+            "Concavity: concave up (smile) vs concave down (frown)",
+            "Inflection points where concavity changes",
+            "f''(c) > 0 at critical point → local min",
+            "f''(c) < 0 at critical point → local max"
+          ]
+        },
+        {
+          "lessonId": "curve-sketching",
+          "title": "Curve Sketching",
+          "order": 6,
+          "concepts": [
+            "Combining all derivative information",
+            "Domain, intercepts, symmetry",
+            "Asymptotes, critical points, inflection points",
+            "Putting it all together"
+          ]
+        },
+        {
+          "lessonId": "optimization",
+          "title": "Optimization",
+          "order": 7,
+          "concepts": [
+            "Finding maximum or minimum values",
+            "Setting up optimization problems from word problems",
+            "Constraint equations",
+            "Classic problems: fencing, volume, distance"
+          ],
+          "teachingNotes": "Read carefully, draw a picture, identify what to maximize/minimize, write equation, take derivative, set to zero."
+        },
+        {
+          "lessonId": "mean-value-theorem",
+          "title": "Mean Value Theorem",
+          "order": 8,
+          "concepts": [
+            "If f is continuous on [a,b] and differentiable on (a,b)",
+            "Then f'(c) = [f(b)-f(a)]/(b-a) for some c in (a,b)",
+            "Geometric interpretation: tangent parallel to secant"
+          ],
+          "keyFormulas": ["f'(c) = [f(b)-f(a)]/(b-a)"]
+        }
+      ]
+    },
+    {
+      "moduleId": "checkpoint_q2",
+      "quarter": 2,
+      "title": "Q2 Checkpoint",
+      "preview": "Differentiation mastery assessment",
+      "isCheckpoint": true
+    },
+    {
+      "moduleId": "antiderivatives_indefinite",
+      "quarter": 3,
+      "title": "Antiderivatives",
+      "preview": "The reverse of differentiation",
+      "skills": ["indefinite-integrals", "u-substitution", "integration-trig"],
+      "lessons": [
+        {
+          "lessonId": "antiderivatives-intro",
+          "title": "Introduction to Antiderivatives",
+          "order": 1,
+          "concepts": [
+            "What function has this derivative?",
+            "The +C constant of integration",
+            "Antiderivative notation: ∫f(x)dx"
+          ],
+          "teachingNotes": "Start by asking 'what function gives us this derivative when we differentiate it?'"
+        },
+        {
+          "lessonId": "basic-integration",
+          "title": "Basic Integration Rules",
+          "order": 2,
+          "concepts": [
+            "Power rule for integration: ∫xⁿdx = xⁿ⁺¹/(n+1) + C",
+            "Sum/difference rule",
+            "Constant multiple rule"
+          ],
+          "keyFormulas": [
+            "∫xⁿdx = xⁿ⁺¹/(n+1) + C (n≠-1)",
+            "∫eˣdx = eˣ + C",
+            "∫(1/x)dx = ln|x| + C"
+          ]
+        },
+        {
+          "lessonId": "trig-integration",
+          "title": "Trigonometric Integrals",
+          "order": 3,
+          "concepts": [
+            "Integrals of sin, cos, sec², etc.",
+            "Reverse of trig derivatives"
+          ],
+          "keyFormulas": [
+            "∫sin(x)dx = -cos(x) + C",
+            "∫cos(x)dx = sin(x) + C",
+            "∫sec²(x)dx = tan(x) + C"
+          ]
+        },
+        {
+          "lessonId": "u-substitution",
+          "title": "u-Substitution",
+          "order": 4,
+          "concepts": [
+            "Reverse chain rule",
+            "Choosing u (usually the inside function)",
+            "Finding du and substituting",
+            "Changing back to x at the end"
+          ],
+          "teachingNotes": "Look for a function and its derivative together. Let u be the 'inside' function."
+        },
+        {
+          "lessonId": "initial-value-problems",
+          "title": "Initial Value Problems",
+          "order": 5,
+          "concepts": [
+            "Using initial conditions to find C",
+            "Position, velocity, acceleration relationships"
+          ]
+        }
+      ]
+    },
+    {
+      "moduleId": "definite_integrals",
+      "quarter": 3,
+      "title": "Definite Integrals",
+      "preview": "Integration with bounds and the Fundamental Theorem",
+      "skills": ["riemann-sums", "definite-integrals-ftc", "accumulation-functions"],
+      "lessons": [
+        {
+          "lessonId": "riemann-sums",
+          "title": "Riemann Sums",
+          "order": 1,
+          "concepts": [
+            "Approximating area with rectangles",
+            "Left, right, and midpoint sums",
+            "As n → ∞, sum → exact area"
+          ],
+          "teachingNotes": "Build intuition for what definite integrals represent geometrically."
+        },
+        {
+          "lessonId": "definite-integral-def",
+          "title": "Definite Integral Definition",
+          "order": 2,
+          "concepts": [
+            "∫ₐᵇ f(x)dx as limit of Riemann sums",
+            "Signed area (below x-axis is negative)",
+            "Properties of definite integrals"
+          ]
+        },
+        {
+          "lessonId": "ftc-part1",
+          "title": "Fundamental Theorem of Calculus - Part 1",
+          "order": 3,
+          "concepts": [
+            "If g(x) = ∫ₐˣ f(t)dt, then g'(x) = f(x)",
+            "Differentiation and integration are inverse operations",
+            "Accumulation functions"
+          ],
+          "keyFormulas": ["d/dx[∫ₐˣ f(t)dt] = f(x)"]
+        },
+        {
+          "lessonId": "ftc-part2",
+          "title": "Fundamental Theorem of Calculus - Part 2",
+          "order": 4,
+          "concepts": [
+            "∫ₐᵇ f(x)dx = F(b) - F(a)",
+            "Where F is any antiderivative of f",
+            "This is how we actually evaluate definite integrals!"
+          ],
+          "keyFormulas": ["∫ₐᵇ f(x)dx = F(b) - F(a)"]
+        },
+        {
+          "lessonId": "u-sub-definite",
+          "title": "u-Substitution with Definite Integrals",
+          "order": 5,
+          "concepts": [
+            "Two approaches: change bounds or substitute back",
+            "Changing bounds to u-values"
+          ]
+        },
+        {
+          "lessonId": "average-value",
+          "title": "Average Value of a Function",
+          "order": 6,
+          "concepts": [
+            "f_avg = (1/(b-a))∫ₐᵇ f(x)dx",
+            "Geometric interpretation"
+          ],
+          "keyFormulas": ["f_avg = (1/(b-a))∫ₐᵇ f(x)dx"]
+        }
+      ]
+    },
+    {
+      "moduleId": "checkpoint_q3",
+      "quarter": 3,
+      "title": "Q3 Checkpoint",
+      "preview": "Integration fundamentals assessment",
+      "isCheckpoint": true
+    },
+    {
+      "moduleId": "applications_integrals",
+      "quarter": 4,
+      "title": "Applications of Integration",
+      "preview": "Using integrals to find areas and volumes",
+      "skills": ["area-under-curve", "area-between-curves", "volume-disks-washers", "volume-shells"],
+      "lessons": [
+        {
+          "lessonId": "area-under-curve",
+          "title": "Area Under a Curve",
+          "order": 1,
+          "concepts": [
+            "Basic area calculation with definite integrals",
+            "Handling negative regions",
+            "Total vs net area"
+          ]
+        },
+        {
+          "lessonId": "area-between-curves",
+          "title": "Area Between Curves",
+          "order": 2,
+          "concepts": [
+            "∫(top - bottom)dx",
+            "Finding intersection points",
+            "Integrating with respect to y when appropriate"
+          ],
+          "keyFormulas": ["A = ∫ₐᵇ [f(x) - g(x)]dx where f(x) ≥ g(x)"]
+        },
+        {
+          "lessonId": "volumes-disks-washers",
+          "title": "Volumes by Disks and Washers",
+          "order": 3,
+          "concepts": [
+            "Rotating regions around an axis",
+            "Disk method: V = π∫[R(x)]²dx",
+            "Washer method: V = π∫([R(x)]² - [r(x)]²)dx"
+          ],
+          "keyFormulas": [
+            "Disk: V = π∫ₐᵇ [R(x)]²dx",
+            "Washer: V = π∫ₐᵇ ([R(x)]² - [r(x)]²)dx"
+          ],
+          "teachingNotes": "Visualize thin slices perpendicular to axis of rotation."
+        },
+        {
+          "lessonId": "volumes-shells",
+          "title": "Volumes by Cylindrical Shells",
+          "order": 4,
+          "concepts": [
+            "V = 2π∫(radius)(height)dx",
+            "When to use shells vs disks/washers",
+            "Rotating around y-axis"
+          ],
+          "keyFormulas": ["V = 2π∫ₐᵇ x·f(x)dx (rotating around y-axis)"]
+        },
+        {
+          "lessonId": "arc-length",
+          "title": "Arc Length (if time permits)",
+          "order": 5,
+          "concepts": [
+            "L = ∫√(1 + [f'(x)]²)dx"
+          ],
+          "keyFormulas": ["L = ∫ₐᵇ √(1 + [f'(x)]²)dx"],
+          "optional": true
+        }
+      ]
+    },
+    {
+      "moduleId": "final_mastery_assessment",
+      "quarter": 4,
+      "title": "Final Mastery Assessment",
+      "preview": "Comprehensive Calculus 1 (AP Calc AB level)",
+      "isCheckpoint": true,
+      "isFinal": true
+    }
+  ],
+  "suggestedPacing": {
+    "totalWeeks": 32,
+    "limitsAndContinuity": "4-5 weeks",
+    "derivativeConcept": "2-3 weeks",
+    "differentiationRules": "3-4 weeks",
+    "advancedDifferentiation": "4-5 weeks",
+    "applicationsOfDerivatives": "5-6 weeks",
+    "antiderivatives": "4-5 weeks",
+    "definiteIntegrals": "4-5 weeks",
+    "applicationsOfIntegrals": "4-5 weeks"
+  },
+  "aiGuidanceNotes": "When a student says 'teach me calculus' or asks for the next topic, follow this progression. Start with limits, which are foundational. Don't skip ahead to derivatives until they understand limits. Within each module, follow the lesson order. Always check for prerequisite understanding before introducing new concepts."
 }

--- a/public/resources/calculus-2-pathway.json
+++ b/public/resources/calculus-2-pathway.json
@@ -1,16 +1,511 @@
 {
+  "courseId": "calculus-2",
   "track": "Calculus 2",
-  "overview": "Advanced integration techniques, sequences and series, parametric/polar calculus, and differential equations.",
+  "overview": "Advanced integration techniques, sequences and series, parametric/polar calculus, and differential equations. Equivalent to AP Calculus BC.",
+  "prerequisites": ["calculus-1"],
+  "naturalProgression": [
+    "Master advanced integration techniques",
+    "Understand sequences and convergence",
+    "Study infinite series and convergence tests",
+    "Learn Taylor and Maclaurin series",
+    "Explore parametric and polar coordinate systems",
+    "Introduction to differential equations"
+  ],
   "modules": [
-    {"moduleId": "integration_techniques", "quarter": 1, "title": "Integration Techniques", "preview": "Integration by parts, trig substitution, partial fractions", "skills": ["integration-by-parts", "trig-substitution", "partial-fractions", "improper-integrals"]},
-    {"moduleId": "checkpoint_q1", "quarter": 1, "title": "Q1 Checkpoint", "preview": "Advanced integration mastery"},
-    {"moduleId": "sequences_series", "quarter": 2, "title": "Sequences and Series", "preview": "Convergence tests for sequences and series", "skills": ["sequences", "series-tests", "geometric-series", "harmonic-series"]},
-    {"moduleId": "power_series", "quarter": 2, "title": "Power Series", "preview": "Radius/interval of convergence, operations", "skills": ["power-series", "radius-convergence", "term-by-term"]},
-    {"moduleId": "checkpoint_q2", "quarter": 2, "title": "Q2 Checkpoint", "preview": "Series convergence"},
-    {"moduleId": "taylor_series", "quarter": 3, "title": "Taylor and Maclaurin Series", "preview": "Series representations, approximations", "skills": ["taylor-series", "maclaurin-series", "taylor-polynomials", "lagrange-error"]},
-    {"moduleId": "parametric_polar", "quarter": 3, "title": "Parametric & Polar Calculus", "preview": "Derivatives, areas, arc length", "skills": ["parametric-calculus", "polar-calculus", "arc-length-polar"]},
-    {"moduleId": "checkpoint_q3", "quarter": 3, "title": "Q3 Checkpoint", "preview": "Taylor series and parametric/polar"},
-    {"moduleId": "differential_equations", "quarter": 4, "title": "Differential Equations", "preview": "Separable DEs, slope fields, logistic growth", "skills": ["differential-equations-intro", "slope-fields", "logistic-growth", "eulers-method"]},
-    {"moduleId": "final_mastery_assessment", "quarter": 4, "title": "Final Mastery Assessment / AP BC Exam Prep", "preview": "Comprehensive Calculus 2 (AP Calc BC level)"}
-  ]
+    {
+      "moduleId": "integration_techniques",
+      "quarter": 1,
+      "title": "Integration Techniques",
+      "preview": "Integration by parts, trig substitution, partial fractions",
+      "skills": ["integration-by-parts", "trig-substitution", "partial-fractions", "improper-integrals"],
+      "lessons": [
+        {
+          "lessonId": "integration-by-parts",
+          "title": "Integration by Parts",
+          "order": 1,
+          "concepts": [
+            "Product rule in reverse",
+            "∫u dv = uv - ∫v du",
+            "Choosing u and dv (LIATE rule)",
+            "Tabular method for repeated IBP"
+          ],
+          "keyFormulas": ["∫u dv = uv - ∫v du"],
+          "teachingNotes": "LIATE: Logarithmic, Inverse trig, Algebraic, Trig, Exponential - choose u in this order."
+        },
+        {
+          "lessonId": "trig-integrals",
+          "title": "Trigonometric Integrals",
+          "order": 2,
+          "concepts": [
+            "∫sinᵐx cosⁿx dx strategies",
+            "Using identities: sin²x + cos²x = 1",
+            "Half-angle formulas for even powers",
+            "∫tanᵐx secⁿx dx strategies"
+          ],
+          "teachingNotes": "The strategy depends on whether powers are odd or even."
+        },
+        {
+          "lessonId": "trig-substitution",
+          "title": "Trigonometric Substitution",
+          "order": 3,
+          "concepts": [
+            "When to use trig sub (square roots of quadratics)",
+            "√(a²-x²): x = a sin θ",
+            "√(a²+x²): x = a tan θ",
+            "√(x²-a²): x = a sec θ",
+            "Setting up the reference triangle"
+          ],
+          "keyFormulas": [
+            "√(a²-x²): let x = a sin θ",
+            "√(a²+x²): let x = a tan θ",
+            "√(x²-a²): let x = a sec θ"
+          ]
+        },
+        {
+          "lessonId": "partial-fractions",
+          "title": "Partial Fractions",
+          "order": 4,
+          "concepts": [
+            "Decomposing rational functions",
+            "Linear factors: A/(x-a)",
+            "Repeated linear factors: A/(x-a) + B/(x-a)²",
+            "Irreducible quadratic factors: (Ax+B)/(x²+bx+c)"
+          ],
+          "teachingNotes": "Always do polynomial long division first if degree of numerator ≥ degree of denominator."
+        },
+        {
+          "lessonId": "improper-integrals",
+          "title": "Improper Integrals",
+          "order": 5,
+          "concepts": [
+            "Infinite limits of integration",
+            "Discontinuous integrands",
+            "Convergence vs divergence",
+            "Comparison tests for improper integrals"
+          ],
+          "keyFormulas": ["∫ₐ^∞ f(x)dx = lim(b→∞) ∫ₐᵇ f(x)dx"]
+        },
+        {
+          "lessonId": "numerical-integration",
+          "title": "Numerical Integration",
+          "order": 6,
+          "concepts": [
+            "Trapezoidal rule",
+            "Simpson's rule",
+            "Error bounds"
+          ],
+          "optional": true
+        }
+      ]
+    },
+    {
+      "moduleId": "checkpoint_q1",
+      "quarter": 1,
+      "title": "Q1 Checkpoint",
+      "preview": "Advanced integration mastery",
+      "isCheckpoint": true
+    },
+    {
+      "moduleId": "sequences_series",
+      "quarter": 2,
+      "title": "Sequences and Series",
+      "preview": "Convergence tests for sequences and series",
+      "skills": ["sequences", "series-tests", "geometric-series", "harmonic-series"],
+      "lessons": [
+        {
+          "lessonId": "sequences-intro",
+          "title": "Sequences",
+          "order": 1,
+          "concepts": [
+            "Explicit vs recursive formulas",
+            "Limits of sequences",
+            "Bounded and monotonic sequences",
+            "Squeeze theorem for sequences"
+          ]
+        },
+        {
+          "lessonId": "series-intro",
+          "title": "Introduction to Series",
+          "order": 2,
+          "concepts": [
+            "Partial sums",
+            "Convergence and divergence",
+            "nth term test for divergence",
+            "Properties of convergent series"
+          ],
+          "keyFormulas": ["If Σaₙ converges, then lim aₙ = 0 (but not conversely!)"]
+        },
+        {
+          "lessonId": "geometric-series",
+          "title": "Geometric Series",
+          "order": 3,
+          "concepts": [
+            "Σarⁿ from n=0 to ∞",
+            "Converges if |r| < 1 to a/(1-r)",
+            "Diverges if |r| ≥ 1",
+            "Applications and telescoping series"
+          ],
+          "keyFormulas": ["Σarⁿ = a/(1-r) if |r| < 1"]
+        },
+        {
+          "lessonId": "p-series",
+          "title": "p-Series and Harmonic Series",
+          "order": 4,
+          "concepts": [
+            "Σ1/nᵖ converges if p > 1",
+            "Harmonic series (p=1) diverges",
+            "Integral test connection"
+          ],
+          "keyFormulas": ["Σ1/nᵖ converges iff p > 1"]
+        },
+        {
+          "lessonId": "comparison-tests",
+          "title": "Comparison Tests",
+          "order": 5,
+          "concepts": [
+            "Direct comparison test",
+            "Limit comparison test",
+            "Choosing comparison series"
+          ]
+        },
+        {
+          "lessonId": "integral-test",
+          "title": "Integral Test",
+          "order": 6,
+          "concepts": [
+            "When to use integral test",
+            "Requirements: positive, continuous, decreasing",
+            "Estimating sums with integrals"
+          ]
+        },
+        {
+          "lessonId": "ratio-root-tests",
+          "title": "Ratio and Root Tests",
+          "order": 7,
+          "concepts": [
+            "Ratio test: lim |aₙ₊₁/aₙ|",
+            "Root test: lim |aₙ|^(1/n)",
+            "When tests are inconclusive"
+          ],
+          "keyFormulas": [
+            "Ratio test: L < 1 converges, L > 1 diverges",
+            "Root test: L < 1 converges, L > 1 diverges"
+          ]
+        },
+        {
+          "lessonId": "alternating-series",
+          "title": "Alternating Series",
+          "order": 8,
+          "concepts": [
+            "Alternating series test",
+            "Error bound for alternating series",
+            "Conditional vs absolute convergence"
+          ],
+          "keyFormulas": ["Error ≤ |aₙ₊₁| for alternating series"]
+        }
+      ]
+    },
+    {
+      "moduleId": "power_series",
+      "quarter": 2,
+      "title": "Power Series",
+      "preview": "Radius/interval of convergence, operations",
+      "skills": ["power-series", "radius-convergence", "term-by-term"],
+      "lessons": [
+        {
+          "lessonId": "power-series-intro",
+          "title": "Introduction to Power Series",
+          "order": 1,
+          "concepts": [
+            "Σcₙ(x-a)ⁿ form",
+            "Center of series",
+            "Convergence at center"
+          ]
+        },
+        {
+          "lessonId": "radius-interval",
+          "title": "Radius and Interval of Convergence",
+          "order": 2,
+          "concepts": [
+            "Radius of convergence R",
+            "Using ratio or root test",
+            "Checking endpoints separately",
+            "Interval notation"
+          ]
+        },
+        {
+          "lessonId": "power-series-operations",
+          "title": "Operations on Power Series",
+          "order": 3,
+          "concepts": [
+            "Term-by-term differentiation",
+            "Term-by-term integration",
+            "Addition and multiplication"
+          ],
+          "teachingNotes": "Differentiation and integration preserve radius of convergence (but maybe not endpoints)."
+        },
+        {
+          "lessonId": "functions-power-series",
+          "title": "Functions as Power Series",
+          "order": 4,
+          "concepts": [
+            "1/(1-x) = Σxⁿ",
+            "Building other series from geometric",
+            "Integration to get ln(1+x), arctan(x)"
+          ],
+          "keyFormulas": ["1/(1-x) = Σxⁿ for |x| < 1"]
+        }
+      ]
+    },
+    {
+      "moduleId": "checkpoint_q2",
+      "quarter": 2,
+      "title": "Q2 Checkpoint",
+      "preview": "Series convergence",
+      "isCheckpoint": true
+    },
+    {
+      "moduleId": "taylor_series",
+      "quarter": 3,
+      "title": "Taylor and Maclaurin Series",
+      "preview": "Series representations, approximations",
+      "skills": ["taylor-series", "maclaurin-series", "taylor-polynomials", "lagrange-error"],
+      "lessons": [
+        {
+          "lessonId": "taylor-polynomials",
+          "title": "Taylor Polynomials",
+          "order": 1,
+          "concepts": [
+            "Approximating functions with polynomials",
+            "nth degree Taylor polynomial",
+            "Coefficients from derivatives at a"
+          ],
+          "keyFormulas": ["Pₙ(x) = Σ[f⁽ᵏ⁾(a)/k!](x-a)ᵏ from k=0 to n"]
+        },
+        {
+          "lessonId": "taylor-series-def",
+          "title": "Taylor Series Definition",
+          "order": 2,
+          "concepts": [
+            "Infinite Taylor polynomial",
+            "Maclaurin series (a = 0)",
+            "When does the series equal the function?"
+          ],
+          "keyFormulas": ["f(x) = Σ[f⁽ⁿ⁾(a)/n!](x-a)ⁿ"]
+        },
+        {
+          "lessonId": "common-maclaurin",
+          "title": "Common Maclaurin Series",
+          "order": 3,
+          "concepts": [
+            "eˣ = Σxⁿ/n!",
+            "sin x = Σ(-1)ⁿx²ⁿ⁺¹/(2n+1)!",
+            "cos x = Σ(-1)ⁿx²ⁿ/(2n)!",
+            "ln(1+x), arctan(x), (1+x)ᵖ"
+          ],
+          "keyFormulas": [
+            "eˣ = 1 + x + x²/2! + x³/3! + ...",
+            "sin x = x - x³/3! + x⁵/5! - ...",
+            "cos x = 1 - x²/2! + x⁴/4! - ..."
+          ],
+          "teachingNotes": "These must be memorized. Notice eˣ is for all x, but ln(1+x) only for |x| ≤ 1."
+        },
+        {
+          "lessonId": "manipulating-series",
+          "title": "Manipulating Known Series",
+          "order": 4,
+          "concepts": [
+            "Substitution into known series",
+            "Building new series from old",
+            "Example: e^(-x²) from eˣ series"
+          ]
+        },
+        {
+          "lessonId": "lagrange-error",
+          "title": "Lagrange Error Bound",
+          "order": 5,
+          "concepts": [
+            "Error in Taylor approximation",
+            "|Rₙ(x)| ≤ M|x-a|ⁿ⁺¹/(n+1)!",
+            "Finding M as max of |f⁽ⁿ⁺¹⁾(z)|",
+            "Applications to approximation problems"
+          ],
+          "keyFormulas": ["|Rₙ(x)| ≤ M|x-a|ⁿ⁺¹/(n+1)!"]
+        }
+      ]
+    },
+    {
+      "moduleId": "parametric_polar",
+      "quarter": 3,
+      "title": "Parametric & Polar Calculus",
+      "preview": "Derivatives, areas, arc length in parametric and polar",
+      "skills": ["parametric-calculus", "polar-calculus", "arc-length-polar"],
+      "lessons": [
+        {
+          "lessonId": "parametric-intro",
+          "title": "Parametric Equations",
+          "order": 1,
+          "concepts": [
+            "x = f(t), y = g(t)",
+            "Eliminating the parameter",
+            "Direction and orientation"
+          ]
+        },
+        {
+          "lessonId": "parametric-derivatives",
+          "title": "Calculus with Parametric Curves",
+          "order": 2,
+          "concepts": [
+            "dy/dx = (dy/dt)/(dx/dt)",
+            "Second derivative d²y/dx²",
+            "Tangent lines to parametric curves"
+          ],
+          "keyFormulas": ["dy/dx = (dy/dt)/(dx/dt)"]
+        },
+        {
+          "lessonId": "parametric-arc-length",
+          "title": "Arc Length in Parametric",
+          "order": 3,
+          "concepts": [
+            "L = ∫√[(dx/dt)² + (dy/dt)²] dt",
+            "Surface area of revolution"
+          ],
+          "keyFormulas": ["L = ∫ₐᵇ √[(dx/dt)² + (dy/dt)²] dt"]
+        },
+        {
+          "lessonId": "polar-intro",
+          "title": "Polar Coordinates",
+          "order": 4,
+          "concepts": [
+            "r and θ coordinates",
+            "Converting to/from rectangular",
+            "Common polar curves"
+          ],
+          "keyFormulas": ["x = r cos θ, y = r sin θ", "r² = x² + y²"]
+        },
+        {
+          "lessonId": "polar-derivatives",
+          "title": "Calculus with Polar Curves",
+          "order": 5,
+          "concepts": [
+            "dy/dx from polar: dy/dx = (dr/dθ sin θ + r cos θ)/(dr/dθ cos θ - r sin θ)",
+            "Tangent lines to polar curves"
+          ]
+        },
+        {
+          "lessonId": "polar-area",
+          "title": "Area in Polar Coordinates",
+          "order": 6,
+          "concepts": [
+            "A = (1/2)∫r² dθ",
+            "Area between polar curves",
+            "Finding intersection points"
+          ],
+          "keyFormulas": ["A = (1/2)∫ₐᵝ r² dθ"]
+        },
+        {
+          "lessonId": "polar-arc-length",
+          "title": "Arc Length in Polar",
+          "order": 7,
+          "concepts": [
+            "L = ∫√[r² + (dr/dθ)²] dθ"
+          ],
+          "keyFormulas": ["L = ∫ₐᵝ √[r² + (dr/dθ)²] dθ"]
+        }
+      ]
+    },
+    {
+      "moduleId": "checkpoint_q3",
+      "quarter": 3,
+      "title": "Q3 Checkpoint",
+      "preview": "Taylor series and parametric/polar",
+      "isCheckpoint": true
+    },
+    {
+      "moduleId": "differential_equations",
+      "quarter": 4,
+      "title": "Differential Equations",
+      "preview": "Separable DEs, slope fields, logistic growth",
+      "skills": ["differential-equations-intro", "slope-fields", "logistic-growth", "eulers-method"],
+      "lessons": [
+        {
+          "lessonId": "de-intro",
+          "title": "Introduction to Differential Equations",
+          "order": 1,
+          "concepts": [
+            "What is a differential equation?",
+            "Order of a DE",
+            "Solutions and initial conditions",
+            "Verifying solutions"
+          ]
+        },
+        {
+          "lessonId": "slope-fields",
+          "title": "Slope Fields",
+          "order": 2,
+          "concepts": [
+            "Visualizing dy/dx = f(x,y)",
+            "Sketching slope fields",
+            "Reading solution curves from fields"
+          ]
+        },
+        {
+          "lessonId": "eulers-method",
+          "title": "Euler's Method",
+          "order": 3,
+          "concepts": [
+            "Numerical approximation",
+            "Step-by-step calculation",
+            "Accuracy and step size"
+          ],
+          "keyFormulas": ["yₙ₊₁ = yₙ + f(xₙ, yₙ)·Δx"]
+        },
+        {
+          "lessonId": "separable-de",
+          "title": "Separable Differential Equations",
+          "order": 4,
+          "concepts": [
+            "When dy/dx = f(x)g(y)",
+            "Separating variables",
+            "Integrating both sides",
+            "Solving for y explicitly"
+          ],
+          "teachingNotes": "Get all y terms on one side with dy, all x terms on other side with dx."
+        },
+        {
+          "lessonId": "exponential-growth-de",
+          "title": "Exponential Growth/Decay Models",
+          "order": 5,
+          "concepts": [
+            "dy/dt = ky",
+            "Solution y = Ce^(kt)",
+            "Half-life and doubling time",
+            "Newton's law of cooling"
+          ],
+          "keyFormulas": ["dy/dt = ky → y = Ce^(kt)"]
+        },
+        {
+          "lessonId": "logistic-growth",
+          "title": "Logistic Growth",
+          "order": 6,
+          "concepts": [
+            "dy/dt = ky(1 - y/L)",
+            "Carrying capacity L",
+            "S-shaped growth curve",
+            "Point of inflection"
+          ],
+          "keyFormulas": ["dy/dt = ky(1 - y/L)", "y = L/(1 + Ae^(-kt))"]
+        }
+      ]
+    },
+    {
+      "moduleId": "final_mastery_assessment",
+      "quarter": 4,
+      "title": "Final Mastery Assessment",
+      "preview": "Comprehensive Calculus 2 (AP Calc BC level)",
+      "isCheckpoint": true,
+      "isFinal": true
+    }
+  ],
+  "aiGuidanceNotes": "Calculus 2 is often considered harder than Calculus 1 because of series. Integration techniques require lots of practice to recognize which method to use. Series convergence tests form a decision tree - help students build this mental flowchart. Taylor series connect everything - they're both the culmination of series and deeply connected to function approximation."
 }

--- a/public/resources/grade-3-pathway.json
+++ b/public/resources/grade-3-pathway.json
@@ -1,11 +1,334 @@
 {
+  "courseId": "grade-3",
   "track": "Grade 3 Math",
-  "overview": "Multiplication, division, fractions, area, and perimeter.",
+  "overview": "Building fluency with multiplication and division, understanding fractions, and exploring area and perimeter.",
+  "prerequisites": ["grade-2"],
+  "naturalProgression": [
+    "Start with multiplication concepts and fact fluency",
+    "Connect multiplication to division as inverse operations",
+    "Introduce fractions as equal parts of a whole",
+    "Apply multiplication to area and perimeter",
+    "Use all skills for measurement and data problems"
+  ],
   "modules": [
-    {"moduleId": "multiplication", "quarter": 1, "title": "Multiplication", "preview": "Concept, strategies, fact fluency 0-12", "skills": ["multiplication-basics", "multiplication-facts", "multiplication-patterns"]},
-    {"moduleId": "division_fractions", "quarter": 2, "title": "Division & Fractions", "preview": "Division basics, unit fractions, number line", "skills": ["division-basics", "division-facts", "fractions-unit-fractions", "fractions-on-number-line"]},
-    {"moduleId": "area_perimeter", "quarter": 3, "title": "Area & Perimeter", "preview": "Rectangles, composite figures, measurement", "skills": ["area-rectangles", "perimeter", "area-perimeter-word-problems"]},
-    {"moduleId": "data_measurement", "quarter": 4, "title": "Data & Measurement", "preview": "Bar graphs, line plots, time, mass, volume", "skills": ["bar-graphs-scaled", "measuring-mass-volume", "elapsed-time"]},
-    {"moduleId": "final_assessment", "quarter": 4, "title": "Grade 3 Assessment", "preview": "Multiplication, division, fractions, area"}
-  ]
+    {
+      "moduleId": "multiplication",
+      "quarter": 1,
+      "title": "Multiplication",
+      "preview": "Understanding multiplication as groups, arrays, and repeated addition",
+      "skills": ["multiplication-basics", "multiplication-facts", "multiplication-patterns"],
+      "lessons": [
+        {
+          "lessonId": "mult-intro",
+          "title": "What is Multiplication?",
+          "order": 1,
+          "concepts": [
+            "Equal groups (3 groups of 4)",
+            "Repeated addition connection",
+            "Multiplication symbol and notation"
+          ],
+          "teachingNotes": "Use concrete objects first - counters, toys, snacks in groups."
+        },
+        {
+          "lessonId": "mult-arrays",
+          "title": "Arrays and Area Models",
+          "order": 2,
+          "concepts": [
+            "Rows and columns",
+            "Reading arrays (3 rows of 4 = 3 × 4)",
+            "Drawing arrays to show multiplication"
+          ],
+          "teachingNotes": "Arrays are powerful for building conceptual understanding."
+        },
+        {
+          "lessonId": "mult-2s-5s-10s",
+          "title": "Multiplying by 2, 5, and 10",
+          "order": 3,
+          "concepts": [
+            "Skip counting patterns",
+            "2s: doubles",
+            "5s: nickel counting",
+            "10s: place value connection"
+          ],
+          "teachingNotes": "Start with these because patterns are easy to see."
+        },
+        {
+          "lessonId": "mult-3s-4s",
+          "title": "Multiplying by 3 and 4",
+          "order": 4,
+          "concepts": [
+            "3s patterns",
+            "4s as double-doubles",
+            "Building fluency"
+          ]
+        },
+        {
+          "lessonId": "mult-6s-7s-8s-9s",
+          "title": "Multiplying by 6, 7, 8, and 9",
+          "order": 5,
+          "concepts": [
+            "Using known facts to find unknown",
+            "6s as 5s + one more group",
+            "9s finger trick and patterns",
+            "Commutative property to reduce facts needed"
+          ],
+          "teachingNotes": "By now they know many of these from commutativity. Focus on the few remaining."
+        },
+        {
+          "lessonId": "mult-properties",
+          "title": "Multiplication Properties",
+          "order": 6,
+          "concepts": [
+            "Commutative: 3 × 4 = 4 × 3",
+            "Associative: (2 × 3) × 4 = 2 × (3 × 4)",
+            "Identity: n × 1 = n",
+            "Zero property: n × 0 = 0"
+          ]
+        },
+        {
+          "lessonId": "mult-word-problems",
+          "title": "Multiplication Word Problems",
+          "order": 7,
+          "concepts": [
+            "Equal groups problems",
+            "Array problems",
+            "Comparison problems (times as many)"
+          ]
+        }
+      ]
+    },
+    {
+      "moduleId": "division_fractions",
+      "quarter": 2,
+      "title": "Division & Fractions",
+      "preview": "Division as sharing equally and fractions as parts of a whole",
+      "skills": ["division-basics", "division-facts", "fractions-unit-fractions", "fractions-on-number-line"],
+      "lessons": [
+        {
+          "lessonId": "div-intro",
+          "title": "What is Division?",
+          "order": 1,
+          "concepts": [
+            "Sharing equally (partitive division)",
+            "How many groups? (quotative division)",
+            "Division symbol and notation"
+          ],
+          "teachingNotes": "Use real objects to share into groups."
+        },
+        {
+          "lessonId": "div-mult-connection",
+          "title": "Division and Multiplication Connection",
+          "order": 2,
+          "concepts": [
+            "Inverse operations",
+            "Fact families: 3 × 4 = 12, so 12 ÷ 3 = 4",
+            "Using multiplication to solve division"
+          ],
+          "teachingNotes": "This is the key insight - division 'undoes' multiplication."
+        },
+        {
+          "lessonId": "div-facts",
+          "title": "Division Fact Fluency",
+          "order": 3,
+          "concepts": [
+            "Using known multiplication facts",
+            "Division by 1, 2, 5, 10",
+            "Division by 3, 4, 6, 7, 8, 9"
+          ]
+        },
+        {
+          "lessonId": "fractions-intro",
+          "title": "Introduction to Fractions",
+          "order": 4,
+          "concepts": [
+            "Equal parts of a whole",
+            "Numerator and denominator",
+            "Unit fractions: 1/2, 1/3, 1/4, etc."
+          ],
+          "teachingNotes": "Use fraction circles, bars, and real-world examples (pizza, brownies)."
+        },
+        {
+          "lessonId": "fractions-models",
+          "title": "Fraction Models",
+          "order": 5,
+          "concepts": [
+            "Area models (circles, rectangles)",
+            "Set models (3 of 6 apples = 3/6)",
+            "Equivalent representations"
+          ]
+        },
+        {
+          "lessonId": "fractions-number-line",
+          "title": "Fractions on a Number Line",
+          "order": 6,
+          "concepts": [
+            "Fractions as points on number line",
+            "Partitioning segments equally",
+            "Locating fractions between 0 and 1"
+          ]
+        },
+        {
+          "lessonId": "fractions-compare",
+          "title": "Comparing Fractions",
+          "order": 7,
+          "concepts": [
+            "Comparing with same denominator",
+            "Comparing with same numerator",
+            "Using benchmarks (1/2)"
+          ]
+        },
+        {
+          "lessonId": "fractions-equivalent",
+          "title": "Equivalent Fractions",
+          "order": 8,
+          "concepts": [
+            "Same amount, different names",
+            "Visual proof of equivalence",
+            "Recognizing equivalent fractions"
+          ]
+        }
+      ]
+    },
+    {
+      "moduleId": "area_perimeter",
+      "quarter": 3,
+      "title": "Area & Perimeter",
+      "preview": "Measuring space inside and distance around shapes",
+      "skills": ["area-rectangles", "perimeter", "area-perimeter-word-problems"],
+      "lessons": [
+        {
+          "lessonId": "perimeter-intro",
+          "title": "What is Perimeter?",
+          "order": 1,
+          "concepts": [
+            "Distance around a shape",
+            "Adding side lengths",
+            "Measuring in units"
+          ],
+          "teachingNotes": "Walk around the classroom, measure the edges of objects."
+        },
+        {
+          "lessonId": "perimeter-rectangles",
+          "title": "Perimeter of Rectangles",
+          "order": 2,
+          "concepts": [
+            "Adding all four sides",
+            "Shortcut: P = 2l + 2w",
+            "Finding missing side lengths"
+          ]
+        },
+        {
+          "lessonId": "area-intro",
+          "title": "What is Area?",
+          "order": 3,
+          "concepts": [
+            "Space inside a shape",
+            "Counting square units",
+            "Square units vs. linear units"
+          ],
+          "teachingNotes": "Cover shapes with square tiles to count area."
+        },
+        {
+          "lessonId": "area-rectangles",
+          "title": "Area of Rectangles",
+          "order": 4,
+          "concepts": [
+            "Rows × columns = total squares",
+            "Area = length × width",
+            "Connection to multiplication arrays"
+          ]
+        },
+        {
+          "lessonId": "area-composite",
+          "title": "Area of Composite Figures",
+          "order": 5,
+          "concepts": [
+            "Breaking shapes into rectangles",
+            "Adding areas together",
+            "Different ways to decompose"
+          ]
+        },
+        {
+          "lessonId": "area-perimeter-problems",
+          "title": "Area and Perimeter Word Problems",
+          "order": 6,
+          "concepts": [
+            "When to use area vs perimeter",
+            "Real-world applications",
+            "Drawing diagrams"
+          ],
+          "teachingNotes": "Perimeter = fence, border, trim. Area = carpet, paint, tiles."
+        }
+      ]
+    },
+    {
+      "moduleId": "data_measurement",
+      "quarter": 4,
+      "title": "Data & Measurement",
+      "preview": "Reading graphs, measuring time, mass, and volume",
+      "skills": ["bar-graphs-scaled", "measuring-mass-volume", "elapsed-time"],
+      "lessons": [
+        {
+          "lessonId": "graphs-pictograph",
+          "title": "Pictographs and Bar Graphs",
+          "order": 1,
+          "concepts": [
+            "Reading scaled pictographs",
+            "Creating and reading bar graphs",
+            "Interpreting data"
+          ]
+        },
+        {
+          "lessonId": "graphs-line-plots",
+          "title": "Line Plots",
+          "order": 2,
+          "concepts": [
+            "Showing data on number lines",
+            "Using fractions of a unit",
+            "Analyzing line plot data"
+          ]
+        },
+        {
+          "lessonId": "time-telling",
+          "title": "Telling Time",
+          "order": 3,
+          "concepts": [
+            "Reading analog and digital clocks",
+            "Time to the minute",
+            "A.M. and P.M."
+          ]
+        },
+        {
+          "lessonId": "time-elapsed",
+          "title": "Elapsed Time",
+          "order": 4,
+          "concepts": [
+            "Finding how much time has passed",
+            "Start time, end time, elapsed time",
+            "Using number lines for time"
+          ],
+          "teachingNotes": "Number lines are very helpful for elapsed time problems."
+        },
+        {
+          "lessonId": "measurement-mass",
+          "title": "Measuring Mass and Volume",
+          "order": 5,
+          "concepts": [
+            "Grams and kilograms",
+            "Milliliters and liters",
+            "Estimating and measuring"
+          ]
+        }
+      ]
+    },
+    {
+      "moduleId": "final_assessment",
+      "quarter": 4,
+      "title": "Grade 3 Assessment",
+      "preview": "Showing mastery of multiplication, division, fractions, and measurement",
+      "isCheckpoint": true,
+      "isFinal": true
+    }
+  ],
+  "aiGuidanceNotes": "For Grade 3, emphasize concrete and visual representations before abstract. Use manipulatives, drawings, and real-world contexts. Multiplication facts need regular practice for fluency. Connect division to multiplication constantly. Fractions should be visual - avoid rushing to procedures."
 }


### PR DESCRIPTION
- Expand pathway files with detailed lesson progressions for:
  - Calculus 1 (limits, derivatives, integrals with lesson order)
  - Calculus 2 (integration techniques, series, Taylor, parametric/polar)
  - Algebra 1 (equations, linear functions, systems, quadratics)
  - Grade 3 (multiplication, division, fractions, area/perimeter)
  - ACT Prep (all math sections with test strategies)

- Add buildCourseProgressionContext() to utils/prompt.js that:
  - Maps student's mathCourse to appropriate pathway file
  - Extracts natural progression steps for AI guidance
  - Provides module overview with lesson topics
  - Only activates as a guide when student is non-committal

- Add course enrollment schema to User model for future use

This enables the AI tutor to guide students through a logical topic progression when they ask "teach me calculus" or similar requests, while still allowing them to ask specific questions.