### PR TITLE
Implement per-session demo cloning for concurrent user isolation

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -4,7 +4,7 @@
 
 const passport = require("passport");
 const rateLimit = require('express-rate-limit');
-const { resetDemoAccount } = require('../utils/demoReset');
+const { cleanupDemoClone } = require('../utils/demoClone');
 
 /**
  * Checks if a user is logged in and their session data is valid.
@@ -129,7 +129,7 @@ function isAuthorizedForLeaderboard(req, res, next) {
 function handleLogout(req, res, next) {
   // Capture demo session info before logout destroys the session
   const isDemo = !!(req.session && req.session.isDemo);
-  const demoProfileId = req.session?.demoProfileId || null;
+  const cloneSessionId = req.session?.cloneSessionId || null;
 
   req.logout(function(err) {
     if (err) {
@@ -143,14 +143,15 @@ function handleLogout(req, res, next) {
       }
       res.clearCookie('connect.sid');
 
-      // If this was a demo/playground session, reset the account to initial state
-      if (isDemo && demoProfileId) {
+      // If this was a demo clone session, delete the clone data
+      if (isDemo && cloneSessionId) {
         try {
-          await resetDemoAccount(demoProfileId);
-          console.log(`[handleLogout] Demo account reset: ${demoProfileId}`);
-        } catch (resetErr) {
-          // Don't fail the logout if reset fails — log and continue
-          console.error(`[handleLogout] Demo reset failed for ${demoProfileId}:`, resetErr);
+          await cleanupDemoClone(cloneSessionId);
+          console.log(`[handleLogout] Demo clone cleaned up: ${cloneSessionId}`);
+        } catch (cleanupErr) {
+          // Don't fail the logout if cleanup fails — log and continue
+          // Expired clone cleanup will catch orphans
+          console.error(`[handleLogout] Demo clone cleanup failed for ${cloneSessionId}:`, cleanupErr);
         }
       }
 

--- a/models/user.js
+++ b/models/user.js
@@ -520,6 +520,9 @@ const userSchema = new Schema({
   /* Demo / Playground Account */
   isDemo:        { type: Boolean, default: false },    // True for playground demo accounts
   demoProfileId: { type: String, trim: true },         // e.g., 'teacher-rivera', 'student-maya'
+  isDemoClone:   { type: Boolean, default: false },    // True for per-session demo clones
+  cloneSessionId:{ type: String, default: null },      // Groups all docs in one clone session
+  cloneExpiresAt:{ type: Date, default: null },        // TTL for orphan cleanup
 
   /* Student-specific profile */
   gradeLevel: { type: String, trim: true },              // e.g., '7th Grade', '9th Grade', 'College'
@@ -1142,6 +1145,7 @@ userSchema.index({ roles: 1 });                // Multi-role queries (all user r
 userSchema.index({ parentIds: 1 });            // Parent dashboard: find children
 userSchema.index({ lastLogin: -1 });           // Activity reports sorted by login
 userSchema.index({ role: 1, lastLogin: -1 });  // Admin usage reports
+userSchema.index({ cloneSessionId: 1 }, { sparse: true }); // Demo clone cleanup
 
 /* ---------- EXPORT MODEL ---------- */
 const User = mongoose.models.User || mongoose.model('User', userSchema);

--- a/routes/demo.js
+++ b/routes/demo.js
@@ -1,23 +1,13 @@
 // routes/demo.js
 // Handles playground/demo account login and state reset.
-// Demo accounts are one-click login (no password required) and reset on logout.
+// Each visitor gets an isolated clone — concurrent users never interfere.
 
 const express = require('express');
 const router = express.Router();
 const User = require('../models/user');
-const { resetDemoAccount } = require('../utils/demoReset');
+const { createDemoClone, cleanupDemoClone, resetDemoClone } = require('../utils/demoClone');
 const { DEMO_PROFILES } = require('../utils/demoData');
 const logger = require('../utils/logger');
-
-// Map demoProfileId → username for login
-const PROFILE_TO_USERNAME = {
-  'teacher-rivera':  'demo-teacher',
-  'is-cooper':       'demo-is',
-  'parent-chen':     'demo-parent',
-  'student-maya':    'demo-student-maya',
-  'student-alex':    'demo-student-alex',
-  'student-jordan':  'demo-student-jordan',
-};
 
 /**
  * GET /api/demo/profiles
@@ -32,7 +22,8 @@ router.get('/profiles', (req, res) => {
 
 /**
  * POST /api/demo/login
- * One-click login as a demo account. Resets the account to initial state first.
+ * One-click login as a demo account.
+ * Creates a per-session clone so concurrent visitors never conflict.
  *
  * Body: { profileId: 'teacher-rivera' }
  */
@@ -47,32 +38,21 @@ router.post('/login', async (req, res) => {
       });
     }
 
-    const username = PROFILE_TO_USERNAME[profileId];
-    if (!username) {
-      return res.status(400).json({ success: false, message: 'Demo profile not configured.' });
-    }
-
-    // 1. Reset the demo account to its initial state
-    logger.info(`[Demo] Resetting playground account: ${profileId}`);
-    const resetOk = await resetDemoAccount(profileId);
-    if (!resetOk) {
-      return res.status(500).json({
-        success: false,
-        message: 'Failed to reset demo account. Please try again or contact support.'
+    // If already in a demo session, clean up the previous clone first
+    if (req.isAuthenticated() && req.session.isDemo && req.session.cloneSessionId) {
+      const oldSessionId = req.session.cloneSessionId;
+      await new Promise((resolve, reject) => {
+        req.logout((err) => {
+          if (err) return reject(err);
+          resolve();
+        });
       });
-    }
-
-    // 2. Find the freshly-reset user
-    const user = await User.findOne({ username, isDemo: true });
-    if (!user) {
-      return res.status(404).json({
-        success: false,
-        message: 'Demo account not found. Please run the playground seed script first.'
-      });
-    }
-
-    // 3. If there's an existing session, destroy it first
-    if (req.isAuthenticated()) {
+      // Clean up old clone in background
+      cleanupDemoClone(oldSessionId).catch(err =>
+        logger.error('[Demo] Old clone cleanup error:', err)
+      );
+    } else if (req.isAuthenticated()) {
+      // Non-demo session — just log out
       await new Promise((resolve, reject) => {
         req.logout((err) => {
           if (err) return reject(err);
@@ -81,7 +61,11 @@ router.post('/login', async (req, res) => {
       });
     }
 
-    // 4. Log the user in
+    // Create an isolated clone for this session
+    logger.info(`[Demo] Creating clone for profile: ${profileId}`);
+    const { user, cloneSessionId } = await createDemoClone(profileId);
+
+    // Log the cloned user in
     await new Promise((resolve, reject) => {
       req.logIn(user, (err) => {
         if (err) return reject(err);
@@ -89,14 +73,15 @@ router.post('/login', async (req, res) => {
       });
     });
 
-    // Mark session as demo for the banner and logout reset
+    // Mark session as demo with clone tracking
     req.session.isDemo = true;
     req.session.demoProfileId = profileId;
+    req.session.cloneSessionId = cloneSessionId;
 
     // Update lastLogin
     await User.findByIdAndUpdate(user._id, { lastLogin: new Date() });
 
-    logger.info(`[Demo] Playground login successful: ${profileId} (${user.username})`);
+    logger.info(`[Demo] Clone login successful: ${profileId} (session ${cloneSessionId})`);
 
     // Determine redirect
     const profile = DEMO_PROFILES[profileId];
@@ -130,8 +115,8 @@ router.post('/login', async (req, res) => {
 
 /**
  * POST /api/demo/reset
- * Manually reset the current demo account (without logging out).
- * Useful for a "Start Over" button in the demo banner.
+ * Manually reset the current demo session (without logging out).
+ * Deletes the old clone and creates a fresh one — "Start Over" button.
  */
 router.post('/reset', async (req, res) => {
   try {
@@ -143,16 +128,26 @@ router.post('/reset', async (req, res) => {
     }
 
     const profileId = req.session.demoProfileId;
+    const oldCloneSessionId = req.session.cloneSessionId;
     if (!profileId) {
       return res.status(400).json({ success: false, message: 'No demo profile in session.' });
     }
 
-    logger.info(`[Demo] Manual reset requested for: ${profileId}`);
-    const resetOk = await resetDemoAccount(profileId);
+    logger.info(`[Demo] Reset requested for: ${profileId} (session ${oldCloneSessionId})`);
 
-    if (!resetOk) {
-      return res.status(500).json({ success: false, message: 'Reset failed.' });
-    }
+    // Create fresh clone (this also cleans up the old one)
+    const { user, cloneSessionId } = await resetDemoClone(oldCloneSessionId, profileId);
+
+    // Re-login as the new clone
+    await new Promise((resolve, reject) => {
+      req.logIn(user, (err) => {
+        if (err) return reject(err);
+        resolve();
+      });
+    });
+
+    // Update session with new clone ID
+    req.session.cloneSessionId = cloneSessionId;
 
     res.json({
       success: true,

--- a/routes/iepTemplates.js
+++ b/routes/iepTemplates.js
@@ -13,6 +13,7 @@ const express = require('express');
 const router = express.Router();
 const User = require('../models/user');
 const { isTeacher } = require('../middleware/auth');
+const { getStudentIdsForTeacher } = require('../services/userService');
 const {
     getAccommodationTemplates,
     getAccommodationTemplate,
@@ -173,11 +174,18 @@ router.post('/apply/accommodations/:studentId', isTeacher, async (req, res) => {
             });
         }
 
-        // Verify teacher has access to this student
+        // Verify teacher has access to this student (direct assignment OR enrollment code)
+        const authorizedIds = await getStudentIdsForTeacher(req.user._id);
+        if (!authorizedIds.includes(studentId)) {
+            return res.status(404).json({
+                success: false,
+                message: 'Student not found or not assigned to you'
+            });
+        }
+
         const student = await User.findOne({
             _id: studentId,
-            role: 'student',
-            teacherId: req.user._id
+            role: 'student'
         });
 
         if (!student) {
@@ -261,11 +269,18 @@ router.post('/apply/goals/:studentId', isTeacher, async (req, res) => {
             });
         }
 
-        // Verify teacher has access to this student
+        // Verify teacher has access to this student (direct assignment OR enrollment code)
+        const authorizedIds = await getStudentIdsForTeacher(req.user._id);
+        if (!authorizedIds.includes(studentId)) {
+            return res.status(404).json({
+                success: false,
+                message: 'Student not found or not assigned to you'
+            });
+        }
+
         const student = await User.findOne({
             _id: studentId,
-            role: 'student',
-            teacherId: req.user._id
+            role: 'student'
         });
 
         if (!student) {
@@ -318,11 +333,18 @@ router.get('/recommended/:studentId', isTeacher, async (req, res) => {
     try {
         const { studentId } = req.params;
 
-        // Verify teacher has access to this student
+        // Verify teacher has access to this student (direct assignment OR enrollment code)
+        const authorizedIds = await getStudentIdsForTeacher(req.user._id);
+        if (!authorizedIds.includes(studentId)) {
+            return res.status(404).json({
+                success: false,
+                message: 'Student not found or not assigned to you'
+            });
+        }
+
         const student = await User.findOne({
             _id: studentId,
-            role: 'student',
-            teacherId: req.user._id
+            role: 'student'
         }, 'firstName lastName gradeLevel learningProfile iepPlan');
 
         if (!student) {

--- a/routes/teacher.js
+++ b/routes/teacher.js
@@ -13,31 +13,7 @@ const ScreenerSession = require('../models/screenerSession');
 const EnrollmentCode = require('../models/enrollmentCode');
 const Skill = require('../models/skill');
 const { callLLMStream } = require('../utils/openaiClient');
-
-/**
- * Get all student IDs for a teacher, combining:
- *  1. Students with teacherId pointing to this teacher
- *  2. Students enrolled via this teacher's enrollment codes
- * Returns deduplicated ObjectId array.
- */
-async function getStudentIdsForTeacher(teacherId) {
-  // 1. Direct teacherId assignment
-  const directStudents = await User.find(
-    { role: 'student', teacherId },
-    '_id'
-  ).lean();
-  const idSet = new Set(directStudents.map(s => s._id.toString()));
-
-  // 2. Students enrolled via this teacher's enrollment codes
-  const codes = await EnrollmentCode.find({ teacherId }, 'enrolledStudents').lean();
-  for (const code of codes) {
-    for (const e of (code.enrolledStudents || [])) {
-      idSet.add(e.studentId.toString());
-    }
-  }
-
-  return [...idSet];
-}
+const { getStudentIdsForTeacher } = require('../services/userService');
 
 // Fetches students assigned to the logged-in teacher (via teacherId OR enrollment codes)
 router.get('/students', isTeacher, async (req, res) => {
@@ -70,10 +46,15 @@ router.get('/students/:studentId/iep', isTeacher, async (req, res) => {
     const { studentId } = req.params;
     const teacherId = req.user._id;
 
+    // Check both direct assignment AND enrollment code assignment
+    const authorizedStudentIds = await getStudentIdsForTeacher(teacherId);
+    if (!authorizedStudentIds.includes(studentId)) {
+      return res.status(404).json({ message: 'Student not found or not assigned to this teacher.' });
+    }
+
     const student = await User.findOne({
       _id: studentId,
-      role: 'student',
-      teacherId: teacherId
+      role: 'student'
     }, 'firstName lastName username iepPlan').lean();
 
     if (!student) {
@@ -123,10 +104,15 @@ router.get('/students/:studentId/iep/goal-history', isTeacher, async (req, res) 
     const { studentId } = req.params;
     const teacherId = req.user._id;
 
+    // Check both direct assignment AND enrollment code assignment
+    const authorizedStudentIds = await getStudentIdsForTeacher(teacherId);
+    if (!authorizedStudentIds.includes(studentId)) {
+      return res.status(404).json({ message: 'Student not found or not assigned to this teacher.' });
+    }
+
     const student = await User.findOne({
       _id: studentId,
-      role: 'student',
-      teacherId: teacherId
+      role: 'student'
     }, 'firstName lastName iepPlan').lean();
 
     if (!student) {

--- a/services/userService.js
+++ b/services/userService.js
@@ -333,6 +333,33 @@ function validatePassword(password) {
   };
 }
 
+/**
+ * Get all student IDs for a teacher, combining:
+ *  1. Students with teacherId pointing to this teacher
+ *  2. Students enrolled via this teacher's enrollment codes
+ * Returns deduplicated string ID array.
+ */
+async function getStudentIdsForTeacher(teacherId) {
+  const EnrollmentCode = require('../models/enrollmentCode');
+
+  // 1. Direct teacherId assignment
+  const directStudents = await User.find(
+    { role: 'student', teacherId },
+    '_id'
+  ).lean();
+  const idSet = new Set(directStudents.map(s => s._id.toString()));
+
+  // 2. Students enrolled via this teacher's enrollment codes
+  const codes = await EnrollmentCode.find({ teacherId }, 'enrolledStudents').lean();
+  for (const code of codes) {
+    for (const e of (code.enrolledStudents || [])) {
+      idSet.add(e.studentId.toString());
+    }
+  }
+
+  return [...idSet];
+}
+
 module.exports = {
   getUserById,
   getUserByUsername,
@@ -343,5 +370,6 @@ module.exports = {
   updateLastLogin,
   getUserStats,
   hasRole,
-  validatePassword
+  validatePassword,
+  getStudentIdsForTeacher
 };

--- a/utils/demoClone.js
+++ b/utils/demoClone.js
@@ -1,0 +1,360 @@
+// utils/demoClone.js
+// Per-session demo cloning — each visitor gets their own isolated copy
+// of demo data so concurrent users never interfere with each other.
+
+const mongoose = require('mongoose');
+const User = require('../models/user');
+const Conversation = require('../models/conversation');
+const EnrollmentCode = require('../models/enrollmentCode');
+const logger = require('./logger');
+
+const {
+  DEMO_IDS,
+  DEMO_PASSWORD,
+  teacherRivera,
+  isCooper,
+  parentChen,
+  studentMaya,
+  studentAlex,
+  studentJordan,
+  teacherForChenKids,
+  mockStudents,
+  enrollmentCode: enrollmentCodeData,
+  enrollmentCodeIS: enrollmentCodeISData,
+  buildConversations,
+} = require('./demoData');
+
+// Map demoProfileId → template + the "world" of related users to clone
+const PROFILE_TEMPLATES = {
+  'teacher-rivera': teacherRivera,
+  'is-cooper': isCooper,
+  'parent-chen': parentChen,
+  'student-maya': studentMaya,
+  'student-alex': studentAlex,
+  'student-jordan': studentJordan,
+};
+
+// Clone expiration (2 hours)
+const CLONE_TTL_MS = 2 * 60 * 60 * 1000;
+
+/**
+ * Define which users + enrollment codes belong to each demo profile's "world".
+ * When a profile is cloned, all users in its world are cloned together.
+ */
+function getWorldForProfile(profileId) {
+  switch (profileId) {
+    case 'teacher-rivera':
+      return {
+        primaryUser: teacherRivera,
+        relatedUsers: [studentJordan, ...mockStudents],
+        enrollmentCodes: [enrollmentCodeData],
+        // All related users get teacherId remapped to cloned teacher
+        remapTeacherId: true,
+      };
+
+    case 'is-cooper':
+      // Cooper's intervention group: Jordan + Jasmine (mock07) + Tyler (mock08)
+      return {
+        primaryUser: isCooper,
+        relatedUsers: [studentJordan, mockStudents[6], mockStudents[7]],
+        enrollmentCodes: [enrollmentCodeISData],
+        remapTeacherId: true,
+      };
+
+    case 'parent-chen':
+      return {
+        primaryUser: parentChen,
+        relatedUsers: [studentMaya, studentAlex],
+        enrollmentCodes: [],
+        // Parent's children[] array gets remapped to cloned child IDs
+        remapChildren: true,
+      };
+
+    case 'student-maya':
+      return {
+        primaryUser: studentMaya,
+        relatedUsers: [],
+        enrollmentCodes: [],
+      };
+
+    case 'student-alex':
+      return {
+        primaryUser: studentAlex,
+        relatedUsers: [],
+        enrollmentCodes: [],
+      };
+
+    case 'student-jordan':
+      return {
+        primaryUser: studentJordan,
+        relatedUsers: [],
+        enrollmentCodes: [],
+      };
+
+    default:
+      return null;
+  }
+}
+
+/**
+ * Create a per-session demo clone.
+ * Returns the cloned primary user (logged-in user) with a fresh _id.
+ *
+ * @param {string} profileId - e.g., 'teacher-rivera'
+ * @returns {Promise<{user: Object, cloneSessionId: string}>}
+ */
+async function createDemoClone(profileId) {
+  const world = getWorldForProfile(profileId);
+  if (!world) {
+    throw new Error(`Unknown demo profile: ${profileId}`);
+  }
+
+  // Clean up any expired clones opportunistically
+  cleanupExpiredClones().catch(err =>
+    logger.error('[DemoClone] Background cleanup error:', err)
+  );
+
+  const cloneSessionId = new mongoose.Types.ObjectId().toString();
+  const cloneExpiresAt = new Date(Date.now() + CLONE_TTL_MS);
+  const suffix = cloneSessionId.slice(-8); // Short suffix for unique usernames
+
+  // Build ID mapping: original template _id → fresh clone _id
+  const idMap = new Map();
+  function mapId(originalId) {
+    const key = originalId.toString();
+    if (!idMap.has(key)) {
+      idMap.set(key, new mongoose.Types.ObjectId());
+    }
+    return idMap.get(key);
+  }
+
+  // Pre-generate IDs for all users in the world
+  mapId(world.primaryUser._id);
+  for (const user of world.relatedUsers) {
+    mapId(user._id);
+  }
+
+  // --- Clone users ---
+  const allUserDocs = [];
+
+  // Clone the primary (loginable) user
+  const primaryDoc = buildCloneDoc(
+    world.primaryUser, mapId(world.primaryUser._id), suffix,
+    cloneSessionId, cloneExpiresAt
+  );
+  // Remap parent's children array if needed
+  if (world.remapChildren && primaryDoc.children) {
+    primaryDoc.children = primaryDoc.children.map(childId => {
+      const mapped = idMap.get(childId.toString());
+      return mapped || childId;
+    });
+  }
+  allUserDocs.push(primaryDoc);
+
+  // Clone related users (students, children, etc.)
+  for (const relUser of world.relatedUsers) {
+    const doc = buildCloneDoc(
+      relUser, mapId(relUser._id), suffix,
+      cloneSessionId, cloneExpiresAt
+    );
+    // Remap teacherId to cloned teacher
+    if (world.remapTeacherId && doc.teacherId) {
+      const mappedTeacher = idMap.get(doc.teacherId.toString());
+      if (mappedTeacher) {
+        doc.teacherId = mappedTeacher;
+      }
+    }
+    // Remap parentIds to cloned parent
+    if (world.remapChildren && doc.parentIds) {
+      doc.parentIds = doc.parentIds.map(pid => {
+        const mapped = idMap.get(pid.toString());
+        return mapped || pid;
+      });
+    }
+    allUserDocs.push(doc);
+  }
+
+  // Bulk insert users (bypass pre-save hook to avoid re-hashing passwords)
+  // We'll set passwordHash to a pre-hashed value instead
+  const bcrypt = require('bcryptjs');
+  const hashedPassword = await bcrypt.hash(DEMO_PASSWORD, 10);
+  for (const doc of allUserDocs) {
+    doc.passwordHash = hashedPassword;
+  }
+
+  await User.insertMany(allUserDocs);
+
+  // --- Clone enrollment codes ---
+  for (const ecTemplate of world.enrollmentCodes) {
+    const clonedEC = {
+      ...ecTemplate,
+      _id: new mongoose.Types.ObjectId(),
+      code: `${ecTemplate.code}-${suffix}`, // Unique code
+      teacherId: mapId(ecTemplate.teacherId),
+      enrolledStudents: (ecTemplate.enrolledStudents || []).map(e => ({
+        ...e,
+        studentId: mapId(e.studentId),
+      })),
+      createdBy: mapId(ecTemplate.createdBy || ecTemplate.teacherId),
+    };
+    await EnrollmentCode.create(clonedEC);
+  }
+
+  // --- Clone conversations ---
+  const allConversations = buildConversations(DEMO_IDS);
+  const clonedUserIds = new Set([...idMap.keys()]);
+
+  const convDocs = [];
+  const activeConvMap = new Map(); // userId → most recent active conv _id
+
+  for (const conv of allConversations) {
+    const originalUserId = conv.userId.toString();
+    if (!clonedUserIds.has(originalUserId)) continue;
+
+    const clonedConvId = new mongoose.Types.ObjectId();
+    const clonedUserId = idMap.get(originalUserId);
+
+    convDocs.push({
+      ...conv,
+      _id: clonedConvId,
+      userId: clonedUserId,
+    });
+
+    if (conv.isActive) {
+      activeConvMap.set(clonedUserId.toString(), clonedConvId);
+    }
+  }
+
+  if (convDocs.length > 0) {
+    await Conversation.insertMany(convDocs);
+  }
+
+  // Link active conversations to cloned users
+  for (const [userId, convId] of activeConvMap) {
+    await User.findByIdAndUpdate(userId, { activeConversationId: convId });
+  }
+
+  // Return the primary cloned user (the one to log in as)
+  const loginUser = await User.findById(mapId(world.primaryUser._id));
+
+  logger.info(`[DemoClone] Created clone session ${cloneSessionId} for profile ${profileId} (${allUserDocs.length} users, ${convDocs.length} conversations)`);
+
+  return { user: loginUser, cloneSessionId };
+}
+
+/**
+ * Build a clone document from a template user.
+ * Generates unique username/email, sets clone metadata.
+ */
+function buildCloneDoc(template, newId, suffix, cloneSessionId, cloneExpiresAt) {
+  const doc = { ...template };
+
+  // New identity
+  doc._id = newId;
+  doc.username = `${template.username}-${suffix}`;
+  doc.email = `${template.email.replace('@', `-${suffix}@`)}`;
+
+  // Clone metadata
+  doc.isDemoClone = true;
+  doc.isDemo = true;
+  doc.cloneSessionId = cloneSessionId;
+  doc.cloneExpiresAt = cloneExpiresAt;
+
+  // Reset session state
+  doc.activeConversationId = null;
+  doc.activeMasteryConversationId = null;
+  doc.activeCourseSessionId = null;
+  doc.lastLogin = null;
+  doc.tourCompleted = false;
+  doc.tourDismissed = false;
+
+  // Remove fields Mongoose will manage
+  delete doc.__v;
+  delete doc.createdAt;
+  delete doc.updatedAt;
+
+  // Ensure OAuth IDs don't conflict (they have unique sparse indexes)
+  delete doc.googleId;
+  delete doc.microsoftId;
+  delete doc.cleverId;
+
+  return doc;
+}
+
+/**
+ * Delete all data for a clone session.
+ *
+ * @param {string} cloneSessionId
+ */
+async function cleanupDemoClone(cloneSessionId) {
+  if (!cloneSessionId) return;
+
+  try {
+    // Find cloned user IDs for conversation/enrollment cleanup
+    const clonedUsers = await User.find({ cloneSessionId }, '_id').lean();
+    const clonedUserIds = clonedUsers.map(u => u._id);
+
+    // Delete conversations for cloned users
+    const convResult = await Conversation.deleteMany({ userId: { $in: clonedUserIds } });
+
+    // Delete enrollment codes created for this session
+    // EnrollmentCode doesn't have cloneSessionId, so match by teacher ID
+    const ecResult = await EnrollmentCode.deleteMany({ teacherId: { $in: clonedUserIds } });
+
+    // Delete cloned users
+    const userResult = await User.deleteMany({ cloneSessionId });
+
+    logger.info(`[DemoClone] Cleaned up session ${cloneSessionId}: ${userResult.deletedCount} users, ${convResult.deletedCount} conversations, ${ecResult.deletedCount} enrollment codes`);
+  } catch (err) {
+    logger.error(`[DemoClone] Cleanup error for session ${cloneSessionId}:`, err);
+  }
+}
+
+/**
+ * Reset a clone session (delete + recreate).
+ * Used by the "Start Over" button.
+ *
+ * @param {string} cloneSessionId
+ * @param {string} profileId
+ * @returns {Promise<{user: Object, cloneSessionId: string}>}
+ */
+async function resetDemoClone(cloneSessionId, profileId) {
+  await cleanupDemoClone(cloneSessionId);
+  return createDemoClone(profileId);
+}
+
+/**
+ * Delete all expired clone sessions.
+ * Called opportunistically on each demo login.
+ */
+async function cleanupExpiredClones() {
+  const now = new Date();
+
+  // Find all expired clone session IDs
+  const expiredUsers = await User.find(
+    { isDemoClone: true, cloneExpiresAt: { $lt: now } },
+    'cloneSessionId'
+  ).lean();
+
+  const sessionIds = [...new Set(expiredUsers.map(u => u.cloneSessionId).filter(Boolean))];
+
+  if (sessionIds.length === 0) return;
+
+  // Find all expired user IDs for related cleanup
+  const expiredUserIds = expiredUsers.map(u => u._id);
+
+  await Promise.all([
+    Conversation.deleteMany({ userId: { $in: expiredUserIds } }),
+    EnrollmentCode.deleteMany({ teacherId: { $in: expiredUserIds } }),
+    User.deleteMany({ isDemoClone: true, cloneExpiresAt: { $lt: now } }),
+  ]);
+
+  logger.info(`[DemoClone] Cleaned up ${sessionIds.length} expired clone sessions`);
+}
+
+module.exports = {
+  createDemoClone,
+  cleanupDemoClone,
+  resetDemoClone,
+  cleanupExpiredClones,
+};


### PR DESCRIPTION
## Summary
Replace the shared demo account reset mechanism with per-session demo cloning. Each visitor now gets an isolated copy of demo data with a unique session ID, preventing concurrent users from interfering with each other's demo experience.

## Key Changes

- **New `utils/demoClone.js` module**: Implements per-session cloning with:
  - `createDemoClone()` — Creates isolated user/conversation/enrollment code copies with unique IDs and usernames
  - `cleanupDemoClone()` — Deletes all data for a clone session
  - `resetDemoClone()` — Deletes old clone and creates a fresh one (for "Start Over" button)
  - `cleanupExpiredClones()` — Background cleanup of expired sessions (2-hour TTL)
  - `getWorldForProfile()` — Defines which related users/codes belong to each demo profile

- **Updated `routes/demo.js`**:
  - `/api/demo/login` now creates a fresh clone instead of resetting a shared account
  - Tracks `cloneSessionId` in session for cleanup on logout
  - Cleans up previous clone if user logs into demo while already authenticated

- **Updated `middleware/auth.js`**:
  - `handleLogout()` now calls `cleanupDemoClone()` instead of `resetDemoAccount()`
  - Deletes clone data when demo session ends

- **Updated `models/user.js`**:
  - Added `isDemoClone`, `cloneSessionId`, and `cloneExpiresAt` fields to track clone metadata

- **Extracted `getStudentIdsForTeacher()` to `services/userService.js`**:
  - Moved from `routes/teacher.js` to shared service
  - Used by `routes/teacher.js` and `routes/iepTemplates.js` to verify teacher access to students (both direct assignment and enrollment code enrollment)

- **Updated authorization checks** in `routes/teacher.js` and `routes/iepTemplates.js`:
  - Now use `getStudentIdsForTeacher()` to check both direct teacherId assignment AND enrollment code enrollment
  - Prevents authorization bypass for enrollment-code-assigned students

## Implementation Details

- Each clone gets a unique suffix (8-char session ID) appended to username/email to ensure uniqueness
- ID mapping pre-generated for all users in a profile's "world" to maintain relationships (teacher→student, parent→child)
- Password hashed once and reused across all clones (bypasses pre-save hook)
- Enrollment codes cloned with unique codes and remapped teacher/student IDs
- Conversations cloned and linked to cloned users; active conversations tracked
- Expired clones cleaned up opportunistically on each demo login and explicitly on logout
- OAuth IDs (Google, Microsoft, Clever) removed from clones to avoid unique index conflicts

https://claude.ai/code/session_01MbbGEwxsN6ScHhgAVnSRg4