### PR TITLE
Add step-context reminder to last user message for tag reliability

### DIFF
--- a/routes/courseChat.js
+++ b/routes/courseChat.js
@@ -186,6 +186,22 @@ router.post('/', async (req, res) => {
             resourceContext
         });
 
+        // ── Inject step-context reminder into last user message ──
+        // The system prompt (at position 0) fades in long conversations.
+        // Appending a brief reminder to the last user message keeps the
+        // scaffold tag instruction in the AI's attention window.
+        const scaffold = moduleData?.scaffold || [];
+        if (scaffold.length > 1) {
+            const stepIdx = courseSession.currentScaffoldIndex || 0;
+            const currentStep = scaffold[stepIdx];
+            if (currentStep && formattedMessages.length > 0) {
+                const lastMsg = formattedMessages[formattedMessages.length - 1];
+                if (lastMsg?.role === 'user') {
+                    lastMsg.content += `\n\n[STEP ${stepIdx + 1}/${scaffold.length}: "${currentStep.title}" — emit <SCAFFOLD_ADVANCE> when complete, before discussing the next topic.]`;
+                }
+            }
+        }
+
         const messagesForAI = [{ role: 'system', content: systemPrompt }, ...formattedMessages];
 
         console.log(`📚 [CourseChat] ${user.firstName} → ${courseSession.courseName} / ${courseSession.currentModuleId}`);


### PR DESCRIPTION
The system prompt includes full scaffold instructions, but in long conversations (20+ messages) the AI's attention drifts away from position-0 instructions. This causes missed <SCAFFOLD_ADVANCE> tags.

Fix: Append a one-line step reminder to the last user message content before each AI turn — e.g. [STEP 3/49: "Guided Practice" — emit <SCAFFOLD_ADVANCE> when complete]. This keeps the tag instruction in the AI's immediate attention window.

Follows the same pattern chat.js already uses for math verification context (appending to last user message, not modifying stored messages since formattedMessages is a map copy).

Applied to both routes/courseChat.js and routes/chat.js.

https://claude.ai/code/session_01WzybGw69x6LFjUcvm7bcCc