### PR TITLE
Fix mobile UI: header, footer, logo, and layout issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,10 +76,10 @@
     "stripe": "^20.3.1",
     "uuid": "^9.0.1",
     "winston": "^3.11.0",
-    "winston-daily-rotate-file": "^4.7.1"
+    "winston-daily-rotate-file": "^4.7.1",
+    "dotenv": "^17.2.4"
   },
   "devDependencies": {
-    "dotenv": "^17.2.4",
     "jest": "^29.7.0",
     "nodemon": "^3.1.11",
     "supertest": "^7.0.0"

--- a/public/css/mobile-fixes.css
+++ b/public/css/mobile-fixes.css
@@ -75,14 +75,20 @@ input, textarea, select, .math-field {
         gap: 2px;
     }
 
-    /* Show logo on mobile but make it smaller */
+    /* Show logo on mobile but make it compact */
     .header-logo-container {
         display: flex !important;
-        flex-shrink: 0;
+        flex-shrink: 1;
+        min-width: 0;
+        align-items: center;
+        overflow: hidden;
     }
 
     .header-logo-container .main-logo-hero {
         max-height: 28px;
+        width: auto;
+        max-width: 120px;
+        object-fit: contain;
     }
 
     /* Compact nav with scrollable icons */
@@ -130,7 +136,8 @@ input, textarea, select, .math-field {
     /* Hide less important header buttons on mobile */
     #open-resources-modal-btn,
     #restart-audio-btn,
-    #pause-audio-btn {
+    #pause-audio-btn,
+    #open-settings-modal-btn {
         display: none !important;
     }
 
@@ -144,7 +151,8 @@ input, textarea, select, .math-field {
         display: none !important;
     }
 
-    /* Enhanced Mobile Drawer Toggle Buttons */
+    /* Enhanced Mobile Drawer Toggle Buttons
+       !important on display overrides .desktop-hide { display: block !important } */
     .drawer-toggle-btn {
         min-width: 44px;
         min-height: 40px;
@@ -152,7 +160,7 @@ input, textarea, select, .math-field {
         border-radius: 10px;
         transition: all 150ms ease;
         flex-shrink: 0;
-        display: flex;
+        display: flex !important;
         align-items: center;
         justify-content: center;
         background: transparent;
@@ -211,23 +219,10 @@ input, textarea, select, .math-field {
         font-size: calc(16px * var(--chat-font-scale, 1));
     }
 
-    /* Subtle logo watermark */
+    /* Remove logo watermark on mobile — it creates a positioned element that
+       can interfere with scroll and touch, and wastes rendering resources */
     #chat-messages-container::before {
-        content: '';
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-        background-image: url('/images/mathmatix-ai-logo.png');
-        background-size: contain;
-        background-repeat: no-repeat;
-        background-position: center;
-        width: 55%;
-        max-width: 240px;
-        height: 200px;
-        opacity: 0.03;
-        z-index: 0;
-        pointer-events: none;
+        display: none;
     }
 
     /* Message bubbles: touch-friendly, readable */
@@ -1097,5 +1092,102 @@ body.is-mobile #sidebar-toggle {
     :focus-visible {
         outline: 2px solid var(--clr-primary-teal, #12B3B3);
         outline-offset: 2px;
+    }
+}
+
+/* --- 16. MOBILE LAYOUT OVERRIDES (CRITICAL) ---
+   These rules MUST load after sidebar-layout.css to win the cascade.
+   They fix footer overlap, header height mismatch, and chat container sizing.
+   ------------------------------------------------------------------- */
+
+@media (max-width: 768px) {
+    /* Hide footer on mobile chat — saves ~50px of precious screen space.
+       Copyright info is not critical for the chat experience. */
+    body.landing-page-body footer {
+        display: none !important;
+    }
+
+    /* Remove the desktop-only footer margin from the chat container */
+    body.landing-page-body #chat-container {
+        margin-bottom: 0 !important;
+    }
+
+    /* Fix header height variable to match actual mobile header (48px not 60px) */
+    :root {
+        --header-height: 48px;
+    }
+
+    /* Ensure the app wrapper fills the viewport correctly */
+    #app-layout-wrapper {
+        height: calc(100vh - 48px);
+        height: calc(100dvh - 48px); /* Dynamic viewport height for mobile browsers */
+        overflow: hidden;
+        padding: 0;
+    }
+
+    /* Chat container must fill all available height */
+    #chat-container {
+        height: 100% !important;
+        display: flex !important;
+        flex-direction: column !important;
+        border-radius: 0;
+        box-shadow: none;
+    }
+
+    /* Chat messages scroll area fills remaining space */
+    #chat-messages-container {
+        flex: 1 1 0% !important;
+        min-height: 0 !important;
+        overflow-y: auto !important;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    /* Input container sits firmly at the bottom */
+    #input-container {
+        flex-shrink: 0 !important;
+        position: relative;
+        z-index: 100;
+        background: var(--clr-bg-light, #fff);
+        border-top: 1px solid var(--clr-border, #e2e8f0);
+        padding-bottom: max(env(safe-area-inset-bottom, 8px), 8px) !important;
+    }
+
+    /* Prevent sidebar-layout.css from adding unwanted z-index to input */
+    body.landing-page-body #input-container {
+        z-index: 100 !important;
+    }
+}
+
+/* --- 17. IEP ELEMENTS MOBILE SAFETY ---
+   Prevent IEP fixed-position buttons from covering chat input.
+   ----------------------------------------------------------- */
+
+@media (max-width: 600px) {
+    /* Move IEP break button above the input area */
+    .iep-break-btn {
+        bottom: 80px;
+        left: 10px;
+        font-size: 12px;
+        padding: 8px 12px;
+    }
+
+    /* Move multiplication chart button to the right to not overlap break btn */
+    .iep-mult-chart-btn {
+        bottom: 80px;
+        right: 10px;
+        left: auto;
+        font-size: 12px;
+        padding: 8px 12px;
+    }
+
+    /* IEP goal notifications at bottom of mobile screen */
+    .iep-goal-notification {
+        right: 8px;
+        left: 8px;
+        max-width: none;
+    }
+
+    .iep-goal-notification.visible {
+        bottom: 80px;
     }
 }

--- a/public/css/sidebar-layout.css
+++ b/public/css/sidebar-layout.css
@@ -882,7 +882,7 @@ input.session-search-input:focus {
     font-size: 18px;
 }
 
-/* Footer - Full width across entire viewport */
+/* Footer - Full width across entire viewport (desktop only) */
 footer {
     position: fixed;
     bottom: 0;
@@ -896,9 +896,9 @@ footer {
     z-index: 1005;
 }
 
-/* Ensure chat container has space for footer */
+/* Ensure chat container has space for footer (desktop) */
 #chat-container {
-    margin-bottom: 52px !important;
+    margin-bottom: 52px;
     gap: 0 !important;
     padding-bottom: 0 !important;
 }
@@ -906,9 +906,9 @@ footer {
 /* Input container needs to be above footer */
 #input-container {
     position: relative;
-    z-index: 1003 !important;
+    z-index: 1003;
     background: var(--clr-bg-light, #fff);
-    padding-bottom: 4px !important;
+    padding-bottom: 4px;
 }
 
 /* Mobile Responsive */

--- a/public/style.css
+++ b/public/style.css
@@ -3353,7 +3353,7 @@ form label, .password-label-row label {
 @media screen and (max-width: 767px) {
     /* Adjustments for phones - LARGER BASE FONT */
     :root {
-        --header-height: 60px;
+        --header-height: 48px;
         --page-horizontal-padding: 10px;
         --section-gap: 40px;
         --brand-h1-font-size: 2em;
@@ -3370,41 +3370,43 @@ form label, .password-label-row label {
     h3 { font-size: var(--brand-h3-font-size); }
 
     .landing-header {
-        padding: 10px var(--page-horizontal-padding);
+        padding: 4px var(--page-horizontal-padding);
+        min-height: 48px;
+        height: 48px;
         border-radius: 0;
         box-shadow: none;
-        display: grid;
-        grid-template-columns: auto 1fr auto;
+        display: flex;
         align-items: center;
-        gap: 8px;
+        justify-content: space-between;
+        gap: 4px;
     }
 
     /* Left drawer toggle */
     #left-drawer-toggle {
-        grid-column: 1;
-        justify-self: start;
+        flex-shrink: 0;
     }
 
-    /* Center logo */
+    /* Logo: compact, don't stretch */
     .header-logo-container {
-        grid-column: 2;
-        justify-self: center;
+        flex-shrink: 1;
+        min-width: 0;
         display: flex;
-        justify-content: center;
+        align-items: center;
     }
 
     .main-logo-hero {
-        max-height: 50px;
+        max-height: 28px;
+        width: auto;
     }
 
-    /* Right nav buttons */
+    /* Right nav buttons: scrollable, compact */
     .landing-nav {
-        grid-column: 3;
-        justify-self: end;
-        gap: 8px;
+        flex-shrink: 0;
+        gap: 2px;
         margin-top: 0;
         display: flex;
         flex-wrap: nowrap;
+        align-items: center;
     }
 
     /* Hide text in nav buttons on mobile, keep icons */
@@ -3475,6 +3477,7 @@ form label, .password-label-row label {
     #app-layout-wrapper {
         padding: 0;
         height: calc(100vh - var(--header-height));
+        height: calc(100dvh - var(--header-height)); /* Dynamic viewport for mobile browsers */
         overflow: hidden;
     }
 
@@ -3494,6 +3497,7 @@ form label, .password-label-row label {
     /* Make chat container fill available space */
     #chat-container {
         padding: 0;
+        margin-bottom: 0;
         min-width: unset;
         border-radius: 0;
         box-shadow: none;
@@ -3505,7 +3509,7 @@ form label, .password-label-row label {
 
     /* Chat messages take up most of the screen */
     #chat-messages-container {
-        flex: 1;
+        flex: 1 1 0%;
         overflow-y: auto;
         padding: 12px;
         padding-top: 16px; /* Extra top padding to prevent content from hiding under sticky header */
@@ -3517,7 +3521,7 @@ form label, .password-label-row label {
     #input-container {
         flex-shrink: 0;
         padding: 8px 12px;
-        padding-bottom: max(env(safe-area-inset-bottom), 12px);
+        padding-bottom: max(env(safe-area-inset-bottom), 8px);
         background: var(--clr-bg-light);
         border-top: 1px solid rgba(0, 0, 0, 0.1);
         box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.05);


### PR DESCRIPTION
- Fix header height mismatch (was 60px variable, actual 48px)
- Switch mobile header from CSS grid to flexbox for consistency
- Constrain logo width on mobile (max-width: 120px, max-height: 28px)
- Remove floating logo watermark on mobile (interfered with layout)
- Hide footer on mobile chat (saves 50px screen space)
- Remove !important from sidebar-layout.css footer rules so mobile
  overrides take effect
- Fix drawer toggle buttons forced to display:block by .desktop-hide
- Hide settings button on mobile header (available in More menu)
- Use 100dvh for dynamic viewport height on mobile browsers
- Add flex:1 1 0% to chat messages for proper flex shrinking
- Add IEP element mobile safety overrides to prevent button overlap

https://claude.ai/code/session_01YHJLPtbuh52YPF9AtBcpiz