### PR TITLE
Feature: Add configurable email sender addresses for transactional em…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,26 +61,54 @@ NODE_ENV=development
 # - Parental consent emails
 # - Account notifications
 #
-# OPTION 1: Gmail (easiest for testing)
-# SMTP_HOST=smtp.gmail.com
-# SMTP_PORT=587
-# SMTP_USER=your_email@gmail.com
-# SMTP_PASS=your_app_password  # Generate at: https://myaccount.google.com/apppasswords
-# BASE_URL=http://localhost:3000
+# === SENDER ADDRESS CONFIGURATION ===
+# These are SEPARATE from SMTP credentials - allows sending from your custom domain
+# EMAIL_FROM=noreply@mathmatix.ai           # Sender address (shows in "From" field)
+# EMAIL_FROM_NAME=MATHMATIX AI              # Display name (shows before email address)
+# EMAIL_REPLY_TO=support@mathmatix.ai       # Where replies go (can be your real inbox)
 #
-# OPTION 2: SendGrid (production recommended - 100 emails/day free)
+# === SMTP PROVIDER OPTIONS ===
+#
+# OPTION 1: SendGrid (RECOMMENDED for production - 100 emails/day free)
+# Sign up: https://signup.sendgrid.com/
+# Steps: 1) Verify your domain (mathmatix.ai) in Settings > Sender Authentication
+#        2) Create API key in Settings > API Keys
 # SMTP_HOST=smtp.sendgrid.net
 # SMTP_PORT=587
 # SMTP_USER=apikey
-# SMTP_PASS=your_sendgrid_api_key  # Get at: https://app.sendgrid.com/settings/api_keys
+# SMTP_PASS=SG.your_sendgrid_api_key
+# EMAIL_FROM=noreply@mathmatix.ai
+# EMAIL_REPLY_TO=support@mathmatix.ai
 # BASE_URL=https://mathmatix.ai
 #
-# OPTION 3: AWS SES (cheapest at scale - $0.10/1000 emails)
+# OPTION 2: AWS SES (cheapest at scale - $0.10/1000 emails)
+# Setup: Verify domain in SES console, create SMTP credentials
 # SMTP_HOST=email-smtp.us-east-1.amazonaws.com
 # SMTP_PORT=587
 # SMTP_USER=your_ses_smtp_username
 # SMTP_PASS=your_ses_smtp_password
+# EMAIL_FROM=noreply@mathmatix.ai
+# EMAIL_REPLY_TO=support@mathmatix.ai
 # BASE_URL=https://mathmatix.ai
+#
+# OPTION 3: Postmark (excellent deliverability, $15/mo for 10k emails)
+# Sign up: https://postmarkapp.com/
+# SMTP_HOST=smtp.postmarkapp.com
+# SMTP_PORT=587
+# SMTP_USER=your_postmark_server_token
+# SMTP_PASS=your_postmark_server_token
+# EMAIL_FROM=noreply@mathmatix.ai
+# EMAIL_REPLY_TO=support@mathmatix.ai
+# BASE_URL=https://mathmatix.ai
+#
+# OPTION 4: Gmail (testing only - NOT recommended for production)
+# Requires: 2FA enabled, App Password generated at https://myaccount.google.com/apppasswords
+# SMTP_HOST=smtp.gmail.com
+# SMTP_PORT=587
+# SMTP_USER=your_email@gmail.com
+# SMTP_PASS=your_app_password
+# EMAIL_FROM=your_email@gmail.com
+# BASE_URL=http://localhost:3000
 
 # ============================================
 # QUICK START FOR LOCAL DEV (Minimal Config)

--- a/routes/email.js
+++ b/routes/email.js
@@ -4,7 +4,7 @@
 const express = require('express');
 const router = express.Router();
 const { isAuthenticated } = require('../middleware/auth');
-const { sendTestEmail, sendParentWeeklyReport } = require('../utils/emailService');
+const { sendTestEmail, sendParentWeeklyReport, getEmailConfig } = require('../utils/emailService');
 const User = require('../models/user');
 const Conversation = require('../models/conversation');
 
@@ -167,12 +167,20 @@ router.post('/weekly-report', isAuthenticated, async (req, res) => {
  */
 router.get('/status', isAuthenticated, async (req, res) => {
   const isConfigured = !!(process.env.SMTP_HOST && process.env.SMTP_USER && process.env.SMTP_PASS);
+  const emailConfig = getEmailConfig();
 
   res.json({
     configured: isConfigured,
-    host: process.env.SMTP_HOST || 'Not configured',
-    user: process.env.SMTP_USER || 'Not configured',
-    port: process.env.SMTP_PORT || 587
+    smtp: {
+      host: process.env.SMTP_HOST || 'Not configured',
+      port: process.env.SMTP_PORT || 587,
+      user: process.env.SMTP_USER ? '(configured)' : 'Not configured'
+    },
+    sender: {
+      from: emailConfig.from || 'Not configured',
+      fromName: emailConfig.fromName,
+      replyTo: emailConfig.replyTo || 'Not configured'
+    }
   });
 });
 


### PR DESCRIPTION
…ails

- Add EMAIL_FROM, EMAIL_FROM_NAME, EMAIL_REPLY_TO environment variables
- Separate sender addresses from SMTP credentials to allow custom domain emails (e.g., noreply@mathmatix.ai, support@mathmatix.ai)
- Update all email functions to use configurable sender with reply-to headers
- Enhance email status endpoint to show sender configuration
- Improve .env.example with detailed provider setup guides (SendGrid, AWS SES, Postmark, Gmail)

https://claude.ai/code/session_01L7xx442skW6WNgUvR5QZ9H