### PR TITLE
Add app store feasibility analysis for Mathmatix AI

### DIFF
--- a/docs/app-store-feasibility.md
+++ b/docs/app-store-feasibility.md
@@ -1,0 +1,161 @@
+# App Store Feasibility Analysis: Mathmatix AI
+
+## Executive Summary
+
+Publishing Mathmatix AI to the Apple App Store and Google Play Store is **worth pursuing**, but the recommended path is a **Progressive Web App (PWA) first, then a native wrapper (e.g., Capacitor/TWA)** rather than a full native rewrite. The K-12 education market strongly favors app store presence, and the current architecture is surprisingly well-positioned for a phased approach.
+
+---
+
+## Current State Assessment
+
+### What We Have
+- **Express.js + vanilla JS web app** (no frontend framework)
+- **PWA manifest** already exists (`public/manifest.json`) with standalone display mode, theme color, and app icons
+- **Responsive design** with mobile-optimized CSS (`mobile-fixes.css`)
+- **Viewport meta tags** on all pages
+- **Voice capabilities** (ElevenLabs TTS, WebSpeech API)
+- **Stripe billing** already integrated
+
+### What's Missing for PWA
+- **No service worker** — no offline support, no push notifications, no background sync
+- **Single icon size** — App stores and install prompts require multiple sizes (192x192, 512x512 minimum)
+- **No screenshots** in manifest (empty array)
+- **No install prompt** handling in the frontend JS
+
+---
+
+## Three Paths to the App Stores
+
+### Path 1: PWA-Only (Lowest effort)
+**What it is:** Enhance the existing web app into a full PWA. Google Play accepts PWAs via Trusted Web Activity (TWA). Apple's PWA support on iOS has improved but remains limited.
+
+| Pros | Cons |
+|------|------|
+| Minimal code changes | iOS PWAs still lack push notifications (as of iOS 16.4+ they work, but adoption is spotty) |
+| Single codebase for all platforms | No App Store listing on Apple (PWAs can't be submitted to Apple App Store) |
+| No app store review delays | Perceived as "less legitimate" by some schools/parents |
+| No 15-30% app store commission on Stripe payments | Limited access to native APIs |
+
+**Effort required:**
+- Add service worker for offline shell + caching
+- Generate proper icon sizes
+- Add install prompt UX
+- For Google Play: wrap in TWA using Bubblewrap CLI
+
+### Path 2: Native Wrapper via Capacitor (Recommended)
+**What it is:** Use [Capacitor](https://capacitorjs.com/) (by the Ionic team) to wrap the existing web app in a native shell for both iOS and Android. The web app runs in a native WebView with access to native APIs.
+
+| Pros | Cons |
+|------|------|
+| Reuse ~95% of existing code | Need Xcode + Mac for iOS builds |
+| Listed on both App Store and Google Play | App store review process (Apple is strict with education apps) |
+| Access to native APIs (push notifications, camera, haptics) | Must comply with Apple's IAP rules for digital content (Stripe may need to be replaced with IAP for subscriptions) |
+| Fast time to market | WebView performance slightly lower than true native |
+| Single codebase maintained | Annual Apple Developer fee ($99/yr) + Google Play fee ($25 one-time) |
+
+**Effort required:**
+- Install Capacitor, configure for iOS + Android
+- Add service worker for offline caching
+- Replace or supplement Stripe with native IAP (Apple requires this for digital subscriptions)
+- Add push notification support via Capacitor plugin
+- Test MathLive/MathJax rendering in native WebViews
+- Generate proper app icons and splash screens
+- Handle OAuth redirects in native context (Google/Microsoft sign-in)
+- Submit to app stores (review process)
+
+### Path 3: Full Native Rewrite (React Native / Flutter)
+**What it is:** Rebuild the frontend from scratch in React Native or Flutter.
+
+| Pros | Cons |
+|------|------|
+| Best native performance | Massive effort — 40+ HTML pages, 60+ JS files, 46K+ lines of frontend code to rewrite |
+| Full access to platform APIs | Two codebases to maintain (web + native) or abandon web entirely |
+| Best app store review experience | MathLive/MathJax have no native equivalents — would need WebView bridges anyway |
+| | Voice, canvas drawing, algebra tiles all need native reimplementation |
+
+**Not recommended** given the codebase size and the heavy reliance on web-specific math rendering libraries.
+
+---
+
+## Key Considerations for K-12 Education
+
+### Why App Store Presence Matters for This Market
+1. **School IT procurement**: Many school districts only approve apps from official stores. A web-only product may be blocked by school firewalls or MDM policies.
+2. **Parent trust**: Parents of K-12 students are more likely to trust and install an app from the App Store than bookmark a website.
+3. **Discoverability**: "Math tutor" searches in app stores have high intent. The App Store and Google Play are discovery channels.
+4. **Push notifications**: Critical for daily quests, streak reminders, and weekly challenge notifications — features already built into the platform.
+5. **Managed devices**: Many schools use iPads. Having an App Store listing means easy deployment via Apple School Manager.
+
+### Apple In-App Purchase Requirement (Critical)
+Apple requires that **digital content and subscriptions** sold within iOS apps use Apple's In-App Purchase (IAP) system, which takes a **15-30% commission**. This directly impacts the Stripe billing already in place.
+
+**Options:**
+- Use Apple IAP for iOS subscriptions (accept the commission)
+- Use the "reader app" exemption if applicable (unlikely for ed-tech)
+- Offer subscriptions via the website only and make the app free to use (risky — Apple may reject)
+- As of 2024, some jurisdictions allow linking out to web for purchases (EU Digital Markets Act)
+
+### COPPA Compliance
+The app already appears COPPA-aware. For app store submission targeting children under 13:
+- Apple requires a privacy policy and "Made for Kids" designation
+- Google requires a "Designed for Families" self-certification
+- Both require teacher/parent gate for account creation (already implemented via roles)
+
+---
+
+## Recommended Approach: Phased Plan
+
+### Phase 1: PWA Enhancement
+- Add service worker with offline shell caching
+- Generate multiple icon sizes (192, 512, maskable)
+- Add web app install prompt
+- Add push notification support (Web Push API)
+- Publish to Google Play via TWA (Bubblewrap)
+
+### Phase 2: Capacitor Wrapper for iOS
+- Initialize Capacitor project
+- Configure native iOS + Android shells
+- Integrate native push notifications
+- Implement Apple IAP for iOS subscriptions
+- Handle OAuth redirect flows in native context
+- Test MathLive/MathJax in native WebViews
+- Submit to Apple App Store
+
+### Phase 3: Native Feature Enhancement
+- Add haptic feedback for correct/incorrect answers
+- Camera integration for handwriting/whiteboard capture (supplement Mathpix OCR)
+- Offline problem sets for use without connectivity
+- Widget for daily quest reminders (iOS/Android home screen widgets)
+
+---
+
+## Technical Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| MathLive/MathJax rendering in WebView | Medium | Test early; these libraries work in WebViews but may need CSS tweaks |
+| Apple App Store rejection | Medium | Follow Human Interface Guidelines; ensure COPPA compliance |
+| Stripe → IAP migration complexity | High | Consider hybrid: IAP on iOS, Stripe on web/Android |
+| OAuth in native WebView | Low | Capacitor has plugins for Google/Microsoft sign-in |
+| Large app size (Puppeteer dependency) | Low | Puppeteer runs server-side only; not bundled in app |
+| Voice features in WebView | Low | WebSpeech API works in WKWebView; ElevenLabs is server-side |
+
+---
+
+## Cost Estimates
+
+| Item | Cost |
+|------|------|
+| Apple Developer Program | $99/year |
+| Google Play Developer | $25 one-time |
+| Apple IAP commission | 15% (first $1M/yr via Small Business Program) or 30% |
+| Google Play commission | 15% (first $1M/yr) or 30% |
+| Mac for iOS builds (if not already available) | ~$1,000+ (Mac Mini) or use cloud CI like GitHub Actions with macOS runners |
+
+---
+
+## Conclusion
+
+**Yes, pursuing app store listings is worth it** for Mathmatix AI, especially given the K-12 education target market. The recommended path is **Capacitor wrapping** (Path 2), which preserves the existing codebase while gaining app store presence. Start with PWA enhancements (Phase 1) as they benefit the web app regardless, then wrap with Capacitor for native distribution.
+
+The biggest decision point is the **Apple IAP requirement** for subscriptions, which will impact revenue margins on iOS. This should be factored into pricing strategy early.


### PR DESCRIPTION
Evaluates three paths (PWA, Capacitor wrapper, native rewrite) and recommends a phased Capacitor approach to get into Apple App Store and Google Play while preserving the existing codebase.

https://claude.ai/code/session_01Tv1BHw7XARRvYfZUivA1cP