### PR TITLE
Style parent-tutor conference like main chat with turn-taking rules

### DIFF
--- a/public/js/parent-dashboard.js
+++ b/public/js/parent-dashboard.js
@@ -358,6 +358,51 @@ document.addEventListener("DOMContentLoaded", async () => {
     // Current tutor info for chat bubbles
     let currentTutorInfo = { name: 'Math Tutor', image: 'default-tutor.png' };
 
+    // --- Markdown rendering for AI messages (matches main chat) ---
+    function renderParentMarkdown(text) {
+        if (typeof marked === 'undefined' || !marked.parse) {
+            // Fallback: escape HTML
+            const div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
+        }
+
+        // Protect LaTeX blocks from markdown parsing
+        const blocks = [];
+        let processed = text
+            .replace(/\\\[([\s\S]*?)\\\]/g, (m) => { blocks.push(m); return `@@LB${blocks.length - 1}@@`; })
+            .replace(/\\\(([\s\S]*?)\\\)/g, (m) => { blocks.push(m); return `@@LB${blocks.length - 1}@@`; });
+
+        let html = marked.parse(processed, { breaks: true });
+
+        // Restore LaTeX blocks
+        blocks.forEach((b, i) => { html = html.replace(`@@LB${i}@@`, b); });
+
+        // Sanitize
+        if (typeof DOMPurify !== 'undefined') {
+            html = DOMPurify.sanitize(html, {
+                ALLOWED_TAGS: ['p', 'br', 'strong', 'em', 'u', 'code', 'pre', 'ul', 'ol', 'li',
+                               'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'a', 'span', 'div', 'blockquote'],
+                ALLOWED_ATTR: ['href', 'class', 'target', 'rel', 'style']
+            });
+        }
+
+        return html;
+    }
+
+    // --- MathJax rendering helper ---
+    function renderParentMath(element) {
+        if (window.MathJax && window.MathJax.typesetPromise) {
+            window.MathJax.typesetPromise([element]).catch(() => {});
+        } else if (window.ensureMathJax) {
+            window.ensureMathJax().then(() => {
+                if (window.MathJax && window.MathJax.typesetPromise) {
+                    window.MathJax.typesetPromise([element]).catch(() => {});
+                }
+            });
+        }
+    }
+
     // --- Helper for appending messages to parent chat widget ---
     function appendParentMessage(sender, text, tutorInfo = null) {
         // Update tutor info if provided
@@ -367,14 +412,10 @@ document.addEventListener("DOMContentLoaded", async () => {
 
         const container = document.createElement("div");
         container.className = `message-container ${sender}`;
-        container.style.cssText = 'display: flex; align-items: flex-start; gap: 10px; margin-bottom: 12px; width: 100%;';
 
         if (sender === 'user') {
-            container.style.justifyContent = 'flex-end';
-            container.style.flexDirection = 'row-reverse';
             container.setAttribute('aria-label', 'Your message');
         } else {
-            container.style.justifyContent = 'flex-start';
             container.setAttribute('aria-label', `Message from ${currentTutorInfo.name}`);
         }
 
@@ -382,12 +423,10 @@ document.addEventListener("DOMContentLoaded", async () => {
         if (sender === 'ai') {
             const avatar = document.createElement("div");
             avatar.className = 'message-avatar';
-            avatar.style.cssText = 'flex-shrink: 0; width: 36px; height: 36px; border-radius: 50%; overflow: hidden; border: 2px solid #e0e0e0; box-shadow: 0 2px 4px rgba(0,0,0,0.1); background: #fff;';
 
             const avatarImg = document.createElement("img");
             avatarImg.src = `/images/tutor_avatars/${currentTutorInfo.image}`;
             avatarImg.alt = currentTutorInfo.name;
-            avatarImg.style.cssText = 'width: 100%; height: 100%; object-fit: cover; object-position: center top;';
             avatarImg.onerror = () => { avatarImg.src = '/images/tutor_avatars/default-tutor.png'; };
 
             avatar.appendChild(avatarImg);
@@ -397,20 +436,22 @@ document.addEventListener("DOMContentLoaded", async () => {
         const msg = document.createElement("div");
         msg.className = `message ${sender} message-widget`;
 
-        // Match main chat bubble styling
-        if (sender === 'user') {
-            msg.style.cssText = 'background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; padding: 12px 16px; border-radius: 18px 18px 4px 18px; max-width: 80%; box-shadow: 0 2px 8px rgba(102,126,234,0.3); line-height: 1.5; font-size: 0.95em;';
-        } else if (sender === 'ai') {
-            msg.style.cssText = 'background-color: #f5f5f5; color: #333; padding: 12px 16px; border-radius: 18px 18px 18px 4px; max-width: 80%; border: 1px solid #e0e0e0; line-height: 1.5; font-size: 0.95em; box-shadow: 0 1px 3px rgba(0,0,0,0.1);';
+        // Render content: markdown + math for AI, plain text for user
+        if (sender === 'ai') {
+            msg.innerHTML = renderParentMarkdown(text);
+        } else {
+            msg.textContent = text;
         }
 
-        msg.innerText = text;
         container.appendChild(msg);
 
-        parentChatContainer.style.display = 'flex';
-        parentChatContainer.style.flexDirection = 'column';
         parentChatContainer.appendChild(container);
         parentChatContainer.scrollTop = parentChatContainer.scrollHeight;
+
+        // Render math in AI messages
+        if (sender === 'ai') {
+            setTimeout(() => renderParentMath(msg), 0);
+        }
     }
 
     // --- Update Tutor Avatar Display ---

--- a/public/parent-dashboard.html
+++ b/public/parent-dashboard.html
@@ -418,8 +418,96 @@
       border-radius: var(--radius-sm);
       padding: 15px;
       min-height: 300px;
-      max-height: 400px;
+      max-height: 500px;
       overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      scroll-behavior: smooth;
+    }
+
+    /* Message container layout - matches main chat */
+    .chat-display-widget .message-container {
+      display: flex;
+      align-items: flex-end;
+      gap: 10px;
+      width: 100%;
+      animation: parentMsgIn 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+    }
+    .chat-display-widget .message-container.ai {
+      justify-content: flex-start;
+    }
+    .chat-display-widget .message-container.user {
+      justify-content: flex-end;
+      flex-direction: row-reverse;
+    }
+
+    @keyframes parentMsgIn {
+      from { opacity: 0; transform: translateY(8px) scale(0.96); }
+      to { opacity: 1; transform: translateY(0) scale(1); }
+    }
+
+    /* AI message bubble */
+    .chat-display-widget .message-widget.ai {
+      background-color: #f8f9fa;
+      color: #333;
+      padding: 12px 16px;
+      border-radius: 18px 18px 18px 4px;
+      max-width: 82%;
+      border: 1px solid #e0e0e0;
+      line-height: 1.6;
+      font-size: 0.95em;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+    }
+
+    /* User (parent) message bubble */
+    .chat-display-widget .message-widget.user {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      padding: 12px 16px;
+      border-radius: 18px 18px 4px 18px;
+      max-width: 82%;
+      box-shadow: 0 2px 8px rgba(102,126,234,0.25);
+      line-height: 1.6;
+      font-size: 0.95em;
+    }
+
+    /* Markdown content inside AI bubbles */
+    .chat-display-widget .message-widget.ai p { margin-bottom: 8px; }
+    .chat-display-widget .message-widget.ai p:last-child { margin-bottom: 0; }
+    .chat-display-widget .message-widget.ai strong { font-weight: 600; }
+    .chat-display-widget .message-widget.ai ul,
+    .chat-display-widget .message-widget.ai ol { margin: 8px 0; padding-left: 20px; }
+    .chat-display-widget .message-widget.ai li { margin-bottom: 4px; }
+    .chat-display-widget .message-widget.ai code {
+      background: rgba(0,0,0,0.06);
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-size: 0.9em;
+    }
+    .chat-display-widget .message-widget.ai blockquote {
+      border-left: 3px solid var(--color-primary);
+      padding-left: 12px;
+      margin: 8px 0;
+      color: var(--color-text-secondary);
+    }
+
+    /* Tutor avatar in chat */
+    .chat-display-widget .message-avatar {
+      flex-shrink: 0;
+      width: 36px;
+      height: 36px;
+      border-radius: 50%;
+      overflow: hidden;
+      border: 2px solid #e0e0e0;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+      background: #fff;
+    }
+    .chat-display-widget .message-avatar img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      object-position: center top;
     }
 
     .chat-input-widget textarea {
@@ -1153,6 +1241,28 @@
   </style>
   <link rel="stylesheet" href="/css/dashboard-mobile.css" />
   <link rel="stylesheet" href="/css/demo-mode.css" />
+  <script defer src="https://cdn.jsdelivr.net/npm/marked@11.1.1/marked.min.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
+  <script>
+    window.MathJax = {
+      tex: { inlineMath: [['\\(', '\\)']], displayMath: [['\\[', '\\]']], processEscapes: true },
+      svg: { fontCache: 'global' }
+    };
+    window._lazyScripts = {};
+    window.loadScript = function(url) {
+      if (window._lazyScripts[url]) return window._lazyScripts[url];
+      window._lazyScripts[url] = new Promise((resolve, reject) => {
+        var s = document.createElement('script');
+        s.src = url; s.onload = resolve; s.onerror = reject;
+        document.head.appendChild(s);
+      });
+      return window._lazyScripts[url];
+    };
+    window.ensureMathJax = function() {
+      if (window.MathJax && window.MathJax.typesetPromise) return Promise.resolve();
+      return window.loadScript('https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js');
+    };
+  </script>
 </head>
 <body>
   <!-- Toast Notification Container -->

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -1984,16 +1984,38 @@ CRITICAL RULES:
 7. NEVER interpret missing problem statistics as a lack of effort, motivation, or engagement. If a session has no Performance line, it means our tracking system didn't capture the data — the student was still learning and working. Do NOT suggest the student is unmotivated, disengaged, or needs intervention based on missing stats.
 
 SPECIAL REQUESTS:
-- If parent asks to "teach me" or "explain the concept": Teach them the math topic from the SESSION DATA at a beginner level. Use simple examples, step-by-step explanations, and relatable analogies. Make it practical so they can help their child.
+- If parent asks to "teach me" or "explain the concept": Teach them the math topic from the SESSION DATA at a beginner level. Use simple examples, step-by-step explanations, and relatable analogies. Make it practical so they can help their child. IMPORTANT: Teach ONE step at a time, then check in before continuing (see CONVERSATIONAL TURN-TAKING below).
 - If parent asks about "help at home": Give specific, actionable activities like practice problems, real-world applications, or study tips based on what ${childName} is learning.
 - If parent asks about "struggles": Be honest but constructive. Explain WHY a concept might be challenging and suggest how to address it.
 
+CONVERSATIONAL TURN-TAKING (CRITICAL):
+This is a CONVERSATION, not a lecture. Follow these rules strictly:
+
+1. ONE CONCEPT PER MESSAGE: Cover one idea, one step, or one piece of information per response. Do NOT pack multiple topics into a single message.
+2. KEEP IT SHORT: Maximum 2-3 sentences per response. Think text message, not email. If you need to explain something complex, break it across multiple exchanges.
+3. ASK BEFORE CONTINUING: After sharing a piece of information, check in: "Want me to explain that more?" or "Should I show you how to practice that at home?" or "Any questions about that?" — then WAIT for their response.
+4. NO LONG BLOCKS: Never send walls of text. No bullet-point dumps. No numbered lists with 5+ items. If you have multiple things to share, give ONE, then ask if they want more.
+5. BACK AND FORTH: This should feel like chatting with a teacher at a conference table, not reading a report. Short exchanges, natural flow.
+6. LAYERED INFORMATION: Start with the key takeaway, then offer to go deeper. Don't front-load everything.
+
+EXAMPLE - CORRECT (teaching a parent):
+Message 1: "${childName} has been working on multiplying fractions. Want me to walk you through it so you can help at home?"
+[WAIT FOR PARENT]
+Message 2: "The trick is multiply straight across — tops times tops, bottoms times bottoms. So 2/3 × 1/4 = 2/12."
+[WAIT FOR PARENT]
+Message 3: "Then simplify: 2/12 = 1/6. Want to try one together?"
+
+EXAMPLE - WRONG (DO NOT DO THIS):
+"${childName} has been working on fractions. Here's everything you need to know: First, to multiply fractions you multiply the numerators and denominators. For example, 2/3 × 1/4 = 2/12 = 1/6. To add fractions, find a common denominator first. For example, 1/3 + 1/4: the LCD is 12, so 4/12 + 3/12 = 7/12. To divide fractions, flip the second fraction and multiply..."
+❌ Way too much at once — information overload
+
 TONE:
 - Be yourself (${tutorName}) but slightly more professional for a parent conversation
-- Be warm, approachable, and conversational - not formal or stiff
-- Keep responses concise (2-3 short paragraphs max)
+- Be warm, approachable, and conversational — not formal or stiff
+- Keep responses SHORT (2-3 sentences max) and let the conversation flow naturally
 - Be honest about challenges while staying encouraging
 - Give specific, actionable suggestions for home practice
+- Sound like a real teacher at a conference, not a generated report
 
 Chat naturally with ${parentName} about ${childName}'s ACTUAL progress based on the session data above.`;
 


### PR DESCRIPTION
- Add marked.js, DOMPurify, MathJax to parent-dashboard for markdown/math rendering
- Restyle chat widget: AI messages left-aligned with avatar, parent messages right-aligned
- Add entrance animations matching main chat (cubic-bezier spring effect)
- Move bubble styling from inline JS to CSS classes for consistency
- Add markdown rendering (bold, lists, code, blockquotes) and LaTeX math support
- Add conversational turn-taking rules to parent-teacher conference prompt:
  one concept per message, 2-3 sentences max, ask before continuing,
  no long blocks, layered information delivery
- Include correct/wrong examples in prompt to enforce back-and-forth style

https://claude.ai/code/session_019xJMwqdnQwvFSZ5VrSuhw2