### PR TITLE
Fix excessive vertical spacing in chat bottom area

### DIFF
--- a/public/css/sidebar-layout.css
+++ b/public/css/sidebar-layout.css
@@ -897,6 +897,8 @@ footer {
 /* Ensure chat container has space for footer */
 #chat-container {
     margin-bottom: 52px !important;
+    gap: 0 !important;
+    padding-bottom: 0 !important;
 }
 
 /* Input container needs to be above footer */
@@ -904,7 +906,7 @@ footer {
     position: relative;
     z-index: 1003 !important;
     background: var(--clr-bg-light, #fff);
-    padding-bottom: 12px !important;
+    padding-bottom: 4px !important;
 }
 
 /* Mobile Responsive */


### PR DESCRIPTION
The chat container inherited gap: var(--section-gap) (48px) from the
shared admin/chat container rule, creating large gaps between the input
area and session stats bar. Combined with dashboard-panel bottom padding
(20px) and input-container bottom padding (12px), the bottom of the chat
had ~80px of unnecessary vertical space.

Changes:
- Override gap to 0 on #chat-container
- Remove bottom padding on #chat-container (dashboard-panel default)
- Reduce #input-container bottom padding from 12px to 4px

https://claude.ai/code/session_01KasQ96NmbD5VzhG82DDxAP