### PR TITLE
Fix hero chat tutor avatars cropping heads off

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -527,7 +527,7 @@
     }
 
     .lp-chat-avatar img {
-      width: 100%; height: 100%; object-fit: cover;
+      width: 100%; height: 100%; object-fit: cover; object-position: top;
     }
 
     /* Animation */


### PR DESCRIPTION
Add object-position: top so the circular avatar crop frames the face/head instead of centering on the torso.

https://claude.ai/code/session_01NdhCi12iNKzhChtUiLWNSx