### PR TITLE
Implement Claude-like sessions: instant new session, remove resume banner

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -154,21 +154,12 @@
           <input type="text" id="session-search-input" class="session-search-input" placeholder="Search sessions...">
         </div>
 
-        <button id="new-topic-btn" class="sidebar-tool-btn special">
+        <button id="new-session-btn" class="sidebar-tool-btn special">
           <i class="fas fa-plus-circle"></i>
-          <span>New Topic Session</span>
+          <span>New Session</span>
         </button>
         <div id="sessions-list">
-          <!-- Sessions will be loaded here dynamically -->
-          <div class="session-item active">
-            <div class="session-main">
-              <span class="session-emoji">💬</span>
-              <div class="session-info">
-                <span class="session-name">General Chat</span>
-                <span class="session-preview">Start a new conversation</span>
-              </div>
-            </div>
-          </div>
+          <!-- Sessions loaded dynamically by sidebar.js -->
         </div>
       </div>
     </div>

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -4232,135 +4232,16 @@ What would you like to work on first?`;
                     `I'm here to help you learn and practice. What would you like to work on?`,
                     'ai'
                 );
+            } else {
+                appendMessage(
+                    `Hey there! What would you like to work on? 😊`,
+                    'ai'
+                );
             }
         }
 
         console.log('[updateChatForSession] Loaded', messages?.length || 0, 'messages');
     };
-
-    /**
-     * Resume Banner - "Continue where you left off"
-     * Shows when user returns to the app with recent session context
-     */
-    async function checkAndShowResumeBanner() {
-        try {
-            const response = await fetch('/api/chat/resume-context', {
-                credentials: 'include'
-            });
-            const data = await response.json();
-
-            if (!data.hasResumeContext) {
-                console.log('[ResumeBanner] No resume context available');
-                return;
-            }
-
-            // Don't show if this is the currently active session already loaded
-            const currentSessionId = window.currentConversationId;
-            if (currentSessionId && currentSessionId === data.sessionId) {
-                console.log('[ResumeBanner] Already on this session');
-                return;
-            }
-
-            // Don't show for very recent activity (< 5 minutes)
-            if (data.timeAgo === 'Just now') {
-                return;
-            }
-
-            showResumeBanner(data);
-        } catch (error) {
-            console.error('[ResumeBanner] Failed to fetch resume context:', error);
-        }
-    }
-
-    function showResumeBanner(context) {
-        // Remove any existing banner
-        const existingBanner = document.getElementById('resume-banner');
-        if (existingBanner) existingBanner.remove();
-
-        // Build context description
-        let contextDescription = '';
-        if (context.lastContext?.userMessage) {
-            contextDescription = `You asked: "${context.lastContext.userMessage}${context.lastContext.userMessage.length >= 100 ? '...' : ''}"`;
-        } else if (context.strugglingWith) {
-            contextDescription = `Working on: ${context.strugglingWith}`;
-        } else if (context.topic) {
-            contextDescription = `Topic: ${context.topic}`;
-        }
-
-        // Build stats string
-        let statsStr = '';
-        if (context.stats.problemsAttempted > 0) {
-            const accuracy = context.stats.problemsCorrect > 0
-                ? Math.round((context.stats.problemsCorrect / context.stats.problemsAttempted) * 100)
-                : 0;
-            statsStr = `${context.stats.problemsAttempted} problems • ${accuracy}% correct`;
-        } else if (context.stats.messageCount > 0) {
-            statsStr = `${context.stats.messageCount} messages`;
-        }
-
-        const banner = document.createElement('div');
-        banner.id = 'resume-banner';
-        banner.className = 'resume-banner';
-        banner.innerHTML = `
-            <div class="resume-banner-content">
-                <div class="resume-banner-icon">${context.topicEmoji || '📚'}</div>
-                <div class="resume-banner-text">
-                    <div class="resume-banner-title">Continue where you left off?</div>
-                    <div class="resume-banner-session">
-                        <strong>${escapeHtml(context.displayName)}</strong>
-                        <span class="resume-banner-time">${context.timeAgo}</span>
-                    </div>
-                    ${contextDescription ? `<div class="resume-banner-context">${escapeHtml(contextDescription)}</div>` : ''}
-                    ${statsStr ? `<div class="resume-banner-stats">${statsStr}</div>` : ''}
-                </div>
-            </div>
-            <div class="resume-banner-actions">
-                <button class="resume-banner-btn resume-btn-primary" id="resume-continue-btn">
-                    <i class="fas fa-play"></i> Continue
-                </button>
-                <button class="resume-banner-btn resume-btn-secondary" id="resume-dismiss-btn">
-                    Start Fresh
-                </button>
-            </div>
-        `;
-
-        // Insert at top of chat container
-        const chatContainer = document.getElementById('chat-container');
-        if (chatContainer) {
-            chatContainer.insertBefore(banner, chatContainer.firstChild);
-
-            // Add event listeners
-            document.getElementById('resume-continue-btn').addEventListener('click', () => {
-                resumeSession(context.sessionId);
-                banner.remove();
-            });
-
-            document.getElementById('resume-dismiss-btn').addEventListener('click', () => {
-                banner.classList.add('resume-banner-dismissed');
-                setTimeout(() => banner.remove(), 300);
-                // Store dismissal in session storage so it doesn't show again this session
-                sessionStorage.setItem('resume-banner-dismissed', 'true');
-            });
-        }
-    }
-
-    async function resumeSession(sessionId) {
-        try {
-            // Use the sidebar's switchSession if available
-            if (window.sidebar && typeof window.sidebar.switchSession === 'function') {
-                await window.sidebar.switchSession(sessionId);
-            } else {
-                // Fallback: call the API directly and reload
-                await fetch(`/api/conversations/${sessionId}/switch`, {
-                    method: 'POST',
-                    credentials: 'include'
-                });
-                window.location.reload();
-            }
-        } catch (error) {
-            console.error('[ResumeBanner] Failed to resume session:', error);
-        }
-    }
 
     function escapeHtml(text) {
         if (!text) return '';
@@ -4368,13 +4249,6 @@ What would you like to work on first?`;
         div.textContent = text;
         return div.innerHTML;
     }
-
-    // Check for resume context after a short delay (let the page settle)
-    setTimeout(() => {
-        if (!sessionStorage.getItem('resume-banner-dismissed')) {
-            checkAndShowResumeBanner();
-        }
-    }, 1000);
 
     initializeApp();
 });

--- a/services/chatService.js
+++ b/services/chatService.js
@@ -476,15 +476,15 @@ async function smartAutoName(conversationId) {
 
     // Only auto-name if:
     // 1. It's a general conversation (not a topic session)
-    // 2. Has enough messages (4+ for meaningful context)
+    // 2. Has enough messages (2+ for meaningful context)
     // 3. Doesn't already have a custom name
     // 4. Current name is generic
-    const genericNames = ['Math Session', 'General Chat', null, ''];
+    const genericNames = ['Math Session', 'General Chat', 'New Chat', null, ''];
 
     if (conversation.conversationType === 'topic') return null; // Already has a topic
     if (conversation.customName) return null; // User set a custom name
     if (!genericNames.includes(conversation.conversationName)) return null; // Already named
-    if (conversation.messages.length < 4) return null; // Not enough context
+    if (conversation.messages.length < 2) return null; // Not enough context
 
     // Detect topic from messages
     const recentText = conversation.messages.slice(-8).map(m => m.content).join(' ').toLowerCase();


### PR DESCRIPTION
- New Session button now instantly creates a blank conversation (no topic modal)
- Remove "pick up where you left off" resume banner (sidebar handles this)
- Remove hardcoded General Chat from sidebar; all sessions rendered equally
- Sessions auto-name after 2 messages based on detected math topic
- Backend allows creating conversations without requiring a topic

https://claude.ai/code/session_01LEKZQtRwrPQB3RzpTpURjy