### PR TITLE
Replace Quests tab with Courses in mobile bottom nav

### DIFF
--- a/public/js/courseCatalog.js
+++ b/public/js/courseCatalog.js
@@ -87,6 +87,15 @@ class CourseManager {
         // Load enrolled courses on startup
         this.loadMySessions();
 
+        // Auto-open catalog if arriving via bottom nav (?courses=1)
+        const params = new URLSearchParams(window.location.search);
+        if (params.get('courses') === '1') {
+            // Clean the URL so a refresh doesn't re-open
+            history.replaceState(null, '', window.location.pathname);
+            // Small delay to let the page finish loading
+            setTimeout(() => this.openCatalog(), 300);
+        }
+
         console.log('[CourseManager] Initialised');
     }
 

--- a/public/js/ux-enhancements.js
+++ b/public/js/ux-enhancements.js
@@ -84,7 +84,7 @@
       { icon: 'fa-home', label: 'Home', href: '/student-dashboard.html', id: 'nav-home' },
       { icon: 'fa-comment', label: 'Chat', href: '/chat.html', id: 'nav-chat' },
       { icon: 'fa-chart-line', label: 'Progress', href: '/progress.html', id: 'nav-progress' },
-      { icon: 'fa-tasks', label: 'Quests', href: '/badge-map.html', id: 'nav-quests' },
+      { icon: 'fa-graduation-cap', label: 'Courses', href: '/chat.html?courses=1', id: 'nav-courses' },
       { icon: 'fa-user-circle', label: 'Profile', href: '/student-dashboard.html#profile', id: 'nav-profile' }
     ];
 
@@ -102,9 +102,20 @@
       link.id = item.id;
       link.setAttribute('aria-label', item.label);
 
-      // Detect active page
-      if (path === item.href || (item.href !== '/' && path.includes(item.href.replace('.html', '')))) {
-        link.classList.add('active');
+      // Detect active page (handle items sharing a path, e.g. Chat vs Courses)
+      const hrefPath = item.href.split('?')[0];
+      const hrefQuery = item.href.includes('?') ? item.href.split('?')[1] : '';
+      const pathMatches = path === hrefPath || (hrefPath !== '/' && path.includes(hrefPath.replace('.html', '')));
+      if (pathMatches) {
+        // If this item has a query param, only activate when the param is present
+        // If it doesn't, only activate when no other item's query param is present
+        if (hrefQuery) {
+          if (window.location.search.includes(hrefQuery)) link.classList.add('active');
+        } else {
+          // Don't activate if the URL has query params that belong to another nav item
+          const hasSpecialParam = navItems.some(n => n.href.includes('?') && n.href.split('?')[0] === hrefPath && window.location.search.includes(n.href.split('?')[1]));
+          if (!hasSpecialParam) link.classList.add('active');
+        }
       }
 
       link.innerHTML = `<i class="fas ${item.icon}"></i><span>${item.label}</span>`;
@@ -488,8 +499,7 @@
     const prefetchMap = {
       '/student-dashboard.html': ['/chat.html'],
       '/chat.html': ['/student-dashboard.html', '/progress.html'],
-      '/progress.html': ['/chat.html', '/student-dashboard.html'],
-      '/badge-map.html': ['/chat.html', '/student-dashboard.html']
+      '/progress.html': ['/chat.html', '/student-dashboard.html']
     };
 
     const toPrefetch = prefetchMap[currentPath] || [];


### PR DESCRIPTION
Quests pointed to badge-map.html which has no mobile layout (overflow:hidden, height:100vh, 3-column desktop grid). Replaced with Courses tab that navigates to /chat.html?courses=1 and auto-opens the course catalog modal.

- Updated nav item: fa-graduation-cap Courses → /chat.html?courses=1
- Added URL param detection in CourseManager.init() to auto-open catalog
- Fixed active-tab detection for items sharing a pathname (Chat vs Courses)
- Removed badge-map.html from prefetch map

https://claude.ai/code/session_01B8BDwwrCHF7vpQtSnfwHnV