### PR TITLE
Add persistent exit lesson button to course progress bar

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -336,6 +336,9 @@
                 <div id="course-progress-fill" style="height: 100%; background: linear-gradient(90deg, #667eea, #764ba2); border-radius: 3px; width: 0%; transition: width 0.3s;"></div>
               </div>
               <span id="course-progress-pct" style="font-size: 12px; color: #888; min-width: 30px;">0%</span>
+              <button id="course-exit-lesson-btn" class="course-exit-lesson-btn" title="Exit lesson and return to general chat" onclick="event.stopPropagation(); window.courseManager?.exitCourse();">
+                <i class="fas fa-sign-out-alt"></i> Exit Lesson
+              </button>
               <i class="fas fa-chevron-down" id="course-dropdown-arrow" style="color: #888; font-size: 11px; transition: transform 0.2s;"></i>
             </div>
           </div>

--- a/public/css/courseCatalog.css
+++ b/public/css/courseCatalog.css
@@ -337,6 +337,33 @@
     color: #333 !important;
 }
 
+/* Persistent exit-lesson button in the progress bar */
+.course-exit-lesson-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 4px 12px;
+    background: #f1f5f9;
+    color: #64748b;
+    border: 1px solid #e2e8f0;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 12px;
+    font-weight: 500;
+    white-space: nowrap;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.course-exit-lesson-btn:hover {
+    background: #fee2e2;
+    color: #dc2626;
+    border-color: #fca5a5;
+}
+
+.course-exit-lesson-btn i {
+    font-size: 11px;
+}
+
 /* ----- Toast animation ----- */
 
 @keyframes fadeInUp {
@@ -387,6 +414,18 @@
 [data-theme="dark"] #course-exit-btn:hover {
     background: #475569 !important;
     color: #e2e8f0 !important;
+}
+
+[data-theme="dark"] .course-exit-lesson-btn {
+    background: #334155;
+    color: #94a3b8;
+    border-color: #475569;
+}
+
+[data-theme="dark"] .course-exit-lesson-btn:hover {
+    background: #7f1d1d;
+    color: #fca5a5;
+    border-color: #991b1b;
 }
 
 [data-theme="dark"] #course-sessions-list {

--- a/public/js/courseCatalog.js
+++ b/public/js/courseCatalog.js
@@ -819,6 +819,11 @@ class CourseManager {
     async exitCourse() {
         this.closeProgressDropdown();
 
+        // Confirm before leaving the lesson
+        if (!confirm('Exit this lesson?\n\nYour progress is saved — you can pick up where you left off anytime.')) {
+            return;
+        }
+
         try {
             await csrfFetch('/api/course-sessions/deactivate', {
                 method: 'POST',
@@ -832,6 +837,13 @@ class CourseManager {
 
             // Switch sidebar back to general context
             if (window.sidebar) window.sidebar.setContext('general');
+
+            // Start a fresh general chat session so the user isn't
+            // left staring at stale course messages
+            if (window.sidebar) {
+                await window.sidebar.loadSessions();
+                await window.sidebar.createNewSession();
+            }
 
             this.showToast('Returned to general tutoring');
         } catch (err) {


### PR DESCRIPTION
## Summary
This PR adds a persistent "Exit Lesson" button to the course progress bar, making it easier for users to leave a lesson and return to general tutoring without needing to access a dropdown menu.

## Key Changes
- **UI Enhancement**: Added a new "Exit Lesson" button in the course progress bar with icon and hover states
- **Styling**: Implemented comprehensive CSS styling for light and dark themes with smooth transitions
- **User Confirmation**: Added a confirmation dialog before exiting a lesson to prevent accidental exits
- **Session Management**: Improved the exit flow to automatically load and create a fresh general chat session, preventing users from seeing stale course messages

## Implementation Details
- The button is positioned in the progress bar next to the progress percentage indicator
- Styled with a light gray background that turns red on hover to indicate a destructive action
- Dark theme support with appropriate color adjustments (#334155 background, #7f1d1d on hover)
- Uses `event.stopPropagation()` to prevent triggering the progress bar dropdown when clicking the button
- Exit confirmation message reassures users that their progress is saved
- Automatically refreshes the sidebar session list and creates a new general chat session upon successful exit
- Button includes Font Awesome icon (fa-sign-out-alt) for visual clarity

https://claude.ai/code/session_01YJTfYdz2ASjX5qeA3SbdVQ