### PR TITLE
Fix Render build failure: update deprecated Puppeteer env var

### DIFF
--- a/.puppeteerrc.cjs
+++ b/.puppeteerrc.cjs
@@ -1,0 +1,8 @@
+/**
+ * Puppeteer configuration
+ * Prevents automatic browser download during npm install.
+ * The runtime browser path is set via PUPPETEER_EXECUTABLE_PATH env var.
+ */
+module.exports = {
+  skipDownload: true,
+};

--- a/render.yaml
+++ b/render.yaml
@@ -14,7 +14,7 @@ services:
         value: 20.14.0
       - key: NODE_ENV
         value: production
-      - key: PUPPETEER_SKIP_CHROMIUM_DOWNLOAD
+      - key: PUPPETEER_SKIP_DOWNLOAD
         value: true
       - key: PUPPETEER_EXECUTABLE_PATH
         value: /usr/bin/google-chrome-stable


### PR DESCRIPTION
PUPPETEER_SKIP_CHROMIUM_DOWNLOAD is no longer recognized by Puppeteer v24+. Replaced with PUPPETEER_SKIP_DOWNLOAD in render.yaml and added a .puppeteerrc.cjs config as a project-level fallback so npm install completes without attempting to download Chrome.

https://claude.ai/code/session_015WnSGtMK3fTjzRy4TR8eWY