### PR TITLE
Only show render error if graph didn't actually display

### DIFF
--- a/public/js/inlineChatVisuals.js
+++ b/public/js/inlineChatVisuals.js
@@ -360,7 +360,12 @@ class InlineChatVisuals {
             console.log(`[InlineChatVisuals] Rendered graph for: ${fn}`);
         } catch (error) {
             console.error(`[InlineChatVisuals] Error rendering graph ${id}:`, error);
-            container.innerHTML = `<div class="icv-error">Could not render: ${error.message}</div>`;
+            // Only show error if graph didn't actually render
+            // (function-plot may render successfully then throw during interactivity setup)
+            const hasRenderedContent = container.querySelector('svg') || container.querySelector('canvas');
+            if (!hasRenderedContent) {
+                container.innerHTML = `<div class="icv-error">Could not render: ${error.message}</div>`;
+            }
         }
     }
 


### PR DESCRIPTION
function-plot may render the graph successfully then throw an error during interactivity/tooltip setup. Previously this would show an error message alongside the working graph. Now we check if SVG/canvas content exists before showing the error - if the graph rendered, we just log the error silently.

https://claude.ai/code/session_019ru5VDxhVY2tTME3HRSXgG