### PR TITLE
Fix demo page: auth error and scroll lock

### DIFF
--- a/public/demo.html
+++ b/public/demo.html
@@ -218,7 +218,7 @@
     }
   </style>
 </head>
-<body class="landing-page-body">
+<body class="landing-page-body" style="overflow-y: auto; height: auto;">
   <header class="landing-header">
     <div class="header-logo-container">
       <a href="/">

--- a/server.js
+++ b/server.js
@@ -473,6 +473,11 @@ app.use('/api/memory', isAuthenticated, memoryRouter);
 app.use('/api/summary', isAuthenticated, summaryGeneratorRouter); // SECURITY FIX: Added authentication to prevent unauthorized access
 app.use('/api/avatars', isAuthenticated, avatarRoutes);
 app.use('/api/avatar', isAuthenticated, avatarRoutes); // DiceBear avatar customization endpoints
+
+// Public API routes (no auth required) — must come BEFORE the catch-all /api mount below
+app.use('/api/waitlist', waitlistRoutes);          // Pre-launch waitlist
+app.use('/api/demo', demoRoutes);                  // Playground demo account login & reset
+
 app.use('/api', isAuthenticated, diagramRoutes); // Controlled diagram generation for visual learners
 app.use('/api/curriculum', isAuthenticated, curriculumRoutes); // Curriculum schedule management
 app.use('/api/courses', isAuthenticated, courseRoutes); // Course catalog, session-based enrollment, and progression
@@ -507,12 +512,6 @@ app.post('/api/clever-sync/webhook', cleverSyncRoutes);
 app.use('/api/clever-sync', isAuthenticated, isAdmin, cleverSyncRoutes); // Clever roster & section sync (admin only)
 app.use('/api/iep-templates', isAuthenticated, isTeacher, iepTemplatesRoutes); // IEP templates for teachers
 app.use('/api/impersonation', isAuthenticated, impersonationRoutes); // User impersonation (student view) for admins/teachers/parents
-
-// Pre-launch waitlist (public — no auth required)
-app.use('/api/waitlist', waitlistRoutes);
-
-// Playground demo accounts (public login, authenticated reset/status)
-app.use('/api/demo', demoRoutes);
 
 // User Profile & Settings Routes
 app.get("/user", isAuthenticated, async (req, res) => {


### PR DESCRIPTION
1. Auth: Moved /api/demo (and /api/waitlist) routes above the catch-all `app.use('/api', isAuthenticated, diagramRoutes)` mount. The catch-all was intercepting all /api/* requests and returning 401 for unauthenticated users before the demo handler could run.

2. Scroll: demo.html uses landing-page-body class which has overflow:hidden (designed for the chat page). Added inline override so the demo card grid can scroll.

https://claude.ai/code/session_012KwuwP9hBeMeNTsaV2brYJ