### PR TITLE
Make chat message window larger by tightening spacing

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -470,7 +470,7 @@
     <div id="file-grid-container" class="file-grid-container"></div>
 
     <!-- Compact Input Row: Suggestions + Toolbar -->
-    <div style="display: flex; align-items: center; gap: 12px; padding: 8px 12px; flex-wrap: wrap;">
+    <div style="display: flex; align-items: center; gap: 8px; padding: 4px 12px; flex-wrap: wrap;">
       <!-- Quick Reply Suggestions (contextual chips) -->
       <div id="suggestion-chips-container" style="
         display: none;

--- a/public/css/base/chat.css
+++ b/public/css/base/chat.css
@@ -8,8 +8,8 @@
 #chat-messages-container {
     display: flex;
     flex-direction: column;
-    gap: var(--space-3);
-    padding: var(--space-4);
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
     overflow-y: auto;
     flex-grow: 1;
     background-color: var(--clr-bg-subtle);
@@ -31,7 +31,7 @@
 
 .message {
     max-width: 82%;
-    padding: 12px 16px;
+    padding: 10px 14px;
     border-radius: var(--radius-lg);
     line-height: var(--line-height-normal);
     word-wrap: break-word;
@@ -288,19 +288,19 @@
 #input-container {
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
+  gap: var(--space-1);
   border-top: 1px solid var(--clr-border);
-  padding: var(--space-3) 0 0;
+  padding: var(--space-2) 0 0;
   flex-shrink: 0;
   background: var(--clr-bg-light);
 }
 
 .chat-disclaimer {
   text-align: center;
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   color: var(--clr-text-dim);
-  margin: var(--space-1) 0 var(--space-2);
-  line-height: 1.4;
+  margin: 2px 0 0;
+  line-height: 1.3;
 }
 
 .chat-disclaimer i {
@@ -326,7 +326,7 @@
 
 #user-input {
   width: 100%;
-  min-height: 52px;
+  min-height: 44px;
   max-height: 200px;
   overflow-y: auto;
   padding: 12px 16px;


### PR DESCRIPTION
- Reduce message container padding (16px → 8px vertical, 12px horizontal)
- Reduce gap between messages (12px → 8px)
- Shrink input container gap and padding
- Lower input field min-height (52px → 44px)
- Compact the toolbar/chips row padding
- Trim message bubble padding (12x16 → 10x14)
- Minimize disclaimer margin and font size

Combined these reclaim ~40-50px of vertical space for more visible chat messages.

https://claude.ai/code/session_01WmBxKz5Zi3C8RXNaQUFWAN