### PR TITLE
Fix billing, usage tracking, and license enforcement gaps that would …

### DIFF
--- a/middleware/usageGate.js
+++ b/middleware/usageGate.js
@@ -37,16 +37,19 @@ async function isLicenseValid(licenseId) {
 
   try {
     const license = await SchoolLicense.findById(licenseId).lean();
-    const valid = license ? license.isValid ? license.isValid() : (
-      (license.status === 'active' || license.status === 'trial') &&
-      (!license.expiresAt || new Date() <= license.expiresAt)
-    ) : false;
+    if (!license) {
+      licenseCache.set(key, { valid: false, checkedAt: Date.now() });
+      return false;
+    }
+    // .lean() returns a plain object — check fields directly instead of calling .isValid()
+    const valid = (license.status === 'active' || license.status === 'trial') &&
+      (!license.expiresAt || new Date() <= license.expiresAt);
     licenseCache.set(key, { valid, checkedAt: Date.now() });
     return valid;
   } catch (err) {
     console.error('[UsageGate] License check error:', err.message);
-    // On error, allow access (don't block students due to lookup failure)
-    return true;
+    // On error, deny access (fail closed) — a brief outage is safer than free access
+    return false;
   }
 }
 
@@ -77,8 +80,17 @@ async function usageGate(req, res, next) {
     // Students covered by a school license get unlimited access
     if (user.schoolLicenseId) {
       const valid = await isLicenseValid(user.schoolLicenseId);
-      if (valid) return next();
-      // License expired/invalid — fall through to free tier
+      if (valid) {
+        // Capacity check: verify school hasn't exceeded student limit
+        const license = await SchoolLicense.findById(user.schoolLicenseId).lean();
+        if (license && license.currentStudentCount > license.maxStudents) {
+          console.warn(`[UsageGate] School "${license.schoolName}" over capacity (${license.currentStudentCount}/${license.maxStudents})`);
+          // Over capacity — fall through to free tier instead of blocking entirely
+        } else {
+          return next();
+        }
+      }
+      // License expired/invalid/over-capacity — fall through to free tier
     }
 
     // Unlimited individual subscribers pass unconditionally
@@ -90,12 +102,11 @@ async function usageGate(req, res, next) {
     const lastReset = user.lastWeeklyReset ? new Date(user.lastWeeklyReset) : new Date(0);
     if ((now - lastReset) / (1000 * 60 * 60 * 24) >= 7) {
       weeklyAIUsed = 0;
-      User.findByIdAndUpdate(user._id, {
-        weeklyAISeconds: 0,
-        weeklyActiveSeconds: 0,
-        weeklyActiveTutoringMinutes: 0,
-        lastWeeklyReset: now
-      }).catch(err => console.error('[UsageGate] Weekly reset error:', err));
+      // Atomic reset: only resets if lastWeeklyReset hasn't changed (prevents race condition)
+      await User.findOneAndUpdate(
+        { _id: user._id, lastWeeklyReset: user.lastWeeklyReset },
+        { $set: { weeklyAISeconds: 0, weeklyActiveSeconds: 0, weeklyActiveTutoringMinutes: 0, lastWeeklyReset: now } }
+      );
     }
 
     // --- Free weekly minutes (every student gets these first) ---
@@ -125,9 +136,10 @@ async function usageGate(req, res, next) {
         return next();
       }
 
-      // Pack empty or expired — auto-downgrade
-      User.findByIdAndUpdate(user._id, { subscriptionTier: 'free' })
-        .catch(err => console.error('[UsageGate] Downgrade error:', err.message));
+      // Pack empty or expired — auto-downgrade and clean up stale fields
+      User.findByIdAndUpdate(user._id, {
+        $set: { subscriptionTier: 'free', packSecondsRemaining: 0, packExpiresAt: null }
+      }).catch(err => console.error('[UsageGate] Downgrade error:', err.message));
 
       return res.status(402).json({
         message: "Your free minutes and minute pack are both used up. Purchase a new pack, ask your school about a Mathmatix license, or come back next week!",

--- a/models/webhookEvent.js
+++ b/models/webhookEvent.js
@@ -1,0 +1,19 @@
+// models/webhookEvent.js — Stripe webhook event deduplication
+//
+// Stores processed Stripe event IDs to prevent duplicate processing.
+// Stripe retries webhook delivery on timeout/error, so we must track
+// which events have already been handled.
+
+const mongoose = require('mongoose');
+
+const webhookEventSchema = new mongoose.Schema({
+  stripeEventId: { type: String, required: true, unique: true, index: true },
+  eventType: { type: String },
+  processedAt: { type: Date, default: Date.now }
+});
+
+// Auto-expire old records after 30 days (TTL index)
+webhookEventSchema.index({ processedAt: 1 }, { expireAfterSeconds: 30 * 24 * 60 * 60 });
+
+const WebhookEvent = mongoose.models.WebhookEvent || mongoose.model('WebhookEvent', webhookEventSchema);
+module.exports = WebhookEvent;

--- a/routes/billing.js
+++ b/routes/billing.js
@@ -14,6 +14,7 @@
 const express = require('express');
 const router = express.Router();
 const User = require('../models/user');
+const WebhookEvent = require('../models/webhookEvent');
 const { isAuthenticated } = require('../middleware/auth');
 
 // ---- Configuration ----
@@ -145,6 +146,19 @@ router.post('/webhook', async (req, res) => {
     return res.status(400).send(`Webhook Error: ${err.message}`);
   }
 
+  // Idempotency check — prevent duplicate processing on Stripe retries
+  try {
+    await WebhookEvent.create({ stripeEventId: event.id, eventType: event.type });
+  } catch (err) {
+    if (err.code === 11000) {
+      // Duplicate key — already processed this event
+      console.log(`[Billing] Duplicate webhook event ${event.id} (${event.type}) — skipping`);
+      return res.json({ received: true });
+    }
+    // Non-duplicate DB error — log but continue processing
+    console.error('[Billing] Webhook dedup check error:', err.message);
+  }
+
   try {
     switch (event.type) {
       case 'checkout.session.completed': {
@@ -204,11 +218,16 @@ router.post('/webhook', async (req, res) => {
       case 'customer.subscription.updated': {
         // Subscription status changed (e.g., payment failed → past_due)
         const subscription = event.data.object;
-        const user = await User.findOne({ stripeSubscriptionId: subscription.id });
+        // Look up by subscription ID first, then fall back to customer ID for reactivations
+        let user = await User.findOne({ stripeSubscriptionId: subscription.id });
+        if (!user) {
+          user = await User.findOne({ stripeCustomerId: subscription.customer });
+        }
         if (!user) break;
 
         if (subscription.status === 'active') {
           user.subscriptionTier = 'unlimited';
+          user.stripeSubscriptionId = subscription.id;
         } else if (['past_due', 'unpaid', 'canceled'].includes(subscription.status)) {
           user.subscriptionTier = 'free';
           user.subscriptionEndDate = new Date();
@@ -221,7 +240,13 @@ router.post('/webhook', async (req, res) => {
         const invoice = event.data.object;
         const user = await User.findOne({ stripeCustomerId: invoice.customer });
         if (user) {
-          console.warn(`[Billing] Payment failed for ${user.firstName} ${user.lastName}`);
+          console.warn(`[Billing] Payment failed for ${user.firstName} ${user.lastName} — downgrading to free`);
+          // Downgrade immediately so user doesn't retain unlimited access
+          if (user.subscriptionTier === 'unlimited') {
+            user.subscriptionTier = 'free';
+            user.subscriptionEndDate = new Date();
+            await user.save();
+          }
         }
         break;
       }
@@ -230,10 +255,12 @@ router.post('/webhook', async (req, res) => {
         break;
     }
 
-    res.json({ received: true });
+    // Return 200 only after successful processing
+    return res.json({ received: true });
   } catch (error) {
     console.error('[Billing] Webhook processing error:', error);
-    res.status(500).json({ error: 'Webhook processing failed' });
+    // Return 500 so Stripe retries the webhook
+    return res.status(500).json({ error: 'Webhook processing failed' });
   }
 });
 
@@ -316,9 +343,11 @@ router.get('/status', isAuthenticated, async (req, res) => {
       const totalRemaining = freeRemainingPack + packRemaining;
       const packLimitReached = totalRemaining <= 0;
 
-      // Auto-downgrade expired/empty packs
+      // Auto-downgrade expired/empty packs and clean up stale fields
       if (packRemaining <= 0) {
         user.subscriptionTier = 'free';
+        user.packSecondsRemaining = 0;
+        user.packExpiresAt = null;
         await user.save();
       }
 

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -946,8 +946,12 @@ router.post('/', isAuthenticated, promptInjectionFilter, async (req, res) => {
         const aiTimeUpdate = { $inc: { weeklyAISeconds: aiProcessingSeconds, totalAISeconds: aiProcessingSeconds } };
 
         // Deduct from pack balance only for seconds beyond the free weekly allowance (20 min)
+        // Re-validate pack hasn't expired since usageGate checked (prevents mid-session expiry bug)
         const FREE_WEEKLY = 20 * 60;
-        if ((user.subscriptionTier === 'pack_60' || user.subscriptionTier === 'pack_120') && user.packSecondsRemaining > 0) {
+        const packStillValid = (user.subscriptionTier === 'pack_60' || user.subscriptionTier === 'pack_120') &&
+            user.packSecondsRemaining > 0 &&
+            (!user.packExpiresAt || new Date() <= user.packExpiresAt);
+        if (packStillValid) {
             const prevPaid = Math.max(0, previousWeeklyAI - FREE_WEEKLY);
             const newPaid = Math.max(0, updatedWeeklyAI - FREE_WEEKLY);
             const packDeduction = newPaid - prevPaid;
@@ -956,8 +960,12 @@ router.post('/', isAuthenticated, promptInjectionFilter, async (req, res) => {
             }
         }
 
-        User.findByIdAndUpdate(userId, aiTimeUpdate)
-            .catch(err => console.error('[Chat] AI time tracking error:', err));
+        // Await the DB update to ensure usage is actually recorded
+        try {
+            await User.findByIdAndUpdate(userId, aiTimeUpdate);
+        } catch (err) {
+            console.error('[Chat] AI time tracking error:', err);
+        }
 
         // ENFORCE visual teaching: Auto-inject commands if AI forgot to use them
         aiResponseText = enforceVisualTeaching(message, aiResponseText);

--- a/routes/courseChat.js
+++ b/routes/courseChat.js
@@ -721,7 +721,11 @@ router.post('/', async (req, res) => {
             }
         }
 
-        // AI time tracking (both parent and student)
+        // AI time tracking — use atomic $inc to prevent race conditions with concurrent requests
+        await User.findByIdAndUpdate(user._id, {
+            $inc: { weeklyAISeconds: aiProcessingSeconds, totalAISeconds: aiProcessingSeconds }
+        });
+        // Update local copy for any downstream reads in this request
         user.weeklyAISeconds = (user.weeklyAISeconds || 0) + aiProcessingSeconds;
         user.totalAISeconds = (user.totalAISeconds || 0) + aiProcessingSeconds;
 

--- a/routes/mastery.js
+++ b/routes/mastery.js
@@ -16,88 +16,20 @@ const { prepareBadgeLaunch } = require('../utils/badgeLaunchService'); // TEACHI
 const { generatePhaseProblem, recordPhaseAttempt, getPhaseInstructions } = require('../utils/badgePhaseController'); // TEACHING ENHANCEMENT
 const { generateHint, trackHintUsage, analyzeHintUsage, shouldReteach } = require('../utils/hintSystem'); // TEACHING ENHANCEMENT
 const { analyzeError, generateReteaching, recordMisconception, markMisconceptionAddressed, analyzeMisconceptionPattern } = require('../utils/misconceptionDetector'); // TEACHING ENHANCEMENT
-const { generateInterviewQuestions, generateFollowUp, evaluateResponse, createInterviewSession } = require('../utils/dynamicInterviewGenerator'); // TEACHING ENHANCEMENT
+// Interview imports removed — mastery interview is shelved
+// const { generateInterviewQuestions, generateFollowUp, evaluateResponse, createInterviewSession } = require('../utils/dynamicInterviewGenerator');
 
 // ============================================================================
-// PHASE 2: AI INTERVIEW PROBE
+// PHASE 2: AI INTERVIEW PROBE — SHELVED
+// Interview endpoints removed. Mastery mode now goes directly to badges.
 // ============================================================================
 
-/**
- * TEACHING ENHANCEMENT: Dynamic Interview Question Generation
- * POST /api/mastery/interview-question
- */
-router.post('/interview-question', isAuthenticated, async (req, res) => {
-  try {
-    const { screenerResults } = req.body;
-
-    if (!screenerResults || !screenerResults.theta) {
-      return res.status(400).json({ error: 'Missing screener results' });
-    }
-
-    // Get frontier skills from screener
-    const frontierSkills = screenerResults.frontierSkills || [];
-
-    if (frontierSkills.length === 0) {
-      return res.status(400).json({ error: 'No frontier skills identified' });
-    }
-
-    // Create full interview session
-    const interviewSession = await createInterviewSession(
-      frontierSkills,
-      screenerResults.theta,
-      screenerResults
-    );
-
-    res.json({
-      success: true,
-      interviewSession,
-      message: 'Dynamic interview questions generated for all frontier skills'
-    });
-
-  } catch (error) {
-    console.error('Error generating interview questions:', error);
-    res.status(500).json({ error: 'Failed to generate interview questions' });
-  }
+// Return clear "shelved" response if frontend still calls these endpoints
+router.post('/interview-question', isAuthenticated, (req, res) => {
+  res.status(410).json({ error: 'Mastery interview has been shelved', message: 'This feature is no longer available.' });
 });
-
-/**
- * TEACHING ENHANCEMENT: Evaluate interview response and generate follow-up
- * POST /api/mastery/interview-response
- */
-router.post('/interview-response', isAuthenticated, async (req, res) => {
-  try {
-    const { question, studentResponse, skillId } = req.body;
-
-    if (!question || !studentResponse) {
-      return res.status(400).json({ error: 'Missing question or response' });
-    }
-
-    const skill = await Skill.findOne({ skillId }).lean();
-
-    if (!skill) {
-      return res.status(404).json({ error: 'Skill not found' });
-    }
-
-    // Evaluate the response
-    const evaluation = await evaluateResponse(question, studentResponse, skill);
-
-    // Generate follow-up if needed
-    let followUp = null;
-    if (evaluation.rating !== 'excellent' || evaluation.understandingLevel === 'surface') {
-      followUp = await generateFollowUp(question, studentResponse, skill);
-    }
-
-    res.json({
-      success: true,
-      evaluation,
-      followUp,
-      shouldContinue: evaluation.rating !== 'excellent'
-    });
-
-  } catch (error) {
-    console.error('Error evaluating interview response:', error);
-    res.status(500).json({ error: 'Failed to evaluate response' });
-  }
+router.post('/interview-response', isAuthenticated, (req, res) => {
+  res.status(410).json({ error: 'Mastery interview has been shelved', message: 'This feature is no longer available.' });
 });
 
 // ============================================================================

--- a/routes/student.js
+++ b/routes/student.js
@@ -564,6 +564,23 @@ router.post('/join-class', isAuthenticated, isStudent, async (req, res) => {
         if (enrollmentCode.mathCourse) updateFields.mathCourse = enrollmentCode.mathCourse;
         if (enrollmentCode.gradeLevel) updateFields.gradeLevel = enrollmentCode.gradeLevel;
 
+        // Auto-propagate school license: if this teacher has a school license, give it to the student
+        try {
+            const teacherDoc = await User.findById(enrollmentCode.teacherId).select('schoolLicenseId').lean();
+            if (teacherDoc && teacherDoc.schoolLicenseId) {
+                const SchoolLicense = require('../models/schoolLicense');
+                const license = await SchoolLicense.findById(teacherDoc.schoolLicenseId);
+                if (license && license.isValid() && license.currentStudentCount < license.maxStudents) {
+                    updateFields.schoolLicenseId = teacherDoc.schoolLicenseId;
+                    license.currentStudentCount = (license.currentStudentCount || 0) + 1;
+                    await license.save();
+                    console.log(`[SchoolLicense] Auto-propagated to student ${studentId} via enrollment (${license.schoolName})`);
+                }
+            }
+        } catch (licenseErr) {
+            console.error('[SchoolLicense] Auto-propagation error:', licenseErr.message);
+        }
+
         await User.findByIdAndUpdate(studentId, { $set: updateFields });
 
         res.json({

--- a/routes/voice.js
+++ b/routes/voice.js
@@ -113,12 +113,20 @@ router.post('/process', isAuthenticated, async (req, res) => {
 
         console.log('📝 [Voice] Calling Whisper API for transcription...');
 
+        // Map preferredLanguage to Whisper ISO-639-1 codes for non-English transcription
+        const userLangPref = await User.findById(userId).select('preferredLanguage').lean();
+        const langMap = {
+            'English': 'en', 'Spanish': 'es', 'Russian': 'ru', 'Chinese': 'zh',
+            'Vietnamese': 'vi', 'Arabic': 'ar', 'Somali': 'so', 'French': 'fr', 'German': 'de'
+        };
+        const whisperLang = langMap[userLangPref?.preferredLanguage] || 'en';
+
         let transcription;
         try {
             transcription = await openai.audio.transcriptions.create({
                 file: fs.createReadStream(tempAudioPath),
                 model: 'whisper-1',
-                language: 'en', // Can be auto-detected by omitting this
+                language: whisperLang,
             });
         } catch (error) {
             console.error('❌ [Voice] Whisper API error:', error.message);


### PR DESCRIPTION
…drive refunds

Billing:
- Add webhook idempotency via WebhookEvent model (prevents duplicate pack credits on Stripe retries)
- Fix webhook response: return 500 on processing errors so Stripe retries (was returning 200)
- Downgrade user to free tier immediately on invoice.payment_failed
- Handle subscription reactivation: fall back to stripeCustomerId lookup when stripeSubscriptionId is null
- Clean up stale packSecondsRemaining/packExpiresAt on expired pack downgrade

Usage tracking:
- Await AI time tracking DB update in chat.js (was fire-and-forget)
- Re-validate pack expiry before deducting seconds (prevents mid-session expiry bug)
- Use atomic $inc for AI time in courseChat.js (was direct assignment, race-prone)

Usage gate:
- Make weekly reset atomic with conditional update (prevents concurrent double-reset)
- Fail closed on license check errors (was returning true = free access on DB errors)
- Fix .lean() + .isValid() bug: check fields directly on plain object
- Enforce school license capacity limits in usageGate
- Clean up stale pack fields on auto-downgrade

School licenses:
- Auto-propagate license to students when they join a class via enrollment code

Voice:
- Use student's preferredLanguage for Whisper transcription (was hardcoded to 'en')

Mastery mode:
- Shelve interview endpoints (return 410 Gone) — mastery goes directly to badges

https://claude.ai/code/session_01MCxx54MXs1kUrRLeo5fWr8