### PR TITLE
Fix course progress bar permanently frozen at practice steps

### DIFF
--- a/models/conversation.js
+++ b/models/conversation.js
@@ -10,7 +10,10 @@ const messageSchema = new Schema({
     role: { type: String, required: true }, // 'user' or 'assistant'
     content: { type: String, required: true },
     timestamp: { type: Date, default: Date.now },
-    reaction: { type: String, default: null } // Emoji reaction (e.g., '❤️', '👍', '💯')
+    reaction: { type: String, default: null }, // Emoji reaction (e.g., '❤️', '👍', '💯')
+    // Course scaffold tracking — persisted so progress survives across requests
+    problemResult: { type: String, default: null }, // 'correct' | 'incorrect' | 'skipped' (set on AI messages)
+    scaffoldAdvanced: { type: Boolean, default: false } // true on the user msg where an advance was granted
 }, { _id: false });
 
 const conversationSchema = new Schema({

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1812,6 +1812,15 @@ document.addEventListener("DOMContentLoaded", () => {
                 }
             }
 
+            // Passive sync: courseContext.overallProgress is in every course-chat response.
+            // Update the bar even when no signal fired (handles page reloads, drift, etc.)
+            if (!data.courseProgress && data.courseContext && data.courseContext.overallProgress != null) {
+                const fill = document.getElementById('course-progress-fill');
+                const pct  = document.getElementById('course-progress-pct');
+                if (fill) fill.style.width = `${data.courseContext.overallProgress}%`;
+                if (pct)  pct.textContent  = `${data.courseContext.overallProgress}%`;
+            }
+
         } catch (error) {
             console.error("Chat error:", error);
 

--- a/routes/courseChat.js
+++ b/routes/courseChat.js
@@ -578,11 +578,18 @@ router.post('/', async (req, res) => {
         }
 
         // ── Save AI response to conversation ────────────────
-        conversation.messages.push({
+        // problemResult is persisted so the scaffold advance counter survives
+        // across requests (previously it was never saved, causing the MIN_CORRECT
+        // gate to be permanently blocked at practice steps).
+        const aiMsg = {
             role: 'assistant',
             content: aiResponseText,
             timestamp: new Date()
-        });
+        };
+        if (problemAnswered) {
+            aiMsg.problemResult = wasCorrect ? 'correct' : 'incorrect';
+        }
+        conversation.messages.push(aiMsg);
         conversation.currentTopic = courseSession.courseName;
         conversation.lastActivity = new Date();
 


### PR DESCRIPTION
Two root bugs prevented the bar from ever moving past guided/independent practice scaffold steps:

1. messageSchema was missing `problemResult` and `scaffoldAdvanced` fields. Mongoose strict mode silently dropped both on every save, so the per- session correct-answer history was always empty when the next request loaded the conversation.

2. Because history was always empty, `correctSinceLastAdvance` could reach at most 1 (the current message only) but MIN_CORRECT = 2. Every SCAFFOLD_ADVANCE tag emitted by the AI was silently blocked for practice phases, freezing the bar permanently.

Fix:
- Add `problemResult` and `scaffoldAdvanced` to messageSchema so they persist in MongoDB across requests.
- Store `problemResult` on the AI message object when saving, so the backward-scan counter accumulates correctly over multiple turns.
- On the client, passively sync the progress bar from `courseContext .overallProgress` (present in every course-chat response) so the bar stays accurate even when no signal fires (page reloads, drift, etc.).

https://claude.ai/code/session_0165zWJ8ATnZ7fXfEB5QkSjd