### PR TITLE
Remove continue course hero banner from chat page

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -353,22 +353,7 @@
           </div>
         </div>
       </div>
-      <!-- Course Resume Nudge (shown when user has active course but is in general chat) -->
-      <div id="course-resume-nudge" style="display: none;">
-        <div style="display: flex; align-items: center; justify-content: space-between; padding: 10px 16px; background: linear-gradient(135deg, #667eea08, #764ba210); border-bottom: 1px solid #e8e0f0;">
-          <div style="display: flex; align-items: center; gap: 10px;">
-            <i class="fas fa-book-open" style="color: #667eea; font-size: 16px;"></i>
-            <div>
-              <span id="nudge-course-name" style="font-weight: 600; font-size: 13px; color: #333;"></span>
-              <span id="nudge-course-progress" style="font-size: 12px; color: #888; margin-left: 6px;"></span>
-            </div>
-          </div>
-          <div style="display: flex; align-items: center; gap: 8px;">
-            <button id="nudge-continue-btn" style="padding: 6px 14px; background: linear-gradient(135deg, #667eea, #764ba2); color: white; border: none; border-radius: 6px; cursor: pointer; font-weight: 600; font-size: 12px;">Continue</button>
-            <button id="nudge-dismiss-btn" style="padding: 6px 10px; background: none; border: none; color: #aaa; cursor: pointer; font-size: 12px;">Not now</button>
-          </div>
-        </div>
-      </div>
+
       <div id="chat-messages-container"></div>
 
       <!-- Live XP Feed -->

--- a/public/js/courseCatalog.js
+++ b/public/js/courseCatalog.js
@@ -70,20 +70,6 @@ class CourseManager {
             }
         });
 
-        // Nudge banner buttons
-        const nudgeContinue = document.getElementById('nudge-continue-btn');
-        if (nudgeContinue) {
-            nudgeContinue.addEventListener('click', () => {
-                const sessionId = nudgeContinue.dataset.sessionId;
-                if (sessionId) this.activateCourse(sessionId);
-                this.hideNudge();
-            });
-        }
-        const nudgeDismiss = document.getElementById('nudge-dismiss-btn');
-        if (nudgeDismiss) {
-            nudgeDismiss.addEventListener('click', () => this.hideNudge());
-        }
-
         // Load enrolled courses on startup
         this.loadMySessions();
 
@@ -118,9 +104,7 @@ class CourseManager {
             this.renderSidebarCourses();
 
             // If there is an active course session tied to the current conversation,
-            // show the progress bar — otherwise show the resume nudge
             this.checkActiveProgressBar();
-            this.checkResumeNudge();
         } catch (err) {
             console.warn('[CourseManager] Failed to load sessions:', err);
         }
@@ -261,50 +245,6 @@ class CourseManager {
                 mod.textContent = '';
             }
         }
-    }
-
-    // --------------------------------------------------
-    // Resume nudge (shown when user has course but is in general chat)
-    // --------------------------------------------------
-    checkResumeNudge() {
-        const nudge = document.getElementById('course-resume-nudge');
-        if (!nudge) return;
-
-        // Don't show if already dismissed this page load
-        if (this._nudgeDismissed) {
-            nudge.style.display = 'none';
-            return;
-        }
-
-        // Don't show if progress bar is already visible (user IS in their course)
-        if (this.activeCourseSessionId) {
-            nudge.style.display = 'none';
-            return;
-        }
-
-        // Find an active course to nudge about
-        const activeCourse = this.courseSessions.find(s => s.status === 'active');
-        if (!activeCourse) {
-            nudge.style.display = 'none';
-            return;
-        }
-
-        // Show the nudge
-        const nameEl = document.getElementById('nudge-course-name');
-        const progressEl = document.getElementById('nudge-course-progress');
-        const continueBtn = document.getElementById('nudge-continue-btn');
-
-        if (nameEl) nameEl.textContent = activeCourse.courseName;
-        if (progressEl) progressEl.textContent = `${activeCourse.overallProgress || 0}% complete`;
-        if (continueBtn) continueBtn.dataset.sessionId = activeCourse._id;
-
-        nudge.style.display = 'block';
-    }
-
-    hideNudge() {
-        const nudge = document.getElementById('course-resume-nudge');
-        if (nudge) nudge.style.display = 'none';
-        this._nudgeDismissed = true;
     }
 
     // --------------------------------------------------
@@ -784,9 +724,6 @@ class CourseManager {
             this.updateProgressBar(data.session);
             const wrapper = document.getElementById('course-progress-wrapper');
             if (wrapper) wrapper.style.display = 'block';
-
-            // Hide nudge if showing
-            this.hideNudge();
 
             // Show welcome splash in the chat (with course tips for first-time, resume for returning)
             if (data.welcomeData) {


### PR DESCRIPTION
Removes the course-resume-nudge banner that appeared at the top of the chat page prompting enrolled students to return to their active course. Deletes the HTML element, the checkResumeNudge/hideNudge methods, and all related event listeners and call sites in courseCatalog.js.

https://claude.ai/code/session_0165zWJ8ATnZ7fXfEB5QkSjd