### PR TITLE
Fix math rendering: allow KaTeX CSS/fonts in CSP and use verified tex…

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1731,7 +1731,7 @@ document.addEventListener("DOMContentLoaded", () => {
                                 }
                                 fullText = event.content;
                                 if (streamRef && streamRef.textNode) {
-                                    streamRef.textNode.textContent = event.content;
+                                    streamRef.textNode.innerHTML = renderMarkdownMath(event.content);
                                 }
                             } else if (event.type === 'complete' && event.data) {
                                 completeData = event.data;
@@ -1750,13 +1750,14 @@ document.addEventListener("DOMContentLoaded", () => {
                     showThinkingIndicator(false);
                 }
 
-                // Finalize the streaming message (adds audio button, reactions)
-                if (streamRef) {
-                    finalizeStreamingMessage(streamRef, fullText);
-                }
-
                 // Use the complete data from the server, or build minimal data from streamed text
                 data = completeData || { text: fullText };
+
+                // Finalize the streaming message with the verified text from
+                // the server (which ran normalizeLatex) instead of raw chunks
+                if (streamRef) {
+                    finalizeStreamingMessage(streamRef, data.text || fullText);
+                }
             } else {
                 // Non-streaming: parse JSON as before
                 data = await response.json();

--- a/server.js
+++ b/server.js
@@ -216,11 +216,13 @@ app.use(helmet({
         "'self'",
         "'unsafe-inline'", // Required for inline styles
         "https://cdnjs.cloudflare.com", // Font Awesome
+        "https://cdn.jsdelivr.net", // KaTeX CSS
         "https://fonts.googleapis.com" // Google Fonts
       ],
       fontSrc: [
         "'self'",
         "https://cdnjs.cloudflare.com", // Font Awesome
+        "https://cdn.jsdelivr.net", // KaTeX fonts
         "https://fonts.gstatic.com", // Google Fonts
         "data:" // Base64 fonts
       ],


### PR DESCRIPTION
…t for streamed messages

Three bugs were preventing math from rendering properly:

1. CSP style-src and font-src were missing cdn.jsdelivr.net, so the browser blocked KaTeX's CSS and fonts — math expressions showed unstyled or as raw \( \) delimiters instead of formatted math.

2. Streaming finalization used raw LLM chunks instead of the verified text from the server's complete event (which runs normalizeLatex), so any delimiter fixes from the verify stage were lost.

3. SSE replacement events set textContent instead of rendering through the markdown+KaTeX pipeline, showing raw text on reading-level simplification or streaming fallback.

https://claude.ai/code/session_01HBKuTTcoMZ3E1GPBne1TBz