### PR TITLE
Fix course conversation routing: enrollment + greeting + chat flow

### DIFF
--- a/routes/courseSession.js
+++ b/routes/courseSession.js
@@ -174,9 +174,10 @@ router.post('/enroll', async (req, res) => {
     });
     await session.save();
 
-    // Set as active course session on user
+    // Set as active course session on user AND switch to the course conversation
     await User.findByIdAndUpdate(req.user._id, {
-      activeCourseSessionId: session._id
+      activeCourseSessionId: session._id,
+      activeConversationId: conversation._id
     });
 
     // Build welcome data for the client splash screen


### PR DESCRIPTION
Root cause: enrollment set activeCourseSessionId but not activeConversationId, so the greeting handler and chat flow loaded a different conversation, the conversationId match failed, and course context was never injected.

Three fixes:
- Enrollment now sets activeConversationId to the course conversation so the student lands in the right workspace
- Greeting handler switches to the course conversation when activeCourseSessionId is present (no longer requires a pre-existing conversationId match)
- Regular chat flow uses loadCourseContext() and checks courseSession.status === 'active' instead of requiring a strict conversationId match

https://claude.ai/code/session_019gctBnrt8XpNm78k147d9m