### PR TITLE
Add dedicated subscript/superscript buttons to math palette

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -279,17 +279,41 @@
         <span>Insert Math Symbol</span>
         <button id="close-inline-palette" class="palette-close-btn" title="Close">&times;</button>
       </div>
+      <!-- Subscripts and Superscripts Section -->
+      <div class="equation-section-header">Subscripts and Superscripts</div>
+      <div class="subscript-superscript-grid">
+        <button class="script-btn" data-latex="#0^{#1}" title="Superscript/Power">
+          <svg viewBox="0 0 40 40" class="script-icon">
+            <rect x="4" y="8" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-dasharray="4,2"/>
+            <rect x="24" y="4" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" stroke-dasharray="4,2"/>
+          </svg>
+        </button>
+        <button class="script-btn" data-latex="#0_{#1}" title="Subscript">
+          <svg viewBox="0 0 40 40" class="script-icon">
+            <rect x="4" y="4" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-dasharray="4,2"/>
+            <rect x="24" y="24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" stroke-dasharray="4,2"/>
+          </svg>
+        </button>
+        <button class="script-btn" data-latex="#0_{#1}^{#2}" title="Subscript and Superscript">
+          <svg viewBox="0 0 40 40" class="script-icon">
+            <rect x="4" y="10" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-dasharray="4,2"/>
+            <rect x="22" y="4" width="10" height="10" fill="none" stroke="currentColor" stroke-width="2" stroke-dasharray="4,2"/>
+            <rect x="22" y="26" width="10" height="10" fill="none" stroke="currentColor" stroke-width="2" stroke-dasharray="4,2"/>
+          </svg>
+        </button>
+        <button class="script-btn" data-latex="{}_{#0}#1" title="Left Subscript">
+          <svg viewBox="0 0 40 40" class="script-icon">
+            <rect x="12" y="4" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-dasharray="4,2"/>
+            <rect x="4" y="24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" stroke-dasharray="4,2"/>
+          </svg>
+        </button>
+      </div>
+
       <div class="equation-symbols-grid">
         <!-- Common operations -->
         <button class="symbol-btn" data-latex="\frac{#0}{#1}" title="Fraction">x/y</button>
-        <button class="symbol-btn" data-latex="#0^{#1}" title="Superscript/Power">x<sup>n</sup></button>
-        <button class="symbol-btn" data-latex="#0_{#1}" title="Subscript">x<sub>n</sub></button>
         <button class="symbol-btn" data-latex="\sqrt{#0}" title="Square root">√</button>
         <button class="symbol-btn" data-latex="\sqrt[#1]{#0}" title="Nth root">ⁿ√</button>
-        <!-- Sequences (common subscript use) -->
-        <button class="symbol-btn" data-latex="a_{n}" title="Sequence term a_n">a<sub>n</sub></button>
-        <button class="symbol-btn" data-latex="a_{n+1}" title="Next term">a<sub>n+1</sub></button>
-        <button class="symbol-btn" data-latex="a_{1}" title="First term">a<sub>1</sub></button>
         <!-- Calculus -->
         <button class="symbol-btn" data-latex="\sum_{#0}^{#1}" title="Summation">∑</button>
         <button class="symbol-btn" data-latex="\int_{#0}^{#1}" title="Integral">∫</button>

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -3470,8 +3470,8 @@ What would you like to work on first?`;
         });
     }
 
-    // Handle symbol button clicks
-    document.querySelectorAll('.symbol-btn').forEach(btn => {
+    // Handle symbol button clicks (both .symbol-btn and .script-btn)
+    document.querySelectorAll('.symbol-btn, .script-btn').forEach(btn => {
         btn.addEventListener('click', () => {
             const latex = btn.getAttribute('data-latex');
             if (inlineMathEditor && latex) {

--- a/public/style.css
+++ b/public/style.css
@@ -2489,6 +2489,54 @@ form label, .password-label-row label {
     box-shadow: 0 2px 6px rgba(18, 179, 179, 0.3);
 }
 
+/* Subscript/Superscript Section */
+.equation-section-header {
+    font-size: 0.85em;
+    color: #aaa;
+    margin-bottom: 8px;
+    padding-bottom: 4px;
+}
+
+.subscript-superscript-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 8px;
+    margin-bottom: 15px;
+}
+
+.script-btn {
+    background: #2a2a2a;
+    border: 1px solid #3a3a3a;
+    border-radius: 6px;
+    padding: 12px;
+    cursor: pointer;
+    transition: all 0.2s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    aspect-ratio: 1;
+}
+
+.script-btn:hover {
+    background: #3a3a3a;
+    border-color: #12B3B3;
+    transform: translateY(-2px);
+    box-shadow: 0 2px 8px rgba(18, 179, 179, 0.3);
+}
+
+.script-btn:hover .script-icon {
+    color: #12B3B3;
+}
+
+.script-icon {
+    width: 100%;
+    height: 100%;
+    max-width: 40px;
+    max-height: 40px;
+    color: #888;
+    transition: color 0.2s;
+}
+
 /* Palette keyboard tip */
 .palette-tip {
     font-size: 0.75em;


### PR DESCRIPTION
## Summary
Reorganized the math symbol palette by creating a dedicated "Subscripts and Superscripts" section with visual button representations, improving discoverability and usability of these commonly-used mathematical operations.

## Changes Made
- **New UI Section**: Added a dedicated "Subscripts and Superscripts" section above the main equation symbols grid with 4 visual buttons:
  - Superscript/Power (`#0^{#1}`)
  - Subscript (`#0_{#1}`)
  - Subscript and Superscript combined (`#0_{#1}^{#2}`)
  - Left Subscript (`{}_{#0}#1`)

- **Visual Design**: Each button displays an SVG icon with dashed rectangles representing the base and script positions, making the function immediately clear

- **Removed Redundancy**: Removed the text-based superscript/subscript buttons and sequence-specific buttons (a_n, a_{n+1}, a_1) from the main grid to reduce clutter

- **Updated Event Handling**: Extended the symbol button click handler to include both `.symbol-btn` and `.script-btn` classes

- **Styling**: Added comprehensive CSS for the new section including:
  - Section header styling
  - 4-column grid layout
  - Button hover effects with cyan accent color
  - SVG icon styling with color transitions

## Implementation Details
- SVG icons use stroke-dasharray to create a visual distinction from solid symbols
- Buttons maintain consistent styling with existing symbol buttons (dark background, hover effects)
- The new section is positioned before the main equation symbols grid for logical organization
- All LaTeX templates follow the existing placeholder convention (#0, #1, #2)

https://claude.ai/code/session_017aRFzKTAA7LBPRj6kZWV9i