### PR TITLE
Fix tutor lacking resource context when student mentions it

### DIFF
--- a/routes/chat.js
+++ b/routes/chat.js
@@ -558,18 +558,7 @@ router.post('/', isAuthenticated, promptInjectionFilter, async (req, res) => {
             .filter(msg => ['user', 'assistant'].includes(msg.role) && msg.content && msg.content.trim().length > 0)
             .map(msg => ({ role: msg.role, content: msg.content }));
 
-        // If a resource was detected, inject it into the conversation
-        if (resourceContext) {
-            const resourceMessage = `[SYSTEM: Student is referencing "${resourceContext.displayName}"${resourceContext.description ? ` - ${resourceContext.description}` : ''}. Content:\n\n${resourceContext.content}\n\nPlease help the student with their question about this resource.]`;
-
-            // Replace the last user message with one that includes the resource context
-            if (formattedMessagesForLLM.length > 0) {
-                const lastMessage = formattedMessagesForLLM[formattedMessagesForLLM.length - 1];
-                if (lastMessage.role === 'user') {
-                    lastMessage.content = resourceMessage + '\n\nStudent question: ' + lastMessage.content;
-                }
-            }
-        }
+        // Resource context is injected into the system prompt via generateSystemPrompt()
 
         // MATH VERIFICATION: Inject verified answer into context for LLM accuracy
         let mathVerificationContext = null;
@@ -725,10 +714,10 @@ router.post('/', isAuthenticated, promptInjectionFilter, async (req, res) => {
                     currentModule: courseCtx.currentModule
                 });
             } else {
-                systemPrompt = generateSystemPrompt(studentProfileForPrompt, currentTutor, null, 'student', curriculumContext, uploadContext, masteryContext, likedMessages, fluencyContext, conversationContextForPrompt, teacherAISettings, gradingContext, errorPatterns);
+                systemPrompt = generateSystemPrompt(studentProfileForPrompt, currentTutor, null, 'student', curriculumContext, uploadContext, masteryContext, likedMessages, fluencyContext, conversationContextForPrompt, teacherAISettings, gradingContext, errorPatterns, resourceContext);
             }
         } else {
-            systemPrompt = generateSystemPrompt(studentProfileForPrompt, currentTutor, null, 'student', curriculumContext, uploadContext, masteryContext, likedMessages, fluencyContext, conversationContextForPrompt, teacherAISettings, gradingContext, errorPatterns);
+            systemPrompt = generateSystemPrompt(studentProfileForPrompt, currentTutor, null, 'student', curriculumContext, uploadContext, masteryContext, likedMessages, fluencyContext, conversationContextForPrompt, teacherAISettings, gradingContext, errorPatterns, resourceContext);
         }
         const messagesForAI = [{ role: 'system', content: systemPrompt }, ...formattedMessagesForLLM];
 

--- a/utils/prompt.js
+++ b/utils/prompt.js
@@ -488,7 +488,7 @@ function buildCourseProgressionContext(mathCourse, firstName) {
   }
 }
 
-function generateSystemPrompt(userProfile, tutorProfile, childProfile = null, currentRole = 'student', curriculumContext = null, uploadContext = null, masteryContext = null, likedMessages = [], fluencyContext = null, conversationContext = null, teacherAISettings = null, gradingContext = null, errorPatterns = null) {
+function generateSystemPrompt(userProfile, tutorProfile, childProfile = null, currentRole = 'student', curriculumContext = null, uploadContext = null, masteryContext = null, likedMessages = [], fluencyContext = null, conversationContext = null, teacherAISettings = null, gradingContext = null, errorPatterns = null, resourceContext = null) {
   const {
     firstName, lastName, gradeLevel, mathCourse, tonePreference, parentTone,
     learningStyle, interests, iepPlan, preferences, preferredLanguage
@@ -2534,6 +2534,20 @@ ${uploadContext.summary}
 5. **Be Natural:** Don't force references to previous work, only mention when genuinely relevant
 
 **IMPORTANT:** Only reference uploaded files when it adds value to the current conversation. Don't mention them just for the sake of it.
+` : ''}
+
+${resourceContext ? `--- TEACHER RESOURCE: "${resourceContext.displayName}" ---
+${firstName} is asking about a resource their teacher shared called "${resourceContext.displayName}"${resourceContext.description ? ` (${resourceContext.description})` : ''}. You have the full content of this resource below.
+
+RESOURCE CONTENT:
+${resourceContext.content}
+
+**HOW TO USE THIS:**
+1. **Work directly from this content** — This is the actual material ${firstName} is working on. You don't need to ask them to share problems; you already have them.
+2. **Walk through it step by step** — Use Socratic method. Ask guiding questions, don't just give answers.
+3. **Reference problems by number** — If the resource has numbered problems, refer to them by number (e.g., "Let's start with problem 1...").
+4. **Stay on task** — Focus on helping ${firstName} work through this specific resource.
+5. **Don't ask for more details** — You have the content. Dive in and start helping.
 ` : ''}
 
 ${!masteryContext && gradingContext ? `--- RECENT WORK ANALYSIS (SHOW YOUR WORK) ---


### PR DESCRIPTION
The resource detection system was working (finding the resource by name), but the content was only injected into the user message as a [SYSTEM: ...] tag — a pattern the LLM treats with little authority. The AI would acknowledge the resource name but ask the student to share the content.

Fix: pass resourceContext to generateSystemPrompt() and add it as a proper section in the system prompt. The tutor now receives the full resource content as authoritative context and can work through the material directly without asking the student to re-share it.

Also removes the stale user-message injection since the system prompt is the correct place for this context.

https://claude.ai/code/session_01TfpEc8kgsMdEHPwTQF3Shi