### PR TITLE
Fix leaderboard empty and quest titles showing 'undefined'

### DIFF
--- a/public/js/engagement-widgets.js
+++ b/public/js/engagement-widgets.js
@@ -232,19 +232,21 @@ window.renderDailyQuests = function(quests) {
     const container = document.getElementById('daily-quests-container');
     if (!container || !quests || quests.length === 0) return;
 
-    const questsHTML = quests.map(quest => `
+    const questsHTML = quests.map(quest => {
+        const progressPercent = quest.targetCount > 0 ? Math.min((quest.progress / quest.targetCount) * 100, 100) : 0;
+        return `
         <div class="quest-item ${quest.completed ? 'completed' : ''}">
-            <div class="quest-name">${quest.type || quest.title}</div>
-            <div class="quest-description">${quest.description || getQuestDescription(quest.type)}</div>
+            <div class="quest-name">${quest.name || quest.type || quest.title}</div>
+            <div class="quest-description">${quest.description || getQuestDescription(quest.name)}</div>
             <div class="quest-progress-bar">
-                <div class="quest-progress-fill" style="width: ${quest.progress || 0}%"></div>
+                <div class="quest-progress-fill" style="width: ${progressPercent}%"></div>
             </div>
             <div class="quest-progress-text">
-                <span>${quest.currentValue || 0}/${quest.targetValue || 0}</span>
+                <span>${quest.progress || 0}/${quest.targetCount || 0}</span>
                 <span class="quest-xp-reward">+${quest.xpReward || 50} XP</span>
             </div>
         </div>
-    `).join('');
+    `}).join('');
 
     container.innerHTML = questsHTML;
 
@@ -263,19 +265,21 @@ window.renderWeeklyChallenges = function(challenges) {
     const container = document.getElementById('weekly-challenges-container');
     if (!container || !challenges || challenges.length === 0) return;
 
-    const challengesHTML = challenges.map(challenge => `
+    const challengesHTML = challenges.map(challenge => {
+        const progressPercent = challenge.targetCount > 0 ? Math.min((challenge.progress / challenge.targetCount) * 100, 100) : 0;
+        return `
         <div class="quest-item ${challenge.completed ? 'completed' : ''}">
-            <div class="quest-name">⭐ ${challenge.type || challenge.title}</div>
-            <div class="quest-description">${challenge.description || getQuestDescription(challenge.type)}</div>
+            <div class="quest-name">⭐ ${challenge.name || challenge.type || challenge.title}</div>
+            <div class="quest-description">${challenge.description || getQuestDescription(challenge.name)}</div>
             <div class="quest-progress-bar">
-                <div class="quest-progress-fill" style="width: ${challenge.progress || 0}%"></div>
+                <div class="quest-progress-fill" style="width: ${progressPercent}%"></div>
             </div>
             <div class="quest-progress-text">
-                <span>${challenge.currentValue || 0}/${challenge.targetValue || 0}</span>
+                <span>${challenge.progress || 0}/${challenge.targetCount || 0}</span>
                 <span class="quest-xp-reward">+${challenge.xpReward || 300} XP</span>
             </div>
         </div>
-    `).join('');
+    `}).join('');
 
     container.innerHTML = challengesHTML;
 

--- a/public/js/sidebar.js
+++ b/public/js/sidebar.js
@@ -643,7 +643,9 @@ class Sidebar {
             }
 
             const data = await response.json();
-            this.renderLeaderboard(data.leaderboard || []);
+            // API returns array directly, or may be wrapped in { leaderboard: [...] }
+            const leaderboard = Array.isArray(data) ? data : (data.leaderboard || []);
+            this.renderLeaderboard(leaderboard);
         } catch (error) {
             console.error('[Sidebar] Error loading leaderboard:', error);
         }
@@ -660,10 +662,10 @@ class Sidebar {
             row.innerHTML = `
                 <td style="font-weight: 600;">#${index + 1}</td>
                 <td style="max-width: 100px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
-                    ${student.firstName || 'Student'}
+                    ${student.name || student.firstName || 'Student'}
                 </td>
                 <td>L${student.level || 1}</td>
-                <td>${student.totalXp || 0}</td>
+                <td>${student.xp || student.totalXp || 0}</td>
             `;
             tbody.appendChild(row);
         });


### PR DESCRIPTION
- engagement-widgets.js: Use quest.name instead of quest.type/quest.title
  to match the field returned by the daily quests API
- engagement-widgets.js: Use quest.progress/quest.targetCount instead of
  quest.currentValue/quest.targetValue for progress display
- engagement-widgets.js: Calculate progress bar percentage from raw counts
  instead of using raw progress value directly as percentage
- sidebar.js: Handle API returning leaderboard as plain array instead of
  expecting data.leaderboard wrapper object
- sidebar.js: Use student.name/student.xp to match the formatted fields
  returned by the leaderboard API

https://claude.ai/code/session_01G9Jo73E3s23SaDuSWApcNy