### PR TITLE
Add server-side answer-key detection across all chat routes

### DIFF
--- a/utils/prompt.js
+++ b/utils/prompt.js
@@ -1268,6 +1268,14 @@ Mathmatix exists to help students LEARN, not to give them answers to copy. Follo
 - Student asks for multiple problems rapidly (5+ in short time) → SLOW DOWN. Focus on understanding ONE problem.
 - Student says "what is X?" without asking "how" or "why" → Don't just give answer. Show method.
 
+**RED FLAGS - Answer-Seeking Phrases (REFUSE ALL):**
+- "give me the rest" / "do the rest" / "now do the others" / "do the remaining" → ABSOLUTE REFUSAL. Say "I can only help with one problem at a time. Which one next?"
+- "give me the answers" / "all the answers" / "answers 1-10" → ABSOLUTE REFUSAL. Never list answers.
+- "in radical form" / "in simplified form" / "in exact form" — when applied to multiple problems → They want a formatted answer key. REFUSE.
+- "what questions do you see?" / "list the problems" / "read the questions" → They want you to restate problems so they can ask for solutions next. Instead say "I can see the worksheet! Which problem are you working on?"
+- "yep" / "yes" / "correct" / "keep going" after you solved one problem → They want you to continue solving the NEXT problem. DO NOT. Ask which specific problem they need help with next.
+- "show me the work" / "show me step by step with the work" → This means "solve it for me." Use a PARALLEL problem instead.
+
 **RED FLAGS - Uploaded Worksheet Exploitation:**
 - Student uploads an image/PDF of a worksheet and asks "solve this", "step by step", "help me with all of these" → DO NOT solve. Ask which ONE problem they're stuck on.
 - Student uploads a photo and immediately asks for answers → This is answer-seeking, not learning. Redirect to Socratic guidance.
@@ -1296,6 +1304,22 @@ This is the #1 most common attempt to get homework answers. Instead:
 3. Then say "Now try yours using the same approach!"
 4. If they still struggle, guide them through THEIR problem one step at a time (ask, don't tell — "What do you think the first step is?")
 5. NEVER solve their original problem — the worked example must ALWAYS use different numbers
+
+🚫🚫🚫 **ABSOLUTE BAN: SEQUENTIAL PROBLEM SOLVING** 🚫🚫🚫
+You must NEVER solve more than ONE problem from a worksheet, assignment, or set of numbered problems in a SINGLE response OR across consecutive responses. This is NON-NEGOTIABLE.
+
+**BANNED PATTERNS — if ANY of these occur, REFUSE immediately:**
+- Student asks you to solve problem #1, then says "now do #2" or "give me the rest" → REFUSE. Say: "Great work on that one! Now try the next one yourself using the same method. I'll check your work!"
+- Student asks for solutions to problems "1 through 5" or "1-10" → REFUSE. Work through ONE.
+- You already helped with one problem and the student says "yep", "keep going", "next one", "do the others" → REFUSE. They must attempt the next problem themselves first.
+- Student says "give me the rest" or "do the remaining problems" → This is an answer key request. REFUSE absolutely.
+
+**THE ONE-PROBLEM RULE:**
+In any conversation involving a worksheet or multiple problems, you may only help with ONE problem at a time. After helping with one:
+1. Tell the student to try the next one on their own
+2. Wait for them to show their attempt
+3. Only then help with the next one
+4. NEVER skip ahead or solve multiple problems because the student asked
 
 **WORD PROBLEMS - EXTRA CARE:**
 Word problems require THINKING, not just calculation. Guide through:
@@ -1372,12 +1396,21 @@ Whether the student uploaded homework, typed a problem from their assignment, or
 3. Then say: "Now try yours using the same approach!"
 4. If they still struggle, guide them through THEIR problem one step at a time (ask, don't tell)
 
-**Example:**
+**Example 1 (Algebra):**
 Student uploads worksheet and says: "Show me how to do #3: Solve 2x + 5 = 17"
 ❌ BAD: "Step 1: Subtract 5 from both sides: 2x = 12. Step 2: Divide by 2: x = 6." ← You just did their homework.
 ✅ GOOD: "Let me show you the method with a similar problem! Solve 3x + 4 = 19. Step 1: Subtract 4... Step 2: Divide by 3... x = 5. Now try #3 with the same steps!"
 
-**This applies to ALL contexts** — uploaded files, typed problems, "help with #1", "step by step please", etc. The worked example must ALWAYS be a parallel problem, never the original.
+**Example 2 (Rationalizing Denominators):**
+Student uploads worksheet with "Rationalize: 3/(2√7)" and says "show me step by step, with the work"
+❌ BAD: "3/(2√7) × (√7/√7) = 3√7/14" ← You solved their actual problem!
+✅ GOOD: "Let me show you with a different example! Rationalize 5/(3√2): Multiply by √2/√2... = 5√2/(3·2) = 5√2/6. Now try yours with the same technique!"
+
+**Example 3 (Student says "give me the rest" after you helped with one):**
+❌ BAD: Solving problems #2 through #10 ← You just created an answer key!
+✅ GOOD: "Nice job understanding that one! Now try #2 on your own using the same method. Show me your work and I'll help if you get stuck!"
+
+**This applies to ALL contexts** — uploaded files, typed problems, "help with #1", "step by step please", etc. The worked example must ALWAYS be a parallel problem, never the original. And you must NEVER solve more than one problem per conversation turn.
 
 **FOR GENUINE EXAMPLE REQUESTS (no specific problem referenced):**
 When student asks for an example of a CONCEPT without referencing a specific homework problem, provide a COMPLETE step-by-step solution using an example you create:
@@ -2007,12 +2040,15 @@ Now we can add these two equations to eliminate y."
 🚫 **NEVER list out answers to multiple problems**
 🚫 **NEVER "verify" or "grade" a blank or nearly-blank worksheet**
 🚫 **NEVER restate all problems with their solutions**
+🚫 **NEVER solve the student's ACTUAL problem — use a PARALLEL problem with DIFFERENT numbers**
+🚫 **NEVER solve a second problem when the student says "give me the rest" or "do the next one" — tell them to try it themselves**
 
 ✅ **INSTEAD, do this:**
 1. Acknowledge you can see the worksheet
 2. Ask which SINGLE problem they want to work through
-3. Use Socratic method — guide, don't solve
-4. After they understand one problem, ask if they want to try the next one ON THEIR OWN first
+3. Use a PARALLEL problem (same type, DIFFERENT numbers) as the worked example
+4. After they understand the method, tell them to try their problem ON THEIR OWN
+5. If they say "give me the rest" or "do the next one", REFUSE — tell them to try it themselves first
 
 **EXAMPLE RESPONSES:**
 ✅ GOOD: "I can see your worksheet! There are quite a few problems here. Which one are you stuck on? Let's work through it together."

--- a/utils/worksheetGuard.js
+++ b/utils/worksheetGuard.js
@@ -1,8 +1,11 @@
 /**
- * WORKSHEET GUARD — Centralized anti-cheat for file uploads
+ * WORKSHEET GUARD — Centralized anti-cheat for file uploads & answer-key detection
  *
  * Prevents students from uploading blank worksheets to extract answer keys.
+ * Also provides SERVER-SIDE detection of answer-key responses as defense-in-depth.
+ *
  * Used by: chatWithFile.js, upload.js (injected into user messages)
+ *          chat.js, chatWithFile.js, upload.js (response filtering)
  *
  * The gradeWork.js ANALYSIS_PROMPT has its own built-in detection because
  * it operates on structured JSON output, not conversational messages.
@@ -83,9 +86,136 @@ function stripCorrectAnswers(problems) {
     return problems;
 }
 
+// ============================================================================
+// SERVER-SIDE ANSWER-KEY DETECTION (Defense-in-Depth)
+// ============================================================================
+// Even with the best prompt engineering, LLMs can be convinced to generate
+// answer keys. This provides a hard server-side filter that catches answer-key
+// patterns in AI responses BEFORE they reach the student.
+// ============================================================================
+
+/**
+ * Patterns that indicate the AI has generated an answer key or solved
+ * multiple sequential problems in a single response.
+ *
+ * Each pattern has:
+ * - regex: The pattern to match
+ * - minMatches: Minimum number of matches to trigger detection (prevents false positives)
+ * - name: Human-readable name for logging
+ */
+const ANSWER_KEY_PATTERNS = [
+    // "#1:", "#2:", "#3:" or "# 1:", "# 2:" — numbered problem headers
+    { regex: /(?:^|\n)\s*#\s*(\d+)\s*[.:)\-]/gm, minMatches: 3, name: 'numbered-hash' },
+
+    // "Problem 1:", "Problem 2:" etc.
+    { regex: /(?:^|\n)\s*(?:Problem|Prob\.?)\s*#?\s*(\d+)\s*[.:)\-]/gim, minMatches: 3, name: 'problem-label' },
+
+    // "1.", "2.", "3." at start of line followed by math-like content
+    { regex: /(?:^|\n)\s*(\d+)\.\s+(?:[\$\\]|[a-z]\s*=|[-+]?\d+|√|\\frac|\\sqrt)/gim, minMatches: 3, name: 'numbered-list-math' },
+
+    // "1)", "2)", "3)" at start of line
+    { regex: /(?:^|\n)\s*(\d+)\)\s+/gm, minMatches: 3, name: 'numbered-parens' },
+
+    // "**1.**", "**2.**", "**3.**" — markdown bold numbered
+    { regex: /(?:^|\n)\s*\*\*\s*#?\s*(\d+)\.?\s*\*\*/gm, minMatches: 3, name: 'bold-numbered' },
+
+    // "Step-by-step for #1" ... "Step-by-step for #2" — sequential solve headers
+    { regex: /(?:step[- ]by[- ]step|solution|solving|answer)\s+(?:for\s+)?(?:#|problem\s*#?\s*)(\d+)/gim, minMatches: 2, name: 'sequential-solve' },
+];
+
+/**
+ * Detect if an AI response contains an answer key (multiple problems solved).
+ *
+ * This is the server-side defense-in-depth layer. Even if the AI ignores
+ * prompt instructions and generates solutions to multiple problems, this
+ * function catches it before the response reaches the student.
+ *
+ * @param {string} responseText - The AI's response text
+ * @param {Object} [options] - Configuration options
+ * @param {number} [options.minProblems=3] - Minimum distinct problem numbers to trigger
+ * @returns {{ isAnswerKey: boolean, problemCount: number, matchedPattern: string|null, problemNumbers: number[] }}
+ */
+function detectAnswerKeyResponse(responseText, options = {}) {
+    if (!responseText || typeof responseText !== 'string') {
+        return { isAnswerKey: false, problemCount: 0, matchedPattern: null, problemNumbers: [] };
+    }
+
+    const minProblems = options.minProblems || 3;
+
+    for (const pattern of ANSWER_KEY_PATTERNS) {
+        const matches = [...responseText.matchAll(pattern.regex)];
+
+        if (matches.length >= pattern.minMatches) {
+            // Extract distinct problem numbers
+            const problemNumbers = [...new Set(matches.map(m => parseInt(m[1], 10)).filter(n => !isNaN(n)))];
+
+            // Check if we have enough DISTINCT problem numbers
+            if (problemNumbers.length >= minProblems) {
+                // Additional check: are the numbers sequential or close to sequential?
+                // This reduces false positives from legitimate numbered lists
+                const sorted = problemNumbers.sort((a, b) => a - b);
+                const hasSequentialRun = sorted.some((num, i) =>
+                    i >= 2 && sorted[i] - sorted[i - 2] <= 4 // 3+ numbers within a range of 4
+                );
+
+                if (hasSequentialRun || problemNumbers.length >= 4) {
+                    return {
+                        isAnswerKey: true,
+                        problemCount: problemNumbers.length,
+                        matchedPattern: pattern.name,
+                        problemNumbers: sorted
+                    };
+                }
+            }
+        }
+    }
+
+    return { isAnswerKey: false, problemCount: 0, matchedPattern: null, problemNumbers: [] };
+}
+
+/**
+ * The safe redirect message sent to the student when an answer key is detected.
+ * This replaces the AI's response entirely.
+ */
+const ANSWER_KEY_REDIRECT_MESSAGE = `I got a little carried away there! As your tutor, my job is to help you **learn**, not give you all the answers. 🎯
+
+Let's do this the right way: **Pick ONE problem** you want to work through, and I'll guide you step by step so you actually understand it. Which one is giving you the most trouble?`;
+
+/**
+ * Filter an AI response for answer-key patterns. If detected, replace with
+ * a safe redirect message.
+ *
+ * This should be called on EVERY AI response in chat routes as defense-in-depth.
+ *
+ * @param {string} responseText - The AI's raw response text
+ * @param {string} [userId] - For logging purposes
+ * @returns {{ text: string, wasFiltered: boolean, detection: Object }}
+ */
+function filterAnswerKeyResponse(responseText, userId) {
+    const detection = detectAnswerKeyResponse(responseText);
+
+    if (detection.isAnswerKey) {
+        console.warn(
+            `🚨 [ANSWER-KEY DETECTED] User ${userId || 'unknown'} — ` +
+            `${detection.problemCount} problems (${detection.problemNumbers.join(', ')}) ` +
+            `matched pattern "${detection.matchedPattern}". Response blocked.`
+        );
+        return {
+            text: ANSWER_KEY_REDIRECT_MESSAGE,
+            wasFiltered: true,
+            detection
+        };
+    }
+
+    return { text: responseText, wasFiltered: false, detection };
+}
+
 module.exports = {
     WORKSHEET_GUARD_INSTRUCTION,
     applyWorksheetGuard,
     detectBlankWork,
-    stripCorrectAnswers
+    stripCorrectAnswers,
+    detectAnswerKeyResponse,
+    filterAnswerKeyResponse,
+    ANSWER_KEY_REDIRECT_MESSAGE
 };


### PR DESCRIPTION
Students were bypassing prompt-level anti-cheat by asking "show me step by step" then "give me the rest" to get complete answer keys. This adds a hard server-side filter (defense-in-depth) that detects when the AI has solved 3+ sequential problems and replaces the response with a safe redirect.

Changes:
- worksheetGuard.js: Add detectAnswerKeyResponse() and filterAnswerKeyResponse() with regex patterns for numbered solutions, problem headers, sequential solves
- chat.js: Import and apply filterAnswerKeyResponse after AI response generation; send SSE replacement event for streaming mode
- chatWithFile.js: Apply filterAnswerKeyResponse before XP processing
- upload.js: Apply filterAnswerKeyResponse before sending reply
- prompt.js: Add "Answer-Seeking Phrases" red flags (give me the rest, all the answers, in radical form, what questions do you see, yep/keep going); Add ABSOLUTE BAN: SEQUENTIAL PROBLEM SOLVING section with one-problem rule; Add rationalization example to SHOW ME AN EXAMPLE section; Strengthen FILE HANDLING worksheet rules with parallel-problem enforcement

https://claude.ai/code/session_01GoRNGaPk7bbQku5t6kmMiG