### PR TITLE
Fix JSON parse error in gradeWork when AI returns LaTeX backslashes

### DIFF
--- a/routes/gradeWork.js
+++ b/routes/gradeWork.js
@@ -145,6 +145,10 @@ function parseAnalysisResponse(raw) {
         jsonStr = fenceMatch[1].trim();
     }
 
+    // LLMs often produce bare LaTeX backslashes (\(, \frac, \[, etc.)
+    // that are invalid JSON escapes. Fix them before parsing.
+    jsonStr = jsonStr.replace(/\\(?!["\\/bfnrtu])/g, '\\\\');
+
     const parsed = JSON.parse(jsonStr);
 
     if (!parsed.problems || !Array.isArray(parsed.problems)) {


### PR DESCRIPTION
The AI analysis prompt tells the model to use LaTeX (e.g. \(x = 3\), \frac{1}{2}) in its feedback, but LLMs don't reliably double-escape backslashes for JSON. Characters like \( and \f are invalid JSON escape sequences, causing "Bad escaped character in JSON at position 294".

Adds a sanitization step in parseAnalysisResponse that escapes any bare backslash not followed by a valid JSON escape character (", \, /, b, f, n, r, t, u) before calling JSON.parse.

https://claude.ai/code/session_01Jkgo6LRZqrGBJft3u1ShBN