### PR TITLE
Fix module file path doubling + whitespace-tolerant signal tag parsing

### DIFF
--- a/routes/chat.js
+++ b/routes/chat.js
@@ -1235,7 +1235,7 @@ router.post('/', isAuthenticated, promptInjectionFilter, async (req, res) => {
         // PROBLEM RESULT TRACKING: Parse structured tags for accurate stats
         // Format: <PROBLEM_RESULT:correct|incorrect|skipped>
         // This MUST happen before saving so stats are persisted correctly
-        const problemResultMatch = aiResponseText.match(/<PROBLEM_RESULT:(correct|incorrect|skipped)>/i);
+        const problemResultMatch = aiResponseText.match(/<\s*PROBLEM_RESULT\s*:\s*(correct|incorrect|skipped)\s*>/i);
         let problemAnswered = false;
         let wasCorrect = false;
         let wasSkipped = false;
@@ -1322,8 +1322,8 @@ router.post('/', isAuthenticated, promptInjectionFilter, async (req, res) => {
         if (user.activeCourseSessionId && conversationContextForPrompt?.courseSession) {
             try {
                 const CourseSessionModel = require('../models/courseSession');
-                const hasScaffoldAdvance = /<SCAFFOLD_ADVANCE>/i.test(aiResponseText);
-                const hasModuleComplete = /<MODULE_COMPLETE>/i.test(aiResponseText);
+                const hasScaffoldAdvance = /<\s*SCAFFOLD_ADVANCE\s*>/i.test(aiResponseText);
+                const hasModuleComplete = /<\s*MODULE_COMPLETE\s*>/i.test(aiResponseText);
 
                 console.log(`[Progression] Engine active — sessionId=${user.activeCourseSessionId}, SCAFFOLD_ADVANCE=${hasScaffoldAdvance}, MODULE_COMPLETE=${hasModuleComplete}`);
                 if (!hasScaffoldAdvance && !hasModuleComplete) {
@@ -1333,8 +1333,8 @@ router.post('/', isAuthenticated, promptInjectionFilter, async (req, res) => {
                 // Strip signal tags from the response text (student should not see them)
                 if (hasScaffoldAdvance || hasModuleComplete) {
                     aiResponseText = aiResponseText
-                        .replace(/<SCAFFOLD_ADVANCE>/gi, '')
-                        .replace(/<MODULE_COMPLETE>/gi, '')
+                        .replace(/<\s*SCAFFOLD_ADVANCE\s*>/gi, '')
+                        .replace(/<\s*MODULE_COMPLETE\s*>/gi, '')
                         .trim();
                     // In streaming mode, tags were already sent — send replacement to overwrite
                     if (useStreaming && !clientDisconnected) {

--- a/routes/courseChat.js
+++ b/routes/courseChat.js
@@ -93,7 +93,8 @@ router.post('/', async (req, res) => {
 
         let moduleData = { title: currentPathwayModule.title, skills: currentPathwayModule.skills || [] };
         if (currentPathwayModule.moduleFile) {
-            const moduleFile = path.join(__dirname, '../public/modules', courseSession.courseId, currentPathwayModule.moduleFile);
+            // moduleFile is stored as "/modules/{courseId}/file.json" — resolve relative to public/
+            const moduleFile = path.join(__dirname, '../public', currentPathwayModule.moduleFile);
             if (fs.existsSync(moduleFile)) {
                 moduleData = JSON.parse(fs.readFileSync(moduleFile, 'utf8'));
             }
@@ -305,7 +306,7 @@ router.post('/', async (req, res) => {
         }
 
         // Problem result tracking
-        const problemResultMatch = aiResponseText.match(/<PROBLEM_RESULT:(correct|incorrect|skipped)>/i);
+        const problemResultMatch = aiResponseText.match(/<\s*PROBLEM_RESULT\s*:\s*(correct|incorrect|skipped)\s*>/i);
         let problemAnswered = false;
         let wasCorrect = false;
 
@@ -388,15 +389,15 @@ router.post('/', async (req, res) => {
 
         // ── SCAFFOLD & MODULE PROGRESS TRACKING ──────────────
         // Parse signal tags that control course progression
-        const hasScaffoldAdvance = /<SCAFFOLD_ADVANCE>/i.test(aiResponseText);
-        const hasModuleComplete = /<MODULE_COMPLETE>/i.test(aiResponseText);
+        const hasScaffoldAdvance = /<\s*SCAFFOLD_ADVANCE\s*>/i.test(aiResponseText);
+        const hasModuleComplete = /<\s*MODULE_COMPLETE\s*>/i.test(aiResponseText);
         let courseProgressUpdate = null;
 
         // Strip signal tags from student-facing text
         if (hasScaffoldAdvance || hasModuleComplete) {
             aiResponseText = aiResponseText
-                .replace(/<SCAFFOLD_ADVANCE>/gi, '')
-                .replace(/<MODULE_COMPLETE>/gi, '')
+                .replace(/<\s*SCAFFOLD_ADVANCE\s*>/gi, '')
+                .replace(/<\s*MODULE_COMPLETE\s*>/gi, '')
                 .trim();
             // In streaming mode, tags were already sent — send replacement to overwrite
             if (useStreaming && !clientDisconnected) {
@@ -840,7 +841,8 @@ async function handleCourseGreeting(req, res, userId) {
 
         let moduleData = { title: currentPathwayModule?.title || courseSession.currentModuleId, skills: currentPathwayModule?.skills || [] };
         if (currentPathwayModule?.moduleFile) {
-            const moduleFile = path.join(__dirname, '../public/modules', courseSession.courseId, currentPathwayModule.moduleFile);
+            // moduleFile is stored as "/modules/{courseId}/file.json" — resolve relative to public/
+            const moduleFile = path.join(__dirname, '../public', currentPathwayModule.moduleFile);
             if (fs.existsSync(moduleFile)) {
                 moduleData = JSON.parse(fs.readFileSync(moduleFile, 'utf8'));
             }

--- a/routes/courseSession.js
+++ b/routes/courseSession.js
@@ -444,7 +444,8 @@ router.get('/:id/lesson-progress', async (req, res) => {
 
     let moduleData = { title: currentPathwayModule?.title || session.currentModuleId, skills: [] };
     if (currentPathwayModule?.moduleFile) {
-      const moduleFile = path.join(__dirname, '../public/modules', session.courseId, currentPathwayModule.moduleFile);
+      // moduleFile is stored as "/modules/{courseId}/file.json" — resolve relative to public/
+      const moduleFile = path.join(__dirname, '../public', currentPathwayModule.moduleFile);
       if (fs.existsSync(moduleFile)) {
         moduleData = JSON.parse(fs.readFileSync(moduleFile, 'utf8'));
       }


### PR DESCRIPTION
Root cause: moduleFile paths in pathway JSON are stored as "/modules/{courseId}/file.json" but courseChat.js and courseSession.js were constructing path.join(__dirname, '../public/modules', courseId, moduleFile) — doubling the directory to .../modules/ap-calculus-ab/ modules/ap-calculus-ab/file.json. fs.existsSync silently returned false, so moduleData.scaffold was always empty, producing "Step 1 of 1" with 0% progress for every course using the /api/course-chat endpoint.

Fix: Use path.join(__dirname, '../public', moduleFile) — matching the already-correct pattern in loadCourseContext() (coursePrompt.js:646).

Also: AI occasionally emits < SCAFFOLD_ADVANCE > with internal spaces. All signal tag regexes now use \s* between angle brackets and tag names so detection + stripping works regardless of whitespace.

Affected files:
- routes/courseChat.js (2 path fixes, 3 regex fixes)
- routes/courseSession.js (1 path fix)
- routes/chat.js (3 regex fixes)

https://claude.ai/code/session_01WzybGw69x6LFjUcvm7bcCc