### PR TITLE
Update landing page imagery and add photo break sections

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1573,7 +1573,7 @@
     <section class="lp-photo-banner lp-reveal">
       <div class="lp-inner">
         <div class="lp-photo-banner-wrap">
-          <img src="/images/girlStudy.png" alt="Student using Mathmatix AI on her laptop" class="lp-photo-banner-img" />
+          <img src="/images/tableGirl.png" alt="Student smiling while using Mathmatix AI on her laptop" class="lp-photo-banner-img" />
           <div class="lp-photo-banner-overlay">
             <p class="lp-photo-banner-text">Built for the way kids actually learn.</p>
           </div>
@@ -1627,6 +1627,18 @@
             <input type="email" class="lp-waitlist-input" placeholder="Your email" required />
             <button type="submit" class="btn btn-primary lp-waitlist-btn">Join the Waitlist</button>
           </form>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── Photo Break: Mom Helping ──────────────────────── -->
+    <section class="lp-photo-banner lp-reveal">
+      <div class="lp-inner">
+        <div class="lp-photo-banner-wrap">
+          <img src="/images/homeworkMom.png" alt="Mother helping her daughter learn math with Mathmatix AI" class="lp-photo-banner-img" />
+          <div class="lp-photo-banner-overlay">
+            <p class="lp-photo-banner-text">Learning together, growing together.</p>
+          </div>
         </div>
       </div>
     </section>
@@ -1772,11 +1784,23 @@
       </div>
     </section>
 
+    <!-- ── Photo Break: Student at Desk ─────────────────── -->
+    <section class="lp-photo-banner lp-reveal">
+      <div class="lp-inner">
+        <div class="lp-photo-banner-wrap">
+          <img src="/images/deskBoy.png" alt="Student working independently on math with Mathmatix AI at his desk" class="lp-photo-banner-img" />
+          <div class="lp-photo-banner-overlay">
+            <p class="lp-photo-banner-text">Real students. Real progress. Every day.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <!-- ── Mission ──────────────────────────────────────── -->
     <section class="lp-mission lp-reveal">
       <div class="lp-mission-layout">
         <div class="lp-mission-photo">
-          <img src="/images/boyClassroom.png" alt="Student working on math in the classroom with Mathmatix AI" />
+          <img src="/images/homeworkDad.png" alt="Father and daughter working together on Mathmatix AI" />
         </div>
         <div class="lp-mission-content">
           <h2>Why I Built This</h2>
@@ -1891,6 +1915,18 @@
             <div class="lp-step-number">3</div>
             <h3>Track &amp; Grow</h3>
             <p>Watch progress unfold with dashboards, badges, skill maps, and weekly digests.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── Photo Break: Laptop Learning ─────────────────── -->
+    <section class="lp-photo-banner lp-reveal">
+      <div class="lp-inner">
+        <div class="lp-photo-banner-wrap">
+          <img src="/images/laptopBoy.png" alt="Student learning math on his laptop with Mathmatix AI" class="lp-photo-banner-img" />
+          <div class="lp-photo-banner-overlay">
+            <p class="lp-photo-banner-text">Anytime, anywhere — math help that never sleeps.</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
Updated the landing page with new hero imagery and added three new photo break sections to enhance visual storytelling and engagement throughout the page.

## Key Changes
- **Hero image replacement**: Changed the main photo banner image from `girlStudy.png` to `tableGirl.png` with updated alt text to reflect a smiling student
- **New photo break sections**: Added three new `lp-photo-banner` sections with accompanying imagery and messaging:
  - "Mom Helping" section after Progress Dashboards with message "Learning together, growing together."
  - "Student at Desk" section after classroom features with message "Real students. Real progress. Every day."
  - "Laptop Learning" section after pricing/features with message "Anytime, anywhere — math help that never sleeps."
- **Mission section imagery update**: Replaced `boyClassroom.png` with `homeworkDad.png` to show parent-child collaboration instead of solo classroom work

## Implementation Details
- All new sections follow the existing `lp-photo-banner` component structure with `lp-reveal` animation class
- Each photo break includes descriptive alt text for accessibility
- Overlay text messaging is strategically placed to reinforce key value propositions at different points in the user journey
- Changes maintain consistent styling and layout patterns with existing page sections

https://claude.ai/code/session_01WmBxKz5Zi3C8RXNaQUFWAN