### PR TITLE
Add admin user creation with any role and parent-student linking

### DIFF
--- a/public/admin-dashboard.html
+++ b/public/admin-dashboard.html
@@ -719,11 +719,14 @@
       <aside class="right-sidebar">
         <div class="dashboard-panel">
           <div class="dashboard-panel-header">
-            <i class="fas fa-chalkboard-teacher"></i> Teacher & Roster Setup
+            <i class="fas fa-chalkboard-teacher"></i> User & Roster Setup
           </div>
-          <p>Create teacher accounts, class codes, and import student rosters.</p>
+          <p>Create user accounts, class codes, and import student rosters.</p>
           <button id="openTeacherSetupBtn" class="btn btn-primary main-action-btn">
-            <i class="fas fa-user-plus"></i> Create Teacher
+            <i class="fas fa-user-plus"></i> Create User
+          </button>
+          <button id="openLinkParentBtn" class="btn btn-primary main-action-btn">
+            <i class="fas fa-link"></i> Link Parent to Student
           </button>
           <button id="openEnrollmentCodeBtn" class="btn btn-secondary main-action-btn">
             <i class="fas fa-key"></i> Create Class Code
@@ -1121,12 +1124,12 @@
     </div>
   </div>
 
-  <!-- Create Teacher Modal -->
+  <!-- Create User Modal -->
   <div id="createTeacherModal" class="modal-overlay">
     <div class="modal-content" style="max-width: 500px;">
       <button class="modal-close-button" id="closeCreateTeacherBtn">&times;</button>
-      <h2><i class="fas fa-chalkboard-teacher"></i> Create Teacher Account</h2>
-      <p style="color: #666; margin-bottom: 20px;">Create a new teacher account. The teacher will be able to manage their assigned students.</p>
+      <h2><i class="fas fa-user-plus"></i> Create User Account</h2>
+      <p style="color: #666; margin-bottom: 20px;">Create a new user account with any role.</p>
 
       <form id="createTeacherForm">
         <div class="modal-form-group">
@@ -1140,6 +1143,15 @@
         <div class="modal-form-group">
           <label for="teacherEmail">Email *</label>
           <input type="email" id="teacherEmail" name="email" required>
+        </div>
+        <div class="modal-form-group">
+          <label for="teacherRole">Role *</label>
+          <select id="teacherRole" name="role" required>
+            <option value="student">Student</option>
+            <option value="teacher" selected>Teacher</option>
+            <option value="parent">Parent</option>
+            <option value="admin">Admin</option>
+          </select>
         </div>
         <div class="modal-form-group">
           <label for="teacherUsername">Username (optional - will be generated from email if blank)</label>
@@ -1157,21 +1169,119 @@
 
         <div class="modal-actions">
           <button type="submit" class="btn btn-primary" id="createTeacherSubmit">
-            <i class="fas fa-user-plus"></i> Create Teacher
+            <i class="fas fa-user-plus"></i> Create User
           </button>
           <button type="button" class="btn btn-tertiary" id="cancelCreateTeacher">Cancel</button>
         </div>
       </form>
 
       <div id="teacherCreatedResult" style="display: none; margin-top: 20px; padding: 15px; background: #d4edda; border-radius: 8px; border: 1px solid #c3e6cb;">
-        <h4 style="color: #155724; margin-bottom: 10px;"><i class="fas fa-check-circle"></i> Teacher Created Successfully!</h4>
+        <h4 style="color: #155724; margin-bottom: 10px;"><i class="fas fa-check-circle"></i> User Created Successfully!</h4>
         <p><strong>Name:</strong> <span id="resultTeacherName"></span></p>
         <p><strong>Email:</strong> <span id="resultTeacherEmail"></span></p>
         <p><strong>Username:</strong> <span id="resultTeacherUsername"></span></p>
+        <p><strong>Role:</strong> <span id="resultTeacherRole"></span></p>
         <p id="resultPasswordRow"><strong>Temporary Password:</strong> <code id="resultTeacherPassword" style="background: #f8f9fa; padding: 2px 6px; border-radius: 4px;"></code></p>
-        <p style="color: #856404; font-size: 0.9em; margin-top: 10px;"><i class="fas fa-exclamation-triangle"></i> Share these credentials securely with the teacher.</p>
+        <p style="color: #856404; font-size: 0.9em; margin-top: 10px;"><i class="fas fa-exclamation-triangle"></i> Share these credentials securely with the user.</p>
+
+        <!-- Teacher follow-up: Set up a class -->
+        <div id="followUpTeacher" style="display: none; margin-top: 15px; padding: 12px; background: #fff; border-radius: 6px; border: 1px solid #c3e6cb;">
+          <h5 style="margin-bottom: 8px;"><i class="fas fa-chalkboard"></i> Set Up a Class</h5>
+          <div class="modal-form-group" style="margin-bottom: 8px;">
+            <label for="followUpClassName">Class Name</label>
+            <input type="text" id="followUpClassName" placeholder="e.g., Period 3 Pre-Algebra">
+          </div>
+          <div class="modal-form-group" style="margin-bottom: 8px;">
+            <label for="followUpGradeLevel">Grade Level (optional)</label>
+            <input type="text" id="followUpGradeLevel" placeholder="e.g., 7th Grade">
+          </div>
+          <div class="modal-form-group" style="margin-bottom: 8px;">
+            <label for="followUpMathCourse">Math Course (optional)</label>
+            <input type="text" id="followUpMathCourse" placeholder="e.g., Pre-Algebra">
+          </div>
+          <button class="btn btn-primary" id="followUpCreateClassBtn" style="margin-top: 5px;">
+            <i class="fas fa-key"></i> Create Class Code
+          </button>
+          <div id="followUpClassResult" style="display: none; margin-top: 10px; color: #155724;"></div>
+        </div>
+
+        <!-- Parent follow-up: Link to a student -->
+        <div id="followUpParent" style="display: none; margin-top: 15px; padding: 12px; background: #fff; border-radius: 6px; border: 1px solid #c3e6cb;">
+          <h5 style="margin-bottom: 8px;"><i class="fas fa-child"></i> Link to a Student</h5>
+          <div class="modal-form-group" style="margin-bottom: 8px;">
+            <label for="followUpParentStudentSelect">Select Student</label>
+            <select id="followUpParentStudentSelect">
+              <option value="">Select a student...</option>
+            </select>
+          </div>
+          <button class="btn btn-primary" id="followUpLinkChildBtn">
+            <i class="fas fa-link"></i> Link Student
+          </button>
+          <div id="followUpParentLinkResult" style="display: none; margin-top: 10px; color: #155724;"></div>
+        </div>
+
+        <!-- Student follow-up: Link parent and/or teacher -->
+        <div id="followUpStudent" style="display: none; margin-top: 15px; padding: 12px; background: #fff; border-radius: 6px; border: 1px solid #c3e6cb;">
+          <h5 style="margin-bottom: 8px;"><i class="fas fa-users"></i> Link Parent &amp; Teacher</h5>
+          <div class="modal-form-group" style="margin-bottom: 8px;">
+            <label for="followUpStudentParentSelect">Parent (optional)</label>
+            <select id="followUpStudentParentSelect">
+              <option value="">Select a parent...</option>
+            </select>
+          </div>
+          <div class="modal-form-group" style="margin-bottom: 8px;">
+            <label for="followUpStudentTeacherSelect">Teacher (optional)</label>
+            <select id="followUpStudentTeacherSelect">
+              <option value="">Select a teacher...</option>
+            </select>
+          </div>
+          <button class="btn btn-primary" id="followUpLinkStudentBtn">
+            <i class="fas fa-link"></i> Link Selected
+          </button>
+          <div id="followUpStudentLinkResult" style="display: none; margin-top: 10px; color: #155724;"></div>
+        </div>
+
         <button class="btn btn-secondary" id="createAnotherTeacher" style="margin-top: 10px;">
-          <i class="fas fa-plus"></i> Create Another Teacher
+          <i class="fas fa-plus"></i> Create Another User
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Link Parent to Student Modal -->
+  <div id="linkParentModal" class="modal-overlay">
+    <div class="modal-content" style="max-width: 500px;">
+      <button class="modal-close-button" id="closeLinkParentBtn">&times;</button>
+      <h2><i class="fas fa-link"></i> Link Parent to Student</h2>
+      <p style="color: #666; margin-bottom: 20px;">Connect a parent account to their child's student account.</p>
+
+      <form id="linkParentForm">
+        <div class="modal-form-group">
+          <label for="linkParentSelect">Parent *</label>
+          <select id="linkParentSelect" name="parentId" required>
+            <option value="">Select a parent...</option>
+          </select>
+        </div>
+        <div class="modal-form-group">
+          <label for="linkStudentSelect">Student *</label>
+          <select id="linkStudentSelect" name="studentId" required>
+            <option value="">Select a student...</option>
+          </select>
+        </div>
+
+        <div class="modal-actions">
+          <button type="submit" class="btn btn-primary" id="linkParentSubmit">
+            <i class="fas fa-link"></i> Link Parent &amp; Student
+          </button>
+          <button type="button" class="btn btn-tertiary" id="cancelLinkParent">Cancel</button>
+        </div>
+      </form>
+
+      <div id="linkParentResult" style="display: none; margin-top: 20px; padding: 15px; background: #d4edda; border-radius: 8px; border: 1px solid #c3e6cb;">
+        <h4 style="color: #155724; margin-bottom: 10px;"><i class="fas fa-check-circle"></i> Linked Successfully!</h4>
+        <p><span id="resultLinkMessage"></span></p>
+        <button class="btn btn-secondary" id="linkAnotherParent" style="margin-top: 10px;">
+          <i class="fas fa-plus"></i> Link Another
         </button>
       </div>
     </div>


### PR DESCRIPTION
Transform the existing teacher creation modal into a general-purpose user creation form with a role selector (student, teacher, parent, admin). After creating a user, role-specific follow-up options appear:
- Teacher: create a class enrollment code
- Parent: link to an existing student
- Student: link to a parent and/or teacher

Also adds a standalone "Link Parent to Student" button in the sidebar with its own modal, plus two new API endpoints:
- POST /api/admin/link-parent-student (bidirectional linking)
- POST /api/admin/assign-teacher (assign teacher to student)

https://claude.ai/code/session_01TYSn7knw85QPooAU6MCAFm