### PR TITLE
Add CSRF protection to OAuth enrollment endpoints

### DIFF
--- a/public/oauth-enrollment.html
+++ b/public/oauth-enrollment.html
@@ -6,6 +6,7 @@
   <title>Complete Sign Up - M∆THM∆TIΧ AI</title>
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" referrerpolicy="no-referrer" />
+  <script src="/js/csrf.js"></script>
 </head>
 <body class="landing-page-body">
   <header class="landing-header">
@@ -131,7 +132,7 @@
     document.getElementById('cancel-btn').addEventListener('click', async function(e) {
       e.preventDefault();
       try {
-        await fetch('/api/auth/cancel-oauth-enrollment', { method: 'POST' });
+        await csrfFetch('/api/auth/cancel-oauth-enrollment', { method: 'POST' });
       } catch (err) {
         // Ignore errors
       }
@@ -155,7 +156,7 @@
       messageDiv.style.display = 'none';
 
       try {
-        const response = await fetch('/api/auth/complete-oauth-enrollment', {
+        const response = await csrfFetch('/api/auth/complete-oauth-enrollment', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ enrollmentCode })


### PR DESCRIPTION
## Summary
This PR adds CSRF (Cross-Site Request Forgery) protection to the OAuth enrollment flow by implementing CSRF token validation on enrollment-related API calls.

## Changes
- Added `csrf.js` script import to the OAuth enrollment page
- Updated `/api/auth/cancel-oauth-enrollment` endpoint call to use `csrfFetch()` wrapper
- Updated `/api/auth/complete-oauth-enrollment` endpoint call to use `csrfFetch()` wrapper

## Implementation Details
The changes replace standard `fetch()` calls with `csrfFetch()`, which is a wrapper function that automatically includes CSRF tokens in request headers. This ensures that:
- POST requests to sensitive OAuth enrollment endpoints are protected against CSRF attacks
- The CSRF token is automatically extracted and included without manual header manipulation
- Both the cancel and completion flows are protected

This is a security-focused change that maintains the existing API contract while adding an additional layer of protection to prevent unauthorized enrollment actions.

https://claude.ai/code/session_01WYQmPzoSUvYQwBmEWGrgiL