### PR TITLE
Fix false positive: exam prep treated as inappropriate content

### DIFF
--- a/utils/prompt.js
+++ b/utils/prompt.js
@@ -1166,6 +1166,8 @@ ${fluencyContext.speedLevel === 'fast' ? `
 
 **IMPORTANT:** Requests to switch math topics (e.g., "I want to study Calculus instead" or "Can we do Algebra 1?") are VALID educational requests, NOT inappropriate. All math subjects are appropriate: Calculus, Algebra, Geometry, Trigonometry, Statistics, Pre-Calculus, etc. Help the student with whatever math topic they want to learn.
 
+**ALSO VALID (NOT inappropriate):** Exam prep, test prep, midterm review, final exam review, quiz practice, SAT/ACT math prep, chapter review, unit review, semester review. These are all legitimate academic activities. When a student says something like "Calc Mid Semester Exam Prep" or "Algebra test review", they want help studying — treat it as a math topic request and start helping them review that subject.
+
 2. **SCHOOL-APPROPRIATE EXAMPLES ONLY:** All word problems and examples must use:
    - Age-appropriate scenarios (school, sports, shopping, cooking, travel, games)
    - Neutral, inclusive language
@@ -1263,7 +1265,8 @@ With inequality: [DIAGRAM:coordinate_plane:xRange=10,yRange=10,inequality={slope
 Mathmatix exists to help students LEARN, not to give them answers to copy. Follow these rules STRICTLY:
 
 **RED FLAGS - Homework/Assignment Language:**
-- Student says "homework", "assignment", "due tomorrow", "test coming up" → STOP. DO NOT solve directly.
+- Student says "homework", "assignment", "due tomorrow", "test coming up" combined with "just give me the answer" or "solve these for me" → STOP. DO NOT solve directly.
+  NOTE: Mentioning a test, exam, or assignment alone is NOT a red flag. "Calc exam prep" or "help me study for my test" are VALID learning requests — help them review and practice.
 - Student says "just give me the answer" → REFUSE. Guide them instead.
 - Student asks for multiple problems rapidly (5+ in short time) → SLOW DOWN. Focus on understanding ONE problem.
 - Student says "what is X?" without asking "how" or "why" → Don't just give answer. Show method.


### PR DESCRIPTION
GPT-4o-mini was rejecting legitimate academic requests like "Calc Mid Semester Exam Prep" with the safety response ("That topic isn't appropriate"). The aggressive anti-cheat language about tests/exams was causing the AI to over-generalize.

Fixes:
- Add explicit whitelist in SAFETY section: exam prep, test prep, midterm review, final exam review, quiz practice, SAT/ACT prep are all valid
- Clarify the "test coming up" red flag only applies when combined with answer-seeking behavior, not when requesting study help

https://claude.ai/code/session_01GoRNGaPk7bbQku5t6kmMiG