### PR TITLE
Fix: Text resize not applying despite indicator showing percentage

### DIFF
--- a/public/css/mobile-fixes.css
+++ b/public/css/mobile-fixes.css
@@ -427,7 +427,8 @@ select,
 /* Chat messages container supports font scaling */
 #chat-messages-container {
     /* Default scale is 1.0, adjusted by pinch-zoom script */
-    font-size: var(--chat-font-scale, 1em);
+    /* Must use calc() to multiply unitless scale value with base unit */
+    font-size: calc(1em * var(--chat-font-scale, 1));
 }
 
 /* Ensure all message elements inherit the scaled size */


### PR DESCRIPTION
The CSS variable --chat-font-scale was set as a unitless number (e.g., 1.5) by JavaScript, but the CSS rule used it directly without calc():

  font-size: var(--chat-font-scale, 1em);  /* Becomes: font-size: 1.5 */

This is invalid CSS (missing unit), so the browser ignored it. The fix uses calc() to properly multiply the scale factor with a base unit:

  font-size: calc(1em * var(--chat-font-scale, 1));

https://claude.ai/code/session_012sZKaP7sYkEg8UBp1pwnBQ