### PR TITLE
Add AI disclaimer notice below chat send button

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -525,6 +525,7 @@
     <button id="send-button" class="btn btn-primary send-button-fullwidth">
       <i class="fas fa-paper-plane"></i> Send
     </button>
+    <p class="chat-disclaimer"><i class="fas fa-info-circle"></i> AI can make mistakes. Always check your work.</p>
 </div>
 
       <!-- Session Stats Bar -->

--- a/public/style.css
+++ b/public/style.css
@@ -1382,6 +1382,19 @@ a:hover {
   background: var(--clr-bg-light);
 }
 
+.chat-disclaimer {
+  text-align: center;
+  font-size: 0.75rem;
+  color: var(--clr-text-dim);
+  margin: var(--space-1) 0 var(--space-2);
+  line-height: 1.4;
+}
+
+.chat-disclaimer i {
+  margin-right: 4px;
+  opacity: 0.7;
+}
+
 /* Toolbar Above Message Box */
 .input-toolbar {
   display: flex;


### PR DESCRIPTION
## Summary
Added a disclaimer notice to the chat interface informing users that AI can make mistakes and they should verify their work.

## Changes
- **CSS Styling** (`public/style.css`):
  - Added `.chat-disclaimer` class with centered text, small font size (0.75rem), dimmed color, and appropriate spacing
  - Added styling for the icon within the disclaimer with right margin and reduced opacity

- **HTML Markup** (`public/chat.html`):
  - Added disclaimer paragraph below the send button with an info icon and disclaimer text: "AI can make mistakes. Always check your work."

## Implementation Details
- The disclaimer uses the existing design system variables (`--clr-text-dim`, `--space-1`, `--space-2`) for consistency
- An info circle icon (`fas fa-info-circle`) is included with slightly reduced opacity (0.7) to provide visual hierarchy
- The disclaimer is positioned directly below the send button as a persistent reminder to users

https://claude.ai/code/session_01365DP8U2YDD2BmbgHipz56