### PR TITLE
Cap spotlight photos at 340px max height

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1143,11 +1143,13 @@
     .lp-spotlight-photo {
       border-radius: 14px;
       overflow: hidden;
+      max-height: 340px;
     }
 
     .lp-spotlight-photo img {
       width: 100%;
       height: 100%;
+      max-height: 340px;
       object-fit: cover;
       display: block;
       border-radius: 14px;


### PR DESCRIPTION
Images were too large and dominating the sections.

https://claude.ai/code/session_01WmBxKz5Zi3C8RXNaQUFWAN