### PR TITLE
Enforce 20-min weekly AI processing time limit across all student-facing endpoints

### DIFF
--- a/middleware/usageGate.js
+++ b/middleware/usageGate.js
@@ -104,6 +104,7 @@ async function usageGate(req, res, next) {
     if (freeRemaining > 0) {
       // Still have free minutes — let them through regardless of tier
       res.setHeader('X-Free-Remaining-Seconds', Math.max(0, freeRemaining).toString());
+      res.setHeader('Access-Control-Expose-Headers', 'X-Free-Remaining-Seconds, X-Usage-Warning');
       if (freeRemaining <= 120) {
         res.setHeader('X-Usage-Warning', 'low');
       }

--- a/public/js/modules/billing.js
+++ b/public/js/modules/billing.js
@@ -30,7 +30,9 @@ export async function checkBillingStatus() {
 }
 
 /**
- * Update the floating time-remaining indicator
+ * Update the floating time-remaining indicator.
+ * Shows AI processing time remaining (not wall-clock time).
+ * Time only counts while the AI is generating a response — reading/thinking is free.
  */
 export function updateFreeTimeIndicator(usage) {
     let indicator = document.getElementById('free-time-indicator');
@@ -38,6 +40,7 @@ export function updateFreeTimeIndicator(usage) {
         indicator = document.createElement('div');
         indicator.id = 'free-time-indicator';
         indicator.style.cssText = 'position:fixed;bottom:12px;right:12px;background:#1a1a2e;color:#fff;padding:8px 14px;border-radius:8px;font-size:13px;z-index:9000;cursor:pointer;border:1px solid #333;transition:all 0.3s;';
+        indicator.title = 'AI processing time only — reading and thinking time is free';
         indicator.addEventListener('click', () => showUpgradePrompt({}));
         document.body.appendChild(indicator);
     }
@@ -46,13 +49,13 @@ export function updateFreeTimeIndicator(usage) {
     const mins = Math.floor(remaining / 60);
 
     if (usage.limitReached || remaining <= 0) {
-        indicator.innerHTML = '<strong>No time left</strong> &mdash; <span style="color:#00d4ff;text-decoration:underline">Buy Pack</span>';
+        indicator.innerHTML = '<strong>No AI time left</strong> &mdash; <span style="color:#00d4ff;text-decoration:underline">Buy Pack</span>';
         indicator.style.borderColor = '#ff4444';
     } else if (remaining <= 300) {
-        indicator.innerHTML = `<strong>${mins} min</strong> left &mdash; <span style="color:#00d4ff;text-decoration:underline">Buy More</span>`;
+        indicator.innerHTML = `<strong>${mins} min</strong> AI time left &mdash; <span style="color:#00d4ff;text-decoration:underline">Buy More</span>`;
         indicator.style.borderColor = '#ffaa00';
     } else {
-        indicator.innerHTML = `<strong>${mins} min</strong> remaining`;
+        indicator.innerHTML = `<strong>${mins} min</strong> AI time left`;
         indicator.style.borderColor = '#333';
     }
 }

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1595,6 +1595,15 @@ document.addEventListener("DOMContentLoaded", () => {
                 throw new Error(errorMessage);
             }
 
+            // Update free time indicator from response headers (AI processing time only)
+            const freeRemainingHeader = response.headers.get('X-Free-Remaining-Seconds');
+            if (freeRemainingHeader !== null && typeof updateFreeTimeIndicator === 'function') {
+                const remaining = parseInt(freeRemainingHeader, 10);
+                if (!isNaN(remaining)) {
+                    updateFreeTimeIndicator({ secondsRemaining: remaining, limitReached: remaining <= 0 });
+                }
+            }
+
             const data = await response.json();
 
             // Process AI response (same logic as original sendMessage)

--- a/public/mastery-chat.html
+++ b/public/mastery-chat.html
@@ -891,6 +891,13 @@
                 });
 
                 if (!response.ok) {
+                    // Handle usage limit (402) — show friendly message
+                    if (response.status === 402) {
+                        const errorData = await response.json().catch(() => ({}));
+                        aiMessageDiv.textContent = errorData.message || "You've used your 20 free AI minutes this week. Come back next week!";
+                        aiMessageDiv.style.color = '#ff6b6b';
+                        return;
+                    }
                     throw new Error('Failed to send message');
                 }
 

--- a/routes/billing.js
+++ b/routes/billing.js
@@ -18,6 +18,7 @@ const { isAuthenticated } = require('../middleware/auth');
 
 // ---- Configuration ----
 const BILLING_ENABLED = process.env.BILLING_ENABLED === 'true';
+const FREE_WEEKLY_SECONDS = 20 * 60; // 20 free AI minutes per week for all students
 
 const PACKS = {
   pack_60: {
@@ -298,14 +299,25 @@ router.get('/status', isAuthenticated, async (req, res) => {
       });
     }
 
-    // Pack users — check expiry and balance
+    // Pack users — check free weekly allowance + pack balance
     if (tier === 'pack_60' || tier === 'pack_120') {
       const expired = user.packExpiresAt && now > user.packExpiresAt;
-      const remaining = expired ? 0 : (user.packSecondsRemaining || 0);
-      const limitReached = remaining <= 0;
+      const packRemaining = expired ? 0 : (user.packSecondsRemaining || 0);
+
+      // Pack users also get 20 free minutes/week before pack is used
+      let weeklyAIUsedPack = user.weeklyAISeconds || 0;
+      const lastResetPack = user.lastWeeklyReset ? new Date(user.lastWeeklyReset) : new Date(0);
+      if ((now - lastResetPack) / (1000 * 60 * 60 * 24) >= 7) {
+        weeklyAIUsedPack = 0;
+      }
+      const freeRemainingPack = Math.max(0, FREE_WEEKLY_SECONDS - weeklyAIUsedPack);
+
+      // Total remaining = free minutes left + pack balance
+      const totalRemaining = freeRemainingPack + packRemaining;
+      const packLimitReached = totalRemaining <= 0;
 
       // Auto-downgrade expired/empty packs
-      if (limitReached && tier !== 'free') {
+      if (packRemaining <= 0) {
         user.subscriptionTier = 'free';
         await user.save();
       }
@@ -313,25 +325,54 @@ router.get('/status', isAuthenticated, async (req, res) => {
       return res.json({
         success: true,
         billingEnabled: true,
-        tier: limitReached ? 'free' : tier,
-        hasAccess: !limitReached,
+        tier: packRemaining <= 0 ? 'free' : tier,
+        hasAccess: !packLimitReached,
         usage: {
-          secondsRemaining: remaining,
-          minutesRemaining: Math.floor(remaining / 60),
+          secondsRemaining: totalRemaining,
+          minutesRemaining: Math.floor(totalRemaining / 60),
+          freeSecondsRemaining: freeRemainingPack,
+          packSecondsRemaining: packRemaining,
           packExpiresAt: user.packExpiresAt,
           expired,
-          limitReached
+          limitReached: packLimitReached
         }
       });
     }
 
-    // Free users
+    // Free users — calculate remaining free weekly AI minutes
+    // Teachers, parents, admins get unlimited; students get 20 free AI minutes/week
+    if (user.role === 'teacher' || user.role === 'parent' || user.role === 'admin') {
+      return res.json({
+        success: true,
+        billingEnabled: true,
+        tier: 'free',
+        hasAccess: true,
+        usage: { secondsRemaining: Infinity, limitReached: false }
+      });
+    }
+
+    // Students: check weekly AI seconds used vs free allowance
+    let weeklyAIUsed = user.weeklyAISeconds || 0;
+    const lastReset = user.lastWeeklyReset ? new Date(user.lastWeeklyReset) : new Date(0);
+    if ((now - lastReset) / (1000 * 60 * 60 * 24) >= 7) {
+      // Reset is pending — they effectively have full free minutes
+      weeklyAIUsed = 0;
+    }
+    const freeRemaining = Math.max(0, FREE_WEEKLY_SECONDS - weeklyAIUsed);
+    const limitReached = freeRemaining <= 0;
+
     res.json({
       success: true,
       billingEnabled: true,
       tier: 'free',
-      hasAccess: false,
-      usage: { secondsRemaining: 0, limitReached: true }
+      hasAccess: !limitReached,
+      usage: {
+        secondsRemaining: freeRemaining,
+        minutesRemaining: Math.floor(freeRemaining / 60),
+        weeklyAISecondsUsed: weeklyAIUsed,
+        freeWeeklySeconds: FREE_WEEKLY_SECONDS,
+        limitReached
+      }
     });
   } catch (error) {
     console.error('[Billing] Status check error:', error);

--- a/routes/chatWithFile.js
+++ b/routes/chatWithFile.js
@@ -175,6 +175,7 @@ router.post('/',
         // Call LLM with vision support (Claude primary, OpenAI fallback)
         const isClaudeModel = PRIMARY_CHAT_MODEL.startsWith('claude-');
         let aiResponseText;
+        const aiStartTime = Date.now(); // Track AI processing time (server-side, for fair billing)
 
         if (isClaudeModel && anthropic) {
             // PRIMARY: Try Claude vision API
@@ -264,6 +265,12 @@ router.post('/',
         if (answerKeyCheck.wasFiltered) {
             aiResponseText = answerKeyCheck.text;
         }
+
+        // Track AI processing time server-side (only counts AI generation, not reading/thinking/idle)
+        const aiProcessingSeconds = Math.ceil((Date.now() - aiStartTime) / 1000);
+        User.findByIdAndUpdate(userId, {
+            $inc: { weeklyAISeconds: aiProcessingSeconds, totalAISeconds: aiProcessingSeconds }
+        }).catch(err => console.error('[chatWithFile] AI time tracking error:', err));
 
         // --- Step 3: Handle Post-Processing (XP, Unlocks, etc.) ---
         // (This logic is copied and adapted from your chat.js)

--- a/routes/guidedLesson.js
+++ b/routes/guidedLesson.js
@@ -132,7 +132,16 @@ ${phasePrompt}
             messages = messages.concat(conversationHistory);
         }
 
+        const lessonAiStart = Date.now();
         const completion = await callLLM("gpt-4o-mini", messages, { temperature: 0.7, max_tokens: 500 });
+
+        // Track AI processing time (server-side, for fair billing)
+        const lessonAiSeconds = Math.ceil((Date.now() - lessonAiStart) / 1000);
+        if (req.user?._id) {
+            User.findByIdAndUpdate(req.user._id, {
+                $inc: { weeklyAISeconds: lessonAiSeconds, totalAISeconds: lessonAiSeconds }
+            }).catch(err => console.error('[GuidedLesson] AI time tracking error:', err));
+        }
 
         const aiResponseText = completion.choices[0].message.content.trim();
 
@@ -227,7 +236,16 @@ A student needs help with a problem. Use your adaptive teaching strategies to pr
 5. Craft a natural, conversational response that builds confidence.
         `;
         
+        const hintAiStart = Date.now();
         const aiHint = await callLLM("gpt-4o-mini", [{ role: "system", content: systemPrompt + taskPrompt }], { temperature: 0.7, max_tokens: 150 }); // Using centralized LLM call
+
+        // Track AI processing time (server-side, for fair billing)
+        const hintAiSeconds = Math.ceil((Date.now() - hintAiStart) / 1000);
+        if (req.user?._id) {
+            User.findByIdAndUpdate(req.user._id, {
+                $inc: { weeklyAISeconds: hintAiSeconds, totalAISeconds: hintAiSeconds }
+            }).catch(err => console.error('[GuidedLesson/Hint] AI time tracking error:', err));
+        }
 
         res.json({ hint: aiHint.choices[0].message.content.trim() });
     } catch (error) {

--- a/routes/masteryChat.js
+++ b/routes/masteryChat.js
@@ -314,6 +314,9 @@ if (!message) return res.status(400).json({ message: "Message is required." });
         // Check for streaming support
         const isStreaming = req.query.stream === 'true';
 
+        // Track AI processing time (server-side, for fair billing — only counts AI generation)
+        const aiStartTime = Date.now();
+
         if (isStreaming) {
             // Set up SSE headers
             res.setHeader('Content-Type', 'text/event-stream');
@@ -375,6 +378,12 @@ if (!message) return res.status(400).json({ message: "Message is required." });
                 user.markModified('masteryProgress');
                 await user.save();
 
+                // Track AI processing time server-side (only counts AI generation, not reading/thinking/idle)
+                const aiProcessingSecondsStream = Math.ceil((Date.now() - aiStartTime) / 1000);
+                User.findByIdAndUpdate(userId, {
+                    $inc: { weeklyAISeconds: aiProcessingSecondsStream, totalAISeconds: aiProcessingSecondsStream }
+                }).catch(err => console.error('[MasteryChat] AI time tracking error:', err));
+
                 // Check for mastery completion
                 const masteryResult = await checkMasteryCompletion(user, activeBadge);
 
@@ -396,6 +405,12 @@ if (!message) return res.status(400).json({ message: "Message is required." });
         } else {
             // Non-streaming response
             const aiResponse = await callLLM(PRIMARY_CHAT_MODEL, messagesForAI);
+
+            // Track AI processing time server-side (only counts AI generation, not reading/thinking/idle)
+            const aiProcessingSeconds = Math.ceil((Date.now() - aiStartTime) / 1000);
+            User.findByIdAndUpdate(userId, {
+                $inc: { weeklyAISeconds: aiProcessingSeconds, totalAISeconds: aiProcessingSeconds }
+            }).catch(err => console.error('[MasteryChat] AI time tracking error:', err));
 
             // Save AI response
             masteryConversation.messages.push({

--- a/routes/rapportBuilding.js
+++ b/routes/rapportBuilding.js
@@ -143,10 +143,17 @@ RESPOND IN JSON:
         ];
 
         // Use GPT-4o-mini for rapport building (keep it brief!)
+        const rapportAiStart = Date.now();
         const completion = await callLLM('gpt-4o-mini', extractionMessages, {
             max_tokens: 150,
             response_format: { type: 'json_object' }
         });
+
+        // Track AI processing time (server-side, for fair billing)
+        const rapportAiSeconds = Math.ceil((Date.now() - rapportAiStart) / 1000);
+        User.findByIdAndUpdate(user._id, {
+            $inc: { weeklyAISeconds: rapportAiSeconds, totalAISeconds: rapportAiSeconds }
+        }).catch(err => console.error('[Rapport] AI time tracking error:', err));
 
         const result = JSON.parse(completion.choices[0].message.content.trim());
 

--- a/routes/welcome.js
+++ b/routes/welcome.js
@@ -260,8 +260,17 @@ router.get('/', async (req, res) => {
         messagesForAI.push({ role: "user", content: userMessagePart });
 
         // Use GPT-4o-mini for natural, engaging welcome messages
+        const welcomeAiStart = Date.now();
         const completion = await callLLM("gpt-4o-mini", messagesForAI, { max_tokens: 80 });
         const initialWelcomeMessage = completion.choices[0].message.content.trim();
+
+        // Track AI processing time (server-side, for fair billing)
+        const welcomeAiSeconds = Math.ceil((Date.now() - welcomeAiStart) / 1000);
+        if (user?._id) {
+            User.findByIdAndUpdate(user._id, {
+                $inc: { weeklyAISeconds: welcomeAiSeconds, totalAISeconds: welcomeAiSeconds }
+            }).catch(err => console.error('[Welcome] AI time tracking error:', err));
+        }
 
         // Save welcome message to conversation history for AI context
         activeConversation.messages.push({

--- a/server.js
+++ b/server.js
@@ -466,7 +466,7 @@ app.use('/api/speak', isAuthenticated, speakRoutes);
 app.use('/api/voice', isAuthenticated, aiEndpointLimiter, premiumFeatureGate('Voice chat'), voiceRoutes); // Premium: voice chat
 app.use('/api/voice', isAuthenticated, voiceTestRoutes); // Voice diagnostics (no rate limit on test endpoint)
 app.use('/api/upload', isAuthenticated, uploadRateLimiter, aiEndpointLimiter, premiumFeatureGate('File uploads'), uploadRoutes); // Premium: file uploads
-app.use('/api/chat-with-file', isAuthenticated, aiEndpointLimiter, chatWithFileRoutes); // SECURITY FIX: Added per-user rate limiting 
+app.use('/api/chat-with-file', isAuthenticated, aiEndpointLimiter, usageGate, chatWithFileRoutes); // Usage-gated for free tier
 app.use('/api/welcome-message', isAuthenticated, welcomeRoutes);
 app.use('/api/rapport', isAuthenticated, rapportBuildingRoutes);
 app.use('/api/memory', isAuthenticated, memoryRouter);
@@ -489,7 +489,7 @@ app.use('/api/assessment', isAuthenticated, assessmentRoutes); // Skills assessm
 app.use('/api/screener', isAuthenticated, screenerRoutes); // IRT-based adaptive screener (Starting Point)
 app.use('/api/growth-check', isAuthenticated, growthCheckRoutes); // Growth Check (short progress assessment)
 app.use('/api/mastery', isAuthenticated, masteryRoutes); // Mastery mode (placement → interview → badges)
-app.use('/api/mastery/chat', isAuthenticated, aiEndpointLimiter, masteryChatRoutes); // Mastery mode dedicated chat
+app.use('/api/mastery/chat', isAuthenticated, aiEndpointLimiter, usageGate, masteryChatRoutes); // Mastery mode dedicated chat (usage-gated)
 app.use('/api/settings', isAuthenticated, settingsRoutes); // User settings and password management
 app.use('/api/email', isAuthenticated, emailRoutes); // Email service for parent reports and notifications
 app.use('/api/grade-work', isAuthenticated, aiEndpointLimiter, premiumFeatureGate('Work grading'), gradeWorkRoutes); // Premium: AI grading


### PR DESCRIPTION
The 20-minute limit counts only server-measured AI processing time (Date.now()
around API calls), not reading/thinking/idle time. Leaving a tab open does not
consume minutes since no AI calls are made.

Changes:
- Add usageGate middleware to mastery chat and chat-with-file routes
- Add AI time tracking ($inc weeklyAISeconds/totalAISeconds) to mastery chat,
  chat-with-file, welcome, rapport building, and guided lesson routes
- Fix billing status endpoint: free-tier users now see actual remaining seconds
  instead of always reporting 0; pack users see combined free + pack balance
- Frontend reads X-Free-Remaining-Seconds header after AI responses to update
  the time indicator in real-time without extra API calls
- Billing indicator labels clarified to say "AI time" so students understand
  reading time is free; tooltip explains the distinction
- Mastery chat handles 402 usage limit responses with friendly message
- Expose custom headers via Access-Control-Expose-Headers for JS access

https://claude.ai/code/session_01UZ2nhga7nD2djgFj2wGEYw