### PR TITLE
Reduce stale session threshold from 60 to 30 minutes

### DIFF
--- a/routes/parent.js
+++ b/routes/parent.js
@@ -134,7 +134,7 @@ router.get('/child/:childId/progress', isAuthenticated, isParent, async (req, re
 
         // Clean up any stale sessions for this child (runs in background)
         // This ensures sessions that weren't properly ended get summaries
-        cleanupStaleSessions(60).catch(err => {
+        cleanupStaleSessions(30).catch(err => {
             console.error('Background cleanup failed:', err);
         });
 

--- a/routes/session.js
+++ b/routes/session.js
@@ -109,7 +109,7 @@ router.post('/cleanup-stale', isAuthenticated, async (req, res) => {
       return res.status(403).json({ error: 'Admin access required' });
     }
 
-    const cleaned = await cleanupStaleSessions(60); // 1 hour threshold
+    const cleaned = await cleanupStaleSessions(30); // 30 min threshold
 
     res.json({
       success: true,
@@ -130,7 +130,7 @@ async function throttledCleanup() {
   if (now - lastCleanupTime > CLEANUP_INTERVAL) {
     lastCleanupTime = now;
     // Run cleanup in background, don't wait
-    cleanupStaleSessions(60).catch(err => {
+    cleanupStaleSessions(30).catch(err => {
       logger.error('Background cleanup failed', { error: err });
     });
   }

--- a/routes/teacher.js
+++ b/routes/teacher.js
@@ -107,7 +107,7 @@ router.get('/live-feed', isTeacher, async (req, res) => {
     const teacherId = req.user._id;
 
     // Clean up stale sessions in background
-    cleanupStaleSessions(60).catch(err => {
+    cleanupStaleSessions(30).catch(err => {
       console.error('Background cleanup failed:', err);
     });
 
@@ -184,7 +184,7 @@ router.get('/activity-feed', isTeacher, async (req, res) => {
     const { studentId, topic, alertType, startDate, endDate, activeOnly } = req.query;
 
     // Clean up stale sessions in background
-    cleanupStaleSessions(60).catch(err => {
+    cleanupStaleSessions(30).catch(err => {
       console.error('Background cleanup failed:', err);
     });
 


### PR DESCRIPTION
Sessions inactive for 30+ minutes will now be automatically ended with summaries, providing faster feedback for parents and teachers.

https://claude.ai/code/session_011s6rkKmBqfWmeZSw9vxuus