### PR TITLE
Render math in starting point assessment questions via renderMarkdown…

### DIFF
--- a/public/js/floating-screener.js
+++ b/public/js/floating-screener.js
@@ -467,10 +467,13 @@ class FloatingScreener {
       questionNum.textContent = `Question ${problem.questionNumber}`;
     }
 
-    // Question content
+    // Question content — render through the full markdown+KaTeX pipeline
     const questionContent = document.getElementById('screener-question-content');
     if (questionContent) {
-      questionContent.innerHTML = this.formatProblemContent(problem.content);
+      const formatted = this.formatProblemContent(problem.content);
+      questionContent.innerHTML = window.renderMarkdownMath
+        ? window.renderMarkdownMath(formatted)
+        : formatted;
     }
 
     // Render options for MC questions
@@ -488,6 +491,13 @@ class FloatingScreener {
           </div>
         `;
       }).join('');
+
+      // Render math in option text through the full KaTeX pipeline
+      if (window.renderMarkdownMath) {
+        optionsContainer.querySelectorAll('.mc-option-text').forEach(span => {
+          span.innerHTML = window.renderMarkdownMath(span.textContent);
+        });
+      }
 
       // Add click handlers
       optionsContainer.querySelectorAll('.mc-option').forEach(option => {
@@ -525,10 +535,10 @@ class FloatingScreener {
       }
     }
 
-    // Typeset any math using KaTeX (via global shim)
+    // Fallback: catch any remaining raw \( \) in text nodes
     if (window.renderMathInElement) {
-      window.renderMathInElement(questionContent);
-      window.renderMathInElement(optionsContainer);
+      if (questionContent) window.renderMathInElement(questionContent);
+      if (optionsContainer) window.renderMathInElement(optionsContainer);
     }
   }
 

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1179,9 +1179,10 @@ document.addEventListener("DOMContentLoaded", () => {
         chatBox.scrollTop = chatBox.scrollHeight;
     }
 
-    // Expose appendMessage and renderMathInElement globally
+    // Expose appendMessage, renderMathInElement, and renderMarkdownMath globally
     window.appendMessage = appendMessage;
     window.renderMathInElement = renderMathInElement;
+    window.renderMarkdownMath = renderMarkdownMath;
 
     // Quick Reply Suggestion Chips (contextual help)
     const suggestionsContainer = document.getElementById('suggestion-chips-container');


### PR DESCRIPTION
…Math

The screener's renderProblem() was using renderMathInElement as a post-processing step on DOM text nodes, which silently did nothing when KaTeX wasn't ready. Now question content and multiple-choice options are rendered through the full renderMarkdownMath pipeline (markdown parsing + KaTeX + DOMPurify) for reliable math display.

Also exposes renderMarkdownMath globally so the floating screener and other components can use the same rendering path as chat messages.

https://claude.ai/code/session_01HBKuTTcoMZ3E1GPBne1TBz