### PR TITLE
Add email waitlist signup management to admin dashboard

### DIFF
--- a/public/admin-dashboard.html
+++ b/public/admin-dashboard.html
@@ -1059,6 +1059,21 @@
             <div><strong>Total Campaigns:</strong> <span id="totalCampaigns">-</span></div>
           </div>
         </div>
+
+        <div class="dashboard-panel">
+          <h2 class="dashboard-panel-header">
+            <i class="fas fa-clipboard-list"></i> Email Waitlist
+          </h2>
+          <p>Pre-launch email signups from the landing page.</p>
+          <button id="openWaitlistBtn" class="btn btn-primary main-action-btn">
+            <i class="fas fa-list"></i> View Waitlist
+          </button>
+          <div id="waitlistQuickStats" style="margin-top: 15px; padding: 10px; background: #f8f9fa; border-radius: 6px; font-size: 0.9em;">
+            <div style="margin-bottom: 5px;"><strong>Total Signups:</strong> <span id="waitlistTotal">-</span></div>
+            <div style="margin-bottom: 5px;"><strong>Students:</strong> <span id="waitlistStudents">-</span> | <strong>Parents:</strong> <span id="waitlistParents">-</span></div>
+            <div><strong>Teachers:</strong> <span id="waitlistTeachers">-</span> | <strong>Other:</strong> <span id="waitlistOther">-</span></div>
+          </div>
+        </div>
       </aside>
     </main>
 
@@ -1959,6 +1974,76 @@ Jane,Doe,jane.doe@school.org,7th Grade</code>
     </div>
   </div>
 
+  <!-- Waitlist Modal -->
+  <div id="waitlistModal" class="modal-overlay">
+    <div class="modal-content" style="max-width: 900px; max-height: 90vh; overflow-y: auto;">
+      <button class="modal-close-button" id="closeWaitlistBtn">&times;</button>
+      <h2><i class="fas fa-clipboard-list"></i> Email Waitlist Signups</h2>
+
+      <div class="modal-section">
+        <div style="display: flex; gap: 15px; flex-wrap: wrap; align-items: center; margin-bottom: 15px;">
+          <div class="modal-form-group" style="flex: 1; margin-bottom: 0;">
+            <input type="text" id="waitlistSearch" placeholder="Search by email..." style="width: 100%; padding: 8px 12px; border: 1px solid #ddd; border-radius: 6px;">
+          </div>
+          <div class="modal-form-group" style="margin-bottom: 0;">
+            <select id="waitlistRoleFilter" style="padding: 8px 12px; border-radius: 6px; border: 1px solid #ddd;">
+              <option value="">All Roles</option>
+              <option value="student">Student</option>
+              <option value="parent">Parent</option>
+              <option value="teacher">Teacher</option>
+              <option value="other">Other</option>
+            </select>
+          </div>
+          <button id="exportWaitlistCSV" class="btn btn-secondary" style="padding: 8px 16px;">
+            <i class="fas fa-download"></i> Export CSV
+          </button>
+        </div>
+
+        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: 10px; margin-bottom: 15px;">
+          <div class="stat-card" style="text-align: center; padding: 10px;">
+            <div class="stat-label">Total</div>
+            <div class="stat-value" id="waitlistModalTotal" style="font-size: 1.4em;">-</div>
+          </div>
+          <div class="stat-card" style="text-align: center; padding: 10px;">
+            <div class="stat-label">Students</div>
+            <div class="stat-value" id="waitlistModalStudents" style="font-size: 1.4em;">-</div>
+          </div>
+          <div class="stat-card" style="text-align: center; padding: 10px;">
+            <div class="stat-label">Parents</div>
+            <div class="stat-value" id="waitlistModalParents" style="font-size: 1.4em;">-</div>
+          </div>
+          <div class="stat-card" style="text-align: center; padding: 10px;">
+            <div class="stat-label">Teachers</div>
+            <div class="stat-value" id="waitlistModalTeachers" style="font-size: 1.4em;">-</div>
+          </div>
+          <div class="stat-card" style="text-align: center; padding: 10px;">
+            <div class="stat-label">Other</div>
+            <div class="stat-value" id="waitlistModalOther" style="font-size: 1.4em;">-</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="modal-section">
+        <div class="table-scroll-container" style="max-height: 400px;">
+          <table class="user-table">
+            <thead>
+              <tr>
+                <th>Email</th>
+                <th>Role</th>
+                <th>Signed Up</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody id="waitlistTableBody">
+              <tr><td colspan="4" style="text-align: center;">Loading...</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <div id="waitlistCount" style="margin-top: 10px; font-size: 0.85em; color: #666;"></div>
+      </div>
+    </div>
+  </div>
+
   <!-- Mobile Bottom Nav (visible < 968px) -->
   <nav class="mobile-bottom-nav" id="mobile-bottom-nav">
     <button class="mobile-nav-btn active" data-mobile-tab="users">
@@ -2026,6 +2111,16 @@ Jane,Doe,jane.doe@school.org,7th Grade</code>
           <button class="mobile-action-btn" id="mobile-email-history">
             <i class="fas fa-history" style="color: #e67e22;"></i>
             Email History
+          </button>
+        </div>
+      </div>
+
+      <div class="drawer-section">
+        <div class="drawer-section-title"><i class="fas fa-clipboard-list" style="color: #e74c3c;"></i> Email Waitlist</div>
+        <div class="mobile-actions-grid">
+          <button class="mobile-action-btn" id="mobile-view-waitlist">
+            <i class="fas fa-list" style="color: #e74c3c;"></i>
+            View Waitlist
           </button>
         </div>
       </div>
@@ -2202,7 +2297,8 @@ Jane,Doe,jane.doe@school.org,7th Grade</code>
           'mobile-live-activity': 'openLiveActivityBtn',
           'mobile-survey-analytics': 'openSurveyResponsesBtn',
           'mobile-compose-email': 'openBulkEmailBtn',
-          'mobile-email-history': 'viewEmailCampaignsBtn'
+          'mobile-email-history': 'viewEmailCampaignsBtn',
+          'mobile-view-waitlist': 'openWaitlistBtn'
         };
 
         Object.entries(actionMap).forEach(([mobileId, desktopId]) => {

--- a/public/js/admin-dashboard.js
+++ b/public/js/admin-dashboard.js
@@ -2546,6 +2546,7 @@ document.addEventListener("DOMContentLoaded", async () => {
             if (usageReportModal) usageReportModal.classList.remove('is-visible');
             if (liveActivityModal) liveActivityModal.classList.remove('is-visible');
             if (summariesModal) summariesModal.classList.remove('is-visible');
+            if (waitlistModal) waitlistModal.classList.remove('is-visible');
             clearBulkSelection();
         }
 
@@ -2558,6 +2559,166 @@ document.addEventListener("DOMContentLoaded", async () => {
     });
 
     // Toast animations are now handled by CSS in the HTML file
+
+    // -------------------------------------------------------------------------
+    // --- Email Waitlist Management ---
+    // -------------------------------------------------------------------------
+
+    const waitlistModal = document.getElementById('waitlistModal');
+    const openWaitlistBtn = document.getElementById('openWaitlistBtn');
+    const closeWaitlistBtn = document.getElementById('closeWaitlistBtn');
+    const waitlistSearch = document.getElementById('waitlistSearch');
+    const waitlistRoleFilter = document.getElementById('waitlistRoleFilter');
+    const exportWaitlistCSV = document.getElementById('exportWaitlistCSV');
+    const waitlistTableBody = document.getElementById('waitlistTableBody');
+
+    let allWaitlistEntries = [];
+
+    async function fetchWaitlistData() {
+        try {
+            const res = await fetch('/api/admin/waitlist', { credentials: 'include' });
+            if (!res.ok) throw new Error('Failed to fetch waitlist');
+            const data = await res.json();
+            allWaitlistEntries = data.entries || [];
+            updateWaitlistQuickStats(allWaitlistEntries);
+            renderWaitlistTable(allWaitlistEntries);
+        } catch (err) {
+            console.error('[Waitlist] Fetch error:', err);
+            if (waitlistTableBody) {
+                waitlistTableBody.innerHTML = '<tr><td colspan="4" style="text-align:center;color:#e74c3c;">Failed to load waitlist data.</td></tr>';
+            }
+        }
+    }
+
+    function updateWaitlistQuickStats(entries) {
+        const counts = { student: 0, parent: 0, teacher: 0, other: 0 };
+        entries.forEach(e => { counts[e.role] = (counts[e.role] || 0) + 1; });
+        const total = entries.length;
+
+        // Sidebar quick stats
+        const qs = id => document.getElementById(id);
+        if (qs('waitlistTotal')) qs('waitlistTotal').textContent = total;
+        if (qs('waitlistStudents')) qs('waitlistStudents').textContent = counts.student;
+        if (qs('waitlistParents')) qs('waitlistParents').textContent = counts.parent;
+        if (qs('waitlistTeachers')) qs('waitlistTeachers').textContent = counts.teacher;
+        if (qs('waitlistOther')) qs('waitlistOther').textContent = counts.other;
+
+        // Modal stats
+        if (qs('waitlistModalTotal')) qs('waitlistModalTotal').textContent = total;
+        if (qs('waitlistModalStudents')) qs('waitlistModalStudents').textContent = counts.student;
+        if (qs('waitlistModalParents')) qs('waitlistModalParents').textContent = counts.parent;
+        if (qs('waitlistModalTeachers')) qs('waitlistModalTeachers').textContent = counts.teacher;
+        if (qs('waitlistModalOther')) qs('waitlistModalOther').textContent = counts.other;
+    }
+
+    function renderWaitlistTable(entries) {
+        if (!waitlistTableBody) return;
+        const search = (waitlistSearch?.value || '').toLowerCase();
+        const roleFilter = waitlistRoleFilter?.value || '';
+
+        const filtered = entries.filter(e => {
+            const matchSearch = !search || e.email.toLowerCase().includes(search);
+            const matchRole = !roleFilter || e.role === roleFilter;
+            return matchSearch && matchRole;
+        });
+
+        if (filtered.length === 0) {
+            waitlistTableBody.innerHTML = '<tr><td colspan="4" style="text-align:center;">No waitlist entries found.</td></tr>';
+        } else {
+            waitlistTableBody.innerHTML = filtered.map(e => {
+                const date = new Date(e.createdAt).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+                const roleLabel = e.role.charAt(0).toUpperCase() + e.role.slice(1);
+                return `<tr>
+                    <td>${escapeHTML(e.email)}</td>
+                    <td><span class="role-badge role-badge-${e.role}">${roleLabel}</span></td>
+                    <td>${date}</td>
+                    <td><button class="btn btn-danger btn-sm waitlist-delete-btn" data-id="${e._id}" title="Delete"><i class="fas fa-trash"></i></button></td>
+                </tr>`;
+            }).join('');
+        }
+
+        const countEl = document.getElementById('waitlistCount');
+        if (countEl) countEl.textContent = `Showing ${filtered.length} of ${entries.length} entries`;
+    }
+
+    function escapeHTML(str) {
+        const div = document.createElement('div');
+        div.textContent = str;
+        return div.innerHTML;
+    }
+
+    // Open modal
+    if (openWaitlistBtn) {
+        openWaitlistBtn.addEventListener('click', () => {
+            if (waitlistModal) {
+                waitlistModal.classList.add('is-visible');
+                fetchWaitlistData();
+            }
+        });
+    }
+
+    // Close modal
+    if (closeWaitlistBtn) {
+        closeWaitlistBtn.addEventListener('click', () => {
+            if (waitlistModal) waitlistModal.classList.remove('is-visible');
+        });
+    }
+    if (waitlistModal) {
+        waitlistModal.addEventListener('click', (e) => {
+            if (e.target === waitlistModal) waitlistModal.classList.remove('is-visible');
+        });
+    }
+
+    // Search & filter
+    if (waitlistSearch) waitlistSearch.addEventListener('input', debounce(() => renderWaitlistTable(allWaitlistEntries), 300));
+    if (waitlistRoleFilter) waitlistRoleFilter.addEventListener('change', () => renderWaitlistTable(allWaitlistEntries));
+
+    // Delete entry
+    if (waitlistTableBody) {
+        waitlistTableBody.addEventListener('click', async (e) => {
+            const btn = e.target.closest('.waitlist-delete-btn');
+            if (!btn) return;
+            const id = btn.dataset.id;
+            if (!confirm('Remove this email from the waitlist?')) return;
+            try {
+                const res = await csrfFetch(`/api/admin/waitlist/${id}`, { method: 'DELETE' });
+                if (!res.ok) throw new Error('Delete failed');
+                showToast('Waitlist entry removed.', 'success');
+                allWaitlistEntries = allWaitlistEntries.filter(e => e._id !== id);
+                updateWaitlistQuickStats(allWaitlistEntries);
+                renderWaitlistTable(allWaitlistEntries);
+            } catch (err) {
+                console.error('[Waitlist] Delete error:', err);
+                showToast('Failed to remove entry.', 'error');
+            }
+        });
+    }
+
+    // Export CSV
+    if (exportWaitlistCSV) {
+        exportWaitlistCSV.addEventListener('click', () => {
+            if (allWaitlistEntries.length === 0) {
+                showToast('No waitlist entries to export.', 'warning');
+                return;
+            }
+            const header = 'Email,Role,Signed Up\n';
+            const rows = allWaitlistEntries.map(e => {
+                const date = new Date(e.createdAt).toISOString().split('T')[0];
+                return `"${e.email}","${e.role}","${date}"`;
+            }).join('\n');
+            const blob = new Blob([header + rows], { type: 'text/csv' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = `waitlist-export-${new Date().toISOString().split('T')[0]}.csv`;
+            a.click();
+            URL.revokeObjectURL(url);
+            showToast('CSV exported successfully.', 'success');
+        });
+    }
+
+    // Fetch initial sidebar stats on load
+    fetchWaitlistData();
 
     console.log('[Admin Dashboard] 3x UX enhancements loaded: Audit Trail, Real-time Polling, Bulk Operations');
 });

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -14,6 +14,7 @@ const Conversation = require('../models/conversation');
 const EnrollmentCode = require('../models/enrollmentCode');
 const { isAdmin } = require('../middleware/auth');
 const ScreenerSession = require('../models/screenerSession');
+const Waitlist = require('../models/waitlist');
 const adminImportRoutes = require('./adminImport'); // CSV import for item bank
 const bcrypt = require('bcryptjs');
 const crypto = require('crypto');
@@ -2091,6 +2092,42 @@ router.get('/students/:studentId/placement-results', isAdmin, async (req, res) =
   } catch (error) {
     console.error('Error fetching student placement results:', error);
     res.status(500).json({ message: 'Error fetching placement results' });
+  }
+});
+
+// -----------------------------------------------------------------------------
+// --- Waitlist Management Routes ---
+// -----------------------------------------------------------------------------
+
+// GET /api/admin/waitlist — list all waitlist signups
+router.get('/waitlist', async (req, res) => {
+  try {
+    const entries = await Waitlist.find({}).sort({ createdAt: -1 }).lean();
+    const counts = {
+      total: entries.length,
+      student: entries.filter(e => e.role === 'student').length,
+      parent: entries.filter(e => e.role === 'parent').length,
+      teacher: entries.filter(e => e.role === 'teacher').length,
+      other: entries.filter(e => e.role === 'other').length
+    };
+    res.json({ success: true, entries, counts });
+  } catch (err) {
+    console.error('ERROR: Failed to fetch waitlist:', err);
+    res.status(500).json({ success: false, message: 'Failed to fetch waitlist entries.' });
+  }
+});
+
+// DELETE /api/admin/waitlist/:id — remove a single waitlist entry
+router.delete('/waitlist/:id', async (req, res) => {
+  try {
+    const result = await Waitlist.findByIdAndDelete(req.params.id);
+    if (!result) {
+      return res.status(404).json({ success: false, message: 'Entry not found.' });
+    }
+    res.json({ success: true, message: 'Waitlist entry removed.' });
+  } catch (err) {
+    console.error('ERROR: Failed to delete waitlist entry:', err);
+    res.status(500).json({ success: false, message: 'Failed to delete entry.' });
   }
 });
 


### PR DESCRIPTION
- Add GET /api/admin/waitlist and DELETE /api/admin/waitlist/:id API endpoints
- Add waitlist quick stats panel in admin dashboard right sidebar
- Add full waitlist modal with search, role filter, export CSV, and delete
- Add mobile drawer entry for waitlist access
- Wire up JavaScript for fetching, filtering, and managing waitlist entries

https://claude.ai/code/session_01WaLkt6MsQUVywD5MnBeVUh