### PR TITLE
Add hard difficulty floor to prevent low-level questions at high theta

### DIFF
--- a/utils/catConfig.js
+++ b/utils/catConfig.js
@@ -41,6 +41,10 @@ const SESSION_DEFAULTS = {
   scoreThreshold: 2.0,         // Skills within this score are "similar enough"
   maxSkillTests: 3,            // Max times to test same skill
   categoryBalanceWeight: 8,    // Stronger weight for category diversity
+
+  // HARD DIFFICULTY FLOOR - Never select skills too far below current level
+  // Prevents calculus students from getting skip counting questions
+  maxDifficultyGapBelow: 2.0,  // Don't select skills more than 2 theta below current level
 };
 
 // ===========================================================================

--- a/utils/skillSelector.js
+++ b/utils/skillSelector.js
@@ -286,7 +286,22 @@ function selectSkill(availableSkills, session, targetDifficulty, options = {}) {
   };
 
   // Filter out excluded skills (conceptual/vague questions)
-  const eligibleSkills = availableSkills.filter(skill => !isScreenerExcluded(skill.skillId));
+  let eligibleSkills = availableSkills.filter(skill => !isScreenerExcluded(skill.skillId));
+
+  // HARD DIFFICULTY FLOOR: Never select skills too far below current level
+  // Prevents calculus students from getting skip counting questions
+  const { maxDifficultyGapBelow } = SESSION_DEFAULTS;
+  const difficultyFloor = theta - maxDifficultyGapBelow;
+
+  eligibleSkills = eligibleSkills.filter(skill => {
+    const skillDifficulty = skill.irtDifficulty ||
+                            templateDifficultyMap[skill.skillId] ||
+                            getCategoryDifficulty(skill.category) ||
+                            0;
+    return skillDifficulty >= difficultyFloor;
+  });
+
+  console.log(`[SkillSelector] θ=${theta.toFixed(2)}, floor=${difficultyFloor.toFixed(2)}, ${eligibleSkills.length}/${availableSkills.length} skills eligible`);
 
   // Score all eligible skills
   let candidates = eligibleSkills.map(skill => {


### PR DESCRIPTION
Problem: Calculus-level students (theta ~2.5) were getting kindergarten questions (skip counting, difficulty -2.5) because content balancing tried to cover all categories including number-operations.

Fix: Added maxDifficultyGapBelow parameter (default 2.0 theta) that creates a hard floor on skill selection. For theta=2.5, skills below difficulty 0.5 (Algebra 1) are now filtered out entirely.

This ensures a calculus student will never see counting questions regardless of content balancing pressures.

https://claude.ai/code/session_01E4ujAkAhnVKQVxKMVPdB38