### PR TITLE
Add multi-lingual tutoring as key feature across landing page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
   <meta name="description" content="Mathmatix AI is an intelligent math tutoring platform that provides personalized, one-on-one learning for students of all levels. Affordable, accessible, and effective." />
 
   <!-- SEO Meta Tags -->
-  <meta name="keywords" content="math tutor, AI tutoring, online math help, personalized learning, math education, K-12 math, homework help, adaptive learning" />
+  <meta name="keywords" content="math tutor, AI tutoring, online math help, personalized learning, math education, K-12 math, homework help, adaptive learning, multilingual math tutor, Spanish math tutor, bilingual tutoring" />
   <meta name="author" content="Mathmatix AI" />
   <meta name="robots" content="index, follow" />
   <link rel="canonical" href="https://www.mathmatix.ai/" />
@@ -114,6 +114,7 @@
     .lp-stagger.lp-visible > *:nth-child(4) { transition-delay: 0.2s; }
     .lp-stagger.lp-visible > *:nth-child(5) { transition-delay: 0.25s; }
     .lp-stagger.lp-visible > *:nth-child(6) { transition-delay: 0.3s; }
+    .lp-stagger.lp-visible > *:nth-child(7) { transition-delay: 0.35s; }
 
     /* ── Section Headings ──────────────────────────────────── */
     .lp-section-heading {
@@ -1163,6 +1164,7 @@
         <div class="lp-trust-item"><i class="fas fa-shield-halved"></i> Will Not Help Them Cheat</div>
         <div class="lp-trust-item"><i class="fas fa-seedling"></i> Starting Point &amp; Growth Checks</div>
         <div class="lp-trust-item"><i class="fas fa-graduation-cap"></i> Grade 3 &ndash; Calc 3</div>
+        <div class="lp-trust-item"><i class="fas fa-language"></i> 9 Languages</div>
       </div>
     </section>
 
@@ -1197,9 +1199,9 @@
             <p>Built-in support for Individualized Education Programs and learning accommodations. Every learner gets tools designed for them.</p>
           </div>
           <div class="lp-feature-card">
-            <div class="lp-feature-icon"><i class="fas fa-clock"></i></div>
-            <h3>Always Available</h3>
-            <p>24/7 tutoring with no appointments, no waitlists, and no scheduling. Help is there whenever your student needs it.</p>
+            <div class="lp-feature-icon"><i class="fas fa-language"></i></div>
+            <h3>Multi-Lingual Tutoring</h3>
+            <p>Students can learn in English, Spanish, French, Arabic, Chinese, Vietnamese, Somali, Russian, or German. Math has no language barrier.</p>
           </div>
           <div class="lp-feature-card">
             <div class="lp-feature-icon"><i class="fas fa-chart-line"></i></div>
@@ -1244,6 +1246,7 @@
                 <li><i class="fas fa-check"></i> Pick a tutor with the personality that fits you</li>
                 <li><i class="fas fa-check"></i> Upload your homework and check it before you turn it in</li>
                 <li><i class="fas fa-check"></i> Earn XP, level up, and unlock achievement badges</li>
+                <li><i class="fas fa-check"></i> Learn in your language &mdash; 9 languages supported</li>
                 <li><i class="fas fa-check"></i> Get help 24/7 &mdash; no appointments, no waiting</li>
               </ul>
             </div>
@@ -1380,6 +1383,7 @@
               <li class="lp-compare-no"><i class="fas fa-xmark"></i> Expensive for most families</li>
               <li class="lp-compare-no"><i class="fas fa-xmark"></i> No homework OCR</li>
               <li class="lp-compare-no"><i class="fas fa-xmark"></i> No parent dashboard</li>
+              <li class="lp-compare-no"><i class="fas fa-xmark"></i> English only (usually)</li>
             </ul>
           </div>
           <div class="lp-compare-card lp-compare-card--highlight">
@@ -1393,6 +1397,7 @@
               <li class="lp-compare-yes"><i class="fas fa-check"></i> OCR homework review</li>
               <li class="lp-compare-yes"><i class="fas fa-check"></i> Real-time progress dashboards</li>
               <li class="lp-compare-yes"><i class="fas fa-check"></i> Teacher curriculum sync</li>
+              <li class="lp-compare-yes"><i class="fas fa-check"></i> 9 languages supported</li>
             </ul>
           </div>
           <div class="lp-compare-card">
@@ -1405,6 +1410,7 @@
               <li class="lp-compare-no"><i class="fas fa-xmark"></i> No homework analysis</li>
               <li class="lp-compare-no"><i class="fas fa-xmark"></i> No progress tracking</li>
               <li class="lp-compare-no"><i class="fas fa-xmark"></i> No teacher tools</li>
+              <li class="lp-compare-no"><i class="fas fa-xmark"></i> No dedicated language support</li>
             </ul>
           </div>
         </div>
@@ -1524,6 +1530,15 @@
             </button>
             <div class="lp-faq-answer">
               <p>Students can upload a photo or PDF of their work. The AI uses OCR to read their handwriting, identifies mistakes, and gives targeted feedback &mdash; so they can fix errors before turning it in. It's like having a tutor look over your shoulder.</p>
+            </div>
+          </div>
+          <div class="lp-faq-item">
+            <button class="lp-faq-question" aria-expanded="false">
+              What languages does Mathmatix support?
+              <i class="fas fa-chevron-down"></i>
+            </button>
+            <div class="lp-faq-answer">
+              <p>Mathmatix currently supports tutoring in 9 languages: English, Spanish, French, Arabic, Chinese, Vietnamese, Somali, Russian, and German. Students can switch their preferred language in settings, and the tutor will teach entirely in that language.</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
9 languages: English, Spanish, French, Arabic, Chinese, Vietnamese, Somali, Russian, German

- Feature card: replaced "Always Available" with "Multi-Lingual Tutoring" (24/7 already mentioned in hero + student benefits)
- Trust bar: added "9 Languages" badge
- Comparison: added "9 languages supported" to Mathmatix card, "English only" to Private Tutor, "No dedicated language support" to Other AI Tools
- Student benefits: added "Learn in your language" bullet
- FAQ: added "What languages does Mathmatix support?" question
- SEO keywords: added multilingual/bilingual terms

https://claude.ai/code/session_017QhTDKwL2HSWknjgCpkzWn