### PR TITLE
Add multi-role support: roles array, role switcher, and migration

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -457,6 +457,7 @@ const userSchema = new Schema({
   lastName:  { type: String, trim: true, required: true },
   name:      { type: String, trim: true },              // derived in pre-save hook
   role:      { type: String, enum: ['student','teacher','parent','admin'], default: 'student' },
+  roles:     [{ type: String, enum: ['student','teacher','parent','admin'] }],
 
   /* Student-specific profile */
   gradeLevel: { type: String, trim: true },              // e.g., '7th Grade', '9th Grade', 'College'
@@ -1023,6 +1024,17 @@ userSchema.pre('save', async function (next) {
   if (this.isModified('firstName') || this.isModified('lastName')) {
     this.name = `${this.firstName || ''} ${this.lastName || ''}`.trim();
   }
+  // Sync roles array with role field
+  // If roles was explicitly set (e.g., admin create-user), ensure role is in roles
+  if (this.isModified('roles') && this.roles && this.roles.length > 0) {
+    if (!this.roles.includes(this.role)) {
+      this.role = this.roles[0]; // active role defaults to first role
+    }
+  }
+  // If only role was set (e.g., legacy code paths, signup), backfill roles
+  if (!this.roles || this.roles.length === 0) {
+    this.roles = [this.role];
+  }
   next();
 });
 
@@ -1030,7 +1042,8 @@ userSchema.pre('save', async function (next) {
 // Critical indexes for dashboard performance
 userSchema.index({ role: 1, teacherId: 1 });  // Teacher dashboard: find students by teacher
 userSchema.index({ teacherId: 1 });            // Student lookups by teacher
-userSchema.index({ role: 1 });                 // Role-based queries
+userSchema.index({ role: 1 });                 // Role-based queries (active role)
+userSchema.index({ roles: 1 });                // Multi-role queries (all user roles)
 userSchema.index({ parentIds: 1 });            // Parent dashboard: find children
 userSchema.index({ lastLogin: -1 });           // Activity reports sorted by login
 userSchema.index({ role: 1, lastLogin: -1 });  // Admin usage reports

--- a/public/admin-dashboard.html
+++ b/public/admin-dashboard.html
@@ -637,6 +637,9 @@
           </div>
         </div>
         <nav class="main-header-nav">
+          <div id="roleSwitcher" class="role-switcher" style="display: none;">
+            <select id="roleSwitcherSelect" class="role-switcher-select" title="Switch Role"></select>
+          </div>
           <button id="logoutBtn" class="nav-btn"><i class="fas fa-sign-out-alt"></i> Logout</button>
         </nav>
       </div>
@@ -1145,13 +1148,21 @@
           <input type="email" id="teacherEmail" name="email" required>
         </div>
         <div class="modal-form-group">
-          <label for="teacherRole">Role *</label>
-          <select id="teacherRole" name="role" required>
-            <option value="student">Student</option>
-            <option value="teacher" selected>Teacher</option>
-            <option value="parent">Parent</option>
-            <option value="admin">Admin</option>
-          </select>
+          <label>Role(s) *</label>
+          <div id="teacherRoleCheckboxes" style="display: flex; gap: 15px; flex-wrap: wrap; margin-top: 5px;">
+            <label style="display: flex; align-items: center; gap: 5px; cursor: pointer;">
+              <input type="checkbox" name="roles" value="student"> Student
+            </label>
+            <label style="display: flex; align-items: center; gap: 5px; cursor: pointer;">
+              <input type="checkbox" name="roles" value="teacher" checked> Teacher
+            </label>
+            <label style="display: flex; align-items: center; gap: 5px; cursor: pointer;">
+              <input type="checkbox" name="roles" value="parent"> Parent
+            </label>
+            <label style="display: flex; align-items: center; gap: 5px; cursor: pointer;">
+              <input type="checkbox" name="roles" value="admin"> Admin
+            </label>
+          </div>
         </div>
         <div class="modal-form-group">
           <label for="teacherUsername">Username (optional - will be generated from email if blank)</label>
@@ -1675,6 +1686,7 @@ Jane,Doe,jane.doe@school.org,7th Grade</code>
   <script src="/js/csrf.js"></script>
   <script src="/js/impersonationBanner.js"></script>
   <script src="/js/logout.js"></script>
+  <script src="/js/role-switcher.js"></script>
   <script src="/js/storage-utils.js"></script>
   <script src="/js/auto-logout.js"></script>
   <script src="/js/admin-dashboard.js"></script>

--- a/public/chat.html
+++ b/public/chat.html
@@ -113,6 +113,9 @@
       <button id="open-feedback-modal-btn" class="btn btn-tertiary icon-only" title="Send Feedback">
         <i class="fas fa-comment-dots"></i>
       </button>
+      <div id="roleSwitcher" class="role-switcher" style="display: none;">
+        <select id="roleSwitcherSelect" class="role-switcher-select" title="Switch Role"></select>
+      </div>
       <button id="logoutBtn" class="btn btn-tertiary logout-button icon-only" title="Logout">
         <i class="fas fa-sign-out-alt"></i>
       </button>
@@ -1506,6 +1509,7 @@
   <script src="/js/storage-utils.js"></script>
   <script src="/js/sanitize-util.js"></script>
   <script src="/js/logout.js"></script>
+  <script src="/js/role-switcher.js"></script>
   <script src="/js/auto-logout.js"></script>
   <!-- ALGEBRA TILES SHELVED FOR BETA -->
   <!-- <script src="/js/algebra-tiles.js"></script> -->

--- a/public/js/admin-dashboard.js
+++ b/public/js/admin-dashboard.js
@@ -1318,12 +1318,21 @@ document.addEventListener("DOMContentLoaded", async () => {
             submitBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Creating...';
 
             try {
-                const selectedRole = document.getElementById('teacherRole').value;
+                // Collect selected roles from checkboxes
+                const selectedRoles = Array.from(
+                    document.querySelectorAll('#teacherRoleCheckboxes input[name="roles"]:checked')
+                ).map(cb => cb.value);
+
+                if (selectedRoles.length === 0) {
+                    alert('Please select at least one role.');
+                    return;
+                }
+
                 const formData = {
                     firstName: document.getElementById('teacherFirstName').value.trim(),
                     lastName: document.getElementById('teacherLastName').value.trim(),
                     email: document.getElementById('teacherEmail').value.trim(),
-                    role: selectedRole,
+                    roles: selectedRoles,
                     username: document.getElementById('teacherUsername').value.trim() || undefined,
                     generatePassword: generatePasswordCheck.checked,
                     password: !generatePasswordCheck.checked ? document.getElementById('teacherPassword').value : undefined
@@ -1345,7 +1354,8 @@ document.addEventListener("DOMContentLoaded", async () => {
                     document.getElementById('resultTeacherName').textContent = `${result.user.firstName} ${result.user.lastName}`;
                     document.getElementById('resultTeacherEmail').textContent = result.user.email;
                     document.getElementById('resultTeacherUsername').textContent = result.user.username;
-                    document.getElementById('resultTeacherRole').textContent = result.user.role.charAt(0).toUpperCase() + result.user.role.slice(1);
+                    const rolesLabel = (result.user.roles || [selectedRoles[0]]).map(r => r.charAt(0).toUpperCase() + r.slice(1)).join(', ');
+                    document.getElementById('resultTeacherRole').textContent = rolesLabel;
 
                     if (result.temporaryPassword) {
                         document.getElementById('resultTeacherPassword').textContent = result.temporaryPassword;
@@ -1354,16 +1364,22 @@ document.addEventListener("DOMContentLoaded", async () => {
                         document.getElementById('resultPasswordRow').style.display = 'none';
                     }
 
-                    // Show role-specific follow-up
+                    // Show role-specific follow-ups (multiple can show for multi-role users)
                     hideAllFollowUps();
-                    if (selectedRole === 'teacher') {
+                    let needsUserSelects = false;
+                    if (selectedRoles.includes('teacher')) {
                         document.getElementById('followUpTeacher').style.display = 'block';
-                    } else if (selectedRole === 'parent') {
-                        await populateFollowUpSelects();
+                    }
+                    if (selectedRoles.includes('parent')) {
+                        needsUserSelects = true;
                         document.getElementById('followUpParent').style.display = 'block';
-                    } else if (selectedRole === 'student') {
-                        await populateFollowUpSelects();
+                    }
+                    if (selectedRoles.includes('student')) {
+                        needsUserSelects = true;
                         document.getElementById('followUpStudent').style.display = 'block';
+                    }
+                    if (needsUserSelects) {
+                        await populateFollowUpSelects();
                     }
 
                     createTeacherForm.style.display = 'none';

--- a/public/js/role-switcher.js
+++ b/public/js/role-switcher.js
@@ -1,0 +1,97 @@
+/**
+ * Role Switcher - Enables multi-role users to switch their active dashboard.
+ *
+ * Looks for #roleSwitcher (container) and #roleSwitcherSelect (dropdown) in the DOM.
+ * Fetches the current user's roles from /user and shows the switcher only when
+ * the user has more than one role.
+ */
+(function () {
+  const container = document.getElementById('roleSwitcher');
+  const select = document.getElementById('roleSwitcherSelect');
+  if (!container || !select) return;
+
+  // Inject minimal styles
+  const style = document.createElement('style');
+  style.textContent = `
+    .role-switcher { display: flex; align-items: center; margin-right: 10px; }
+    .role-switcher-select {
+      padding: 6px 12px; border-radius: 6px; border: 1px solid rgba(255,255,255,0.3);
+      background: rgba(255,255,255,0.15); color: #fff; font-size: 0.85em;
+      cursor: pointer; outline: none; font-weight: 500;
+    }
+    .role-switcher-select:hover { background: rgba(255,255,255,0.25); }
+    .role-switcher-select option { color: #333; background: #fff; }
+  `;
+  document.head.appendChild(style);
+
+  const roleLabels = {
+    admin: 'Admin',
+    teacher: 'Teacher',
+    parent: 'Parent',
+    student: 'Student'
+  };
+
+  const roleIcons = {
+    admin: 'fa-user-shield',
+    teacher: 'fa-chalkboard-teacher',
+    parent: 'fa-heart',
+    student: 'fa-graduation-cap'
+  };
+
+  async function init() {
+    try {
+      const res = await fetch('/user', { credentials: 'include' });
+      if (!res.ok) return;
+      const data = await res.json();
+      const user = data.user;
+      if (!user) return;
+
+      const roles = user.roles && user.roles.length > 0 ? user.roles : [user.role];
+      if (roles.length <= 1) return; // Single-role user, no switcher needed
+
+      // Build options
+      select.innerHTML = roles.map(r =>
+        `<option value="${r}" ${r === user.role ? 'selected' : ''}>${roleLabels[r] || r}</option>`
+      ).join('');
+
+      container.style.display = 'flex';
+
+      select.addEventListener('change', async () => {
+        const newRole = select.value;
+        if (!newRole) return;
+        select.disabled = true;
+
+        try {
+          // Use csrfFetch if available (admin/teacher dashboards), otherwise plain fetch
+          const fetchFn = typeof csrfFetch === 'function' ? csrfFetch : fetch;
+          const res = await fetchFn('/api/user/switch-role', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify({ role: newRole })
+          });
+          const result = await res.json();
+          if (res.ok && result.success && result.redirect) {
+            window.location.href = result.redirect;
+          } else {
+            alert(result.message || 'Failed to switch role.');
+            select.disabled = false;
+          }
+        } catch (err) {
+          alert('Failed to switch role. Please try again.');
+          select.disabled = false;
+        }
+      });
+    } catch (err) {
+      // Silently fail - role switcher is non-critical
+      console.error('Role switcher init error:', err);
+    }
+  }
+
+  // Run after DOM is ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/public/parent-dashboard.html
+++ b/public/parent-dashboard.html
@@ -614,6 +614,9 @@
           </div>
         </div>
         <nav class="main-header-nav">
+          <div id="roleSwitcher" class="role-switcher" style="display: none;">
+            <select id="roleSwitcherSelect" class="role-switcher-select" title="Switch Role"></select>
+          </div>
           <button id="logoutBtn" class="nav-btn"><i class="fas fa-sign-out-alt"></i> Logout</button>
         </nav>
       </div>
@@ -857,6 +860,7 @@
   <script src="/js/csrf.js"></script>
   <script src="/js/impersonationBanner.js"></script>
   <script src="/js/logout.js"></script>
+  <script src="/js/role-switcher.js"></script>
   <script src="/js/storage-utils.js"></script>
   <script src="/js/auto-logout.js"></script>
   <script src="/js/parent-dashboard.js"></script>

--- a/public/teacher-dashboard.html
+++ b/public/teacher-dashboard.html
@@ -1768,6 +1768,9 @@
           </div>
         </div>
         <nav class="main-header-nav">
+          <div id="roleSwitcher" class="role-switcher" style="display: none;">
+            <select id="roleSwitcherSelect" class="role-switcher-select" title="Switch Role"></select>
+          </div>
           <button id="logoutBtn" class="nav-btn"><i class="fas fa-sign-out-alt"></i> Logout</button>
         </nav>
       </div>
@@ -2416,6 +2419,7 @@
   <script src="/js/csrf.js"></script>
   <script src="/js/impersonationBanner.js"></script>
   <script src="/js/logout.js"></script>
+  <script src="/js/role-switcher.js"></script>
   <script src="/js/storage-utils.js"></script>
   <script src="/js/auto-logout.js"></script>
   <script src="/js/teacher-live-feed.js"></script>

--- a/scripts/migrateRolesArray.js
+++ b/scripts/migrateRolesArray.js
@@ -1,0 +1,62 @@
+/**
+ * Migration Script: Backfill `roles` array from `role` field
+ *
+ * For every user that has a `role` but no `roles` array (or an empty one),
+ * sets `roles` to `[role]`.
+ *
+ * Safe to run multiple times (idempotent).
+ *
+ * Usage:
+ *   node scripts/migrateRolesArray.js
+ *
+ * Or with a custom MONGODB_URI:
+ *   MONGODB_URI=mongodb://localhost:27017/mathmatix node scripts/migrateRolesArray.js
+ */
+const mongoose = require('mongoose');
+require('dotenv').config();
+
+const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017/mathmatix';
+
+async function migrate() {
+  console.log('Connecting to MongoDB...');
+  await mongoose.connect(MONGODB_URI);
+  console.log('Connected.');
+
+  const User = require('../models/user');
+
+  // Find all users with an empty or missing roles array
+  const users = await User.find({
+    $or: [
+      { roles: { $exists: false } },
+      { roles: { $size: 0 } },
+      { roles: null }
+    ]
+  }).select('_id role roles firstName lastName email');
+
+  console.log(`Found ${users.length} user(s) needing roles backfill.`);
+
+  let updated = 0;
+  for (const user of users) {
+    if (!user.role) {
+      console.log(`  SKIP: ${user.email} - no role field set`);
+      continue;
+    }
+    await User.updateOne(
+      { _id: user._id },
+      { $set: { roles: [user.role] } }
+    );
+    updated++;
+    if (updated % 100 === 0) {
+      console.log(`  ...updated ${updated} users`);
+    }
+  }
+
+  console.log(`Done. Updated ${updated} user(s).`);
+  await mongoose.disconnect();
+  process.exit(0);
+}
+
+migrate().catch(err => {
+  console.error('Migration failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
Schema:
- Add `roles` array field alongside existing `role` (active role)
- Pre-save hook syncs roles<->role bidirectionally
- New index on `roles` for multi-role queries

Auth middleware:
- Authorization (isAdmin, isTeacher, etc.) now checks `roles` array
- Users with multiple roles can access all their authorized routes
- Backward compatible: falls back to `role` if `roles` is empty

Role switching:
- POST /api/user/switch-role endpoint updates active `role`
- New role-switcher.js (self-contained, injected CSS) added to all four dashboards (admin, teacher, parent, chat)
- Dropdown only appears for users with 2+ roles
- Selecting a role switches dashboard immediately

Admin create-user:
- Role selector changed from single dropdown to checkboxes
- Supports creating users with multiple roles (e.g., teacher+parent)
- Backend accepts `roles` array, backward compatible with single `role`

Migration:
- scripts/migrateRolesArray.js backfills `roles` from `role` for all existing users (idempotent, safe to run multiple times)

https://claude.ai/code/session_01TYSn7knw85QPooAU6MCAFm