### PR TITLE
Fix: Use session topic for course progression instead of user profile

### DIFF
--- a/utils/prompt.js
+++ b/utils/prompt.js
@@ -2074,7 +2074,7 @@ ${masteryContext ?
 
 ${buildLearningProfileContext(userProfile)}
 
-${buildCourseProgressionContext(mathCourse, firstName)}`}
+${buildCourseProgressionContext(conversationContext?.topic || mathCourse, firstName)}`}
 
 ${!masteryContext && curriculumContext ? `--- CURRICULUM CONTEXT (FROM TEACHER) ---
 ${curriculumContext}


### PR DESCRIPTION
When a user creates a topic session (e.g., "Calculus 1"), the system now uses that session topic for buildCourseProgressionContext() instead of the user's profile mathCourse setting.

This fixes the bug where a 9th grader in a "Calculus 1" session would be suggested elementary content like skip-counting because their profile mathCourse was set differently.

The change: conversationContext?.topic || mathCourse

https://claude.ai/code/session_017uCiusWWstyPD6EepXXMcs