### PR TITLE
Fix mobile layout issues with tour elements and logo scaling

### DIFF
--- a/public/css/mobile-fixes.css
+++ b/public/css/mobile-fixes.css
@@ -44,6 +44,23 @@ input, textarea, select, .math-field {
     }
 }
 
+/* --- 1b. TOUR ELEMENTS — keep them out of the way on mobile --- */
+
+@media (max-width: 768px) {
+    /* The persistent tour help button (position:fixed via inline JS) overlaps
+       the chat input area on mobile.  Hide it so it doesn't block interactive
+       elements.  The initial tour prompt still appears for new users. */
+    .tour-help-btn {
+        display: none !important;
+    }
+
+    /* The one-time tour prompt popup is positioned fixed at bottom-right via
+       inline styles.  Push it above the input area so it doesn't overlap. */
+    #tour-prompt > div {
+        bottom: 80px !important;
+    }
+}
+
 /* --- 2. MOBILE HEADER (<=768px) --- */
 
 @media (max-width: 768px) {

--- a/public/style.css
+++ b/public/style.css
@@ -5128,11 +5128,14 @@ body:not(.landing-page-body) {
 
 /* --- UI Overhaul Based on Design Notes --- */
 
-/* 1. Logo Prominence */
-.main-logo-hero {
-  transform: scale(1.5);
-  transform-origin: left center;
-  margin-left: 1rem;
+/* 1. Logo Prominence — desktop only; on mobile the logo is compact
+   and scale(1.5) causes clipping inside the overflow-hidden header. */
+@media (min-width: 769px) {
+  .main-logo-hero {
+    transform: scale(1.5);
+    transform-origin: left center;
+    margin-left: 1rem;
+  }
 }
 
 /* 2. Consistent Panel Titles */


### PR DESCRIPTION
## Summary
This PR fixes layout and usability issues on mobile devices by hiding the persistent tour help button, repositioning the tour prompt popup, and restricting logo scaling to desktop viewports only.

## Key Changes
- **Tour elements on mobile**: Added media query to hide the `.tour-help-btn` (persistent help button) on screens ≤768px, as it was overlapping the chat input area. The initial tour prompt for new users is preserved.
- **Tour prompt positioning**: Repositioned the `#tour-prompt` popup to `bottom: 80px` on mobile to prevent overlap with the input area while keeping it visible.
- **Logo scaling**: Wrapped the `.main-logo-hero` scale transformation in a `min-width: 769px` media query. The 1.5x scaling was causing the logo to clip inside the overflow-hidden header on mobile devices.

## Implementation Details
- Used `!important` flag on the tour button display rule to ensure it overrides any inline styles
- Maintained the initial tour experience for new users while improving the persistent UI on mobile
- Logo now displays at normal size on mobile and scales up only on desktop, preventing visual clipping

https://claude.ai/code/session_01RWfBEMpr4kSaEEPZ47WAH3