### PR TITLE
Restore countdown banner with HTML, CSS, and live JS timer

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -71,10 +71,70 @@
   <link rel="stylesheet" href="/style.css" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" referrerpolicy="no-referrer" />
   <style>
-    /* ── Countdown banner above header; header above everything else ── */
+    /* ── Countdown Banner ────────────────────────────────────── */
     .lp-countdown-banner {
-      position: relative;
+      position: sticky;
+      top: 0;
       z-index: 101;
+      background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);
+      color: #fff;
+      text-align: center;
+      padding: 0.75rem 1rem;
+      font-family: 'Inter', sans-serif;
+    }
+
+    .lp-countdown-title {
+      font-size: 0.95rem;
+      font-weight: 600;
+      letter-spacing: 0.03em;
+      margin-bottom: 0.4rem;
+    }
+
+    .lp-countdown-title i { margin-right: 0.3rem; }
+
+    .lp-countdown-timer {
+      display: flex;
+      justify-content: center;
+      gap: 0.5rem;
+      align-items: baseline;
+    }
+
+    .lp-countdown-block {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    .lp-countdown-number {
+      font-size: 1.5rem;
+      font-weight: 700;
+      line-height: 1;
+      min-width: 2.2rem;
+      background: rgba(255, 255, 255, 0.12);
+      border-radius: 6px;
+      padding: 0.3rem 0.5rem;
+    }
+
+    .lp-countdown-label {
+      font-size: 0.6rem;
+      font-weight: 500;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      opacity: 0.7;
+      margin-top: 0.2rem;
+    }
+
+    .lp-countdown-sep {
+      font-size: 1.3rem;
+      font-weight: 700;
+      opacity: 0.5;
+      align-self: center;
+      margin-bottom: 0.8rem;
+    }
+
+    @media (max-width: 768px) {
+      .lp-countdown-number { font-size: 1.25rem; padding: 0.25rem 0.4rem; }
+      .lp-countdown-banner { padding: 0.6rem 0.75rem; }
     }
 
     /* ── Landing Page Overrides ─────────────────────────────── */
@@ -1119,6 +1179,32 @@
     </nav>
   </header>
 
+  <!-- Countdown Banner -->
+  <div class="lp-countdown-banner" id="lp-countdown-banner">
+    <div class="lp-countdown-title"><i class="fas fa-rocket"></i> Launching March 14</div>
+    <div class="lp-countdown-timer">
+      <div class="lp-countdown-block">
+        <span class="lp-countdown-number" id="lp-cd-days">--</span>
+        <span class="lp-countdown-label">Days</span>
+      </div>
+      <span class="lp-countdown-sep">:</span>
+      <div class="lp-countdown-block">
+        <span class="lp-countdown-number" id="lp-cd-hours">--</span>
+        <span class="lp-countdown-label">Hours</span>
+      </div>
+      <span class="lp-countdown-sep">:</span>
+      <div class="lp-countdown-block">
+        <span class="lp-countdown-number" id="lp-cd-min">--</span>
+        <span class="lp-countdown-label">Min</span>
+      </div>
+      <span class="lp-countdown-sep">:</span>
+      <div class="lp-countdown-block">
+        <span class="lp-countdown-number" id="lp-cd-sec">--</span>
+        <span class="lp-countdown-label">Sec</span>
+      </div>
+    </div>
+  </div>
+
   <main class="landing-main">
     <!-- ── Hero ──────────────────────────────────────────── -->
     <section class="lp-hero">
@@ -1580,6 +1666,30 @@
   <script>
     (function () {
       'use strict';
+
+      /* ── Launch Countdown ───────────────────────────────── */
+      (function () {
+        var launchDate = new Date('2026-03-14T00:00:00').getTime();
+        var daysEl = document.getElementById('lp-cd-days');
+        var hoursEl = document.getElementById('lp-cd-hours');
+        var minEl = document.getElementById('lp-cd-min');
+        var secEl = document.getElementById('lp-cd-sec');
+        var banner = document.getElementById('lp-countdown-banner');
+
+        function pad(n) { return n < 10 ? '0' + n : String(n); }
+
+        function tick() {
+          var diff = launchDate - Date.now();
+          if (diff <= 0) { if (banner) banner.style.display = 'none'; return; }
+          daysEl.textContent = pad(Math.floor(diff / 864e5));
+          hoursEl.textContent = pad(Math.floor((diff % 864e5) / 36e5));
+          minEl.textContent = pad(Math.floor((diff % 36e5) / 6e4));
+          secEl.textContent = pad(Math.floor((diff % 6e4) / 1e3));
+        }
+
+        tick();
+        setInterval(tick, 1000);
+      })();
 
       /* ── Scroll Reveal ─────────────────────────────────── */
       var revealEls = document.querySelectorAll('.lp-reveal');


### PR DESCRIPTION
Adds back the full countdown banner: HTML structure, dark gradient styling, and JavaScript that counts down to March 14, 2026. Banner sits at z-index 101 (above the sticky header at 100) so it renders in front of Log In / Sign Up while the header stays in front of all other page content. Banner auto-hides after launch date.

https://claude.ai/code/session_017QhTDKwL2HSWknjgCpkzWn