### PR TITLE
Fix missing CSRF protection in multiple API calls

### DIFF
--- a/public/js/badgeProgress.js
+++ b/public/js/badgeProgress.js
@@ -169,7 +169,7 @@ function toggleBadgeWidget() {
  */
 async function claimBadge() {
   try {
-    const response = await fetch('/api/mastery/complete-badge', {
+    const response = await csrfFetch('/api/mastery/complete-badge', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include'

--- a/public/js/dailyQuests.js
+++ b/public/js/dailyQuests.js
@@ -27,7 +27,7 @@ class DailyQuestManager {
 
   async updateProgress(action, data) {
     try {
-      const response = await fetch('/api/daily-quests/update', {
+      const response = await csrfFetch('/api/daily-quests/update', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action, data })

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -3820,7 +3820,7 @@ What would you like to work on first?`;
 
         try {
             // Send to backend
-            const response = await fetch('/api/chat/reaction', {
+            const response = await csrfFetch('/api/chat/reaction', {
                 method: 'PATCH',
                 headers: { 'Content-Type': 'application/json' },
                 credentials: 'include',

--- a/public/js/sessionManager.js
+++ b/public/js/sessionManager.js
@@ -88,7 +88,7 @@ class SessionManager {
 
   async sendHeartbeat() {
     try {
-      const response = await fetch('/api/session/heartbeat', {
+      const response = await csrfFetch('/api/session/heartbeat', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'

--- a/public/js/skill-map.js
+++ b/public/js/skill-map.js
@@ -844,7 +844,7 @@ async function startPractice() {
 
     try {
         // Call API to set up active badge for this skill
-        const response = await fetch('/api/mastery/start-skill-practice', {
+        const response = await csrfFetch('/api/mastery/start-skill-practice', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             credentials: 'include',


### PR DESCRIPTION
Several files were using plain fetch() instead of csrfFetch() for POST/PATCH requests, which would cause 403 errors due to missing CSRF tokens:

- sessionManager.js: /api/session/heartbeat
- script.js: /api/chat/reaction
- badgeProgress.js: /api/mastery/complete-badge
- skill-map.js: /api/mastery/start-skill-practice
- dailyQuests.js: /api/daily-quests/update

https://claude.ai/code/session_01KF9HVj8frGt6ntWJRpB1SN