### PR TITLE
Fix textarea auto-expand for contenteditable elements and unlockedItems initialization

### DIFF
--- a/public/js/auto-expand-textarea.js
+++ b/public/js/auto-expand-textarea.js
@@ -105,20 +105,38 @@
         });
 
         // Also reset when textarea is cleared programmatically
-        const originalValue = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value');
-        Object.defineProperty(textarea, 'value', {
-            get: function() {
-                return originalValue.get.call(this);
-            },
-            set: function(newValue) {
-                originalValue.set.call(this, newValue);
-                if (newValue === '') {
-                    resetHeight();
-                } else {
-                    setTimeout(autoExpand, 0);
+        // Only apply custom value property to actual textarea elements
+        if (textarea.tagName === 'TEXTAREA') {
+            const originalValue = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value');
+            Object.defineProperty(textarea, 'value', {
+                get: function() {
+                    return originalValue.get.call(this);
+                },
+                set: function(newValue) {
+                    originalValue.set.call(this, newValue);
+                    if (newValue === '') {
+                        resetHeight();
+                    } else {
+                        setTimeout(autoExpand, 0);
+                    }
                 }
-            }
-        });
+            });
+        } else if (textarea.hasAttribute('contenteditable')) {
+            // For contenteditable elements, use textContent
+            Object.defineProperty(textarea, 'value', {
+                get: function() {
+                    return this.textContent || '';
+                },
+                set: function(newValue) {
+                    this.textContent = newValue;
+                    if (newValue === '') {
+                        resetHeight();
+                    } else {
+                        setTimeout(autoExpand, 0);
+                    }
+                }
+            });
+        }
 
         // Initial height adjustment in case there's default content
         setTimeout(autoExpand, 0);

--- a/routes/chatWithFile.js
+++ b/routes/chatWithFile.js
@@ -338,6 +338,10 @@ router.post('/',
 
         const tutorsJustUnlocked = getTutorsToUnlock(user.level, user.unlockedItems || []);
 		if (tutorsJustUnlocked.length > 0) {
+			// Ensure unlockedItems is initialized before pushing
+			if (!user.unlockedItems) {
+				user.unlockedItems = [];
+			}
 			user.unlockedItems.push(...tutorsJustUnlocked);
 			user.markModified('unlockedItems');
 		}


### PR DESCRIPTION
## Summary
This PR fixes two bugs: (1) the auto-expand textarea script now properly handles contenteditable elements in addition to native textarea elements, and (2) ensures the `unlockedItems` array is initialized before pushing new items to prevent potential runtime errors.

## Key Changes

- **auto-expand-textarea.js**: Added element type checking to handle both native `<textarea>` elements and `contenteditable` div/span elements
  - Native textareas use the original `value` property descriptor
  - Contenteditable elements use `textContent` for getting/setting content
  - Both trigger the same auto-expand and reset height logic

- **chatWithFile.js**: Added null check to initialize `user.unlockedItems` array before pushing new tutor unlock items
  - Prevents potential errors when `unlockedItems` is undefined on user objects
  - Ensures consistent array behavior across different user states

## Implementation Details
The textarea auto-expand feature now detects the element type via `tagName` and `hasAttribute()` checks, allowing it to work seamlessly with both semantic textarea elements and contenteditable divs commonly used in modern rich text editors.

https://claude.ai/code/session_019XgJuu4u7aimE6NXp8PbdP