### PR TITLE
Add Upload Class Resources button to teacher dashboard Quick Actions

### DIFF
--- a/public/js/teacher-dashboard.js
+++ b/public/js/teacher-dashboard.js
@@ -715,6 +715,20 @@ document.addEventListener("DOMContentLoaded", async () => {
             });
         }
 
+        // Upload Resources quick action
+        const uploadResourcesBtn = document.getElementById('qa-upload-resources');
+        if (uploadResourcesBtn) {
+            uploadResourcesBtn.addEventListener('click', () => {
+                // Switch to the Resources tab
+                const resourcesTabBtn = document.querySelector('[data-tab="resources"]');
+                if (resourcesTabBtn) resourcesTabBtn.click();
+
+                // Open the upload modal
+                const uploadModal = document.getElementById('upload-resource-modal');
+                if (uploadModal) uploadModal.classList.add('is-visible');
+            });
+        }
+
         // Shortcuts toggle
         const helpBtn = document.getElementById('qa-help');
         const shortcutsPanel = document.getElementById('shortcuts-panel');

--- a/public/teacher-dashboard.html
+++ b/public/teacher-dashboard.html
@@ -2129,6 +2129,9 @@
               <span>Refresh</span>
             </button>
           </div>
+          <button class="btn btn-primary main-action-btn" id="qa-upload-resources" title="Upload worksheets, practice sheets, and other files for your students">
+            <i class="fas fa-upload"></i> Upload Class Resources
+          </button>
         </div>
 
         <!-- Today's Summary Panel -->


### PR DESCRIPTION
The resource upload feature was hidden behind the 4th tab (Resources), making it hard to discover. Added a prominent button in the Quick Actions panel on the right sidebar so teachers can immediately find and use the upload functionality from the main dashboard view.

https://claude.ai/code/session_01VuX5RMAeWZbHmsunN4rctq