### PR TITLE
Fix LaTeX rendering repetition in chat messages

### DIFF
--- a/public/css/base/chat.css
+++ b/public/css/base/chat.css
@@ -132,6 +132,18 @@
     border: 1px solid var(--clr-border);
 }
 
+/* KaTeX MathML — hidden (screen-reader only).
+   Local fallback in case the CDN katex.min.css fails to load. */
+.katex-mathml {
+    position: absolute !important;
+    clip: rect(1px, 1px, 1px, 1px);
+    padding: 0;
+    border: 0;
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+}
+
 /* KaTeX inline math — size to match surrounding text */
 .message .katex {
     font-size: 1.05em;

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -614,6 +614,14 @@ document.addEventListener("DOMContentLoaded", () => {
             const text = textNode.textContent;
             if (!text || (!text.includes('\\(') && !text.includes('\\['))) return;
 
+            // Skip text nodes inside already-rendered KaTeX elements to prevent
+            // double-rendering (e.g. annotation elements contain raw LaTeX source)
+            let ancestor = textNode.parentElement;
+            while (ancestor && ancestor !== element) {
+                if (ancestor.classList && ancestor.classList.contains('katex')) return;
+                ancestor = ancestor.parentElement;
+            }
+
             const span = document.createElement('span');
             // Replace \(...\) and \[...\] with rendered KaTeX
             let html = text;
@@ -1151,9 +1159,6 @@ document.addEventListener("DOMContentLoaded", () => {
                  playAudio(speakableText, tutor.voiceId, bubble.id);
             }
         }
-
-        // Re-render any raw \(...\) in the bubble (e.g. equation editor inserts)
-        renderMathInElement(bubble);
 
         // Update watermark visibility based on message count
         updateChatWatermark();


### PR DESCRIPTION
- Add local CSS fallback for .katex-mathml hiding so MathML content stays invisible even when the CDN katex.min.css fails to load. Without this, both the MathML and HTML representations display, causing formulas to appear duplicated.
- Remove redundant renderMathInElement(bubble) call in appendMessage; renderMarkdownMath already handles all LaTeX via markdown-it-texmath.
- Guard renderMathInElement against double-rendering by skipping text nodes that are inside already-rendered .katex elements.

https://claude.ai/code/session_01PYWpPvJqAfHBZaW1cgNdiA