### PR TITLE
Add CSRF protection to avatar API request

### DIFF
--- a/public/js/avatar-builder.js
+++ b/public/js/avatar-builder.js
@@ -347,7 +347,7 @@ class AvatarBuilder {
         try {
             const avatarUrl = this.buildAvatarUrl();
 
-            const response = await fetch('/api/avatar/dicebear', {
+            const response = await csrfFetch('/api/avatar/dicebear', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'


### PR DESCRIPTION
## Summary
Updated the avatar builder to use CSRF-protected fetch requests when communicating with the avatar API endpoint.

## Changes
- Replaced standard `fetch()` call with `csrfFetch()` in the avatar builder's API request to `/api/avatar/dicebear`
- This ensures CSRF tokens are properly included in POST requests to protect against cross-site request forgery attacks

## Details
The change affects the avatar generation flow where the client sends a POST request to generate a new avatar. By using `csrfFetch()` instead of the native `fetch()` API, the application now automatically includes the necessary CSRF token in the request headers, improving security posture for this sensitive operation.

https://claude.ai/code/session_01KF9HVj8frGt6ntWJRpB1SN