### PR TITLE
Change survey default frequency to every-session for beta

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -652,12 +652,19 @@ const userSchema = new Schema({
     enabled: { type: Boolean, default: true },  // Can be disabled by user
     lastShownAt: { type: Date },
     nextShowAfter: { type: Date },
-    frequency: { type: String, enum: ['every-session', 'daily', 'weekly', 'never'], default: 'every-session' },
+    frequency: { type: String, enum: ['every-session', 'daily', 'weekly', 'never'], default: 'daily' },
     responsesCount: { type: Number, default: 0 },
     consecutiveDismissals: { type: Number, default: 0 },  // Track if user keeps dismissing
+    lastTrigger: String,  // What triggered the survey: 'problems_completed', 'milestone', 'time_based', 'tab_return', 'manual'
+    lastTriggerContext: {
+      problemsSolved: Number,
+      sessionDuration: Number,
+      timestamp: Date
+    },
     responses: [{
       submittedAt: { type: Date, default: Date.now },
       sessionDuration: Number,  // Minutes in session
+      problemsSolved: Number,  // Problems solved this session
       rating: Number,  // 1-5 star rating
       experience: String,  // 'excellent', 'good', 'okay', 'frustrating', 'confusing'
       feedback: String,  // Open-ended feedback
@@ -665,7 +672,8 @@ const userSchema = new Schema({
       features: String,  // Feature requests
       helpfulness: Number,  // 1-5 rating
       difficulty: Number,  // 1-5 rating
-      willingness: Number  // 1-5 - how likely to recommend
+      willingness: Number,  // 0-10 NPS score
+      isQuickResponse: { type: Boolean, default: false }  // Was this a quick 1-tap response
     }]
   },
 

--- a/models/user.js
+++ b/models/user.js
@@ -652,7 +652,7 @@ const userSchema = new Schema({
     enabled: { type: Boolean, default: true },  // Can be disabled by user
     lastShownAt: { type: Date },
     nextShowAfter: { type: Date },
-    frequency: { type: String, enum: ['every-session', 'daily', 'weekly', 'never'], default: 'daily' },
+    frequency: { type: String, enum: ['every-session', 'daily', 'weekly', 'never'], default: 'every-session' },
     responsesCount: { type: Number, default: 0 },
     consecutiveDismissals: { type: Number, default: 0 },  // Track if user keeps dismissing
     responses: [{

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -256,6 +256,11 @@ function triggerXpAnimation(message, isLevelUp = false, isSpecialXp = false) {
         // Show celebration video modal
         showLevelUpCelebration();
 
+        // Track milestone for survey triggers
+        if (window.MathMatixSurvey) {
+            window.MathMatixSurvey.trackMilestone('level_up');
+        }
+
         if (typeof confetti === 'function') {
             const duration = 3 * 1000;
             const animationEnd = Date.now() + duration;
@@ -2578,6 +2583,11 @@ document.addEventListener("DOMContentLoaded", () => {
             }
             // TIER 1: Silent (no display at all)
             // The +2 XP is added to their total but never shown
+
+            // Track problem solved for survey triggers (any XP tier = correct answer)
+            if ((xp.tier1 > 0 || xp.tier2 > 0 || xp.tier3 > 0) && window.MathMatixSurvey) {
+                window.MathMatixSurvey.trackProblemSolved();
+            }
         }
         // Legacy fallback for old response format
         else if (data.specialXpAwarded) {


### PR DESCRIPTION
## Summary
Updates the session survey feature to use 'every-session' as the default frequency instead of 'daily' during the beta period. This maximizes feedback collection by showing surveys to users every session rather than limiting to once per day.

## Key Changes
- Changed default `frequency` value from 'daily' to 'every-session' in the user schema
- Updated survey status endpoint to return 'every-session' as the default frequency
- Modified survey dismissal logic to prevent downgrading from 'every-session' frequency during beta
- Updated survey submission logic to only set cooldown periods for non-'every-session' frequencies
- Added conditional cooldown logic: surveys shown every session don't have a `nextShowAfter` delay, while daily/weekly frequencies maintain 24-hour cooldowns

## Implementation Details
- The `nextShowAfter` field is now only set when frequency is not 'every-session', allowing surveys to appear in every session when that frequency is active
- Dismissal counter still increments, but won't downgrade 'every-session' frequency (only 'daily' → 'weekly' downgrade occurs)
- Both survey dismissal and submission endpoints respect the new frequency-based cooldown logic
- This change is explicitly marked as beta behavior with code comments for future reference

https://claude.ai/code/session_01AkypFFDVbfyixAXf1KuxPr