### PR TITLE
Fix session duration reporting 0 and improve Retry-After header parsing

### DIFF
--- a/services/sessionService.js
+++ b/services/sessionService.js
@@ -43,7 +43,7 @@ async function generateSessionSummary(userId, sessionId, sessionData = {}) {
       role: user.role,
       startTime: sessionData.startTime || new Date(),
       endTime: new Date(),
-      duration: sessionData.duration || 0,
+      duration: sessionData.duration || sessionData.timeSpent || 0,
       metrics: {
         messagesExchanged: sessionData.messagesExchanged || 0,
         problemsAttempted: sessionData.problemsAttempted || 0,

--- a/utils/openaiClient.js
+++ b/utils/openaiClient.js
@@ -55,7 +55,12 @@ async function retryWithExponentialBackoff(fn, retries = 5, delay = 1000) {
             if (isTransientError) {
                 attempts++;
                 // Prioritize 'Retry-After' header if available (for HTTP errors)
-                const retryAfterHeader = error.response?.headers?.get('Retry-After') || error.headers?.get('Retry-After');
+                // Handle both Headers objects (.get()) and plain objects (bracket access)
+                const retryAfterHeader =
+                    error.response?.headers?.get?.('Retry-After') ||
+                    error.response?.headers?.['retry-after'] ||
+                    error.headers?.get?.('Retry-After') ||
+                    error.headers?.['retry-after'];
                 const waitTime = retryAfterHeader ? parseInt(retryAfterHeader) * 1000 : delay * (2 ** (attempts - 1)); // Exponential backoff
 
                 console.warn(`AI Service transient error (Status: ${error.status || 'N/A'}). Retrying in ${waitTime / 1000}s... (Attempt ${attempts}/${retries})`);


### PR DESCRIPTION
The client sends session duration as `timeSpent` but the server reads `duration`, causing all session summaries to log duration as 0. Also fix Retry-After header reading to handle both Headers objects and plain objects from Anthropic/OpenAI SDK error responses.

https://claude.ai/code/session_01T6uAKmCS6WGY2xNjZLbjvG