### PR TITLE
Redesign mobile bottom nav: 4 focused tabs with settings access

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -605,29 +605,65 @@
         </div>
       </div>
 
+      <!-- Streak & Quick Stats -->
+      <div class="drawer-section">
+        <div class="drawer-quick-stats">
+          <div class="drawer-quick-stat">
+            <i class="fas fa-fire" style="color: #f59e0b;"></i>
+            <span id="drawer-streak-count" class="drawer-quick-stat-value">0</span>
+            <span class="drawer-quick-stat-label">Day Streak</span>
+          </div>
+          <div class="drawer-quick-stat">
+            <i class="fas fa-star" style="color: var(--clr-primary-teal, #12B3B3);"></i>
+            <span id="drawer-total-xp" class="drawer-quick-stat-value">0</span>
+            <span class="drawer-quick-stat-label">Total XP</span>
+          </div>
+          <div class="drawer-quick-stat">
+            <i class="fas fa-check-circle" style="color: #22c55e;"></i>
+            <span id="drawer-total-problems" class="drawer-quick-stat-value">0</span>
+            <span class="drawer-quick-stat-label">Solved</span>
+          </div>
+        </div>
+      </div>
+
       <!-- Session Stats -->
       <div class="drawer-section">
-        <h4><i class="fas fa-chart-line"></i> Session Stats</h4>
+        <h4><i class="fas fa-chart-line"></i> This Session</h4>
         <div class="drawer-stats-grid">
           <div class="drawer-stat-item">
-            <span class="drawer-stat-label">Session XP:</span>
+            <span class="drawer-stat-label">XP Earned</span>
             <span id="drawer-session-xp" class="drawer-stat-value">0</span>
           </div>
           <div class="drawer-stat-item">
-            <span class="drawer-stat-label">Accuracy:</span>
+            <span class="drawer-stat-label">Accuracy</span>
             <span id="drawer-session-accuracy" class="drawer-stat-value">--</span>
           </div>
           <div class="drawer-stat-item">
-            <span class="drawer-stat-label">Problems:</span>
+            <span class="drawer-stat-label">Problems</span>
             <span id="drawer-session-problems" class="drawer-stat-value">0/0</span>
           </div>
         </div>
       </div>
 
+      <!-- Quick Settings -->
+      <div class="drawer-section">
+        <h4><i class="fas fa-sliders-h"></i> Quick Settings</h4>
+        <button id="drawer-open-settings-btn" class="drawer-action-btn" onclick="document.getElementById('open-settings-modal-btn').click(); document.getElementById('close-right-drawer').click();">
+          <i class="fas fa-cog"></i>
+          <span>Open Settings</span>
+          <i class="fas fa-chevron-right drawer-action-arrow"></i>
+        </button>
+        <button id="drawer-change-tutor-btn" class="drawer-action-btn" onclick="document.getElementById('change-tutor-btn')?.click(); document.getElementById('close-right-drawer').click();">
+          <i class="fas fa-user-graduate"></i>
+          <span>Change Tutor</span>
+          <i class="fas fa-chevron-right drawer-action-arrow"></i>
+        </button>
+      </div>
+
       <!-- Parent Link -->
       <div class="drawer-section">
         <h4><i class="fas fa-link"></i> Share Progress</h4>
-        <p style="font-size: 0.9rem; color: #666; margin-bottom: 8px;">Share this code with a parent or teacher to link accounts.</p>
+        <p style="font-size: 0.85rem; color: var(--clr-text-dim, #666); margin-bottom: 8px;">Share this code with a parent or teacher.</p>
         <div id="drawer-student-link-code-value" class="drawer-link-code" title="Click to copy"></div>
       </div>
     </div>

--- a/public/css/base/modals.css
+++ b/public/css/base/modals.css
@@ -16,9 +16,10 @@
     transition: opacity 0.3s ease;
 }
 
-/* Settings modal specific z-index */
+/* Settings modal specific z-index — must be above mobile nav (1800),
+   drawers (2000), and menu sheet (2100) */
 #settings-modal {
-    z-index: 1006;
+    z-index: 2200;
 }
 
 /* This is the class JavaScript will add to show the modal */

--- a/public/css/mobile-fixes.css
+++ b/public/css/mobile-fixes.css
@@ -558,6 +558,218 @@ input, textarea, select, .math-field {
     }
 }
 
+/* --- 6d. MOBILE MENU BOTTOM SHEET ---
+   Slide-up sheet with Settings, Tools, Theme toggle, etc.
+   Built dynamically by mobile-chat-nav.js.
+   -------------------------------------------------------- */
+
+.mobile-menu-overlay {
+    position: fixed;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background: rgba(0, 0, 0, 0.35);
+    backdrop-filter: blur(2px);
+    -webkit-backdrop-filter: blur(2px);
+    z-index: 2049;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 300ms ease, visibility 300ms ease;
+}
+
+.mobile-menu-overlay.active {
+    opacity: 1;
+    visibility: visible;
+}
+
+.mobile-menu-sheet {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: var(--clr-bg-light, #fff);
+    border-top-left-radius: 20px;
+    border-top-right-radius: 20px;
+    box-shadow: 0 -8px 32px rgba(0, 0, 0, 0.14);
+    z-index: 2050;
+    display: none;
+    transform: translateY(100%);
+    transition: transform 300ms cubic-bezier(0.22, 1, 0.36, 1);
+    padding-bottom: max(env(safe-area-inset-bottom, 16px), 16px);
+}
+
+.mobile-menu-sheet.active {
+    transform: translateY(0);
+}
+
+/* Drag handle */
+.menu-sheet-handle {
+    width: 36px;
+    height: 4px;
+    background: #d1d5db;
+    border-radius: 2px;
+    margin: 10px auto 4px;
+}
+
+.menu-sheet-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 20px 14px;
+    border-bottom: 1px solid var(--clr-border-light, #f1f5f9);
+}
+
+.menu-sheet-header span {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: var(--clr-text, #18202B);
+}
+
+.menu-sheet-close {
+    background: var(--clr-bg-subtle, #f8fafb);
+    border: none;
+    font-size: 1.2rem;
+    color: var(--clr-text-dim, #5B6876);
+    width: 34px;
+    height: 34px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    padding: 0;
+    cursor: pointer;
+}
+
+.menu-sheet-close:active {
+    background: var(--clr-border, #e2e8f0);
+}
+
+/* Menu items list */
+.menu-sheet-list {
+    padding: 8px 12px;
+}
+
+.menu-sheet-item {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    width: 100%;
+    padding: 14px 16px;
+    background: none;
+    border: none;
+    border-radius: 12px;
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: var(--clr-text, #18202B);
+    cursor: pointer;
+    transition: background 150ms ease;
+    text-align: left;
+}
+
+.menu-sheet-item:active {
+    background: rgba(18, 179, 179, 0.06);
+}
+
+.menu-sheet-item i:first-child {
+    width: 22px;
+    text-align: center;
+    font-size: 1.1rem;
+    color: var(--clr-primary-teal, #12B3B3);
+    flex-shrink: 0;
+}
+
+.menu-sheet-arrow {
+    margin-left: auto;
+    font-size: 0.7rem !important;
+    color: var(--clr-text-dim, #aaa) !important;
+    opacity: 0.5;
+}
+
+/* Settings row — make it visually prominent */
+.menu-sheet-item[data-menu-action="open-settings"] {
+    font-weight: 600;
+}
+
+/* Toggle row for theme */
+.menu-sheet-toggle-row {
+    justify-content: space-between;
+}
+
+.menu-sheet-item-left {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+}
+
+.menu-sheet-item-left i {
+    width: 22px;
+    text-align: center;
+    font-size: 1.1rem;
+    color: var(--clr-primary-teal, #12B3B3);
+}
+
+/* Toggle switch */
+.menu-toggle-switch {
+    position: relative;
+    display: inline-block;
+    width: 44px;
+    height: 24px;
+    flex-shrink: 0;
+}
+
+.menu-toggle-switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.menu-toggle-slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background: #ccd5de;
+    border-radius: 24px;
+    transition: background 200ms ease;
+}
+
+.menu-toggle-slider::before {
+    content: '';
+    position: absolute;
+    height: 18px;
+    width: 18px;
+    left: 3px;
+    bottom: 3px;
+    background: white;
+    border-radius: 50%;
+    transition: transform 200ms ease;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.15);
+}
+
+.menu-toggle-switch input:checked + .menu-toggle-slider {
+    background: var(--clr-primary-teal, #12B3B3);
+}
+
+.menu-toggle-switch input:checked + .menu-toggle-slider::before {
+    transform: translateX(20px);
+}
+
+/* Dark mode menu sheet */
+[data-theme="dark"] .mobile-menu-sheet {
+    background: var(--clr-bg-dark, #1a1d2e);
+    box-shadow: 0 -8px 32px rgba(0, 0, 0, 0.4);
+}
+
+[data-theme="dark"] .menu-sheet-handle {
+    background: #444;
+}
+
+[data-theme="dark"] .menu-sheet-close {
+    background: rgba(255, 255, 255, 0.08);
+    color: #aaa;
+}
+
+[data-theme="dark"] .menu-sheet-item:active {
+    background: rgba(18, 179, 179, 0.1);
+}
+
 /* --- 6c. CHAT WATERMARK ---
    Semi-transparent brand mark behind the message area.
    pointer-events: none keeps it completely touch-safe. */
@@ -779,6 +991,85 @@ input, textarea, select, .math-field {
     font-size: 1rem;
     font-weight: 700;
     color: var(--clr-primary-teal);
+}
+
+/* Quick Stats Row (streak, total XP, solved) */
+.drawer-quick-stats {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 8px;
+    text-align: center;
+}
+
+.drawer-quick-stat {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    padding: 10px 4px;
+    background: var(--clr-bg-subtle, #f8fafb);
+    border-radius: 12px;
+    border: 1px solid var(--clr-border-light, #f1f5f9);
+}
+
+.drawer-quick-stat i {
+    font-size: 1.2rem;
+    margin-bottom: 2px;
+}
+
+.drawer-quick-stat-value {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: var(--clr-text, #18202B);
+}
+
+.drawer-quick-stat-label {
+    font-size: 0.68rem;
+    font-weight: 600;
+    color: var(--clr-text-dim, #8896a6);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+/* Drawer Action Buttons (Settings, Change Tutor) */
+.drawer-action-btn {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    padding: 12px 14px;
+    background: var(--clr-bg-subtle, #f8fafb);
+    border: 1px solid var(--clr-border-light, #f1f5f9);
+    border-radius: 10px;
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: var(--clr-text, #18202B);
+    cursor: pointer;
+    transition: background 150ms ease;
+    text-align: left;
+    margin-bottom: 8px;
+}
+
+.drawer-action-btn:last-child {
+    margin-bottom: 0;
+}
+
+.drawer-action-btn:active {
+    background: rgba(18, 179, 179, 0.06);
+}
+
+.drawer-action-btn i:first-child {
+    width: 20px;
+    text-align: center;
+    color: var(--clr-primary-teal, #12B3B3);
+    font-size: 1rem;
+}
+
+.drawer-action-arrow {
+    margin-left: auto;
+    font-size: 0.7rem !important;
+    color: var(--clr-text-dim, #aaa) !important;
+    opacity: 0.5;
 }
 
 /* Leaderboard Table */

--- a/public/js/mobile-chat-nav.js
+++ b/public/js/mobile-chat-nav.js
@@ -1,6 +1,6 @@
 /* ============================================
    MOBILE CHAT NAVIGATION — MATHMATIX AI
-   Bottom nav bar + floating watermark for mobile chat.
+   Bottom nav bar + menu sheet + floating watermark for mobile chat.
    Creates DOM on the fly; wires into existing drawer / menu JS.
    ============================================ */
 
@@ -11,26 +11,47 @@
     if (!document.body.classList.contains('landing-page-body')) return;
 
     var MOBILE_BP = 769;          // matches CSS max-width: 768px
+
+    /* ---- Four-tab layout ----
+       Explore  ·  Chat  ·  Progress  ·  Menu
+       ------------------------------------ */
     var NAV_ITEMS = [
-        { action: 'sessions', icon: 'fa-comments',     label: 'Sessions' },
-        { action: 'tools',    icon: 'fa-toolbox',      label: 'Tools' },
+        { action: 'explore',  icon: 'fa-compass',      label: 'Explore' },
         { action: 'chat',     icon: 'fa-comment-dots',  label: 'Chat', active: true },
-        { action: 'theme',    icon: 'fa-moon',          label: 'Theme', id: 'chat-nav-theme-icon' },
-        { action: 'profile',  icon: 'fa-user-circle',   label: 'Profile' }
+        { action: 'progress', icon: 'fa-chart-line',    label: 'Progress' },
+        { action: 'menu',     icon: 'fa-bars',          label: 'Menu' }
+    ];
+
+    /* ---- Menu sheet items ---- */
+    var MENU_ITEMS = [
+        { id: 'menu-settings',  icon: 'fa-cog',          label: 'Settings',       action: 'open-settings'  },
+        { id: 'menu-tools',     icon: 'fa-toolbox',      label: 'Tools',          action: 'open-tools'     },
+        { id: 'menu-theme',     icon: 'fa-moon',         label: 'Dark Mode',      action: 'toggle-theme',  toggle: true },
+        { id: 'menu-share',     icon: 'fa-share-alt',    label: 'Share Progress', action: 'share-progress' },
+        { id: 'menu-feedback',  icon: 'fa-comment-dots', label: 'Send Feedback',  action: 'open-feedback'  },
+        { id: 'menu-resources', icon: 'fa-book-open',    label: 'Resources',      action: 'open-resources' }
     ];
 
     /* ---- helpers ---- */
 
     function isMobile() { return window.innerWidth < MOBILE_BP; }
 
-    function syncThemeIcon() {
-        var icon = document.getElementById('chat-nav-theme-icon');
-        if (!icon) return;
-        var dark = document.documentElement.getAttribute('data-theme') === 'dark';
-        icon.className = 'fas ' + (dark ? 'fa-sun' : 'fa-moon');
-        // Update the label too
-        var label = icon.parentElement && icon.parentElement.querySelector('span');
-        if (label) label.textContent = dark ? 'Light' : 'Dark';
+    function isDark() {
+        return document.documentElement.getAttribute('data-theme') === 'dark';
+    }
+
+    function syncThemeRow() {
+        var icon = document.getElementById('menu-theme-icon');
+        var label = document.getElementById('menu-theme-label');
+        var toggle = document.getElementById('menu-theme-toggle');
+        if (icon) icon.className = 'fas ' + (isDark() ? 'fa-sun' : 'fa-moon');
+        if (label) label.textContent = isDark() ? 'Light Mode' : 'Dark Mode';
+        if (toggle) toggle.checked = isDark();
+    }
+
+    function triggerClick(id) {
+        var el = document.getElementById(id);
+        if (el) el.click();
     }
 
     /* ---- bottom nav ---- */
@@ -48,7 +69,7 @@
             html += '<button class="chat-nav-item' + (item.active ? ' active' : '') + '"'
                 + ' data-action="' + item.action + '"'
                 + ' aria-label="' + item.label + '">'
-                + '<i class="fas ' + item.icon + '"' + (item.id ? ' id="' + item.id + '"' : '') + '></i>'
+                + '<i class="fas ' + item.icon + '"></i>'
                 + '<span>' + item.label + '</span>'
                 + '</button>';
         });
@@ -62,17 +83,12 @@
             if (!btn) return;
             handleAction(btn.dataset.action);
         });
-
-        syncThemeIcon();
     }
 
     function handleAction(action) {
         switch (action) {
-            case 'sessions':
+            case 'explore':
                 triggerClick('left-drawer-toggle');
-                break;
-            case 'tools':
-                triggerClick('more-tools-btn');
                 break;
             case 'chat':
                 var box = document.getElementById('chat-messages-container');
@@ -80,19 +96,154 @@
                 var input = document.getElementById('user-input');
                 if (input) input.focus();
                 break;
-            case 'theme':
-                triggerClick('theme-toggle-btn');
-                setTimeout(syncThemeIcon, 150);
-                break;
-            case 'profile':
+            case 'progress':
                 triggerClick('right-drawer-toggle');
+                break;
+            case 'menu':
+                openMenuSheet();
                 break;
         }
     }
 
-    function triggerClick(id) {
-        var el = document.getElementById(id);
-        if (el) el.click();
+    /* ---- menu bottom sheet ---- */
+
+    function buildMenuSheet() {
+        if (document.getElementById('mobile-menu-overlay')) return;
+
+        // Overlay
+        var overlay = document.createElement('div');
+        overlay.id = 'mobile-menu-overlay';
+        overlay.className = 'mobile-menu-overlay';
+        overlay.addEventListener('click', closeMenuSheet);
+        document.body.appendChild(overlay);
+
+        // Sheet
+        var sheet = document.createElement('div');
+        sheet.id = 'mobile-menu-sheet';
+        sheet.className = 'mobile-menu-sheet';
+        sheet.setAttribute('role', 'dialog');
+        sheet.setAttribute('aria-label', 'Menu');
+
+        var html = '<div class="menu-sheet-handle"></div>';
+        html += '<div class="menu-sheet-header">';
+        html += '<span>Menu</span>';
+        html += '<button class="menu-sheet-close" aria-label="Close menu"><i class="fas fa-times"></i></button>';
+        html += '</div>';
+        html += '<div class="menu-sheet-list">';
+
+        MENU_ITEMS.forEach(function (item) {
+            if (item.toggle) {
+                // Theme toggle row
+                html += '<div class="menu-sheet-item menu-sheet-toggle-row" data-menu-action="' + item.action + '">';
+                html += '<div class="menu-sheet-item-left">';
+                html += '<i id="menu-theme-icon" class="fas ' + (isDark() ? 'fa-sun' : item.icon) + '"></i>';
+                html += '<span id="menu-theme-label">' + (isDark() ? 'Light Mode' : item.label) + '</span>';
+                html += '</div>';
+                html += '<label class="menu-toggle-switch">';
+                html += '<input type="checkbox" id="menu-theme-toggle"' + (isDark() ? ' checked' : '') + '>';
+                html += '<span class="menu-toggle-slider"></span>';
+                html += '</label>';
+                html += '</div>';
+            } else {
+                html += '<button class="menu-sheet-item" data-menu-action="' + item.action + '">';
+                html += '<i class="fas ' + item.icon + '"></i>';
+                html += '<span>' + item.label + '</span>';
+                html += '<i class="fas fa-chevron-right menu-sheet-arrow"></i>';
+                html += '</button>';
+            }
+        });
+
+        html += '</div>';
+        sheet.innerHTML = html;
+        document.body.appendChild(sheet);
+
+        // Wire up events
+        sheet.querySelector('.menu-sheet-close').addEventListener('click', closeMenuSheet);
+
+        sheet.addEventListener('click', function (e) {
+            var item = e.target.closest('.menu-sheet-item');
+            if (!item) return;
+            var menuAction = item.dataset.menuAction;
+            if (menuAction) handleMenuAction(menuAction);
+        });
+
+        // Theme toggle change
+        var themeToggle = document.getElementById('menu-theme-toggle');
+        if (themeToggle) {
+            themeToggle.addEventListener('change', function (e) {
+                e.stopPropagation();
+                triggerClick('theme-toggle-btn');
+                setTimeout(syncThemeRow, 150);
+            });
+        }
+
+        // Swipe-down to close
+        var startY = 0;
+        sheet.addEventListener('touchstart', function (e) {
+            startY = e.touches[0].clientY;
+        }, { passive: true });
+        sheet.addEventListener('touchmove', function (e) {
+            if (e.touches[0].clientY - startY > 60) closeMenuSheet();
+        }, { passive: true });
+    }
+
+    function handleMenuAction(action) {
+        switch (action) {
+            case 'open-settings':
+                closeMenuSheet();
+                // triggerClick fires the settings.js click handler which opens the
+                // modal AND loads account info + language preference
+                setTimeout(function () { triggerClick('open-settings-modal-btn'); }, 280);
+                break;
+            case 'open-tools':
+                closeMenuSheet();
+                setTimeout(function () { triggerClick('more-tools-btn'); }, 280);
+                break;
+            case 'toggle-theme':
+                triggerClick('theme-toggle-btn');
+                setTimeout(syncThemeRow, 150);
+                break;
+            case 'share-progress':
+                closeMenuSheet();
+                setTimeout(function () { triggerClick('share-progress-header-btn'); }, 280);
+                break;
+            case 'open-feedback':
+                closeMenuSheet();
+                setTimeout(function () { triggerClick('open-feedback-modal-btn'); }, 280);
+                break;
+            case 'open-resources':
+                closeMenuSheet();
+                setTimeout(function () { triggerClick('open-resources-modal-btn'); }, 280);
+                break;
+        }
+    }
+
+    function openMenuSheet() {
+        buildMenuSheet();
+        syncThemeRow();
+        var overlay = document.getElementById('mobile-menu-overlay');
+        var sheet = document.getElementById('mobile-menu-sheet');
+        if (!overlay || !sheet) return;
+
+        sheet.style.display = 'block';
+        overlay.classList.add('active');
+        requestAnimationFrame(function () {
+            sheet.classList.add('active');
+        });
+        document.body.style.overflow = 'hidden';
+    }
+
+    function closeMenuSheet() {
+        var overlay = document.getElementById('mobile-menu-overlay');
+        var sheet = document.getElementById('mobile-menu-sheet');
+        if (!overlay || !sheet) return;
+
+        sheet.classList.remove('active');
+        overlay.classList.remove('active');
+        setTimeout(function () {
+            sheet.style.display = 'none';
+        }, 300);
+        document.body.style.overflow = '';
     }
 
     /* ---- watermark ---- */
@@ -122,14 +273,20 @@
             document.body.classList.add('has-chat-nav');
         } else {
             document.body.classList.remove('has-chat-nav');
+            // Close menu sheet if open when switching to desktop
+            closeMenuSheet();
         }
     }
 
-    // Keep theme icon in sync
-    document.addEventListener('themechange', syncThemeIcon);
-    // Also catch manual storage updates (cross-tab)
+    // Keep theme row in sync
+    document.addEventListener('themechange', syncThemeRow);
     window.addEventListener('storage', function (e) {
-        if (e.key === 'theme') syncThemeIcon();
+        if (e.key === 'theme') syncThemeRow();
+    });
+
+    // ESC closes menu sheet
+    document.addEventListener('keydown', function (e) {
+        if (e.key === 'Escape') closeMenuSheet();
     });
 
     document.addEventListener('DOMContentLoaded', function () {

--- a/public/js/sidebar.js
+++ b/public/js/sidebar.js
@@ -739,13 +739,27 @@ class Sidebar {
     }
 
     async loadProgress() {
-        if (!window.currentUser) return;
+        // Fetch user data if window.currentUser isn't available yet
+        // (script.js runs as ES module so its currentUser is module-scoped)
+        let user = window.currentUser;
+        if (!user) {
+            try {
+                const res = await fetch('/user', { credentials: 'include' });
+                if (res.ok) {
+                    const data = await res.json();
+                    user = data.user;
+                }
+            } catch (e) {
+                console.warn('Sidebar: could not fetch user for progress', e);
+            }
+        }
+        if (!user) return;
 
-        const level = window.currentUser.level || 1;
+        const level = user.level || 1;
         // xpForCurrentLevel and xpForNextLevel are computed by the backend
         // (set on page load via /user endpoint and updated after each chat response)
-        const xp = window.currentUser.xpForCurrentLevel || 0;
-        const xpNeeded = window.currentUser.xpForNextLevel || 100;
+        const xp = user.xpForCurrentLevel || 0;
+        const xpNeeded = user.xpForNextLevel || 100;
         const progress = (xp / xpNeeded) * 100;
 
         // Update sidebar progress
@@ -765,6 +779,15 @@ class Sidebar {
         if (drawerLevelEl) drawerLevelEl.textContent = level;
         if (drawerXpEl) drawerXpEl.textContent = `${xp} / ${xpNeeded} XP`;
         if (drawerProgressBar) drawerProgressBar.style.width = `${Math.min(progress, 100)}%`;
+
+        // Update mobile drawer quick stats (streak, total XP, total solved)
+        const drawerStreak = document.getElementById('drawer-streak-count');
+        const drawerTotalXp = document.getElementById('drawer-total-xp');
+        const drawerTotalProblems = document.getElementById('drawer-total-problems');
+
+        if (drawerStreak) drawerStreak.textContent = user.currentStreak || 0;
+        if (drawerTotalXp) drawerTotalXp.textContent = user.xp || 0;
+        if (drawerTotalProblems) drawerTotalProblems.textContent = user.totalProblemsCorrect || 0;
 
         // Update link code in drawer
         const drawerLinkCode = document.getElementById('drawer-student-link-code-value');


### PR DESCRIPTION
- Replace 5-tab layout (Sessions/Tools/Chat/Theme/Profile) with 4 meaningful
  tabs: Explore, Chat, Progress, Menu
- Add Menu bottom sheet with Settings, Tools, Theme toggle, Share Progress,
  Feedback, and Resources — gives direct mobile settings access
- Enhance Progress drawer with streak counter, total XP, total problems
  solved, and quick-access Settings/Change Tutor buttons
- Fix sidebar.js loadProgress() to fetch user data when window.currentUser
  is unavailable (ES module scoping issue)
- Fix settings modal z-index (1006 → 2200) so it renders above mobile nav,
  drawers, and menu sheet
- Clean z-index stacking: nav(1800) < drawers(2000) < menu(2050) <
  more-tools(2100) < settings(2200) < modals(9999)

https://claude.ai/code/session_017fGUiGGvhkMq8iQdEMWpgJ