### PR TITLE
Fix: use marked.js + KaTeX instead of broken markdown-it-texmath CDN

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -37,8 +37,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.21/dist/katex.min.css" crossorigin="anonymous" />
   <!-- Core libs (needed before first render) -->
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.21/dist/katex.min.js" crossorigin="anonymous"></script>
-  <script defer src="https://cdn.jsdelivr.net/npm/markdown-it@14.1.0/dist/markdown-it.min.js"></script>
-  <script defer src="https://cdn.jsdelivr.net/npm/markdown-it-texmath@1.0.0/texmath.min.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/marked@11.1.1/marked.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
   <script defer src="/vendor/mathlive/mathlive.min.js"></script>
 

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -502,52 +502,71 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     }
 
-    // ── Unified Markdown + Math renderer (KaTeX + markdown-it) ──
-    // markdown-it-texmath handles \(...\) and \[...\] in a single parse pass,
-    // so we no longer need protect/parse/restore or async MathJax typesetting.
+    // ── Unified Markdown + Math renderer (marked + KaTeX) ──
+    // Pipeline: protect LaTeX → marked.parse → restore with katex.renderToString
+    // KaTeX renders synchronously — no FOUC, no debounce, no post-processing.
 
-    let _md = null; // lazy-init'd markdown-it instance
-
-    function getMd() {
-        if (_md) return _md;
-        if (typeof markdownit === 'undefined' || typeof texmath === 'undefined' || typeof katex === 'undefined') {
-            return null; // libs not loaded yet
+    /**
+     * Render a KaTeX math string to HTML. Returns raw LaTeX on error.
+     */
+    function renderKatex(math, displayMode) {
+        if (typeof katex === 'undefined') return (displayMode ? '\\[' : '\\(') + math + (displayMode ? '\\]' : '\\)');
+        try {
+            return katex.renderToString(math, { displayMode, throwOnError: false, strict: false, trust: true });
+        } catch (e) {
+            return (displayMode ? '\\[' : '\\(') + math + (displayMode ? '\\]' : '\\)');
         }
-        _md = markdownit({ html: false, linkify: true, breaks: true })
-            .use(texmath, {
-                engine: katex,
-                delimiters: ['dollars', 'brackets', 'dollarsaliased'],
-                katexOptions: { throwOnError: false, strict: false, trust: true }
-            });
-        return _md;
     }
 
     /**
-     * Render markdown + LaTeX → sanitized HTML in one pass.
-     * KaTeX renders inline during the parse — no async, no FOUC.
+     * Render markdown + LaTeX → sanitized HTML.
+     * Protect LaTeX from markdown, parse markdown, restore LaTeX as rendered KaTeX HTML.
      */
     function renderMarkdownMath(text) {
-        const md = getMd();
-        if (!md) {
-            // Fallback if libs haven't loaded yet (shouldn't happen with defer)
-            return DOMPurify ? DOMPurify.sanitize(text) : text;
+        if (!text) return '';
+        if (typeof marked === 'undefined' || !marked.parse) {
+            return typeof DOMPurify !== 'undefined' ? DOMPurify.sanitize(text) : text;
         }
 
-        // Protect inline visual HTML from markdown parsing
+        let processedText = text;
+
+        // Protect LaTeX blocks from markdown parsing
+        const latexBlocks = [];
+
+        // Display math \[...\]
+        processedText = processedText.replace(/\\\[([\s\S]*?)\\\]/g, (match, math) => {
+            const index = latexBlocks.length;
+            latexBlocks.push({ math, display: true });
+            return `@@LATEX_BLOCK_${index}@@`;
+        });
+
+        // Inline math \(...\)
+        processedText = processedText.replace(/\\\(([\s\S]*?)\\\)/g, (match, math) => {
+            const index = latexBlocks.length;
+            latexBlocks.push({ math, display: false });
+            return `@@LATEX_BLOCK_${index}@@`;
+        });
+
+        // Protect inline visual HTML (SVG containers from inlineChatVisuals)
         const visualBlocks = [];
-        let protectedText = text;
-        protectedText = protectedText.replace(/<div class="icv-container[^"]*"[^>]*>[\s\S]*?<\/svg>\s*<\/div>/g, (match) => {
+        processedText = processedText.replace(/<div class="icv-container[^"]*"[^>]*>[\s\S]*?<\/svg>\s*<\/div>/g, (match) => {
             const index = visualBlocks.length;
             visualBlocks.push(match);
             return `@@VISUAL_BLOCK_${index}@@`;
         });
-        protectedText = protectedText.replace(/<div class="icv-container[^"]*"[^>]*>(?:(?!<svg)[\s\S])*?<\/div>\s*<\/div>/g, (match) => {
+        processedText = processedText.replace(/<div class="icv-container[^"]*"[^>]*>(?:(?!<svg)[\s\S])*?<\/div>\s*<\/div>/g, (match) => {
             const index = visualBlocks.length;
             visualBlocks.push(match);
             return `@@VISUAL_BLOCK_${index}@@`;
         });
 
-        let html = md.render(protectedText);
+        // Parse markdown
+        let html = marked.parse(processedText, { breaks: true });
+
+        // Restore LaTeX blocks — render to KaTeX HTML inline (synchronous)
+        latexBlocks.forEach((block, index) => {
+            html = html.replace(`@@LATEX_BLOCK_${index}@@`, renderKatex(block.math, block.display));
+        });
 
         // Restore visual blocks
         visualBlocks.forEach((block, index) => {
@@ -598,12 +617,12 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     /**
-     * Backward-compat: re-render any raw \(...\) or \[...\] in a DOM element.
+     * Re-render any raw \(...\) or \[...\] text in a DOM element using KaTeX.
      * Used by equation editor insertion and step reveals.
-     * With KaTeX this is synchronous — no debounce needed.
+     * Synchronous — no debounce needed.
      */
     function renderMathInElement(element) {
-        if (typeof katex === 'undefined') return;
+        if (typeof katex === 'undefined' || !element) return;
         // Find text nodes containing \( or \[ and render them
         const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT, null);
         const textNodes = [];
@@ -617,14 +636,8 @@ document.addEventListener("DOMContentLoaded", () => {
             const span = document.createElement('span');
             // Replace \(...\) and \[...\] with rendered KaTeX
             let html = text;
-            html = html.replace(/\\\[([\s\S]*?)\\\]/g, (_, math) => {
-                try { return katex.renderToString(math, { displayMode: true, throwOnError: false }); }
-                catch(e) { return _; }
-            });
-            html = html.replace(/\\\(([\s\S]*?)\\\)/g, (_, math) => {
-                try { return katex.renderToString(math, { displayMode: false, throwOnError: false }); }
-                catch(e) { return _; }
-            });
+            html = html.replace(/\\\[([\s\S]*?)\\\]/g, (_, math) => renderKatex(math, true));
+            html = html.replace(/\\\(([\s\S]*?)\\\)/g, (_, math) => renderKatex(math, false));
 
             if (html !== text) {
                 span.innerHTML = html;


### PR DESCRIPTION
markdown-it-texmath doesn't expose a browser global from CDN, causing getMd() to return null and fall through to a raw-text fallback — math was partially rendering via the DOM shim but also printing raw LaTeX.

Fix: restore marked.js (proven CDN-friendly) and render KaTeX inline during the protect/restore step. Pipeline is now:
  protect \(...\) → marked.parse() → restore with katex.renderToString()

This keeps the key win (synchronous KaTeX, no FOUC, no debounce) while using CDN-compatible libraries that actually work in the browser.

https://claude.ai/code/session_014A6sJs9DWAM5G3VqLzfaiF