### PR TITLE
Fix guided tour skip logic and wire up dark mode on chat page

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -144,6 +144,9 @@
         <i class="fas fa-book-open"></i> <span class="mobile-hide">Resources</span>
       </button>
       <!-- Primary actions (always visible) -->
+      <button id="theme-toggle-btn" class="btn btn-tertiary icon-only" title="Toggle dark mode" aria-label="Toggle dark mode">
+        <i class="fas fa-moon"></i>
+      </button>
       <button id="open-settings-modal-btn" class="btn btn-tertiary icon-only" title="Settings" aria-label="Settings">
         <i class="fas fa-cog"></i>
       </button>
@@ -1707,6 +1710,22 @@
   <script src="/js/auto-expand-textarea.js"></script>
   <script src="/js/chat-pinch-zoom.js"></script>
   <script src="/js/file-upload.js"></script>
+  <script src="/js/theme-toggle.js"></script>
+  <script>
+    // Wire up the dark mode toggle button in the header
+    (function() {
+      const btn = document.getElementById('theme-toggle-btn');
+      if (!btn || !window.ThemeToggle) return;
+      function updateIcon() {
+        const dark = ThemeToggle.getTheme() === 'dark';
+        btn.innerHTML = dark ? '<i class="fas fa-sun"></i>' : '<i class="fas fa-moon"></i>';
+        btn.title = dark ? 'Switch to light mode' : 'Switch to dark mode';
+      }
+      btn.addEventListener('click', () => { ThemeToggle.toggle(); updateIcon(); });
+      document.addEventListener('themechange', updateIcon);
+      updateIcon();
+    })();
+  </script>
   <script src="/js/student-resources.js"></script>
   <script src="/js/settings.js"></script>
   <script src="/js/show-your-work.js"></script>


### PR DESCRIPTION
guided-tour.js:
- Fix auto-complete cascade when elements are missing/hidden: the old logic recursively called showStep(index+1) for each missing element, chain-completing the entire tour if several consecutive steps had hidden targets (e.g. sidebar collapsed on mobile). New _skipStep() finds the next VISIBLE step forward, or backward, only completing if zero steps are visible.
- Detect hidden elements (offsetParent === null) in addition to missing ones — covers elements inside collapsed sidebar.
- prev() now also skips hidden elements instead of blindly going to currentStep - 1.

chat.html:
- Added dark mode toggle button (moon/sun icon) in header toolbar next to Settings. Uses existing ThemeToggle API + dark-mode.css (both already existed but were not loaded/wired on chat page).
- Added theme-toggle.js script load + inline wiring to sync button icon with current theme state.
- dark-mode.css was already linked (line 27) but had no toggle to activate it — now users can click the moon icon.

https://claude.ai/code/session_019gctBnrt8XpNm78k147d9m