### PR TITLE
Fix demo page main element still blocking scroll on mobile

### DIFF
--- a/public/css/mobile-fixes.css
+++ b/public/css/mobile-fixes.css
@@ -1201,6 +1201,18 @@ body.is-mobile #sidebar-toggle {
         display: block !important;
     }
 
+    /* Undo the flex/overflow lock on <main> so demo cards can scroll */
+    body.landing-page-body.demo-page-body main {
+        overflow: visible !important;
+        display: block !important;
+        min-height: auto !important;
+    }
+
+    /* Show footer on demo page (hidden for chat pages) */
+    body.landing-page-body.demo-page-body footer {
+        display: block !important;
+    }
+
     /* Header hidden — no flex space needed */
     body.landing-page-body .landing-header {
         flex: 0 0 0px !important;


### PR DESCRIPTION
The body-level override (demo-page-body) was correctly restoring overflow-y: auto, but style.css applies overflow: hidden to body.landing-page-body main at all screen sizes, clipping the demo cards inside <main>. Added overrides for main (overflow, display, min-height) and restored the footer on the demo page.

https://claude.ai/code/session_01LS8EMHyxHRqQ9fFHG7U24p