### PR TITLE
Fix custom avatar not saving due to Mongoose nested object detection

### DIFF
--- a/routes/avatar.js
+++ b/routes/avatar.js
@@ -31,16 +31,21 @@ router.post('/', isAuthenticated, async (req, res) => { //
             }
         }
 
-        // Update avatar sub-document
-        user.avatar = { //
-            skin: skin !== undefined ? skin : user.avatar.skin, //
-            hair: hair !== undefined ? hair : user.avatar.hair, //
-            top: top !== undefined ? top : user.avatar.top, //
-            bottom: bottom !== undefined ? bottom : user.avatar.bottom, //
-            accessory: accessory !== undefined ? accessory : user.avatar.accessory, //
-            lottiePath: lottiePath !== undefined ? lottiePath : user.avatar.lottiePath // For custom Lottie
+        // Update avatar sub-document while preserving existing DiceBear config
+        user.avatar = {
+            // Preserve existing DiceBear data if present
+            dicebearConfig: user.avatar?.dicebearConfig,
+            dicebearUrl: user.avatar?.dicebearUrl,
+            // Update legacy avatar parts
+            skin: skin !== undefined ? skin : user.avatar?.skin,
+            hair: hair !== undefined ? hair : user.avatar?.hair,
+            top: top !== undefined ? top : user.avatar?.top,
+            bottom: bottom !== undefined ? bottom : user.avatar?.bottom,
+            accessory: accessory !== undefined ? accessory : user.avatar?.accessory,
+            lottiePath: lottiePath !== undefined ? lottiePath : user.avatar?.lottiePath
         };
-        await user.save(); //
+        user.markModified('avatar');
+        await user.save();
 
         res.json({ success: true, message: 'Avatar updated successfully!', avatar: user.avatar }); //
 
@@ -126,6 +131,10 @@ router.post('/dicebear', isAuthenticated, async (req, res) => {
 
         // Clear the old selectedAvatarId since they're using a custom avatar now
         user.selectedAvatarId = null;
+
+        // CRITICAL: Mongoose doesn't automatically detect changes to nested subdocuments
+        // We must explicitly mark the avatar path as modified for the save to persist
+        user.markModified('avatar');
 
         await user.save();
 


### PR DESCRIPTION
Mongoose doesn't automatically detect changes to nested subdocuments. Added markModified('avatar') calls to ensure avatar data persists. Also preserved existing DiceBear config when updating legacy avatar parts.

https://claude.ai/code/session_01CdbYyxKhjNBxMp1MCtSnUq