### PR TITLE
Implement COPPA compliance with bidirectional parent-child linking

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -440,6 +440,7 @@ const userSchema = new Schema({
   gradeLevel: { type: String, trim: true },              // e.g., '7th Grade', '9th Grade', 'College'
   mathCourse: { type: String, trim: true },              // e.g., 'Algebra 1', 'Geometry', 'Pre-Calculus'
   dateOfBirth: { type: Date },                           // For COPPA compliance (under 13 requires parental consent)
+  hasParentalConsent: { type: Boolean, default: false }, // True when linked to a parent account (required for under 13)
   tonePreference: { type: String, enum: ['encouraging', 'straightforward', 'casual', 'motivational', 'Motivational'], default: 'encouraging' },
   learningStyle: { type: String, trim: true },           // 'Visual', 'Auditory', 'Kinesthetic'
   preferredLanguage: { type: String, enum: ['English', 'Spanish', 'Russian', 'Chinese', 'Vietnamese', 'Arabic'], default: 'English' }, // Student's preferred language for tutoring

--- a/public/js/complete-profile.js
+++ b/public/js/complete-profile.js
@@ -114,7 +114,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
                 // COPPA compliance: Under 13 requires parental consent
                 if (age < 13 && !currentUser.hasParentalConsent) {
-                    alert('Students under 13 require parental consent. Please have your parent or guardian create a parent account and link to your student account using your invite code: ' + (currentUser.inviteCode || '[loading...]'));
+                    alert('Students under 13 require parental consent.\n\nTo get consent, your parent needs to:\n1. Create a parent account at our signup page\n2. Generate an invite code from their dashboard\n3. You can then link your account using their code from your Settings page\n\nOr, they can link to your account using your student invite code (generate one from Settings after completing profile).');
                     return;
                 }
 

--- a/public/signup.html
+++ b/public/signup.html
@@ -82,10 +82,16 @@
           </select>
         </div>
 
-        <div id="inviteCodeGroup" class="form-group">
-          <label for="inviteCode">Child's Invite Code:</label>
+        <div id="inviteCodeGroup" class="form-group" style="display: none;">
+          <label for="inviteCode">Child's Invite Code (Optional):</label>
           <input type="text" name="inviteCode" id="inviteCode" placeholder="e.g. MATH-728Q" autocomplete="off" />
-          <p class="note">You must enter your child's invite code to create a parent account.</p>
+          <p class="note">If your child already has an account, enter their invite code to link accounts. Otherwise, you can generate an invite code for them after signing up.</p>
+        </div>
+
+        <div id="parentInviteCodeGroup" class="form-group" style="display: none;">
+          <label for="parentInviteCode">Parent's Invite Code:</label>
+          <input type="text" name="parentInviteCode" id="parentInviteCode" placeholder="e.g. ABC123" autocomplete="off" />
+          <p class="note">Under 13? Enter your parent's invite code to get parental consent. Your parent can generate this code from their dashboard.</p>
         </div>
 
         <button type="submit" class="submit-btn btn-primary">Create Account</button>
@@ -110,25 +116,30 @@
   <script>
     const roleSelect = document.getElementById("role");
     const inviteCodeGroup = document.getElementById("inviteCodeGroup");
+    const parentInviteCodeGroup = document.getElementById("parentInviteCodeGroup");
     const signupForm = document.getElementById("signupForm");
     const signupMessage = document.getElementById("signup-message");
     const passwordInput = document.getElementById("password");
     const confirmPasswordInput = document.getElementById("confirm-password");
 
-    // Initial check on page load
-    if (roleSelect.value === "parent") {
+    // Function to update invite code field visibility based on role
+    function updateInviteCodeFields() {
+      if (roleSelect.value === "parent") {
         inviteCodeGroup.style.display = "block";
-    } else {
+        parentInviteCodeGroup.style.display = "none";
+      } else if (roleSelect.value === "student") {
         inviteCodeGroup.style.display = "none";
-    }
-
-    roleSelect.addEventListener("change", function () {
-      if (this.value === "parent") {
-        inviteCodeGroup.style.display = "block";
+        parentInviteCodeGroup.style.display = "block";
       } else {
         inviteCodeGroup.style.display = "none";
+        parentInviteCodeGroup.style.display = "none";
       }
-    });
+    }
+
+    // Initial check on page load
+    updateInviteCodeFields();
+
+    roleSelect.addEventListener("change", updateInviteCodeFields);
 
     // Handle form submission with Fetch API
     signupForm.addEventListener("submit", async function (event) {

--- a/public/signup.html
+++ b/public/signup.html
@@ -82,6 +82,16 @@
           </select>
         </div>
 
+        <div id="dobGroup" class="form-group" style="display: none;">
+          <label for="dateOfBirth">Date of Birth:</label>
+          <input type="date" name="dateOfBirth" id="dateOfBirth" autocomplete="bday" />
+          <p class="note">Required for students to verify age (COPPA compliance).</p>
+        </div>
+
+        <div id="under13Warning" class="form-group" style="display: none; background: #fff3cd; border: 1px solid #ffc107; padding: 12px; border-radius: 8px; margin-bottom: 15px;">
+          <p style="margin: 0; color: #856404;"><strong>Parental consent required:</strong> Students under 13 need a parent's invite code to create an account. Ask your parent to sign up first and give you their invite code.</p>
+        </div>
+
         <div id="inviteCodeGroup" class="form-group" style="display: none;">
           <label for="inviteCode">Child's Invite Code (Optional):</label>
           <input type="text" name="inviteCode" id="inviteCode" placeholder="e.g. MATH-728Q" autocomplete="off" />
@@ -89,9 +99,9 @@
         </div>
 
         <div id="parentInviteCodeGroup" class="form-group" style="display: none;">
-          <label for="parentInviteCode">Parent's Invite Code:</label>
+          <label for="parentInviteCode" id="parentInviteCodeLabel">Parent's Invite Code:</label>
           <input type="text" name="parentInviteCode" id="parentInviteCode" placeholder="e.g. ABC123" autocomplete="off" />
-          <p class="note">Under 13? Enter your parent's invite code to get parental consent. Your parent can generate this code from their dashboard.</p>
+          <p class="note" id="parentInviteCodeNote">Optional: Enter your parent's invite code to link accounts.</p>
         </div>
 
         <button type="submit" class="submit-btn btn-primary">Create Account</button>
@@ -115,31 +125,91 @@
   <script src="/js/csrf.js"></script>
   <script>
     const roleSelect = document.getElementById("role");
+    const dobGroup = document.getElementById("dobGroup");
+    const dobInput = document.getElementById("dateOfBirth");
+    const under13Warning = document.getElementById("under13Warning");
     const inviteCodeGroup = document.getElementById("inviteCodeGroup");
     const parentInviteCodeGroup = document.getElementById("parentInviteCodeGroup");
+    const parentInviteCodeInput = document.getElementById("parentInviteCode");
+    const parentInviteCodeLabel = document.getElementById("parentInviteCodeLabel");
+    const parentInviteCodeNote = document.getElementById("parentInviteCodeNote");
     const signupForm = document.getElementById("signupForm");
     const signupMessage = document.getElementById("signup-message");
     const passwordInput = document.getElementById("password");
     const confirmPasswordInput = document.getElementById("confirm-password");
 
-    // Function to update invite code field visibility based on role
-    function updateInviteCodeFields() {
+    let isUnder13 = false;
+
+    // Set max date for DOB to today
+    const today = new Date().toISOString().split('T')[0];
+    dobInput.setAttribute('max', today);
+
+    // Calculate age from date of birth
+    function calculateAge(dob) {
+      const birthDate = new Date(dob);
+      const today = new Date();
+      let age = today.getFullYear() - birthDate.getFullYear();
+      const monthDiff = today.getMonth() - birthDate.getMonth();
+      if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birthDate.getDate())) {
+        age--;
+      }
+      return age;
+    }
+
+    // Check if user is under 13 and update UI accordingly
+    function checkAgeAndUpdateUI() {
+      if (roleSelect.value !== "student" || !dobInput.value) {
+        isUnder13 = false;
+        under13Warning.style.display = "none";
+        parentInviteCodeLabel.textContent = "Parent's Invite Code (Optional):";
+        parentInviteCodeNote.textContent = "Optional: Enter your parent's invite code to link accounts.";
+        parentInviteCodeInput.removeAttribute("required");
+        return;
+      }
+
+      const age = calculateAge(dobInput.value);
+      isUnder13 = age < 13;
+
+      if (isUnder13) {
+        under13Warning.style.display = "block";
+        parentInviteCodeLabel.textContent = "Parent's Invite Code (Required):";
+        parentInviteCodeNote.textContent = "Required: Your parent must create an account first and give you their invite code.";
+        parentInviteCodeInput.setAttribute("required", "required");
+      } else {
+        under13Warning.style.display = "none";
+        parentInviteCodeLabel.textContent = "Parent's Invite Code (Optional):";
+        parentInviteCodeNote.textContent = "Optional: Enter your parent's invite code to link accounts.";
+        parentInviteCodeInput.removeAttribute("required");
+      }
+    }
+
+    // Function to update field visibility based on role
+    function updateFieldsForRole() {
       if (roleSelect.value === "parent") {
+        dobGroup.style.display = "none";
+        under13Warning.style.display = "none";
         inviteCodeGroup.style.display = "block";
         parentInviteCodeGroup.style.display = "none";
+        isUnder13 = false;
       } else if (roleSelect.value === "student") {
+        dobGroup.style.display = "block";
         inviteCodeGroup.style.display = "none";
         parentInviteCodeGroup.style.display = "block";
+        checkAgeAndUpdateUI();
       } else {
+        dobGroup.style.display = "none";
+        under13Warning.style.display = "none";
         inviteCodeGroup.style.display = "none";
         parentInviteCodeGroup.style.display = "none";
+        isUnder13 = false;
       }
     }
 
     // Initial check on page load
-    updateInviteCodeFields();
+    updateFieldsForRole();
 
-    roleSelect.addEventListener("change", updateInviteCodeFields);
+    roleSelect.addEventListener("change", updateFieldsForRole);
+    dobInput.addEventListener("change", checkAgeAndUpdateUI);
 
     // Handle form submission with Fetch API
     signupForm.addEventListener("submit", async function (event) {
@@ -161,6 +231,18 @@
           signupMessage.className = 'error';
           signupMessage.style.display = 'block';
           return;
+        }
+
+        // COPPA check: Under 13 requires parent invite code
+        if (roleSelect.value === "student" && dobInput.value) {
+          const age = calculateAge(dobInput.value);
+          if (age < 13 && !parentInviteCodeInput.value.trim()) {
+            signupMessage.textContent = 'Students under 13 require a parent\'s invite code. Please ask your parent to create an account first and give you their invite code.';
+            signupMessage.className = 'error';
+            signupMessage.style.display = 'block';
+            parentInviteCodeInput.focus();
+            return;
+          }
         }
 
         const formData = new FormData(signupForm);

--- a/public/signup.html
+++ b/public/signup.html
@@ -84,8 +84,8 @@
 
         <div id="dobGroup" class="form-group" style="display: none;">
           <label for="dateOfBirth">Date of Birth:</label>
-          <input type="date" name="dateOfBirth" id="dateOfBirth" autocomplete="bday" />
-          <p class="note">Required for students to verify age (COPPA compliance).</p>
+          <input type="date" name="dateOfBirth" id="dateOfBirth" required autocomplete="bday" />
+          <p class="note">Required for all students.</p>
         </div>
 
         <div id="under13Warning" class="form-group" style="display: none; background: #fff3cd; border: 1px solid #ffc107; padding: 12px; border-radius: 8px; margin-bottom: 15px;">

--- a/routes/parent.js
+++ b/routes/parent.js
@@ -87,6 +87,10 @@ router.post('/link-to-student', isAuthenticated, isParent, async (req, res) => {
             parent.children.push(student._id);
         }
         student.studentToParentLinkCode.parentLinked = true;
+
+        // Grant parental consent since student is now linked to a parent (COPPA compliance)
+        student.hasParentalConsent = true;
+
         await student.save();
         await parent.save();
         res.status(200).json({ success: true, message: `Successfully linked to student ${student.firstName} ${student.lastName}!` });

--- a/routes/signup.js
+++ b/routes/signup.js
@@ -16,6 +16,12 @@ router.post('/', ensureNotAuthenticated, async (req, res, next) => {
         return res.status(400).json({ message: 'All basic fields are required.' });
     }
 
+    // --- Date of Birth required for all students ---
+    if (role === 'student' && !dateOfBirth) {
+        console.warn("WARN: Signup failed - student missing date of birth.");
+        return res.status(400).json({ message: 'Date of birth is required for all students.' });
+    }
+
     // --- COPPA Compliance: Check if student is under 13 ---
     // Under 13 students MUST provide a valid parent invite code
     if (role === 'student' && dateOfBirth) {


### PR DESCRIPTION
## Summary
This PR implements COPPA (Children's Online Privacy Protection Act) compliance by adding parental consent tracking and enabling bidirectional parent-child account linking. Students under 13 can now link to parent accounts either during signup or from their settings, and parents can link to existing student accounts.

## Key Changes

- **Added `hasParentalConsent` field** to user schema to track COPPA compliance status (defaults to `false`)

- **Implemented bidirectional linking flow:**
  - Parents can sign up independently and generate invite codes for their children
  - Students can sign up with a parent's invite code for immediate linking
  - Students can link to parents post-signup via settings using parent's invite code
  - Parents can link to existing student accounts using student's invite code

- **Updated signup flow:**
  - Made parent invite code optional (parents can now sign up first)
  - Added `parentInviteCode` field for students to link during signup
  - Automatically grants `hasParentalConsent = true` when linking occurs

- **Enhanced signup UI:**
  - Separated invite code fields for parents and students
  - Updated labels and help text to clarify the linking process
  - Made fields conditionally visible based on selected role

- **Added new student endpoint** `POST /api/student/link-to-parent` to allow students to link to parents post-signup using parent's invite code

- **Updated parent linking endpoint** to automatically grant parental consent when linking succeeds

- **Improved COPPA compliance messaging** in profile completion to guide users through the linking process

## Implementation Details

- Parent-to-child linking uses `parentToChildInviteCode` with expiration validation
- Student-to-parent linking uses the same parent invite code mechanism
- Both linking paths automatically set `hasParentalConsent = true` for COPPA compliance
- Invite codes are marked as used after successful linking to prevent reuse
- Graceful fallback: accounts are created even if linking fails; users can link later from settings

https://claude.ai/code/session_012U3HN6HKnrJp1saLnj7gQv