### PR TITLE
Fix: Add missing modal overlay base styles for new topic modal

### DIFF
--- a/public/css/sidebar-layout.css
+++ b/public/css/sidebar-layout.css
@@ -455,6 +455,53 @@
 }
 
 /* New Topic Modal Styles */
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 9999;
+}
+
+.modal-content {
+    background: white;
+    border-radius: 12px;
+    padding: 24px;
+    max-width: 90%;
+    max-height: 90vh;
+    overflow-y: auto;
+    position: relative;
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
+}
+
+.modal-close-button {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    width: 32px;
+    height: 32px;
+    border: none;
+    background: #f0f0f0;
+    border-radius: 50%;
+    font-size: 20px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #666;
+    transition: all 0.2s;
+}
+
+.modal-close-button:hover {
+    background: #e0e0e0;
+    color: #333;
+}
+
 .new-topic-modal-content {
     max-width: 500px;
 }

--- a/public/js/sidebar.js
+++ b/public/js/sidebar.js
@@ -510,6 +510,7 @@ class Sidebar {
     }
 
     async createNewTopic() {
+        console.log('[Sidebar] createNewTopic called');
         // Show topic selection modal
         this.showNewTopicModal();
     }
@@ -518,6 +519,7 @@ class Sidebar {
      * Show new topic modal with suggestions
      */
     showNewTopicModal() {
+        console.log('[Sidebar] showNewTopicModal called');
         // Create modal if it doesn't exist
         let modal = document.getElementById('new-topic-modal');
         if (!modal) {


### PR DESCRIPTION
The modal wasn't displaying because the base CSS styles for .modal-overlay were missing. Added display, positioning, and styling for the modal overlay and content components.

https://claude.ai/code/session_01KpdDxq5A9piSAjWqtREG7q