### PR TITLE
Fix sidebar session text visibility in dark mode

### DIFF
--- a/public/css/dark-mode.css
+++ b/public/css/dark-mode.css
@@ -398,6 +398,23 @@
     border-color: var(--clr-primary-teal);
 }
 
+/* Session item text elements */
+[data-theme="dark"] .session-name {
+    color: var(--text-primary);
+}
+
+[data-theme="dark"] .session-preview {
+    color: var(--text-secondary);
+}
+
+[data-theme="dark"] .session-time {
+    color: var(--text-secondary);
+}
+
+[data-theme="dark"] .session-stats {
+    color: var(--clr-primary-teal);
+}
+
 /* Mobile drawers in dark mode */
 [data-theme="dark"] .mobile-drawer {
     background: #0D151D;


### PR DESCRIPTION
Override hardcoded light-mode colors on .session-name (#333), .session-preview (#777), .session-time (#999), and .session-stats so they use theme-aware text colors in dark mode.

https://claude.ai/code/session_01FJdjJN4k6kU49dkCcR1xfL