### PR TITLE
Fix course catalog modal disappearing after <1 second

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -1465,7 +1465,7 @@
   </div>
 
   <!-- Course Catalog Modal -->
-  <div id="course-catalog-modal" class="modal-overlay" style="display: none;">
+  <div id="course-catalog-modal" class="modal-overlay">
     <div class="modal-content" style="max-width: 700px; max-height: 80vh; overflow-y: auto;">
       <button class="modal-close-button" id="close-catalog-modal-btn">&times;</button>
       <div style="padding: 24px;">

--- a/public/js/courseCatalog.js
+++ b/public/js/courseCatalog.js
@@ -470,7 +470,7 @@ class CourseManager {
         const modal = document.getElementById('course-catalog-modal');
         if (!modal) return;
 
-        modal.style.display = 'flex';
+        modal.classList.add('is-visible');
 
         const grid = document.getElementById('catalog-grid');
         if (grid) grid.innerHTML = '<div style="text-align:center; padding:40px; color:#aaa;">Loading courses...</div>';
@@ -492,7 +492,7 @@ class CourseManager {
 
     closeCatalog() {
         const modal = document.getElementById('course-catalog-modal');
-        if (modal) modal.style.display = 'none';
+        if (modal) modal.classList.remove('is-visible');
     }
 
     renderCatalog(catalog, recommended) {


### PR DESCRIPTION
The modal was using inline `style.display = 'flex'` to show, but the global `.modal-content` CSS sets `opacity: 0` by default. Other modals use the `is-visible` class which overrides this via `.modal-overlay.is-visible .modal-content { opacity: 1 }`. Without that class, the `catalogSlideIn` animation temporarily showed the content, but it reverted to `opacity: 0` once the 0.25s animation ended.

Switch to the `is-visible` class pattern used by other modals.

https://claude.ai/code/session_01MSjG5w6oviGYvYAGZngrd5