### PR TITLE
Rename studentIds to filteredStudentIds for clarity

### DIFF
--- a/routes/teacher.js
+++ b/routes/teacher.js
@@ -203,11 +203,11 @@ router.get('/live-feed', isTeacher, async (req, res) => {
       '_id firstName lastName username'
     ).lean();
 
-    const studentIds = students.map(s => s._id);
+    const filteredStudentIds = students.map(s => s._id);
 
     // Get active conversations for these students
     const activeConversations = await Conversation.find({
-      userId: { $in: studentIds },
+      userId: { $in: filteredStudentIds },
       isActive: true,
       lastActivity: { $gte: new Date(Date.now() - 30 * 60 * 1000) } // Active within last 30 min
     }).sort({ lastActivity: -1 }).lean();
@@ -281,10 +281,10 @@ router.get('/activity-feed', isTeacher, async (req, res) => {
       '_id firstName lastName username'
     ).lean();
 
-    const studentIds = students.map(s => s._id);
+    const filteredStudentIds = students.map(s => s._id);
 
     // Build query
-    const query = { userId: { $in: studentIds } };
+    const query = { userId: { $in: filteredStudentIds } };
 
     if (studentId) query.userId = studentId;
     if (activeOnly === 'true') query.isActive = true;


### PR DESCRIPTION
## Summary
Improved code clarity by renaming the `studentIds` variable to `filteredStudentIds` in the teacher routes to better reflect its purpose and usage.

## Key Changes
- Renamed `studentIds` to `filteredStudentIds` in the `/live-feed` endpoint (lines 206-210)
- Renamed `studentIds` to `filteredStudentIds` in the `/activity-feed` endpoint (lines 284-287)
- Updated all references to use the new variable name in query filters

## Implementation Details
The variable name change makes the code more self-documenting by explicitly indicating that these are filtered student IDs (derived from the teacher's class/section) rather than all student IDs in the system. This improves maintainability and reduces potential confusion when reading the code.

https://claude.ai/code/session_01XGBVGGcJu7GENJ9CWqwZCU