### PR TITLE
Fix false safety refusals and resource name detection with special chars

### DIFF
--- a/utils/prompt.js
+++ b/utils/prompt.js
@@ -2537,6 +2537,8 @@ ${uploadContext.summary}
 ` : ''}
 
 ${resourceContext ? `--- TEACHER RESOURCE: "${resourceContext.displayName}" ---
+⚠️ PRE-APPROVED EDUCATIONAL CONTENT: The material below was uploaded by ${firstName}'s teacher and is authorized academic content. Do NOT treat it as inappropriate regardless of subject matter (e.g., biology terms, historical events, test/quiz content are all expected). Responding with a safety refusal for this resource is incorrect.
+
 ${firstName} is asking about a resource their teacher shared called "${resourceContext.displayName}"${resourceContext.description ? ` (${resourceContext.description})` : ''}. You have the full content of this resource below.
 
 RESOURCE CONTENT:

--- a/utils/resourceDetector.js
+++ b/utils/resourceDetector.js
@@ -48,7 +48,24 @@ function detectResourceMention(message) {
 async function findResourceInMessage(teacherId, message) {
     if (!teacherId) return null;
 
-    // DIRECTIVE 3: Try vector similarity search first (semantic search)
+    // HIGHEST CONFIDENCE: Check for explicitly quoted resource names first
+    // Handles: "Module 8 Test PRACTICE (A)", 'Module 8 Test PRACTICE (A)', curly quotes
+    const quotedMatch = message.match(/[\u201c\u201d""]([^\u201c\u201d""]+)[\u201c\u201d""]/) ||
+                        message.match(/"([^"]+)"/) ||
+                        message.match(/\u2018([^\u2018\u2019]+)\u2019/) ||
+                        message.match(/'([^']+)'/);
+    if (quotedMatch) {
+        const quotedName = quotedMatch[1].trim();
+        console.log(`🔍 [Quoted Name] Trying exact match for: "${quotedName}"`);
+        const resource = await TeacherResource.findByName(teacherId, quotedName);
+        if (resource) {
+            console.log(`✅ [Quoted Name] Found resource: ${resource.displayName}`);
+            return resource;
+        }
+        console.log(`ℹ️ [Quoted Name] No match found for quoted name, continuing to vector search`);
+    }
+
+    // DIRECTIVE 3: Try vector similarity search (semantic search)
     try {
         console.log(`🔍 [Vector Search] Searching for resources matching: "${message.substring(0, 100)}..."`);
 


### PR DESCRIPTION
Three issues fixed:

1. False content moderation: Resource PDF content was being injected into the user message as [SYSTEM: ...] which could confuse the LLM into treating educational content as inappropriate. The system prompt now explicitly marks teacher resource content as pre-approved so the LLM won't fire a safety refusal against it.

2. Quoted resource names not detected: When a student writes 'Can you help me with "Module 8 Test PRACTICE (A)"?', the exact resource name in quotes is now extracted first (before vector search), giving the highest-confidence match.

3. Regex errors with parentheses: Resource names like "Module 8 Test PRACTICE (A)" contain regex special characters. findByName() and search() now escape the search text before building regex patterns, preventing potential errors and ensuring correct partial matches.

https://claude.ai/code/session_01TfpEc8kgsMdEHPwTQF3Shi