### PR TITLE
Fix negative XP display by adding level/XP sync safety checks

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -2888,7 +2888,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
             if (data.userXp !== undefined) {
                 currentUser.level = data.userLevel;
-                currentUser.xpForCurrentLevel = data.userXp;
+                currentUser.xpForCurrentLevel = Math.max(0, data.userXp);
                 currentUser.xpForNextLevel = data.xpNeeded;
                 updateGamificationDisplay();
             }

--- a/services/userService.js
+++ b/services/userService.js
@@ -5,6 +5,7 @@
 const logger = require('../utils/logger').child({ service: 'user-service' });
 const User = require('../models/user');
 const bcrypt = require('bcryptjs');
+const BRAND_CONFIG = require('../utils/brand');
 
 /**
  * Get user by ID with error handling
@@ -195,8 +196,11 @@ async function awardXP(userId, amount, reason) {
       reason
     });
 
-    // Calculate level (basic formula - adjust as needed)
-    const newLevel = Math.floor(user.xp / 1000) + 1;
+    // Calculate level using brand config's cumulative XP formula
+    let newLevel = user.level || 1;
+    while (user.xp >= BRAND_CONFIG.cumulativeXpForLevel(newLevel + 1)) {
+        newLevel++;
+    }
     user.level = newLevel;
 
     await user.save();


### PR DESCRIPTION
The XP display was showing -12649 / 610 XP because user.level and user.xp were out of sync. When computing XP-within-current-level as (user.xp - cumulativeXpForLevel(user.level)), a level higher than the XP supports produces a negative value.

Fixes:
- Add Math.max(0, ...) guard in chat.js, chatWithFile.js, and the frontend to prevent negative XP display
- Add level recalculation safety net in chat.js, chatWithFile.js, and server.js /user endpoint to auto-correct level/XP mismatches
- Fix outdated level formula in userService.js (was using flat xp/1000 instead of brand config's scaling formula)

https://claude.ai/code/session_013R2wbN6QZzUDVyvWHht4x5