### PR TITLE
Fix screener layout and replace confidence scale with skip button

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -1195,6 +1195,11 @@
 
       <!-- Question Screen -->
       <div id="screener-question-screen" class="screener-question">
+        <!-- Progress Bar -->
+        <div class="screener-progress" id="screener-progress">
+          <div class="screener-progress-fill" id="screener-progress-fill"></div>
+        </div>
+
         <div class="question-card">
           <div class="question-header">
             <span class="question-number" id="screener-question-num">Question 1</span>
@@ -1219,6 +1224,10 @@
           <button class="btn-submit-answer" id="screener-submit-btn" disabled>
             Submit Answer <i class="fas fa-arrow-right"></i>
           </button>
+
+          <p class="keyboard-hint" id="screener-keyboard-hint">
+            <kbd>A</kbd>-<kbd>D</kbd> to select &middot; <kbd>Enter</kbd> to submit
+          </p>
         </div>
       </div>
 

--- a/public/chat.html
+++ b/public/chat.html
@@ -1209,23 +1209,11 @@
             <!-- Options will be loaded here -->
           </div>
 
-          <!-- Optional Confidence Meter -->
-          <div class="confidence-meter">
-            <h4>How sure are you?</h4>
-            <div class="confidence-options">
-              <div class="confidence-option" data-level="1">
-                <span class="level">1</span>
-                <span class="label">I pretty much guessed</span>
-              </div>
-              <div class="confidence-option" data-level="2">
-                <span class="level">2</span>
-                <span class="label">In the middle</span>
-              </div>
-              <div class="confidence-option" data-level="3">
-                <span class="level">3</span>
-                <span class="label">I've got this!</span>
-              </div>
-            </div>
+          <!-- Skip Skill Button -->
+          <div class="skip-skill-section">
+            <button class="btn-skip-skill" id="screener-skip-btn">
+              <i class="fas fa-forward"></i> I haven't learned this yet
+            </button>
           </div>
 
           <button class="btn-submit-answer" id="screener-submit-btn" disabled>

--- a/public/css/floating-screener.css
+++ b/public/css/floating-screener.css
@@ -138,8 +138,13 @@
 
 /* Instruction Screen */
 .screener-instruction {
+  display: none;
   text-align: center;
   padding: 20px;
+}
+
+.screener-instruction.active {
+  display: block;
 }
 
 .screener-instruction h2 {
@@ -338,58 +343,33 @@
   flex: 1;
 }
 
-/* Confidence Meter */
-.confidence-meter {
-  background: #f8f9fa;
-  border-radius: 10px;
-  padding: 16px;
+/* Skip Skill Button */
+.skip-skill-section {
   margin: 20px 0;
-}
-
-.confidence-meter h4 {
-  font-size: 0.9em;
-  color: #666;
-  margin-bottom: 12px;
   text-align: center;
 }
 
-.confidence-options {
-  display: flex;
-  justify-content: space-around;
-  gap: 8px;
-}
-
-.confidence-option {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 12px 8px;
-  background: white;
-  border: 2px solid #e0e0e0;
-  border-radius: 8px;
+.btn-skip-skill {
+  background: transparent;
+  color: #888;
+  border: 1px dashed #ccc;
+  padding: 12px 24px;
+  font-size: 0.95em;
+  font-weight: 500;
+  border-radius: 10px;
   cursor: pointer;
   transition: all 0.2s;
+  width: 100%;
 }
 
-.confidence-option:hover {
+.btn-skip-skill:hover {
+  color: #667eea;
   border-color: #667eea;
+  background: rgba(102, 126, 234, 0.05);
 }
 
-.confidence-option.selected {
-  background: #e8edff;
-  border-color: #667eea;
-}
-
-.confidence-option .level {
-  font-size: 1.5em;
-  margin-bottom: 4px;
-}
-
-.confidence-option .label {
-  font-size: 0.75em;
-  color: #666;
-  text-align: center;
+.btn-skip-skill i {
+  margin-right: 6px;
 }
 
 /* Submit Button */
@@ -712,20 +692,9 @@
     padding: 12px;
   }
 
-  .confidence-options {
-    flex-wrap: nowrap;
-  }
-
-  .confidence-option {
-    padding: 10px 6px;
-  }
-
-  .confidence-option .level {
-    font-size: 1.2em;
-  }
-
-  .confidence-option .label {
-    font-size: 0.65em;
+  .btn-skip-skill {
+    padding: 10px 16px;
+    font-size: 0.9em;
   }
 
   .results-stats {

--- a/public/css/floating-screener.css
+++ b/public/css/floating-screener.css
@@ -262,11 +262,36 @@
   display: block;
 }
 
+/* Progress Bar */
+.screener-progress {
+  height: 4px;
+  background: #e0e0e0;
+  border-radius: 4px;
+  margin-bottom: 16px;
+  overflow: hidden;
+}
+
+.screener-progress-fill {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, #667eea, #764ba2);
+  border-radius: 4px;
+  transition: width 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
 .question-card {
   background: white;
   border-radius: 12px;
   padding: 24px;
   box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  border: 2px solid transparent;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+/* Answer feedback flash - green for correct, neutral for miss */
+.question-card.flash-correct {
+  border-color: #2ecc71;
+  box-shadow: 0 0 16px rgba(46, 204, 113, 0.3);
 }
 
 .question-header {
@@ -393,6 +418,24 @@
 .btn-submit-answer:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+/* Keyboard Hint */
+.keyboard-hint {
+  text-align: center;
+  font-size: 0.75em;
+  color: #aaa;
+  margin-top: 12px;
+}
+
+.keyboard-hint kbd {
+  display: inline-block;
+  padding: 1px 5px;
+  font-size: 0.9em;
+  font-family: inherit;
+  background: #f0f0f0;
+  border: 1px solid #ddd;
+  border-radius: 3px;
 }
 
 /* Results Screen */
@@ -661,27 +704,37 @@
   border-radius: 0 0 16px 0;
 }
 
-/* Mobile Responsive */
+/* Mobile Responsive - full-screen overlay instead of floating */
 @media (max-width: 768px) {
   .floating-screener {
-    width: 95vw;
-    max-width: 95vw;
-    min-width: 320px;
-    max-height: 85vh;
-    top: 55%;
+    width: 100%;
+    max-width: 100%;
+    min-width: 100%;
+    height: 100%;
+    max-height: 100%;
+    top: 0;
+    left: 0;
+    transform: none;
+    border-radius: 0;
     resize: none;
+  }
+
+  .floating-screener.active {
+    display: flex;
   }
 
   .screener-header-bar {
     padding: 10px 12px;
-  }
-
-  .screener-title {
-    font-size: 14px;
+    border-radius: 0;
+    cursor: default;
   }
 
   .screener-body {
     padding: 16px;
+  }
+
+  .screener-title {
+    font-size: 14px;
   }
 
   .mc-options {
@@ -695,6 +748,14 @@
   .btn-skip-skill {
     padding: 10px 16px;
     font-size: 0.9em;
+  }
+
+  .keyboard-hint {
+    display: none;
+  }
+
+  .floating-screener .resize-handle {
+    display: none;
   }
 
   .results-stats {


### PR DESCRIPTION
The instruction screen was not hiding when switching to the question
screen because .screener-instruction lacked display:none, forcing
users to scroll past instructions for every question. Added proper
show/hide toggle via .active class.

Replaced the 1-3 confidence meter ("How sure are you?") with an
"I haven't learned this yet" skip button so students can skip skills
they haven't been taught. Skipped questions are treated as incorrect
for IRT scoring purposes. Backend now tracks skipped status in
response data.

https://claude.ai/code/session_01NqcS7WdQXRLhAFUrThJNTm