### PR TITLE
Add 5 missing categories from database audit

### DIFF
--- a/models/skill.js
+++ b/models/skill.js
@@ -107,6 +107,13 @@ const skillSchema = new mongoose.Schema({
       'right-triangles',
       'coordinate-geometry',
 
+      // Additional categories from database audit
+      'integrals',
+      'estimation',
+      'number-sense',
+      'mental-math',
+      'linear-functions',
+
       // Catch-all
       'advanced'
     ]

--- a/routes/screener.js
+++ b/routes/screener.js
@@ -507,6 +507,13 @@ router.get('/next-problem', isAuthenticated, async (req, res) => {
       'right-triangles': 1.2,        // Right triangle trig
       'coordinate-geometry': 1.2,    // Coordinate plane geometry
 
+      // Additional categories from database audit
+      'integrals': 3.0,              // Definite/indefinite integrals
+      'estimation': -1.5,            // Estimating sums, checking reasonableness
+      'number-sense': -2.0,          // Number bonds, basic number relationships
+      'mental-math': -1.8,           // Make-ten, doubles, mental strategies
+      'linear-functions': 1.0,       // Slope concepts, graphing linear equations
+
       'advanced': 2.5
     };
 

--- a/scripts/calibrate-skill-difficulties.js
+++ b/scripts/calibrate-skill-difficulties.js
@@ -149,6 +149,13 @@ const CATEGORY_DIFFICULTY_MAP = {
   'right-triangles': 1.2,
   'coordinate-geometry': 1.2,
 
+  // Categories from database audit
+  'integrals': 3.0,
+  'estimation': -1.5,
+  'number-sense': -2.0,
+  'mental-math': -1.8,
+  'linear-functions': 1.0,
+
   'advanced': 2.5
 };
 

--- a/scripts/cleanup-database.js
+++ b/scripts/cleanup-database.js
@@ -47,6 +47,8 @@ const VALID_CATEGORIES = [
   'congruence', 'similarity', 'sequences', 'counting', 'number-theory',
   'rates', 'conversions', 'proofs', 'circles', 'triangles',
   'parallel-perpendicular', 'surface-area', 'right-triangles', 'coordinate-geometry',
+  // Categories from database audit
+  'integrals', 'estimation', 'number-sense', 'mental-math', 'linear-functions',
   'advanced'
 ];
 


### PR DESCRIPTION
Added to Skill model enum, categoryDifficultyMap in screener.js, and both cleanup and calibration scripts:
- integrals (calculus)
- estimation (elementary)
- number-sense (elementary)
- mental-math (elementary)
- linear-functions (algebra)

https://claude.ai/code/session_01HHHx7H6hQu9mW8q7QTjVc9