### PR TITLE
Fix unique index on badges.key that prevents shared badge keys

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -137,7 +137,7 @@ const userPreferencesSchema = new Schema({
 
 /* ---------- BADGES ---------- */
 const badgeSchema = new Schema({
-  key:        { type: String, unique: true, sparse: true },
+  key:        { type: String },
   badgeId:    { type: String },  // For mastery mode badges
   unlockedAt: { type: Date,   default: Date.now },
   earnedDate: { type: Date },

--- a/scripts/seedPlaygroundAccounts.js
+++ b/scripts/seedPlaygroundAccounts.js
@@ -54,6 +54,14 @@ async function seedPlaygroundAccounts() {
       process.exit(0);
     }
 
+    // --- Drop stale unique index on badges.key if it exists ---
+    try {
+      await mongoose.connection.collection('users').dropIndex('badges.key_1');
+      console.log('[FIX] Dropped stale unique index badges.key_1');
+    } catch (e) {
+      // Index doesn't exist — nothing to do
+    }
+
     // --- CLEAN UP existing playground data ---
     console.log('[1/5] Cleaning up existing playground data...');
     await clearPlaygroundData();


### PR DESCRIPTION
The badgeSchema had `unique: true` on the `key` field, which created a collection-level unique index. This meant no two users could have the same badge (e.g. "first-problem"), causing E11000 duplicate key errors when seeding multiple students with common badges.

Removed `unique: true` from the schema and added index cleanup to the seed script so the stale index gets dropped on existing databases.

https://claude.ai/code/session_012KwuwP9hBeMeNTsaV2brYJ