### PR TITLE
Fix API key fallback logic and escape sequence in prompts

### DIFF
--- a/utils/openaiClient.js
+++ b/utils/openaiClient.js
@@ -13,10 +13,10 @@ let anthropic = null;
 const isProduction = process.env.NODE_ENV === 'production';
 
 // Select appropriate API key based on environment
+// Legacy ANTHROPIC_API_KEY is used as fallback for both environments
 const anthropicApiKey = isProduction
-    ? process.env.ANTHROPIC_API_KEY_PROD    // Production: Use dedicated prod key
-    : process.env.ANTHROPIC_API_KEY_DEV     // Development/Testing: Use dev key
-    || process.env.ANTHROPIC_API_KEY;       // Legacy fallback (deprecated)
+    ? (process.env.ANTHROPIC_API_KEY_PROD || process.env.ANTHROPIC_API_KEY)   // Production: PROD key, fallback to legacy
+    : (process.env.ANTHROPIC_API_KEY_DEV || process.env.ANTHROPIC_API_KEY);   // Development: DEV key, fallback to legacy
 
 if (anthropicApiKey) {
     anthropic = new Anthropic({

--- a/utils/prompt.js
+++ b/utils/prompt.js
@@ -541,7 +541,7 @@ When ${firstName} asks about themselves, ANSWER DIRECTLY with the information yo
 **RESPOND WITH ACTUAL INFORMATION:**
 - "What grade am I in?" → "${gradeLevel ? `You're in ${gradeLevel}!` : `I don't have your grade on file yet - what grade are you in?`}"
 - "What are my interests?" → "${interests && interests.length > 0 ? `You're into ${interests.join(', ')}!` : `I don't have your interests saved yet - tell me what you're into!`}"
-- "What do you know about me?" → "${gradeLevel ? `You're in ${gradeLevel}` : 'I don\\'t have your grade yet'}${interests && interests.length > 0 ? `, and you're into ${interests.join(', ')}` : ''}${learningStyle ? `. You learn best with ${learningStyle.toLowerCase()} approaches` : ''}."
+- "What do you know about me?" → "${gradeLevel ? `You're in ${gradeLevel}` : `I don't have your grade yet`}${interests && interests.length > 0 ? `, and you're into ${interests.join(', ')}` : ''}${learningStyle ? `. You learn best with ${learningStyle.toLowerCase()} approaches` : ''}."
 - "Do you remember me?" → "Of course! You're ${firstName}${gradeLevel ? `, ${gradeLevel}` : ''}${interests && interests.length > 0 ? `, who's into ${interests[0]}` : ''}!"
 
 **🚫 FORBIDDEN DEFLECTION PATTERNS (FROM REAL FAILURES - NEVER DO THESE):**


### PR DESCRIPTION
## Summary
This PR fixes two issues: improves the Anthropic API key fallback logic to be more consistent across environments, and corrects an unnecessary escape sequence in the prompt template.

## Key Changes

- **API Key Fallback Logic** (`utils/openaiClient.js`):
  - Restructured the API key selection to use the legacy `ANTHROPIC_API_KEY` as a fallback for both production and development environments
  - Production now tries `ANTHROPIC_API_KEY_PROD` first, then falls back to `ANTHROPIC_API_KEY`
  - Development now tries `ANTHROPIC_API_KEY_DEV` first, then falls back to `ANTHROPIC_API_KEY`
  - This provides a more graceful degradation path and simplifies the logic

- **Prompt Template Fix** (`utils/prompt.js`):
  - Removed unnecessary escape sequence (`\\'`) in the "What do you know about me?" example
  - Changed from `'I don\\'t have your grade yet'` to `` `I don't have your grade yet` ``
  - This improves readability and maintains consistency with the template literal syntax already in use

## Implementation Details
The API key changes maintain backward compatibility while making the fallback behavior more predictable. Both environment-specific keys are now treated equally with the legacy key as a safety net, rather than having different fallback behaviors between production and development.

https://claude.ai/code/session_01Mrjoxsi1mBvaTdquYnz1E2