### PR TITLE
Add Clever SSO integration for school district single sign-on

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,14 @@ MICROSOFT_CLIENT_ID=your_microsoft_client_id
 MICROSOFT_CLIENT_SECRET=your_microsoft_client_secret
 MICROSOFT_CALLBACK_URL=http://localhost:3000/auth/microsoft/callback
 
+# --- CLEVER SSO (Optional - for school district SSO) ---
+# Get from: https://dev.clever.com/ (create a developer account)
+# Free for app partners - used by ~77% of US K-12 schools
+# Requires Clever certification for live district connections
+CLEVER_CLIENT_ID=your_clever_client_id
+CLEVER_CLIENT_SECRET=your_clever_client_secret
+CLEVER_CALLBACK_URL=http://localhost:3000/auth/clever/callback
+
 # --- AI SERVICES ---
 # REQUIRED: Get from https://platform.openai.com/api-keys
 OPENAI_API_KEY=sk-your_openai_key_here

--- a/models/user.js
+++ b/models/user.js
@@ -497,6 +497,7 @@ const userSchema = new Schema({
   passwordHash: { type: String },                       // populated only for local-strategy users
   googleId:     { type: String, unique: true, sparse: true },
   microsoftId:  { type: String, unique: true, sparse: true },
+  cleverId:     { type: String, unique: true, sparse: true },
 
   /* Password Reset */
   resetPasswordToken:   { type: String },

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "passport-google-oauth20": "^2.0.0",
         "passport-local": "^1.0.0",
         "passport-microsoft": "^2.1.0",
+        "passport-oauth2": "^1.8.0",
         "pdfjs-dist": "^5.4.530",
         "puppeteer": "^24.10.2",
         "sharp": "^0.34.5",
@@ -7407,6 +7408,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.8.0.tgz",
       "integrity": "sha512-cjsQbOrXIDE4P8nNb3FQRCCmJJ/utnFKEz2NX209f7KOHPoX18gF7gBzBbLLsj2/je4KrgiwLLGjf0lm9rtTBA==",
+      "license": "MIT",
       "dependencies": {
         "base64url": "3.x.x",
         "oauth": "0.10.x",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "passport-google-oauth20": "^2.0.0",
     "passport-local": "^1.0.0",
     "passport-microsoft": "^2.1.0",
+    "passport-oauth2": "^1.8.0",
     "pdfjs-dist": "^5.4.530",
     "puppeteer": "^24.10.2",
     "sharp": "^0.34.5",

--- a/public/images/clever-icon.svg
+++ b/public/images/clever-icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" width="40" height="40">
+  <rect width="40" height="40" rx="8" fill="#4274F6"/>
+  <text x="50%" y="54%" dominant-baseline="middle" text-anchor="middle"
+        font-family="Arial, Helvetica, sans-serif" font-weight="bold" font-size="26" fill="#FFFFFF">C</text>
+</svg>

--- a/public/login.html
+++ b/public/login.html
@@ -97,6 +97,10 @@
           <img src="/images/microsoft-icon.png" alt="Microsoft" />
           Continue with Microsoft
         </a>
+        <a href="/auth/clever" class="social-btn clever-btn" style="background: #4274f6; color: #fff; border-color: #4274f6;">
+          <img src="/images/clever-icon.svg" alt="Clever" style="height: 20px; width: 20px;" />
+          Log in with Clever
+        </a>
       </div>
 
       <p class="signup-link">

--- a/public/oauth-enrollment.html
+++ b/public/oauth-enrollment.html
@@ -116,9 +116,12 @@
         document.getElementById('user-name').textContent = fullName;
         document.getElementById('user-email').textContent = data.email;
 
-        const providerIcon = data.provider === 'google' ? 'fab fa-google' : 'fab fa-microsoft';
+        const providerIcons = { google: 'fab fa-google', microsoft: 'fab fa-microsoft', clever: 'fas fa-graduation-cap' };
+        const providerColors = { google: '#4285F4', microsoft: '#00A4EF', clever: '#4274f6' };
+        const providerIcon = providerIcons[data.provider] || 'fas fa-user';
+        const providerColor = providerColors[data.provider] || '#667eea';
         document.getElementById('welcome-text').innerHTML =
-          `<i class="${providerIcon}" style="color: ${data.provider === 'google' ? '#4285F4' : '#00A4EF'};"></i> ` +
+          `<i class="${providerIcon}" style="color: ${providerColor};"></i> ` +
           `Welcome! Enter your class enrollment code to complete sign up.`;
 
       } catch (error) {

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -194,7 +194,7 @@ router.post('/complete-oauth-enrollment', async (req, res) => {
     const newUser = new User({
       username,
       email: pendingProfile.email,
-      [pendingProfile.provider === 'google' ? 'googleId' : 'microsoftId']: pendingProfile.providerId,
+      [pendingProfile.provider === 'google' ? 'googleId' : pendingProfile.provider === 'microsoft' ? 'microsoftId' : 'cleverId']: pendingProfile.providerId,
       role: 'student',
       firstName: pendingProfile.firstName,
       lastName: pendingProfile.lastName,


### PR DESCRIPTION
Clever SSO enables students and teachers at ~77% of US K-12 schools to log into Mathmatix AI through their school's Clever portal without managing separate credentials. Free for app partners.

Changes:
- Add passport-oauth2 dependency and Clever OAuth2 strategy
- Add cleverId field to User model
- Add /auth/clever and /auth/clever/callback routes in server.js
- Add "Log in with Clever" button to login page
- Update oauth-enrollment flow to support Clever provider
- Add Clever API to CSP connectSrc whitelist
- Add CLEVER_CLIENT_ID/SECRET/CALLBACK_URL to .env.example

The integration is conditional — routes and strategy only register when CLEVER_CLIENT_ID and CLEVER_CLIENT_SECRET env vars are set.

https://claude.ai/code/session_01H3dtYmAgv8U2sZE4uzHTZm