### PR TITLE
Fix 5 IEP accommodation gaps: read-aloud, chunking, dark mode, parent chat

### DIFF
--- a/public/css/iep-accommodations.css
+++ b/public/css/iep-accommodations.css
@@ -459,8 +459,21 @@ body:not(.iep-reduced-distraction) .iep-mult-chart-btn {
     color: #ddd;
 }
 
-.dark-mode .iep-high-contrast .message.ai {
-    background: #1a1a30;
+/* High contrast forces light mode — dark mode is removed when this
+   accommodation is active (see applyIepAccommodations in script.js).
+   If dark-mode somehow persists, high-contrast still wins. */
+.iep-high-contrast.dark-mode,
+.dark-mode .iep-high-contrast {
+    --clr-text: #000000;
+    --clr-text-dim: #333333;
+    --clr-border: #000000;
+    --clr-bg: #ffffff;
+    background-color: #ffffff !important;
+    color: #000000 !important;
+}
+
+.iep-high-contrast .message.ai {
+    background: #fffff0;
 }
 
 /* -----------------------------------------------------------

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -1785,6 +1785,10 @@ ${summary ? `- Summary: ${summary}` : ''}`;
         if (accom.audioReadAloud) accommodations.push('Audio Read-Aloud');
         if (accom.chunkedAssignments) accommodations.push('Chunked Assignments');
         if (accom.mathAnxietySupport) accommodations.push('Math Anxiety Support');
+        if (accom.reducedDistraction) accommodations.push('Reduced Distraction');
+        if (accom.breaksAsNeeded) accommodations.push('Breaks As Needed');
+        if (accom.digitalMultiplicationChart) accommodations.push('Digital Multiplication Chart');
+        if (accom.largePrintHighContrast) accommodations.push('Large Print/High Contrast');
 
         if (accommodations.length > 0) {
             iepSection += `\nACCOMMODATIONS: ${accommodations.join(', ')}`;

--- a/tests/unit/iepAccommodations.test.js
+++ b/tests/unit/iepAccommodations.test.js
@@ -168,7 +168,8 @@ describe('IEP Accommodation Prompt Builder', () => {
         const result = buildIepAccommodationsPrompt(iep, 'Maya');
         expect(result).toContain('Reading Level Adjustment');
         expect(result).toContain('Grade 4');
-        expect(result).toContain('shorter sentences');
+        expect(result).toContain('MAXIMUM sentence length');
+        expect(result).toContain('automatically scored');
     });
 
     test('readingLevel: includes Lexile adjustment for large values', () => {

--- a/tests/unit/readability.test.js
+++ b/tests/unit/readability.test.js
@@ -1,0 +1,210 @@
+/**
+ * Readability Scoring & IEP Reading Level Enforcement Tests
+ *
+ * Verifies that:
+ * 1. Coleman-Liau Index produces correct grade-level scores
+ * 2. Lexile-to-grade conversion is accurate
+ * 3. Reading level checks pass/fail correctly
+ * 4. Text stripping handles markdown, LaTeX, emoji, and IEP tags
+ * 5. Simplification prompts are correctly formed
+ */
+
+const {
+    colemanLiauIndex,
+    checkReadingLevel,
+    buildSimplificationPrompt,
+    lexileToGrade,
+    stripForScoring
+} = require('../../utils/readability');
+
+describe('Readability Scoring', () => {
+
+    describe('stripForScoring', () => {
+        test('removes markdown bold and italic', () => {
+            const result = stripForScoring('This is **bold** and *italic* text');
+            expect(result).not.toContain('**');
+            expect(result).not.toContain('*');
+            expect(result).toContain('bold');
+            expect(result).toContain('italic');
+        });
+
+        test('removes markdown headers', () => {
+            const result = stripForScoring('## My Header\nSome text');
+            expect(result).not.toContain('##');
+            expect(result).toContain('My Header');
+        });
+
+        test('removes IEP system tags', () => {
+            const result = stripForScoring('Good job! <IEP_GOAL_PROGRESS:fractions,+5> Keep going.');
+            expect(result).not.toContain('IEP_GOAL_PROGRESS');
+            expect(result).toContain('Good job');
+            expect(result).toContain('Keep going');
+        });
+
+        test('replaces LaTeX math with placeholder', () => {
+            const result = stripForScoring('Solve $x + 5 = 10$ for x.');
+            expect(result).not.toContain('$');
+            expect(result).toContain('[math]');
+        });
+
+        test('preserves link text but removes URL', () => {
+            const result = stripForScoring('Click [here](https://example.com) for help.');
+            expect(result).toContain('here');
+            expect(result).not.toContain('https://');
+        });
+
+        test('removes code blocks', () => {
+            const result = stripForScoring('Try this:\n```\nlet x = 5;\n```\nNow solve.');
+            expect(result).not.toContain('```');
+            expect(result).not.toContain('let x');
+            expect(result).toContain('Now solve');
+        });
+
+        test('removes bullet markers', () => {
+            const result = stripForScoring('Steps:\n- Step one\n- Step two');
+            expect(result).not.toMatch(/^-/m);
+            expect(result).toContain('Step one');
+        });
+    });
+
+    describe('colemanLiauIndex', () => {
+        test('returns grade 0 for very short text', () => {
+            const result = colemanLiauIndex('Hi there.');
+            expect(result.gradeLevel).toBe(0);
+            expect(result.wordCount).toBeLessThan(5);
+        });
+
+        test('scores simple text at a low grade level', () => {
+            // Simple, short sentences with common words
+            const simpleText = 'The cat sat on the mat. The dog ran to the park. It was a fun day. The sun was big and hot.';
+            const result = colemanLiauIndex(simpleText);
+            expect(result.gradeLevel).toBeLessThan(5);
+            expect(result.wordCount).toBeGreaterThan(10);
+        });
+
+        test('scores complex text at a higher grade level', () => {
+            // Complex sentences with advanced vocabulary
+            const complexText = 'The implementation of comprehensive mathematical algorithms necessitates understanding sophisticated computational paradigms. Theoretical frameworks encompassing multidimensional analysis require substantial intellectual prerequisites that fundamentally challenge conventional pedagogical methodologies.';
+            const result = colemanLiauIndex(complexText);
+            expect(result.gradeLevel).toBeGreaterThan(10);
+        });
+
+        test('returns expected structure', () => {
+            const result = colemanLiauIndex('The quick brown fox jumps over the lazy dog. It ran far away.');
+            expect(result).toHaveProperty('gradeLevel');
+            expect(result).toHaveProperty('wordCount');
+            expect(result).toHaveProperty('sentenceCount');
+            expect(result).toHaveProperty('letterCount');
+            expect(typeof result.gradeLevel).toBe('number');
+        });
+
+        test('handles text with markdown formatting', () => {
+            // Should strip markdown before scoring
+            const result = colemanLiauIndex('**Good job!** You got the right answer. The answer is ten.');
+            expect(result.wordCount).toBeGreaterThan(5);
+            expect(result.gradeLevel).toBeLessThan(8);
+        });
+    });
+
+    describe('lexileToGrade', () => {
+        test('maps low Lexile to Grade 1', () => {
+            expect(lexileToGrade(100)).toBe(1);
+            expect(lexileToGrade(190)).toBe(1);
+        });
+
+        test('maps mid-range Lexile correctly', () => {
+            expect(lexileToGrade(500)).toBe(3);
+            expect(lexileToGrade(650)).toBe(4);
+            expect(lexileToGrade(800)).toBe(5);
+        });
+
+        test('maps high Lexile to upper grades', () => {
+            expect(lexileToGrade(1000)).toBe(8);
+            expect(lexileToGrade(1100)).toBe(11);
+            expect(lexileToGrade(1200)).toBe(12);
+        });
+
+        test('handles boundary values', () => {
+            expect(lexileToGrade(420)).toBe(2);
+            expect(lexileToGrade(421)).toBe(3);
+            expect(lexileToGrade(520)).toBe(3);
+            expect(lexileToGrade(521)).toBe(4);
+        });
+    });
+
+    describe('checkReadingLevel', () => {
+        test('passes when no reading level is set', () => {
+            const result = checkReadingLevel('Any text here.', null);
+            expect(result.passes).toBe(true);
+        });
+
+        test('passes when text is empty', () => {
+            const result = checkReadingLevel('', 4);
+            expect(result.passes).toBe(true);
+        });
+
+        test('passes for simple text at Grade 4 target', () => {
+            const simpleText = 'Add five and three. You get eight. Good job! Now try the next one. What is two plus six?';
+            const result = checkReadingLevel(simpleText, 4);
+            expect(result.passes).toBe(true);
+            expect(result.targetGrade).toBe(4);
+        });
+
+        test('fails for complex text at Grade 3 target', () => {
+            const complexText = 'The implementation of comprehensive mathematical algorithms necessitates understanding sophisticated computational paradigms and multidimensional theoretical frameworks.';
+            const result = checkReadingLevel(complexText, 3);
+            expect(result.passes).toBe(false);
+            expect(result.responseGrade).toBeGreaterThan(5);
+            expect(result.margin).toBeGreaterThan(0);
+        });
+
+        test('converts Lexile to grade before checking', () => {
+            const simpleText = 'The cat is big. The dog is small. They play in the sun.';
+            const result = checkReadingLevel(simpleText, 500); // Lexile 500 ≈ Grade 3
+            expect(result.targetGrade).toBe(3);
+            expect(result.passes).toBe(true);
+        });
+
+        test('allows 2 grade levels of tolerance', () => {
+            // Text that scores around Grade 6 should pass for Grade 4 target (4+2=6)
+            const result = checkReadingLevel('The cat is big. The dog is small.', 4);
+            // Simple text should be well within tolerance
+            expect(result.passes).toBe(true);
+        });
+
+        test('returns margin showing how far over target', () => {
+            const complexText = 'The implementation of comprehensive mathematical algorithms necessitates understanding sophisticated computational paradigms and multidimensional theoretical analysis.';
+            const result = checkReadingLevel(complexText, 3);
+            expect(result.margin).toBeGreaterThan(2); // Should be well over tolerance
+        });
+    });
+
+    describe('buildSimplificationPrompt', () => {
+        test('includes original response text', () => {
+            const prompt = buildSimplificationPrompt('Some AI response here.', 4, 'Alex');
+            expect(prompt).toContain('Some AI response here.');
+        });
+
+        test('includes target grade level', () => {
+            const prompt = buildSimplificationPrompt('Response text.', 3, 'Alex');
+            expect(prompt).toContain('Grade 3');
+        });
+
+        test('includes student name', () => {
+            const prompt = buildSimplificationPrompt('Response text.', 4, 'Jordan');
+            expect(prompt).toContain('Jordan');
+        });
+
+        test('sets lower word limit for younger grades', () => {
+            const prompt3 = buildSimplificationPrompt('Text.', 3, 'A');
+            const prompt7 = buildSimplificationPrompt('Text.', 7, 'A');
+            expect(prompt3).toContain('8 words');
+            expect(prompt7).toContain('15 words');
+        });
+
+        test('sets medium word limit for middle grades', () => {
+            const prompt5 = buildSimplificationPrompt('Text.', 5, 'A');
+            expect(prompt5).toContain('12 words');
+        });
+    });
+});

--- a/utils/prompt.js
+++ b/utils/prompt.js
@@ -265,12 +265,19 @@ function buildIepAccommodationsPrompt(iepPlan, firstName) {
   if (iepPlan.readingLevel) {
     const rl = iepPlan.readingLevel;
     const isLexile = rl > 20; // Lexile scores are typically 100-1600; grade levels are 1-12
-    prompt += `✓ **Reading Level Adjustment:**\n`;
-    prompt += `  - ${firstName}'s reading level is ${isLexile ? `${rl}L (Lexile)` : `Grade ${rl}`}\n`;
-    prompt += `  - Adjust ALL word problem text and explanations to this reading level\n`;
-    prompt += `  - Use shorter sentences, simpler vocabulary, and concrete examples\n`;
-    prompt += `  - Avoid multi-clause sentences and abstract language above this level\n`;
-    prompt += `  - When math vocabulary is necessary, define it in context\n\n`;
+    const { lexileToGrade } = require('./readability');
+    const targetGrade = isLexile ? lexileToGrade(rl) : rl;
+    const maxSentenceWords = targetGrade <= 3 ? 8 : targetGrade <= 5 ? 12 : 15;
+    prompt += `✓ **Reading Level Adjustment (ENFORCED — responses are automatically scored):**\n`;
+    prompt += `  - ${firstName}'s reading level is ${isLexile ? `${rl}L (Lexile) ≈ Grade ${targetGrade}` : `Grade ${rl}`}\n`;
+    prompt += `  - Target: Grade ${targetGrade} readability or below\n`;
+    prompt += `  - MAXIMUM sentence length: ${maxSentenceWords} words per sentence\n`;
+    prompt += `  - Use only common, everyday vocabulary a Grade ${targetGrade} student would know\n`;
+    prompt += `  - Replace multi-syllable words with simpler ones (e.g., "figure out" not "determine")\n`;
+    prompt += `  - Break compound sentences into separate short sentences\n`;
+    prompt += `  - When math vocabulary is necessary, define it immediately in parentheses\n`;
+    prompt += `  - Avoid abstract language — use concrete, visual examples\n`;
+    prompt += `  - NOTE: Your response WILL be automatically scored for readability. If it exceeds Grade ${targetGrade + 2}, it will be rewritten.\n\n`;
   }
 
   // Preferred scaffolds

--- a/utils/readability.js
+++ b/utils/readability.js
@@ -1,0 +1,205 @@
+/**
+ * READABILITY SCORING — IEP Reading Level Enforcement
+ *
+ * Uses the Coleman-Liau Index (CLI) to score AI responses.
+ * CLI is character-based (not syllable-based), making it deterministic,
+ * fast, and well-suited for scoring short AI-generated text.
+ *
+ * Formula: CLI = 0.0588 * L - 0.296 * S - 15.8
+ *   L = avg number of letters per 100 words
+ *   S = avg number of sentences per 100 words
+ *
+ * @module readability
+ */
+
+/**
+ * Strip markdown formatting, math notation, IEP tags, and emoji from text
+ * so readability scoring measures the actual prose the student reads.
+ */
+function stripForScoring(text) {
+  let cleaned = text;
+
+  // Remove IEP/system tags like <IEP_GOAL_PROGRESS:...>, <SKILL_MASTERED:...>, etc.
+  cleaned = cleaned.replace(/<[A-Z_]+:[^>]*>/g, '');
+
+  // Remove markdown images ![alt](url)
+  cleaned = cleaned.replace(/!\[[^\]]*\]\([^)]*\)/g, '');
+
+  // Remove markdown links [text](url) → keep text
+  cleaned = cleaned.replace(/\[([^\]]*)\]\([^)]*\)/g, '$1');
+
+  // Remove markdown bold/italic markers
+  cleaned = cleaned.replace(/[*_]{1,3}/g, '');
+
+  // Remove markdown headers (# ## ###)
+  cleaned = cleaned.replace(/^#{1,6}\s+/gm, '');
+
+  // Remove code blocks and inline code
+  cleaned = cleaned.replace(/```[\s\S]*?```/g, '');
+  cleaned = cleaned.replace(/`[^`]+`/g, '');
+
+  // Remove LaTeX math notation ($...$ and $$...$$)
+  cleaned = cleaned.replace(/\$\$[\s\S]*?\$\$/g, ' [math] ');
+  cleaned = cleaned.replace(/\$[^$]+\$/g, ' [math] ');
+
+  // Remove emoji (unicode ranges for common emoji)
+  cleaned = cleaned.replace(/[\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{1F1E0}-\u{1F1FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}\u{FE00}-\u{FE0F}\u{1F900}-\u{1F9FF}\u{1FA00}-\u{1FA6F}\u{1FA70}-\u{1FAFF}\u{200D}\u{20E3}]/gu, '');
+
+  // Remove bullet points and list markers
+  cleaned = cleaned.replace(/^[\s]*[-•*]\s+/gm, '');
+  cleaned = cleaned.replace(/^[\s]*\d+\.\s+/gm, '');
+
+  // Collapse whitespace
+  cleaned = cleaned.replace(/\s+/g, ' ').trim();
+
+  return cleaned;
+}
+
+/**
+ * Split text into words (letters + apostrophes only).
+ */
+function getWords(text) {
+  const words = text.match(/[a-zA-Z'][a-zA-Z']*/g);
+  return words || [];
+}
+
+/**
+ * Count sentences. Uses period, exclamation, question mark as terminators.
+ * Handles abbreviations (Mr., Dr., etc.) by requiring the terminator
+ * to be followed by a space + uppercase or end of string.
+ */
+function countSentences(text) {
+  // Split on sentence-ending punctuation followed by space or end
+  const sentenceEnders = text.match(/[.!?]+(?:\s|$)/g);
+  return Math.max(sentenceEnders ? sentenceEnders.length : 1, 1);
+}
+
+/**
+ * Count letters (a-z, A-Z) in text.
+ */
+function countLetters(text) {
+  const letters = text.match(/[a-zA-Z]/g);
+  return letters ? letters.length : 0;
+}
+
+/**
+ * Calculate the Coleman-Liau Index for a passage of text.
+ * Returns a grade level (e.g., 4.2 means ~4th grade reading level).
+ *
+ * @param {string} text - The text to analyze
+ * @returns {{ gradeLevel: number, wordCount: number, sentenceCount: number, letterCount: number }}
+ */
+function colemanLiauIndex(text) {
+  const cleaned = stripForScoring(text);
+  const words = getWords(cleaned);
+  const wordCount = words.length;
+
+  // Need at least a few words for a meaningful score
+  if (wordCount < 5) {
+    return { gradeLevel: 0, wordCount, sentenceCount: 0, letterCount: 0 };
+  }
+
+  const letterCount = countLetters(cleaned);
+  const sentenceCount = countSentences(cleaned);
+
+  // L = average number of letters per 100 words
+  const L = (letterCount / wordCount) * 100;
+
+  // S = average number of sentences per 100 words
+  const S = (sentenceCount / wordCount) * 100;
+
+  // Coleman-Liau formula
+  const gradeLevel = Math.max(0, 0.0588 * L - 0.296 * S - 15.8);
+
+  return {
+    gradeLevel: Math.round(gradeLevel * 10) / 10, // 1 decimal place
+    wordCount,
+    sentenceCount,
+    letterCount
+  };
+}
+
+/**
+ * Convert a Lexile score to an approximate grade level.
+ * Based on the MetaMetrics Lexile-to-grade correspondence table.
+ *
+ * @param {number} lexile - Lexile score (e.g., 650)
+ * @returns {number} Approximate grade level
+ */
+function lexileToGrade(lexile) {
+  if (lexile <= 190) return 1;
+  if (lexile <= 420) return 2;
+  if (lexile <= 520) return 3;
+  if (lexile <= 740) return 4;
+  if (lexile <= 830) return 5;
+  if (lexile <= 925) return 6;
+  if (lexile <= 970) return 7;
+  if (lexile <= 1010) return 8;
+  if (lexile <= 1050) return 9;
+  if (lexile <= 1080) return 10;
+  if (lexile <= 1130) return 11;
+  return 12;
+}
+
+/**
+ * Check whether an AI response exceeds a student's IEP reading level.
+ *
+ * @param {string} responseText - The AI's response text
+ * @param {number} targetReadingLevel - The student's reading level (grade or Lexile)
+ * @returns {{ passes: boolean, responseGrade: number, targetGrade: number, margin: number, detail: object }}
+ */
+function checkReadingLevel(responseText, targetReadingLevel) {
+  if (!responseText || !targetReadingLevel) {
+    return { passes: true, responseGrade: 0, targetGrade: 0, margin: 0, detail: null };
+  }
+
+  const isLexile = targetReadingLevel > 20;
+  const targetGrade = isLexile ? lexileToGrade(targetReadingLevel) : targetReadingLevel;
+
+  const detail = colemanLiauIndex(responseText);
+
+  // Allow 2 grade levels of headroom. Readability formulas have inherent
+  // variance (~1-2 grade levels), and math vocabulary naturally pushes scores
+  // higher. A hard exact-grade cutoff would cause excessive re-prompts.
+  const tolerance = 2;
+  const passes = detail.gradeLevel <= targetGrade + tolerance;
+  const margin = detail.gradeLevel - targetGrade;
+
+  return { passes, responseGrade: detail.gradeLevel, targetGrade, margin, detail };
+}
+
+/**
+ * Build a simplification prompt that asks the LLM to rewrite its own
+ * response at a lower reading level. Used when checkReadingLevel fails.
+ *
+ * @param {string} originalResponse - The AI's original response
+ * @param {number} targetGrade - Target grade level
+ * @param {string} firstName - Student's first name
+ * @returns {string} System instruction for the re-prompt
+ */
+function buildSimplificationPrompt(originalResponse, targetGrade, firstName) {
+  return `Your previous response was written above ${firstName}'s reading level (IEP target: Grade ${targetGrade}).
+
+Rewrite your EXACT same response — same math content, same teaching approach, same meaning — but simplified to a Grade ${targetGrade} reading level:
+- Maximum sentence length: ${targetGrade <= 3 ? '8' : targetGrade <= 5 ? '12' : '15'} words
+- Use only common, everyday vocabulary
+- Replace multi-syllable words with simpler ones where possible
+- Break compound sentences into separate short sentences
+- Define any math term you must use in parentheses
+- Keep the same encouraging tone
+
+Your previous response to simplify:
+"""
+${originalResponse}
+"""
+
+Rewrite it now at Grade ${targetGrade} level. Do NOT add any commentary about the rewrite — just output the simplified version.`;
+}
+
+module.exports = {
+  colemanLiauIndex,
+  checkReadingLevel,
+  buildSimplificationPrompt,
+  lexileToGrade,
+  stripForScoring
+};


### PR DESCRIPTION
1. Audio Read-Aloud was completely broken — playAudioForMessage() was never
   defined. Rewired to use the existing playAudio + generateSpeakableText
   TTS pipeline (same path as hands-free mode). Added console warning when
   TTS is unavailable so failures are visible.

2. Chunked Assignments had zero frontend enforcement — the AI was asked
   nicely via prompt but nothing stopped it from ignoring chunking. Added
   a problem counter and check-in overlay that fires every 4 problems,
   giving students a structured pause with a "Keep Going" or "Take a Break"
   choice.

3. High-Contrast mode was undermined by dark mode — the dark-mode override
   forced a dark background on high-contrast users. Now applyIepAccommodations
   removes dark-mode when high-contrast is active, and the CSS has a fallback
   that forces light colors even if dark-mode somehow persists.

4. Parent Chat route was missing 4 of 9 accommodations — the AI prompt for
   parent-tutor conversations only listed 5 accommodations. Added Reduced
   Distraction, Breaks As Needed, Digital Multiplication Chart, and Large
   Print/High Contrast so the tutor can discuss all active accommodations.

5. handleIepResponseFeatures now also drives chunked assignment check-ins
   per response, rather than being a read-aloud-only stub.

https://claude.ai/code/session_01PHfU4DKsX2r1tbczLFtNjw