### PR TITLE
Remove Claude/Anthropic support, standardize on OpenAI

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "node": ">=20.14"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.71.2",
     "@aws-sdk/client-s3": "^3.991.0",
     "archiver": "^7.0.1",
     "axios": "^1.13.2",

--- a/routes/chatWithFile.js
+++ b/routes/chatWithFile.js
@@ -16,7 +16,7 @@ const BRAND_CONFIG = require('../utils/brand');
 const { getTutorsToUnlock } = require('../utils/unlockTutors');
 const pdfOcr = require('../utils/pdfOcr');
 const { validateUpload, uploadRateLimiter } = require('../middleware/uploadSecurity');
-const { anthropic, openai, retryWithExponentialBackoff } = require('../utils/openaiClient');
+const { openai, retryWithExponentialBackoff } = require('../utils/openaiClient');
 const { applyWorksheetGuard, filterAnswerKeyResponse } = require('../utils/worksheetGuard');
 const { verify: pipelineVerify } = require('../utils/pipeline');
 
@@ -174,93 +174,23 @@ router.post('/',
             visionUserMessage
         ];
 
-        // Call LLM with vision support (Claude primary, OpenAI fallback)
-        const isClaudeModel = PRIMARY_CHAT_MODEL.startsWith('claude-');
+        // Call OpenAI vision API
         let aiResponseText;
         const aiStartTime = Date.now(); // Track AI processing time (server-side, for fair billing)
 
-        if (isClaudeModel && anthropic) {
-            // PRIMARY: Try Claude vision API
-            try {
-                console.log(`[chatWithFile] Calling Claude vision API (${PRIMARY_CHAT_MODEL})...`);
+        console.log(`[chatWithFile] Calling OpenAI vision API (${PRIMARY_CHAT_MODEL})...`);
 
-                // Convert to Claude format: extract system, convert images
-                const systemMessage = messagesForAI.find(m => m.role === 'system')?.content;
-                const userMessages = messagesForAI.filter(m => m.role !== 'system');
+        const completion = await retryWithExponentialBackoff(() =>
+            openai.chat.completions.create({
+                model: PRIMARY_CHAT_MODEL,
+                messages: messagesForAI,
+                temperature: 0.7,
+                max_completion_tokens: 1500
+            })
+        );
 
-                // Convert image formats from OpenAI to Claude
-                const claudeContent = [];
-                for (const item of visionUserMessage.content) {
-                    if (item.type === 'text') {
-                        claudeContent.push({ type: 'text', text: item.text });
-                    } else if (item.type === 'image_url') {
-                        // Extract base64 data from data URL
-                        const match = item.image_url.url.match(/^data:image\/(.*?);base64,(.*)$/);
-                        if (match) {
-                            const [, mediaType, base64Data] = match;
-                            claudeContent.push({
-                                type: 'image',
-                                source: {
-                                    type: 'base64',
-                                    media_type: `image/${mediaType}`,
-                                    data: base64Data
-                                }
-                            });
-                        }
-                    }
-                }
-
-                const completion = await retryWithExponentialBackoff(() =>
-                    anthropic.messages.create({
-                        model: PRIMARY_CHAT_MODEL,
-                        max_tokens: 1500,
-                        temperature: 0.7,
-                        system: systemMessage,
-                        messages: [
-                            ...userMessages.slice(0, -1).map(m => ({ role: m.role, content: m.content })),
-                            { role: 'user', content: claudeContent }
-                        ]
-                    })
-                );
-
-                aiResponseText = completion.content[0]?.text?.trim() || "I'm not sure how to respond.";
-                console.log('[chatWithFile] Received response from Claude');
-
-            } catch (claudeError) {
-                console.warn(`[chatWithFile] Claude failed:`, claudeError.message);
-                console.warn('[chatWithFile] Falling back to GPT-4o-mini...');
-
-                // FALLBACK: Try OpenAI vision API
-                const fallbackModel = 'gpt-4o-mini';
-                const completion = await retryWithExponentialBackoff(() =>
-                    openai.chat.completions.create({
-                        model: fallbackModel,
-                        messages: messagesForAI,
-                        temperature: 0.7,
-                        max_tokens: 1500
-                    })
-                );
-
-                aiResponseText = completion.choices[0]?.message?.content?.trim() || "I'm not sure how to respond.";
-                console.log('[chatWithFile] Received response from GPT-4o-mini (fallback)');
-            }
-        } else {
-            // OpenAI model requested or no Anthropic key
-            const model = isClaudeModel ? 'gpt-4o-mini' : PRIMARY_CHAT_MODEL;
-            console.log(`[chatWithFile] Calling OpenAI vision API (${model})...`);
-
-            const completion = await retryWithExponentialBackoff(() =>
-                openai.chat.completions.create({
-                    model: model,
-                    messages: messagesForAI,
-                    temperature: 0.7,
-                    max_tokens: 1500
-                })
-            );
-
-            aiResponseText = completion.choices[0]?.message?.content?.trim() || "I'm not sure how to respond.";
-            console.log('[chatWithFile] Received response from OpenAI');
-        }
+        aiResponseText = completion.choices[0]?.message?.content?.trim() || "I'm not sure how to respond.";
+        console.log('[chatWithFile] Received response from OpenAI');
 
         // Run pipeline verify stage (anti-cheat + reading level + LaTeX normalization + tag extraction)
         try {

--- a/routes/courseChat.js
+++ b/routes/courseChat.js
@@ -241,16 +241,10 @@ router.post('/', async (req, res) => {
             try {
                 const stream = await callLLMStream(PRIMARY_CHAT_MODEL, messagesForAI, { temperature: 0.7, max_tokens: 1500 });
                 let buffer = '';
-                const isClaudeModel = PRIMARY_CHAT_MODEL.startsWith('claude-');
 
                 for await (const chunk of stream) {
                     if (clientDisconnected) break;
-                    let content = '';
-                    if (isClaudeModel) {
-                        if (chunk.type === 'content_block_delta' && chunk.delta?.text) content = chunk.delta.text;
-                    } else {
-                        content = chunk.choices[0]?.delta?.content || '';
-                    }
+                    const content = chunk.choices[0]?.delta?.content || '';
                     if (content) {
                         buffer += content;
                         res.write(`data: ${JSON.stringify({ type: 'chunk', content })}\n\n`);

--- a/routes/gradeWork.js
+++ b/routes/gradeWork.js
@@ -397,6 +397,18 @@ router.post('/',
             });
         }
 
+        // Detect AI service billing/capacity errors and return 503
+        const errMsg = (error.message || '').toLowerCase();
+        const errStatus = error.status || error.statusCode;
+        const isBillingError = errMsg.includes('credit balance') || errMsg.includes('billing') || errMsg.includes('quota');
+        const isAuthError = (errStatus === 401 || errStatus === 403) && (errMsg.includes('api') || errMsg.includes('key'));
+        if (isBillingError || isAuthError) {
+            return res.status(503).json({
+                success: false,
+                message: 'Our grading service is temporarily unavailable. Please try again later.'
+            });
+        }
+
         res.status(500).json({
             success: false,
             message: 'Failed to analyze work. Please try again.',

--- a/server.js
+++ b/server.js
@@ -27,23 +27,7 @@ if (missingVars.length > 0) {
   process.exit(1);
 }
 
-// --- ANTHROPIC API KEY VALIDATION (Environment-Specific) ---
 const isProduction = process.env.NODE_ENV === 'production';
-const hasAnthropicKey = isProduction
-  ? !!process.env.ANTHROPIC_API_KEY_PROD
-  : !!process.env.ANTHROPIC_API_KEY_DEV;
-const hasLegacyKey = !!process.env.ANTHROPIC_API_KEY;
-
-if (!hasAnthropicKey && !hasLegacyKey) {
-  logger.warn('⚠️  WARNING: No Anthropic API key found - Claude models will not be available');
-  logger.warn(`⚠️  Set ANTHROPIC_API_KEY_${isProduction ? 'PROD' : 'DEV'} in your .env file`);
-} else if (!hasAnthropicKey && hasLegacyKey) {
-  logger.warn('⚠️  WARNING: Using legacy ANTHROPIC_API_KEY (deprecated)');
-  logger.warn(`⚠️  Recommended: Migrate to ANTHROPIC_API_KEY_PROD and ANTHROPIC_API_KEY_DEV`);
-  logger.warn('⚠️  This allows separate cost tracking for development vs production usage');
-} else {
-  logger.info(`✅ Anthropic API key configured for ${isProduction ? 'PRODUCTION' : 'DEVELOPMENT'} environment`);
-}
 
 // --- 2. IMPORTS ---
 const express = require("express");
@@ -234,7 +218,6 @@ app.use(helmet({
       ],
       connectSrc: [
         "'self'",
-        "https://api.anthropic.com", // Claude API
         "https://api.openai.com", // OpenAI API
         "https://api.mathpix.com", // Mathpix OCR
         "https://api.elevenlabs.io", // ElevenLabs TTS

--- a/utils/llmGateway.js
+++ b/utils/llmGateway.js
@@ -1,23 +1,17 @@
 /**
  * LLM GATEWAY - Unified AI Brain for Mathmatix
  *
- * CTO REVIEW FIX: Centralized interface for ALL AI interactions
+ * Centralized interface for ALL AI interactions.
+ * Uses OpenAI (GPT) models exclusively.
  *
- * PROBLEM: Routes were using different LLM clients inconsistently:
- * - chat.js used callLLM() from openaiClient.js
- * - gradeWork.js used raw axios POST to OpenAI
- * - Different prompts, different error handling, inconsistent persona
- *
- * SOLUTION: Single gateway that:
  * - Ensures consistent tutor persona across all routes
  * - Handles chat, vision, streaming, embeddings
  * - Centralizes retry logic and error handling
- * - Makes it easy to swap LLM providers in the future
  *
  * @module llmGateway
  */
 
-const { openai, anthropic, retryWithExponentialBackoff, callLLM, callLLMStream, generateEmbedding } = require('./openaiClient');
+const { openai, retryWithExponentialBackoff, callLLM, callLLMStream, generateEmbedding } = require('./openaiClient');
 const { generateSystemPrompt } = require('./prompt');
 const { createAnonymizationContext, anonymizeMessages, anonymizeSystemPrompt, rehydrateResponse, logAnonymizationEvent } = require('./piiAnonymizer');
 
@@ -27,7 +21,7 @@ const { createAnonymizationContext, anonymizeMessages, anonymizeSystemPrompt, re
 
 const DEFAULT_MODELS = {
     chat: 'gpt-4o-mini',                     // Fast, cost-effective teaching model
-    grading: 'claude-3-5-sonnet-20241022',   // Claude vision: superior handwriting recognition
+    grading: 'gpt-4o',                       // GPT-4o vision for handwriting recognition
     reasoning: 'gpt-4o-mini',                // Fast reasoning
     embedding: 'text-embedding-3-small'      // OpenAI embeddings (specialized task)
 };
@@ -180,82 +174,39 @@ async function gradeWithVision(context, options = {}) {
 
     console.log(`[LLMGateway] Calling vision model: ${model}`);
 
-    const isClaudeModel = model.startsWith('claude-');
-
     try {
-        if (isClaudeModel && anthropic) {
-            // Claude vision API (superior image analysis)
-            // Extract base64 data from data URL
-            const base64Match = imageDataUrl.match(/^data:image\/(.*?);base64,(.*)$/);
-            if (!base64Match) {
-                throw new Error('Invalid image data URL format');
-            }
-            const [, mediaType, base64Data] = base64Match;
+        // Use max_completion_tokens for newer gpt-4o/gpt-5 models
+        const tokenParam = (model.includes('gpt-5') || model.includes('gpt-4o'))
+            ? { max_completion_tokens: maxTokens }
+            : { max_tokens: maxTokens };
 
-            const completion = await retryWithExponentialBackoff(() =>
-                anthropic.messages.create({
-                    model: model,
-                    max_tokens: maxTokens,
-                    temperature: temperature,
-                    messages: [
-                        {
-                            role: 'user',
-                            content: [
-                                {
-                                    type: 'image',
-                                    source: {
-                                        type: 'base64',
-                                        media_type: `image/${mediaType}`,
-                                        data: base64Data
-                                    }
-                                },
-                                {
-                                    type: 'text',
-                                    text: anonymizedPrompt
+        const completion = await retryWithExponentialBackoff(() =>
+            openai.chat.completions.create({
+                model: model,
+                messages: [
+                    {
+                        role: 'user',
+                        content: [
+                            {
+                                type: 'text',
+                                text: anonymizedPrompt
+                            },
+                            {
+                                type: 'image_url',
+                                image_url: {
+                                    url: imageDataUrl,
+                                    detail: 'high'
                                 }
-                            ]
-                        }
-                    ]
-                })
-            );
+                            }
+                        ]
+                    }
+                ],
+                ...tokenParam,
+                temperature: temperature
+            })
+        );
 
-            return rehydrateResponse(completion.content[0].text, user?.firstName);
-
-        } else {
-            // OpenAI vision API
-            // Use max_completion_tokens for newer gpt-4o/gpt-5 models
-            const tokenParam = (model.includes('gpt-5') || model.includes('gpt-4o'))
-                ? { max_completion_tokens: maxTokens }
-                : { max_tokens: maxTokens };
-
-            const completion = await retryWithExponentialBackoff(() =>
-                openai.chat.completions.create({
-                    model: model,
-                    messages: [
-                        {
-                            role: 'user',
-                            content: [
-                                {
-                                    type: 'text',
-                                    text: anonymizedPrompt
-                                },
-                                {
-                                    type: 'image_url',
-                                    image_url: {
-                                        url: imageDataUrl,
-                                        detail: 'high'
-                                    }
-                                }
-                            ]
-                        }
-                    ],
-                    ...tokenParam,
-                    temperature: temperature
-                })
-            );
-
-            return rehydrateResponse(completion.choices[0].message.content, user?.firstName);
-        }
+        return rehydrateResponse(completion.choices[0].message.content, user?.firstName);
 
     } catch (error) {
         console.error('[LLMGateway] Vision grading failed:', error.message);

--- a/utils/openaiClient.js
+++ b/utils/openaiClient.js
@@ -1,37 +1,11 @@
-// utils/openaiClient.js - MODIFIED (Claude primary, GPT fallback, with retry logic)
+// utils/openaiClient.js - OpenAI-only LLM client with retry logic
 
 const OpenAI = require("openai");
-const Anthropic = require("@anthropic-ai/sdk"); // For Claude fallback
 
 // Initialize OpenAI client
 const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY
 });
-
-// Initialize Anthropic (Claude) client, with environment-specific API keys
-let anthropic = null;
-const isProduction = process.env.NODE_ENV === 'production';
-
-// Select appropriate API key based on environment
-// Legacy ANTHROPIC_API_KEY is used as fallback for both environments
-const anthropicApiKey = isProduction
-    ? (process.env.ANTHROPIC_API_KEY_PROD || process.env.ANTHROPIC_API_KEY)   // Production: PROD key, fallback to legacy
-    : (process.env.ANTHROPIC_API_KEY_DEV || process.env.ANTHROPIC_API_KEY);   // Development: DEV key, fallback to legacy
-
-if (anthropicApiKey) {
-    anthropic = new Anthropic({
-        apiKey: anthropicApiKey,
-    });
-    const keyType = isProduction ? 'PRODUCTION' : 'DEVELOPMENT';
-    const keySource = isProduction
-        ? (process.env.ANTHROPIC_API_KEY_PROD ? 'ANTHROPIC_API_KEY_PROD' : 'ANTHROPIC_API_KEY (fallback)')
-        : (process.env.ANTHROPIC_API_KEY_DEV ? 'ANTHROPIC_API_KEY_DEV' : 'ANTHROPIC_API_KEY (fallback)');
-
-    console.log(`✅ [Init] Anthropic client initialized successfully (${keyType} mode using ${keySource})`);
-} else {
-    console.warn('⚠️  [Init] No Anthropic API key found - Claude models will not be available');
-    console.warn('⚠️  [Init] Set ANTHROPIC_API_KEY_PROD (production) or ANTHROPIC_API_KEY_DEV (development)');
-}
 
 // Log OpenAI client status
 if (process.env.OPENAI_API_KEY) {
@@ -41,7 +15,7 @@ if (process.env.OPENAI_API_KEY) {
 }
 
 
-// Utility for exponential backoff and retry (for both OpenAI and Anthropic)
+// Utility for exponential backoff and retry
 async function retryWithExponentialBackoff(fn, retries = 5, delay = 1000) {
     let attempts = 0;
     while (attempts < retries) {
@@ -75,205 +49,85 @@ async function retryWithExponentialBackoff(fn, retries = 5, delay = 1000) {
 }
 
 /**
- * Centralized function to call the LLM with intelligent routing.
- * PRIMARY: Claude Sonnet 3.5 (best teaching & reasoning)
- * FALLBACK: GPT-4o-mini (fast & cheap backup)
- * @param {string} model - The model name (e.g., "claude-3-5-sonnet-20241022", "gpt-4o-mini")
+ * Centralized function to call the LLM via OpenAI.
+ * @param {string} model - The model name (e.g., "gpt-4o-mini", "gpt-4o")
  * @param {Array<Object>} messages - Array of message objects for the AI.
  * @param {Object} options - Additional options like temperature, max_tokens.
  * @returns {Promise<Object>} The completion object from the AI.
  */
 async function callLLM(model, messages, options = {}) {
-    // Detect if this is a Claude or OpenAI model
-    const isClaudeModel = model.startsWith('claude-');
+    try {
+        console.log(`LOG: Calling OpenAI model (${model})`);
 
-    if (isClaudeModel && anthropic) {
-        // PRIMARY PATH: Try Claude first
-        try {
-            console.log(`LOG: Calling primary model (${model})`);
+        // CRITICAL FIX: Newer OpenAI models (gpt-4o, gpt-5, etc.) require max_completion_tokens
+        // Legacy models still use max_tokens
+        const tokenParam = options.max_tokens ?
+            (model.includes('gpt-5') || model.includes('gpt-4o') ?
+                { max_completion_tokens: options.max_tokens } :
+                { max_tokens: options.max_tokens })
+            : {};
 
-            // Convert messages to Anthropic format
-            const anthropicMessages = messages.filter(msg => msg.role !== 'system').map(msg => ({
-                role: msg.role === 'assistant' ? 'assistant' : 'user',
-                content: msg.content
-            }));
+        // CRITICAL FIX: Some models (like gpt-5-nano) only support default temperature
+        // Don't pass temperature for these models
+        const temperatureParam = model.includes('nano') ?
+            {} :
+            { temperature: options.temperature || 0.7 };
 
-            // Extract system message
-            const systemMessage = messages.find(msg => msg.role === 'system')?.content;
-
-            const completion = await retryWithExponentialBackoff(() =>
-                anthropic.messages.create({
-                    model: model,
-                    max_tokens: options.max_tokens || 4000, // Claude supports up to 8k, use 4k default
-                    temperature: options.temperature || 0.7,
-                    messages: anthropicMessages,
-                    system: systemMessage
-                })
-            );
-
-            // Convert to OpenAI format for consistency
-            return {
-                choices: [{
-                    message: {
-                        content: completion.content[0].text,
-                        role: 'assistant'
-                    }
-                }]
-            };
-
-        } catch (claudeError) {
-            console.error(`❌ ERROR: Primary model (${model}) failed`);
-            console.error('Claude error details:', {
-                message: claudeError.message,
-                status: claudeError.status,
-                type: claudeError.type,
-                error: claudeError.error,
-                stack: claudeError.stack?.split('\n').slice(0, 3).join('\n')
-            });
-            console.warn('⚠️  Attempting fallback to GPT-4o-mini...');
-
-            // FALLBACK: Try GPT-4o-mini
-            try {
-                const fallbackModel = 'gpt-4o-mini';
-                console.log(`LOG: Calling fallback model (${fallbackModel})`);
-
-                // CRITICAL FIX: Use max_completion_tokens for gpt-4o models
-                const tokenParam = options.max_tokens ?
-                    { max_completion_tokens: options.max_tokens } : {};
-
-                const completion = await retryWithExponentialBackoff(() =>
-                    openai.chat.completions.create({
-                        model: fallbackModel,
-                        messages: messages,
-                        temperature: options.temperature || 0.7,
-                        ...tokenParam,
-                        stream: options.stream || false,
-                    })
-                );
-                console.log('✅ Fallback to GPT succeeded');
-                return completion;
-            } catch (gptError) {
-                console.error("❌ ERROR: Fallback model (GPT-4o-mini) also failed");
-                console.error('GPT error details:', {
-                    message: gptError.message,
-                    status: gptError.status,
-                    type: gptError.type,
-                    error: gptError.error,
-                    code: gptError.code,
-                    stack: gptError.stack?.split('\n').slice(0, 3).join('\n')
-                });
-                throw new Error(`Both primary (Claude) and fallback (GPT) AI models failed. Claude: ${claudeError.message}, GPT: ${gptError.message}`);
-            }
-        }
-
-    } else {
-        // OpenAI model requested (or no Anthropic key)
-        try {
-            console.log(`LOG: Calling OpenAI model (${model})`);
-
-            // CRITICAL FIX: Newer OpenAI models (gpt-4o, gpt-5, etc.) require max_completion_tokens
-            // Legacy models still use max_tokens
-            const tokenParam = options.max_tokens ?
-                (model.includes('gpt-5') || model.includes('gpt-4o') ?
-                    { max_completion_tokens: options.max_tokens } :
-                    { max_tokens: options.max_tokens })
-                : {};
-
-            // CRITICAL FIX: Some models (like gpt-5-nano) only support default temperature
-            // Don't pass temperature for these models
-            const temperatureParam = model.includes('nano') ?
-                {} :
-                { temperature: options.temperature || 0.7 };
-
-            const completion = await retryWithExponentialBackoff(() =>
-                openai.chat.completions.create({
-                    model: model,
-                    messages: messages,
-                    ...temperatureParam,
-                    ...tokenParam,
-                    stream: options.stream || false,
-                })
-            );
-            return completion;
-        } catch (openAiError) {
-            console.error(`ERROR: OpenAI model (${model}) failed:`, openAiError.message);
-            throw openAiError;
-        }
+        const completion = await retryWithExponentialBackoff(() =>
+            openai.chat.completions.create({
+                model: model,
+                messages: messages,
+                ...temperatureParam,
+                ...tokenParam,
+                stream: options.stream || false,
+            })
+        );
+        return completion;
+    } catch (openAiError) {
+        console.error(`ERROR: OpenAI model (${model}) failed:`, openAiError.message);
+        throw openAiError;
     }
 }
 
 /**
  * Streaming version of callLLM - returns a stream object for real-time responses
- * Supports both Claude and OpenAI streaming
- * @param {string} model - The model name (e.g., "claude-3-5-sonnet-20241022", "gpt-4o-mini")
+ * @param {string} model - The model name (e.g., "gpt-4o-mini", "gpt-4o")
  * @param {Array<Object>} messages - Array of message objects for the AI
  * @param {Object} options - Additional options like temperature, max_tokens
  * @returns {Promise<Stream>} The stream object
  */
 async function callLLMStream(model, messages, options = {}) {
-    const isClaudeModel = model.startsWith('claude-');
+    try {
+        console.log(`LOG: Calling OpenAI streaming (${model})`);
 
-    if (isClaudeModel && anthropic) {
-        // Claude streaming
-        try {
-            console.log(`LOG: Calling Claude streaming (${model})`);
+        // CRITICAL FIX: Newer OpenAI models require max_completion_tokens
+        const tokenParam = options.max_tokens ?
+            (model.includes('gpt-5') || model.includes('gpt-4o') ?
+                { max_completion_tokens: options.max_tokens } :
+                { max_tokens: options.max_tokens })
+            : {};
 
-            // Convert messages to Anthropic format
-            const anthropicMessages = messages.filter(msg => msg.role !== 'system').map(msg => ({
-                role: msg.role === 'assistant' ? 'assistant' : 'user',
-                content: msg.content
-            }));
+        // CRITICAL FIX: Some models (like gpt-5-nano) only support default temperature
+        const temperatureParam = model.includes('nano') ?
+            {} :
+            { temperature: options.temperature || 0.7 };
 
-            const systemMessage = messages.find(msg => msg.role === 'system')?.content;
-
-            const stream = await anthropic.messages.create({
-                model: model,
-                max_tokens: options.max_tokens || 4000,
-                temperature: options.temperature || 0.7,
-                messages: anthropicMessages,
-                system: systemMessage,
-                stream: true
-            });
-
-            return stream;
-        } catch (claudeError) {
-            console.error(`ERROR: Claude streaming failed for ${model}:`, claudeError.message);
-            throw claudeError;
-        }
-    } else {
-        // OpenAI streaming
-        try {
-            console.log(`LOG: Calling OpenAI streaming (${model})`);
-
-            // CRITICAL FIX: Newer OpenAI models require max_completion_tokens
-            const tokenParam = options.max_tokens ?
-                (model.includes('gpt-5') || model.includes('gpt-4o') ?
-                    { max_completion_tokens: options.max_tokens } :
-                    { max_tokens: options.max_tokens })
-                : {};
-
-            // CRITICAL FIX: Some models (like gpt-5-nano) only support default temperature
-            const temperatureParam = model.includes('nano') ?
-                {} :
-                { temperature: options.temperature || 0.7 };
-
-            const stream = await openai.chat.completions.create({
-                model: model,
-                messages: messages,
-                ...temperatureParam,
-                ...tokenParam,
-                stream: true,
-            });
-            return stream;
-        } catch (openAiError) {
-            console.error(`ERROR: OpenAI streaming failed for ${model}:`, openAiError.message);
-            throw openAiError;
-        }
+        const stream = await openai.chat.completions.create({
+            model: model,
+            messages: messages,
+            ...temperatureParam,
+            ...tokenParam,
+            stream: true,
+        });
+        return stream;
+    } catch (openAiError) {
+        console.error(`ERROR: OpenAI streaming failed for ${model}:`, openAiError.message);
+        throw openAiError;
     }
 }
 
 /**
- * DIRECTIVE 3: Generate text embedding using OpenAI's text-embedding-3-small
+ * Generate text embedding using OpenAI's text-embedding-3-small
  * @param {string} text - The text to embed
  * @returns {Promise<Array<number>>} The embedding vector
  */
@@ -308,12 +162,10 @@ async function generateEmbedding(text) {
     }
 }
 
-// Export the OpenAI client (still useful for direct access if needed) and the retry utility
 module.exports = {
-    openai, // Renamed from 'openai' to 'openaiClient' in some previous versions, but keep original if it was 'openai'
-    anthropic,
+    openai,
     retryWithExponentialBackoff,
-    callLLM, // Centralized LLM call function (non-streaming)
-    callLLMStream, // Streaming version for real-time responses
-    generateEmbedding // DIRECTIVE 3: Vector embedding generation
+    callLLM,
+    callLLMStream,
+    generateEmbedding
 };

--- a/utils/pipeline/generate.js
+++ b/utils/pipeline/generate.js
@@ -252,7 +252,6 @@ async function generateStreaming(model, messages, llmOptions, res) {
   let fullResponse = '';
   try {
     const stream = await callLLMStream(model, messages, llmOptions);
-    const isClaudeModel = model.startsWith('claude-');
     let clientDisconnected = false;
 
     res.req.on('close', () => { clientDisconnected = true; });
@@ -260,14 +259,7 @@ async function generateStreaming(model, messages, llmOptions, res) {
     for await (const chunk of stream) {
       if (clientDisconnected) break;
 
-      let content = '';
-      if (isClaudeModel) {
-        if (chunk.type === 'content_block_delta' && chunk.delta?.text) {
-          content = chunk.delta.text;
-        }
-      } else {
-        content = chunk.choices[0]?.delta?.content || '';
-      }
+      const content = chunk.choices[0]?.delta?.content || '';
 
       if (content) {
         fullResponse += content;


### PR DESCRIPTION
## Summary
This PR removes all Claude/Anthropic API integration and standardizes the application to use OpenAI models exclusively. The codebase previously supported dual LLM providers with Claude as primary and GPT as fallback; this change simplifies the architecture by removing that complexity.

## Key Changes

- **Removed Anthropic SDK dependency** from `package.json` and all imports across the codebase
- **Simplified `openaiClient.js`**: Removed Claude initialization logic, environment-specific API key handling, and dual-provider routing. The `callLLM()` and `callLLMStream()` functions now exclusively use OpenAI
- **Updated `llmGateway.js`**: Changed grading model from `claude-3-5-sonnet-20241022` to `gpt-4o` for vision tasks; removed Claude-specific message format conversion
- **Cleaned up `chatWithFile.js`**: Removed Claude vision API fallback logic and message format conversion; now uses OpenAI vision API directly
- **Updated `server.js`**: Removed Anthropic API key validation and environment-specific configuration checks; removed Anthropic API domain from CSP headers
- **Simplified streaming logic** in `pipeline/generate.js` and `courseChat.js`: Removed conditional chunk parsing for Claude vs OpenAI stream formats
- **Added billing/auth error handling** in `gradeWork.js` to detect and report service capacity issues with 503 status

## Implementation Details

- All LLM calls now route through OpenAI's API exclusively
- Vision grading tasks use `gpt-4o` instead of Claude Sonnet for handwriting recognition
- Retry logic and exponential backoff remain unchanged and continue to apply to all OpenAI calls
- Error handling simplified by removing dual-provider error recovery paths
- CSP configuration updated to remove unnecessary Anthropic API domain allowlist

https://claude.ai/code/session_01Jkgo6LRZqrGBJft3u1ShBN