### PR TITLE
Add lesson progress tracker with real-time updates

### DIFF
--- a/models/courseSession.js
+++ b/models/courseSession.js
@@ -60,6 +60,9 @@ const courseSessionSchema = new Schema({
   // Overall progress
   overallProgress: { type: Number, default: 0, min: 0, max: 100 },
 
+  // Progress floor: highest progress ever achieved (bar never moves backward)
+  progressFloorPct: { type: Number, default: 0, min: 0, max: 100 },
+
   // Status
   status: {
     type: String,

--- a/public/chat.html
+++ b/public/chat.html
@@ -20,6 +20,7 @@
   <link rel="stylesheet" href="/css/sidebar-layout.css" />
   <link rel="stylesheet" href="/css/dark-mode.css" />
   <link rel="stylesheet" href="/css/ux-enhancements.css" />
+  <link rel="stylesheet" href="/css/lessonTracker.css" />
   <link rel="stylesheet" href="/css/tour-survey.css" />
   <link rel="stylesheet" href="/css/impersonation-banner.css" />
   <link rel="stylesheet" href="/css/iep-accommodations.css" />
@@ -356,6 +357,32 @@
               Exit Course
             </button>
           </div>
+        </div>
+      </div>
+
+      <!-- Lesson Progress Tracker (phase dots + step bar + expandable details) -->
+      <div id="lesson-tracker-wrapper" style="display: none;">
+        <div class="lt-container">
+          <!-- Phase checkpoint dots (5 buckets) -->
+          <div id="lt-phase-dots" class="lt-phase-dots"></div>
+
+          <!-- Main progress bar + step label -->
+          <div class="lt-bar-row">
+            <div class="lt-bar-track">
+              <div id="lt-progress-fill" class="lt-bar-fill"></div>
+            </div>
+            <div class="lt-labels">
+              <span id="lt-step-label" class="lt-step-label"></span>
+              <span class="lt-label-sep">&middot;</span>
+              <span id="lt-phase-label" class="lt-phase-label"></span>
+              <button id="lt-details-toggle" class="lt-details-toggle" title="Show details">
+                <i class="fas fa-chevron-down lt-toggle-icon"></i>
+              </button>
+            </div>
+          </div>
+
+          <!-- Expandable details panel -->
+          <div id="lt-details-panel" class="lt-details-panel"></div>
         </div>
       </div>
 
@@ -1539,6 +1566,7 @@
   <script src="/js/floating-screener.js"></script>
   <script src="/js/sidebar.js"></script>
   <script src="/js/courseCatalog.js"></script>
+  <script src="/js/lessonTracker.js"></script>
   <script src="/js/returningUserModal.js"></script>
   <script src="/js/graphTool.js"></script>
   <script src="/js/diagram-display.js"></script>

--- a/public/css/lessonTracker.css
+++ b/public/css/lessonTracker.css
@@ -1,0 +1,244 @@
+/* ============================================
+   LESSON PROGRESS TRACKER
+   Calm, clear, never threatening.
+   Phase dots + step bar + expandable details.
+   ============================================ */
+
+/* Container */
+.lt-container {
+  background: linear-gradient(135deg, #667eea08, #764ba208);
+  border-bottom: 1px solid #e2e8f0;
+  padding: 10px 16px 8px;
+}
+
+/* ── Phase checkpoint dots ────────────────── */
+.lt-phase-dots {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0;
+  margin-bottom: 8px;
+  padding: 0 8px;
+}
+
+.lt-phase-group {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  flex-shrink: 0;
+}
+
+.lt-dot {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.3s ease;
+  position: relative;
+}
+
+.lt-dot-label {
+  font-size: 10px;
+  color: #94a3b8;
+  white-space: nowrap;
+  transition: color 0.3s;
+}
+
+/* Connector line between dots */
+.lt-dot-connector {
+  flex: 1;
+  height: 2px;
+  background: #e2e8f0;
+  min-width: 12px;
+  max-width: 60px;
+  margin: 0 2px;
+  align-self: flex-start;
+  margin-top: 9px; /* center with dot */
+  transition: background 0.3s;
+}
+
+/* Completed dot */
+.lt-dot-completed .lt-dot {
+  background: #667eea;
+}
+.lt-dot-completed .lt-dot-label {
+  color: #667eea;
+  font-weight: 600;
+}
+.lt-dot-completed + .lt-dot-connector {
+  background: #667eea;
+}
+
+/* Current dot */
+.lt-dot-current .lt-dot {
+  background: white;
+  border: 2.5px solid #667eea;
+  box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.15);
+}
+.lt-dot-current .lt-dot-label {
+  color: #667eea;
+  font-weight: 700;
+}
+
+/* Pulse animation for current dot */
+.lt-dot-pulse {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #667eea;
+  animation: ltPulse 2s ease-in-out infinite;
+}
+
+@keyframes ltPulse {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.3); opacity: 0.7; }
+}
+
+/* Future dot */
+.lt-dot-future .lt-dot {
+  background: #e2e8f0;
+}
+.lt-dot-future .lt-dot-label {
+  color: #cbd5e1;
+}
+
+/* ── Main progress bar ────────────────────── */
+.lt-bar-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.lt-bar-track {
+  width: 100%;
+  height: 6px;
+  background: #e2e8f0;
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.lt-bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #667eea, #764ba2);
+  border-radius: 3px;
+  width: 0%;
+  transition: width 0.4s ease;
+}
+
+.lt-labels {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+}
+
+.lt-step-label {
+  color: #475569;
+  font-weight: 600;
+}
+
+.lt-label-sep {
+  color: #cbd5e1;
+}
+
+.lt-phase-label {
+  color: #94a3b8;
+  font-weight: 400;
+}
+
+/* Details toggle button */
+.lt-details-toggle {
+  background: none;
+  border: none;
+  padding: 2px 6px;
+  cursor: pointer;
+  color: #94a3b8;
+  font-size: 10px;
+  margin-left: auto;
+  border-radius: 4px;
+  transition: all 0.15s;
+}
+.lt-details-toggle:hover {
+  background: #f1f5f9;
+  color: #667eea;
+}
+.lt-toggle-icon {
+  transition: transform 0.2s;
+}
+.lt-details-toggle.expanded .lt-toggle-icon {
+  transform: rotate(180deg);
+}
+
+/* ── Details panel (expandable) ───────────── */
+.lt-details-panel {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.25s ease, padding 0.25s ease;
+  padding: 0 4px;
+}
+.lt-details-panel.expanded {
+  max-height: 120px;
+  padding: 8px 4px 4px;
+}
+
+.lt-detail-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 3px 0;
+  font-size: 12px;
+}
+
+.lt-detail-key {
+  color: #94a3b8;
+}
+
+.lt-detail-val {
+  color: #475569;
+  font-weight: 500;
+}
+
+.lt-streak {
+  color: #667eea;
+}
+
+/* ── Dev overlay ──────────────────────────── */
+.lt-dev-overlay {
+  background: #faf5ff;
+  border: 1px dashed #c4b5fd;
+  border-radius: 6px;
+  padding: 8px;
+  margin-top: 6px;
+  max-height: 200px;
+  overflow-y: auto;
+  display: none;
+}
+
+/* ── Responsive ──────────────────────────── */
+@media (max-width: 600px) {
+  .lt-phase-dots {
+    padding: 0 2px;
+  }
+  .lt-dot-label {
+    font-size: 8px;
+  }
+  .lt-dot {
+    width: 16px;
+    height: 16px;
+  }
+  .lt-dot-connector {
+    min-width: 6px;
+    margin-top: 7px;
+  }
+  .lt-dot-pulse {
+    width: 6px;
+    height: 6px;
+  }
+  .lt-dot-completed .lt-dot svg {
+    width: 8px;
+    height: 8px;
+  }
+}

--- a/public/js/courseCatalog.js
+++ b/public/js/courseCatalog.js
@@ -208,10 +208,20 @@ class CourseManager {
             this.updateProgressBar(match);
             wrapper.style.display = 'block';
             if (window.sidebar) window.sidebar.setContext('course');
+
+            // Rehydrate the lesson progress tracker
+            if (window.lessonTracker) {
+                window.lessonTracker.rehydrate(match._id);
+            }
         } else {
             wrapper.style.display = 'none';
             this.activeCourseSessionId = null;
             if (window.sidebar) window.sidebar.setContext('general');
+
+            // Hide the lesson tracker when not in a course
+            if (window.lessonTracker) {
+                window.lessonTracker.hide();
+            }
         }
     }
 
@@ -807,6 +817,10 @@ class CourseManager {
             if (data.text && window.appendMessage) {
                 window.appendMessage(data.text, 'ai');
             }
+            // Feed the lesson tracker from greeting response
+            if (data.progressUpdate && window.lessonTracker) {
+                window.lessonTracker.update(data.progressUpdate);
+            }
         } catch (err) {
             if (window.showThinkingIndicator) window.showThinkingIndicator(false);
             console.error('[CourseManager] Course greeting failed:', err);
@@ -830,9 +844,10 @@ class CourseManager {
                 credentials: 'include'
             });
 
-            // Hide progress bar
+            // Hide progress bar and lesson tracker
             const wrapper = document.getElementById('course-progress-wrapper');
             if (wrapper) wrapper.style.display = 'none';
+            if (window.lessonTracker) window.lessonTracker.hide();
             this.activeCourseSessionId = null;
 
             // Switch sidebar back to general context

--- a/public/js/lessonTracker.js
+++ b/public/js/lessonTracker.js
@@ -1,0 +1,202 @@
+// ============================================
+// LESSON PROGRESS TRACKER
+// Renders a student-safe, calm progress UI from
+// the server-authoritative progressUpdate payload.
+// Called on every /api/course-chat response and
+// on page load via the rehydration endpoint.
+// ============================================
+
+class LessonTracker {
+    constructor() {
+        this._lastUpdate = null;
+        this._devMode = false; // Toggle via LessonTracker.dev()
+        this._initialized = false;
+    }
+
+    // --------------------------------------------------
+    // Public API
+    // --------------------------------------------------
+
+    /**
+     * Update the tracker with a progressUpdate payload.
+     * Called after every course-chat response.
+     */
+    update(progressUpdate) {
+        if (!progressUpdate) return;
+        this._lastUpdate = progressUpdate;
+        this._render(progressUpdate);
+    }
+
+    /**
+     * Rehydrate: fetch progress from server and render.
+     * Called on page load, tab refocus, reconnect.
+     */
+    async rehydrate(sessionId) {
+        if (!sessionId) return;
+        try {
+            const res = await csrfFetch(`/api/course-sessions/${sessionId}/lesson-progress`, {
+                method: 'GET',
+                credentials: 'include'
+            });
+            const data = await res.json();
+            if (data.success && data.progressUpdate) {
+                this.update(data.progressUpdate);
+            }
+        } catch (err) {
+            console.warn('[LessonTracker] Rehydration failed:', err);
+        }
+    }
+
+    /**
+     * Show the tracker (when entering a course).
+     */
+    show() {
+        const wrapper = document.getElementById('lesson-tracker-wrapper');
+        if (wrapper) wrapper.style.display = 'block';
+    }
+
+    /**
+     * Hide the tracker (when exiting a course).
+     */
+    hide() {
+        const wrapper = document.getElementById('lesson-tracker-wrapper');
+        if (wrapper) wrapper.style.display = 'none';
+    }
+
+    /**
+     * Toggle dev overlay for debugging.
+     */
+    static dev() {
+        if (window.lessonTracker) {
+            window.lessonTracker._devMode = !window.lessonTracker._devMode;
+            if (window.lessonTracker._lastUpdate) {
+                window.lessonTracker._render(window.lessonTracker._lastUpdate);
+            }
+            console.log(`[LessonTracker] Dev mode: ${window.lessonTracker._devMode ? 'ON' : 'OFF'}`);
+        }
+    }
+
+    // --------------------------------------------------
+    // Rendering
+    // --------------------------------------------------
+
+    _render(pu) {
+        // Phase dots
+        this._renderPhaseDots(pu.phaseGroups);
+
+        // Main progress bar
+        const displayPct = Math.max(pu.progressFloorPct || 0, pu.computedPct || 0);
+        const fill = document.getElementById('lt-progress-fill');
+        const stepText = document.getElementById('lt-step-label');
+        const phaseText = document.getElementById('lt-phase-label');
+
+        if (fill) {
+            fill.style.width = `${displayPct}%`;
+        }
+        if (stepText) {
+            stepText.textContent = pu.stepLabel || '';
+        }
+        if (phaseText) {
+            phaseText.textContent = pu.phaseLabel || '';
+        }
+
+        // Details panel (expandable)
+        this._renderDetails(pu);
+
+        // Dev overlay
+        this._renderDevOverlay(pu);
+
+        // Ensure visibility
+        const wrapper = document.getElementById('lesson-tracker-wrapper');
+        if (wrapper && wrapper.style.display === 'none') {
+            wrapper.style.display = 'block';
+        }
+    }
+
+    _renderPhaseDots(phaseGroups) {
+        const container = document.getElementById('lt-phase-dots');
+        if (!container || !phaseGroups) return;
+
+        container.innerHTML = phaseGroups.map(pg => {
+            let dotClass = 'lt-dot-future';
+            let icon = '';
+            if (pg.status === 'completed') {
+                dotClass = 'lt-dot-completed';
+                icon = '<svg width="10" height="10" viewBox="0 0 16 16" fill="none"><path d="M3 8l3.5 3.5L13 5" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+            } else if (pg.status === 'current') {
+                dotClass = 'lt-dot-current';
+                icon = '<div class="lt-dot-pulse"></div>';
+            }
+
+            return `
+                <div class="lt-phase-group ${dotClass}" title="${pg.label}">
+                    <div class="lt-dot">${icon}</div>
+                    <span class="lt-dot-label">${pg.label}</span>
+                </div>
+            `;
+        }).join('<div class="lt-dot-connector"></div>');
+    }
+
+    _renderDetails(pu) {
+        const panel = document.getElementById('lt-details-panel');
+        if (!panel) return;
+
+        let html = `<div class="lt-detail-row"><span class="lt-detail-key">Phase</span><span class="lt-detail-val">${pu.phaseGroupLabel || ''}</span></div>`;
+
+        if (pu.uiFlags?.showAccuracy && pu.problemsAttempted > 0) {
+            html += `<div class="lt-detail-row"><span class="lt-detail-key">Accuracy</span><span class="lt-detail-val">${pu.problemsCorrect}/${pu.problemsAttempted} correct</span></div>`;
+        }
+
+        // Streak: count recent consecutive correct
+        if (pu.problemsCorrect > 0) {
+            html += `<div class="lt-detail-row"><span class="lt-detail-key">Progress</span><span class="lt-detail-val lt-streak">${pu.problemsCorrect} problem${pu.problemsCorrect !== 1 ? 's' : ''} solved</span></div>`;
+        }
+
+        panel.innerHTML = html;
+    }
+
+    _renderDevOverlay(pu) {
+        let overlay = document.getElementById('lt-dev-overlay');
+        if (!this._devMode) {
+            if (overlay) overlay.style.display = 'none';
+            return;
+        }
+        if (!overlay) {
+            overlay = document.createElement('div');
+            overlay.id = 'lt-dev-overlay';
+            overlay.className = 'lt-dev-overlay';
+            const wrapper = document.getElementById('lesson-tracker-wrapper');
+            if (wrapper) wrapper.appendChild(overlay);
+        }
+        overlay.style.display = 'block';
+        overlay.innerHTML = `<pre style="margin:0;font-size:10px;line-height:1.3;color:#8b5cf6;white-space:pre-wrap;">${JSON.stringify(pu, null, 2)}</pre>`;
+    }
+}
+
+// --------------------------------------------------
+// Tab refocus rehydration
+// --------------------------------------------------
+document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible' && window.lessonTracker && window.courseManager?.activeCourseSessionId) {
+        window.lessonTracker.rehydrate(window.courseManager.activeCourseSessionId);
+    }
+});
+
+// Auto-initialise
+document.addEventListener('DOMContentLoaded', () => {
+    window.lessonTracker = new LessonTracker();
+
+    // Wire up the details toggle
+    const toggle = document.getElementById('lt-details-toggle');
+    const panel = document.getElementById('lt-details-panel');
+    if (toggle && panel) {
+        toggle.addEventListener('click', () => {
+            const expanded = panel.classList.toggle('expanded');
+            toggle.classList.toggle('expanded', expanded);
+        });
+    }
+
+    console.log('[LessonTracker] Initialised. Use LessonTracker.dev() to toggle debug overlay.');
+});
+
+console.log('[LessonTracker] Module loaded');

--- a/public/js/lessonTracker.js
+++ b/public/js/lessonTracker.js
@@ -84,8 +84,8 @@ class LessonTracker {
         // Phase dots
         this._renderPhaseDots(pu.phaseGroups);
 
-        // Main progress bar
-        const displayPct = Math.max(pu.progressFloorPct || 0, pu.computedPct || 0);
+        // Main progress bar — use server-computed displayPct directly (no client math)
+        const displayPct = pu.displayPct || 0;
         const fill = document.getElementById('lt-progress-fill');
         const stepText = document.getElementById('lt-step-label');
         const phaseText = document.getElementById('lt-phase-label');

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1821,6 +1821,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 if (pct)  pct.textContent  = `${data.courseContext.overallProgress}%`;
             }
 
+            // Lesson progress tracker: update on every course-chat response
+            if (data.progressUpdate && window.lessonTracker) {
+                window.lessonTracker.update(data.progressUpdate);
+            }
+
         } catch (error) {
             console.error("Chat error:", error);
 

--- a/routes/courseChat.js
+++ b/routes/courseChat.js
@@ -686,9 +686,13 @@ router.post('/', async (req, res) => {
         // ── Build progressUpdate (ALWAYS — every response) ──
         // Determine last assessment signal for this turn
         let lastSignal = null;
+        let signalSource = null;
         if (problemAnswered) {
-            // Map problem result to signal nomenclature
+            // Binary signal from <PROBLEM_RESULT> tag — not real timing data.
+            // signalSource tracks which generator produced this so future code
+            // doesn't confuse it with lessonPhaseManager telemetry.
             lastSignal = wasCorrect ? 'correct_fast' : 'incorrect_close';
+            signalSource = 'problem_result';
         }
 
         const progressUpdate = buildProgressUpdate({
@@ -696,6 +700,7 @@ router.post('/', async (req, res) => {
             moduleData,
             conversation,
             lastSignal,
+            signalSource,
             showCheckpoint: false
         });
 

--- a/utils/progressState.js
+++ b/utils/progressState.js
@@ -169,6 +169,15 @@ function buildProgressUpdate({ courseSession, moduleData, conversation, lastSign
     showPercent: false  // Default: show step label instead
   };
 
+  // displayPct: the ONLY value the UI should use for the bar width.
+  // max(floor, computed) — enforced here so the frontend does zero math.
+  const displayPct = Math.max(progressFloorPct, computedPct);
+
+  // signalQuality: "approx" when lastSignal is inferred from binary
+  // PROBLEM_RESULT tags, "real" when sourced from lessonPhaseManager
+  // timing data. Prevents future-us from treating guesses as telemetry.
+  const signalQuality = lastSignal ? 'approx' : null;
+
   return {
     sessionId:         courseSession._id,
     lessonId:          courseSession.currentLessonId || null,
@@ -189,10 +198,12 @@ function buildProgressUpdate({ courseSession, moduleData, conversation, lastSign
     problemsCorrect,
 
     lastSignal:        lastSignal || null,
+    signalQuality,
     struggleFlag,
 
     computedPct,
     progressFloorPct,
+    displayPct,
 
     masterySignal:     null,
 

--- a/utils/progressState.js
+++ b/utils/progressState.js
@@ -1,0 +1,214 @@
+/**
+ * PROGRESS STATE BUILDER
+ *
+ * Builds a deterministic, student-safe progressUpdate payload
+ * returned on EVERY /api/course-chat response and from the
+ * GET /api/course-progress rehydration endpoint.
+ *
+ * Internal phases (9) are mapped to 5 student-facing buckets.
+ * The progress bar never moves backward (progressFloorPct).
+ */
+
+// ── Phase group mapping ───────────────────────────────────────
+// Internal phase keys → student-safe bucket
+const PHASE_GROUP_MAP = {
+  // Scaffold step types (from module JSON)
+  'intro':                  'WARMUP',
+  'warmup':                 'WARMUP',
+  'explanation':            'LEARN',
+  'concept-intro':          'LEARN',
+  'model':                  'LEARN',
+  'i-do':                   'LEARN',
+  'concept-check':          'GUIDED',
+  'guided_practice':        'GUIDED',
+  'we-do':                  'GUIDED',
+  'check-in':               'GUIDED',
+  'independent_practice':   'INDEPENDENT',
+  'you-do':                 'INDEPENDENT',
+  'mastery-check':          'CHECKPOINT',
+  'mastery':                'CHECKPOINT',
+  'assessment':             'CHECKPOINT'
+};
+
+const PHASE_GROUP_LABELS = {
+  WARMUP:      'Warm-up',
+  LEARN:       'Learn',
+  GUIDED:      'Practice (Guided)',
+  INDEPENDENT: 'Practice (Independent)',
+  CHECKPOINT:  'Checkpoint'
+};
+
+// Friendly labels for internal scaffold step types
+const PHASE_LABELS = {
+  'intro':                  'Introduction',
+  'warmup':                 'Warm-up',
+  'explanation':            'Concept Intro',
+  'concept-intro':          'Concept Intro',
+  'model':                  'Worked Examples',
+  'i-do':                   'Worked Examples',
+  'concept-check':          'Understanding Check',
+  'guided_practice':        'Guided Practice',
+  'we-do':                  'Guided Practice',
+  'check-in':               'Check-in',
+  'independent_practice':   'Independent Practice',
+  'you-do':                 'Independent Practice',
+  'mastery-check':          'Checkpoint',
+  'mastery':                'Checkpoint',
+  'assessment':             'Checkpoint'
+};
+
+// The 5 ordered bucket keys for the checkpoint dots
+const PHASE_GROUP_ORDER = ['WARMUP', 'LEARN', 'GUIDED', 'INDEPENDENT', 'CHECKPOINT'];
+
+/**
+ * Map a raw scaffold step type to student-safe group info.
+ */
+function mapPhaseGroup(rawPhaseKey) {
+  const key = (rawPhaseKey || '').toLowerCase();
+  const groupKey = PHASE_GROUP_MAP[key] || 'LEARN';
+  return {
+    phaseGroupKey:   groupKey,
+    phaseGroupLabel: PHASE_GROUP_LABELS[groupKey] || groupKey,
+    phaseLabel:      PHASE_LABELS[key] || rawPhaseKey || 'Lesson'
+  };
+}
+
+/**
+ * Determine which phase groups are completed/current/future
+ * based on the current scaffold index and module scaffold data.
+ */
+function computePhaseGroupStatuses(scaffoldData, currentScaffoldIndex) {
+  const scaffolds = scaffoldData?.scaffold || [];
+  if (scaffolds.length === 0) return [];
+
+  // Walk through scaffolds and find the highest group reached
+  const groupsSeen = new Set();
+  const currentStep = scaffolds[currentScaffoldIndex];
+  const currentRaw = currentStep?.type || currentStep?.lessonPhase || '';
+  const currentGroup = (PHASE_GROUP_MAP[currentRaw] || 'LEARN');
+
+  // All steps before the current index contribute to "completed" groups
+  for (let i = 0; i < currentScaffoldIndex; i++) {
+    const step = scaffolds[i];
+    const raw = step?.type || step?.lessonPhase || '';
+    const group = PHASE_GROUP_MAP[raw] || 'LEARN';
+    groupsSeen.add(group);
+  }
+
+  const currentGroupIdx = PHASE_GROUP_ORDER.indexOf(currentGroup);
+
+  return PHASE_GROUP_ORDER.map((groupKey, idx) => {
+    let status;
+    if (idx < currentGroupIdx || (groupsSeen.has(groupKey) && groupKey !== currentGroup)) {
+      status = 'completed';
+    } else if (groupKey === currentGroup) {
+      status = 'current';
+    } else {
+      status = 'future';
+    }
+    return {
+      groupKey,
+      label: PHASE_GROUP_LABELS[groupKey],
+      status
+    };
+  });
+}
+
+/**
+ * Build the full progressUpdate payload.
+ *
+ * @param {Object} opts
+ * @param {Object} opts.courseSession - The CourseSession document
+ * @param {Object} opts.moduleData   - The loaded module JSON (has scaffold[])
+ * @param {Object} opts.conversation - The Conversation document (for problem stats)
+ * @param {string|null} opts.lastSignal - Last assessment signal (correct_fast, etc.)
+ * @param {boolean} opts.showCheckpoint - Whether the checkpoint phase is visible
+ * @returns {Object} progressUpdate payload
+ */
+function buildProgressUpdate({ courseSession, moduleData, conversation, lastSignal = null, showCheckpoint = false }) {
+  const scaffolds = moduleData?.scaffold || [];
+  const totalScaffolds = scaffolds.length || 1;
+  const scaffoldIndex = courseSession.currentScaffoldIndex || 0;
+  const currentStep = scaffolds[scaffoldIndex];
+
+  // Raw phase key from scaffold step
+  const rawPhaseKey = currentStep?.type || currentStep?.lessonPhase || 'explanation';
+
+  // Map to student-safe labels
+  const { phaseGroupKey, phaseGroupLabel, phaseLabel } = mapPhaseGroup(rawPhaseKey);
+
+  // Step label: "Step 3 of 7"
+  const stepLabel = `Step ${scaffoldIndex + 1} of ${totalScaffolds}`;
+
+  // Computed progress percentage based on traversed path
+  const computedPct = Math.round(((scaffoldIndex + 1) / totalScaffolds) * 100);
+
+  // Floor: never go below the highest progress ever achieved
+  const existingFloor = courseSession.progressFloorPct || 0;
+  const progressFloorPct = Math.max(existingFloor, computedPct);
+
+  // Problem stats from conversation
+  const problemsAttempted = conversation?.problemsAttempted || 0;
+  const problemsCorrect = conversation?.problemsCorrect || 0;
+
+  // Struggle flag: 3+ recent incorrect answers
+  let struggleFlag = false;
+  if (conversation?.messages) {
+    const recent = conversation.messages.slice(-6);
+    const recentIncorrect = recent.filter(m => m.problemResult === 'incorrect').length;
+    struggleFlag = recentIncorrect >= 3;
+  }
+
+  // Phase group statuses for checkpoint dots
+  const phaseGroups = computePhaseGroupStatuses(moduleData, scaffoldIndex);
+
+  // UI flags: what to show/hide
+  const uiFlags = {
+    showCheckpoint: showCheckpoint || phaseGroupKey === 'CHECKPOINT',
+    showAccuracy: problemsAttempted >= 2,
+    showPercent: false  // Default: show step label instead
+  };
+
+  return {
+    sessionId:         courseSession._id,
+    lessonId:          courseSession.currentLessonId || null,
+
+    rawPhaseKey,
+    phaseLabel,
+    phaseGroupKey,
+    phaseGroupLabel,
+
+    phaseIndex:        scaffoldIndex,
+    totalPhases:       totalScaffolds,
+
+    scaffoldIndex,
+    totalScaffolds,
+    stepLabel,
+
+    problemsAttempted,
+    problemsCorrect,
+
+    lastSignal:        lastSignal || null,
+    struggleFlag,
+
+    computedPct,
+    progressFloorPct,
+
+    masterySignal:     null,
+
+    uiFlags,
+    phaseGroups,
+
+    updatedAt:         new Date().toISOString()
+  };
+}
+
+module.exports = {
+  PHASE_GROUP_MAP,
+  PHASE_GROUP_LABELS,
+  PHASE_GROUP_ORDER,
+  PHASE_LABELS,
+  mapPhaseGroup,
+  computePhaseGroupStatuses,
+  buildProgressUpdate
+};


### PR DESCRIPTION
- New progressState utility: maps 9 internal phases to 5 student-safe
  buckets (Warm-up, Learn, Guided, Independent, Checkpoint), builds
  deterministic progressUpdate payload with monotonic floor logic
- progressFloorPct persisted on CourseSession model so the progress bar
  never moves backward, even during remediation/branching
- progressUpdate returned on EVERY /api/course-chat response (including
  greetings), not just on scaffold advances
- GET /api/course-sessions/:id/lesson-progress rehydration endpoint for
  page load, tab refocus, and reconnect scenarios
- Frontend lesson tracker component: phase checkpoint dots, step bar,
  expandable details panel, dev overlay (LessonTracker.dev())
- Integrated into chat.html, script.js, and courseCatalog.js at all
  touch points: response handler, greeting, page load, course exit

https://claude.ai/code/session_01WzybGw69x6LFjUcvm7bcCc