### PR TITLE
Enlarge landing page logo to 1.3x (65px) without breaking layout

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -138,6 +138,13 @@
     }
 
     /* ── Landing Page Overrides ─────────────────────────────── */
+    .landing-header .main-logo-hero {
+      max-height: 65px;
+      transform: none;
+      position: relative;
+      z-index: 2;
+    }
+
     .landing-main {
       max-width: 100%;
       padding: 0;


### PR DESCRIPTION
Overrides the global logo styling on the landing header only: sets max-height to 65px (1.3x of 50px) and removes the global scale(1.5) transform so the logo renders at a clean, predictable size.

https://claude.ai/code/session_017QhTDKwL2HSWknjgCpkzWn