### PR TITLE
Redesign chat page with iMessage-style UI

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -96,7 +96,7 @@
       <img src="/images/mathmatix-ai-logo.png" alt="Mathmatix Logo" class="main-logo-hero" />
     </a>
     <nav class="landing-nav" aria-label="Chat controls">
-      <!-- TTS Playback Controls -->
+      <!-- TTS Playback Controls (only visible during audio playback) -->
       <button id="restart-audio-btn" class="btn btn-tertiary icon-only" title="Restart Audio" aria-label="Restart audio" style="display: none;">
         <i class="fas fa-redo"></i>
       </button>
@@ -119,34 +119,26 @@
           <button data-speed="2" role="menuitem">2x</button>
         </div>
       </div>
+
+      <!-- Hidden buttons (triggered via hamburger menu items) -->
       <button id="open-resources-modal-btn" class="btn btn-tertiary" title="Resources" aria-label="Learning resources" style="display: none;">
         <i class="fas fa-book-open"></i> <span class="mobile-hide">Resources</span>
       </button>
-      <!-- Primary actions (always visible) -->
-      <button id="theme-toggle-btn" class="btn btn-tertiary icon-only" title="Toggle dark mode" aria-label="Toggle dark mode">
-        <i class="fas fa-moon"></i>
-      </button>
-      <button id="open-settings-modal-btn" class="btn btn-tertiary icon-only" title="Settings" aria-label="Settings">
-        <i class="fas fa-cog"></i>
-      </button>
+      <button id="open-settings-modal-btn" style="display: none;">Settings</button>
+      <button id="share-progress-header-btn" style="display: none;">Share Progress</button>
+      <button id="open-feedback-modal-btn" style="display: none;">Send Feedback</button>
       <div id="roleSwitcher" class="role-switcher" style="display: none;">
         <select id="roleSwitcherSelect" class="role-switcher-select" title="Switch Role" aria-label="Switch Role"></select>
       </div>
-      <button id="logoutBtn" class="btn btn-tertiary logout-button icon-only" title="Logout" aria-label="Logout">
-        <i class="fas fa-sign-out-alt"></i>
+
+      <!-- Theme toggle — always visible -->
+      <button id="theme-toggle-btn" class="btn btn-tertiary icon-only" title="Toggle dark mode" aria-label="Toggle dark mode">
+        <i class="fas fa-moon"></i>
       </button>
 
-      <!-- Secondary actions (hidden on mobile, available via More menu) -->
-      <button id="share-progress-header-btn" class="btn btn-tertiary icon-only toolbar-secondary" title="Share Progress Code" aria-label="Share Progress Code">
-        <i class="fas fa-link"></i>
-      </button>
-      <button id="open-feedback-modal-btn" class="btn btn-tertiary icon-only toolbar-secondary" title="Send Feedback" aria-label="Send Feedback">
-        <i class="fas fa-comment-dots"></i>
-      </button>
-
-      <!-- More menu trigger (mobile only) -->
-      <button id="more-tools-btn" class="btn btn-tertiary icon-only toolbar-more" title="More" aria-label="More options">
-        <i class="fas fa-ellipsis-v"></i>
+      <!-- Hamburger menu button — upper right -->
+      <button id="header-menu-btn" class="btn btn-tertiary icon-only" title="Menu" aria-label="Open menu">
+        <i class="fas fa-bars"></i>
       </button>
 
       <!-- Mobile Progress Toggle Button -->
@@ -154,6 +146,61 @@
         <i class="fas fa-user-circle"></i>
       </button>
     </nav>
+
+    <!-- Hamburger dropdown menu -->
+    <div id="header-dropdown-menu" class="header-dropdown-menu">
+      <button class="header-menu-item" data-trigger="open-settings-modal-btn">
+        <i class="fas fa-cog"></i> Settings
+      </button>
+      <button class="header-menu-item" data-trigger="open-resources-modal-btn">
+        <i class="fas fa-book-open"></i> Resources
+      </button>
+      <button class="header-menu-item" data-trigger="share-progress-header-btn">
+        <i class="fas fa-link"></i> Share Progress
+      </button>
+      <button class="header-menu-item" data-trigger="open-feedback-modal-btn">
+        <i class="fas fa-comment-dots"></i> Feedback
+      </button>
+      <div class="header-menu-divider"></div>
+      <button class="header-menu-item" id="logoutBtn">
+        <i class="fas fa-sign-out-alt"></i> Log Out
+      </button>
+    </div>
+    <script>
+    // Hamburger dropdown toggle
+    (function() {
+      var menuBtn = document.getElementById('header-menu-btn');
+      var menu = document.getElementById('header-dropdown-menu');
+      if (!menuBtn || !menu) return;
+
+      menuBtn.addEventListener('click', function(e) {
+        e.stopPropagation();
+        menu.classList.toggle('is-open');
+      });
+
+      // Close on outside click
+      document.addEventListener('click', function(e) {
+        if (!menu.contains(e.target) && e.target !== menuBtn) {
+          menu.classList.remove('is-open');
+        }
+      });
+
+      // Menu items trigger their target buttons
+      menu.querySelectorAll('.header-menu-item[data-trigger]').forEach(function(item) {
+        item.addEventListener('click', function() {
+          var targetId = this.getAttribute('data-trigger');
+          var targetBtn = document.getElementById(targetId);
+          menu.classList.remove('is-open');
+          if (targetBtn) setTimeout(function() { targetBtn.click(); }, 50);
+        });
+      });
+
+      // Close on ESC
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') menu.classList.remove('is-open');
+      });
+    })();
+    </script>
   </header>
 
   <!-- Sidebar Toggle Button -->
@@ -468,44 +515,35 @@
     <!-- Modern File Grid Container -->
     <div id="file-grid-container" class="file-grid-container"></div>
 
-    <!-- Compact Input Row: Suggestions + Toolbar -->
-    <div style="display: flex; align-items: center; gap: 8px; padding: 4px 12px; flex-wrap: wrap;">
-      <!-- Quick Reply Suggestions (contextual chips) -->
-      <div id="suggestion-chips-container" style="
-        display: none;
-        gap: 8px;
-        flex-wrap: wrap;
-        flex: 1;
-        min-width: 200px;
-      ">
-        <!-- Chips will be dynamically inserted here -->
-      </div>
+    <!-- Quick Reply Suggestions -->
+    <div id="suggestion-chips-container" class="imessage-chips-row">
+      <!-- Chips will be dynamically inserted here -->
+    </div>
 
-      <!-- Compact Toolbar (inline with chips) -->
-      <div class="input-toolbar-compact" style="display: flex; gap: 6px; flex-shrink: 0;">
-        <button id="insert-equation-btn" title="Insert Equation" aria-label="Insert equation" class="btn btn-tertiary btn-sm">
+    <!-- iMessage-style compose bar -->
+    <div class="imessage-compose-bar">
+      <div class="imessage-tool-btns">
+        <button id="insert-equation-btn" title="Insert Equation" aria-label="Insert equation" class="imessage-tool-btn">
           <i class="fas fa-square-root-variable"></i>
         </button>
-        <button id="attach-button" title="Upload Files" aria-label="Upload files" class="btn btn-tertiary btn-sm">
+        <button id="attach-button" title="Upload Files" aria-label="Upload files" class="imessage-tool-btn">
           <i class="fas fa-paperclip"></i>
         </button>
-        <button id="camera-button" title="Show Your Work - Get Graded" aria-label="Show your work" class="btn btn-tertiary btn-sm">
+        <button id="camera-button" title="Show Your Work" aria-label="Show your work" class="imessage-tool-btn">
           <i class="fas fa-camera-retro"></i>
         </button>
-        <button id="mic-button" title="Voice Input" aria-label="Voice input" class="btn btn-tertiary btn-sm">
+        <button id="mic-button" title="Voice Input" aria-label="Voice input" class="imessage-tool-btn">
           <i class="fas fa-microphone"></i>
         </button>
       </div>
+      <div class="imessage-input-row">
+        <div id="user-input" contenteditable="true" data-placeholder="Ask a math question..." role="textbox" aria-multiline="true"></div>
+        <button id="send-button" class="imessage-send-btn" title="Send" aria-label="Send message">
+          <i class="fas fa-arrow-up"></i>
+        </button>
+      </div>
     </div>
-
-    <!-- Message Input (Full Width) -->
-    <div id="user-input" contenteditable="true" data-placeholder="Ask a math question..." role="textbox" aria-multiline="true"></div>
     <input type="file" name="file" id="file-input" style="display:none;" accept="image/png,image/jpeg,image/jpg,image/webp,image/heic,image/svg+xml,application/pdf" multiple/>
-
-    <!-- Send Button (Full Width) -->
-    <button id="send-button" class="btn btn-primary send-button-fullwidth">
-      <i class="fas fa-paper-plane"></i> Send
-    </button>
     <p class="chat-disclaimer"><i class="fas fa-info-circle"></i> AI can make mistakes. Always check your work.</p>
 </div>
 

--- a/public/css/base/chat.css
+++ b/public/css/base/chat.css
@@ -4,132 +4,163 @@
 /* This is already covered by .admin-central-content, #chat-container rules above */
 
 
-/* Chat messages inner container */
+/* Chat messages inner container — iMessage-style */
 #chat-messages-container {
     display: flex;
     flex-direction: column;
-    gap: var(--space-2);
-    padding: var(--space-2) var(--space-3);
+    gap: 2px;
+    padding: 12px 16px;
     overflow-y: auto;
     flex-grow: 1;
-    background-color: var(--clr-bg-subtle);
-    border-radius: var(--radius-md);
+    background-color: var(--clr-bg-light);
+    border-radius: 0;
     min-height: 0;
-    border: 1px solid var(--clr-border);
+    border: none;
     scroll-behavior: smooth;
-    /* Better scrollbar */
     scrollbar-width: thin;
-    scrollbar-color: rgba(var(--clr-primary-teal-rgb), 0.2) transparent;
+    scrollbar-color: rgba(0, 0, 0, 0.1) transparent;
 }
 
-#chat-messages-container::-webkit-scrollbar { width: 6px; }
+#chat-messages-container::-webkit-scrollbar { width: 5px; }
 #chat-messages-container::-webkit-scrollbar-track { background: transparent; }
 #chat-messages-container::-webkit-scrollbar-thumb {
-    background-color: rgba(var(--clr-primary-teal-rgb), 0.2);
+    background-color: rgba(0, 0, 0, 0.12);
     border-radius: 3px;
 }
 
 .message {
-    max-width: 82%;
-    padding: 10px 14px;
-    border-radius: var(--radius-lg);
-    line-height: var(--line-height-normal);
+    max-width: 75%;
+    padding: 9px 14px;
+    border-radius: 18px;
+    line-height: 1.45;
     word-wrap: break-word;
     overflow-wrap: break-word;
-    font-size: 0.95em;
-    box-shadow: var(--shadow-xs);
-    animation: messageIn 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+    font-size: 0.94em;
+    box-shadow: none;
+    animation: messageIn 0.25s ease-out;
 }
 
 @keyframes messageIn {
-    from { opacity: 0; transform: translateY(8px) scale(0.96); }
-    to { opacity: 1; transform: translateY(0) scale(1); }
+    from { opacity: 0; transform: translateY(6px); }
+    to { opacity: 1; transform: translateY(0); }
 }
 
 /* Message Container with Avatar */
 .message-container {
     display: flex;
     align-items: flex-end;
-    gap: var(--space-2);
-    margin-bottom: var(--space-1);
+    gap: 6px;
+    margin-bottom: 1px;
     width: 100%;
+}
+
+/* Add breathing room between messages from different senders */
+.message-container.user + .message-container.ai,
+.message-container.ai + .message-container.user,
+.message-container.system-error + .message-container {
+    margin-top: 10px;
 }
 
 .message-container.user {
     justify-content: flex-end;
-    flex-direction: row-reverse; /* Avatar on right side */
+    flex-direction: row-reverse;
 }
 
 .message-container.ai {
     justify-content: flex-start;
 }
 
-/* Avatar Styling */
+/* Avatar Styling — smaller, cleaner */
 .message-avatar {
     flex-shrink: 0;
-    width: 32px;
-    height: 32px;
+    width: 28px;
+    height: 28px;
     border-radius: 50%;
     overflow: hidden;
-    border: 2px solid var(--clr-border-light);
-    box-shadow: var(--shadow-xs);
-    background: var(--clr-bg-light);
+    border: none;
+    box-shadow: none;
+    background: var(--clr-bg-subtle);
 }
 
 .message-avatar img {
     width: 100%;
     height: 100%;
     object-fit: cover;
-    object-position: center top; /* Focus on the face at the top of full-body images */
+    object-position: center top;
+}
+
+/* Hide avatar on consecutive same-sender messages */
+.message-container.ai + .message-container.ai .message-avatar,
+.message-container.user + .message-container.user .message-avatar {
+    visibility: hidden;
 }
 
 /* Message Animations */
 .message.message-enter {
     opacity: 0;
-    transform: translateY(10px) scale(0.95);
+    transform: translateY(8px);
 }
 
 .message.message-entered {
     opacity: 1;
-    transform: translateY(0) scale(1);
-    transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+    transform: translateY(0);
+    transition: all 0.25s ease-out;
 }
 
-/* Styles for user messages (right aligned) */
+/* User messages — iMessage blue bubble */
 .message.user {
     align-self: flex-end;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: #007AFF;
     color: white;
-    border-bottom-right-radius: var(--radius-sm);
+    border-radius: 18px;
+    border-bottom-right-radius: 4px;
     margin-left: auto;
-    margin-right: var(--space-2);
-    box-shadow: 0 2px 12px rgba(102, 126, 234, 0.25);
+    margin-right: 0;
+    box-shadow: none;
 }
 
-/* Queued message style - for back-to-back messages waiting to be sent */
+/* Consecutive user messages: round the non-tail corners */
+.message-container.user + .message-container.user .message.user {
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+}
+
+/* Last in a user group: restore the tail */
+.message-container.user + .message-container.ai .message.user,
+.message-container.user:last-child .message.user {
+    border-bottom-right-radius: 4px;
+}
+
+/* Queued message style */
 .message.user.queued {
-    opacity: 0.7;
-    background: linear-gradient(135deg, #9ba3d4 0%, #a98bb5 100%);
-    box-shadow: 0 2px 4px rgba(102, 126, 234, 0.15);
+    opacity: 0.65;
+    background: #5AA0F0;
 }
 
 .message.user.queued .queued-indicator {
     font-size: 0.75em;
-    color: rgba(255, 255, 255, 0.85);
-    margin-bottom: 4px;
+    color: rgba(255, 255, 255, 0.8);
+    margin-bottom: 3px;
     font-style: italic;
 }
 
-/* Styles for AI messages (left aligned) */
+/* AI messages — iMessage-style light gray bubble */
 .message.ai {
     align-self: flex-start;
-    background-color: var(--clr-bg-light);
-    color: var(--text-primary);
-    border-bottom-left-radius: var(--radius-sm);
+    background-color: #E9E9EB;
+    color: #1c1c1e;
+    border-radius: 18px;
+    border-bottom-left-radius: 4px;
     position: relative;
-    margin-right: 12%;
-    margin-left: var(--space-1);
-    border: 1px solid var(--clr-border);
+    margin-right: 15%;
+    margin-left: 0;
+    border: none;
+}
+
+/* Consecutive AI messages: tighter grouping */
+.message-container.ai + .message-container.ai .message.ai {
+    border-top-left-radius: 4px;
+    border-bottom-left-radius: 4px;
 }
 
 /* KaTeX MathML — hidden (screen-reader only).
@@ -166,17 +197,17 @@
     overflow-y: hidden;
 }
 
-/* Message Timestamps */
+/* Message Timestamps — subtle, iMessage-style */
 .message-timestamp {
-    font-size: 0.7rem;
-    color: #999;
-    margin-top: 4px;
+    font-size: 0.65rem;
+    color: #8e8e93;
+    margin-top: 2px;
     display: block;
     text-align: right;
 }
 
 .message.user .message-timestamp {
-    color: rgba(255, 255, 255, 0.7);
+    color: rgba(255, 255, 255, 0.6);
     text-align: left;
 }
 
@@ -297,73 +328,102 @@
     margin-top: 5px;
 }
 
+/* ============================================
+   iMessage-style Compose Bar
+   ============================================ */
 #input-container {
   display: flex;
   flex-direction: column;
-  gap: var(--space-1);
-  border-top: 1px solid var(--clr-border);
-  padding: var(--space-2) 0 0;
+  gap: 0;
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+  padding: 6px 12px 4px;
   flex-shrink: 0;
   background: var(--clr-bg-light);
 }
 
-.chat-disclaimer {
-  text-align: center;
-  font-size: 0.7rem;
-  color: var(--clr-text-dim);
-  margin: 2px 0 0;
-  line-height: 1.3;
-}
-
-.chat-disclaimer i {
-  margin-right: 4px;
-  opacity: 0.7;
-}
-
-/* Toolbar Above Message Box */
-.input-toolbar {
-  display: flex;
-  gap: var(--space-1);
-  padding: var(--space-2);
-  background: var(--clr-bg-subtle);
-  border-radius: var(--radius-base);
+/* Suggestion chips row */
+.imessage-chips-row {
+  display: none;
+  gap: 6px;
   flex-wrap: wrap;
-  border: 1px solid var(--clr-border-light);
+  padding: 4px 0 6px;
 }
 
-.input-toolbar .btn {
-  flex: 0 0 auto;
-  min-width: 40px;
+/* Compose bar layout */
+.imessage-compose-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* Tool buttons row — compact, subtle */
+.imessage-tool-btns {
+  display: flex;
+  gap: 2px;
+  padding: 0 4px;
+}
+
+.imessage-tool-btn {
+  background: none;
+  border: none;
+  width: 34px;
+  height: 30px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #007AFF;
+  font-size: 15px;
+  cursor: pointer;
+  transition: background 0.15s;
+  padding: 0;
+  box-shadow: none;
+}
+
+.imessage-tool-btn:hover {
+  background: rgba(0, 122, 255, 0.08);
+}
+
+.imessage-tool-btn:active {
+  background: rgba(0, 122, 255, 0.15);
+  transform: scale(0.95);
+}
+
+/* Input row: text field + send button on one line */
+.imessage-input-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
 }
 
 #user-input {
-  width: 100%;
-  min-height: 44px;
-  max-height: 200px;
+  flex: 1;
+  min-height: 36px;
+  max-height: 120px;
   overflow-y: auto;
-  padding: 12px 16px;
-  border-radius: var(--radius-lg);
-  border: 1.5px solid var(--clr-border);
-  font-size: 1rem;
+  padding: 8px 14px;
+  border-radius: 20px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  font-size: 0.95rem;
   resize: none;
   white-space: pre-wrap;
   word-wrap: break-word;
-  background: var(--clr-bg-light);
-  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
-  line-height: var(--line-height-normal);
+  background: var(--clr-bg-subtle);
+  transition: border-color 0.15s, box-shadow 0.15s;
+  line-height: 1.4;
 }
 
 /* Placeholder for contenteditable */
 #user-input:empty::before {
   content: attr(data-placeholder);
-  color: #999;
+  color: #8e8e93;
   pointer-events: none;
 }
 
 #user-input:focus {
   outline: none;
-  border-color: var(--clr-primary-teal);
-  box-shadow: 0 0 0 2px rgba(18, 179, 179, 0.1);
+  border-color: rgba(0, 122, 255, 0.4);
+  box-shadow: none;
 }
 
 /* Math rendering in input field */
@@ -372,27 +432,55 @@
   vertical-align: middle;
   padding: 2px 4px;
   margin: 0 2px;
-  background-color: rgba(var(--clr-primary-teal-rgb), 0.05);
+  background-color: rgba(0, 122, 255, 0.06);
   border-radius: 3px;
 }
 
-#send-button {
-  padding: 10px 18px;
-  background: linear-gradient(135deg, var(--clr-primary-teal) 0%, #0E9494 100%);
-  color: var(--clr-bg-light);
-  border-radius: var(--radius-full);
-  min-width: 48px;
-  min-height: 44px;
-  box-shadow: var(--shadow-card-primary);
-  transition: all var(--transition-base);
+/* Circular send button — iMessage arrow */
+.imessage-send-btn {
+  width: 34px;
+  height: 34px;
+  min-width: 34px;
+  border-radius: 50%;
+  border: none;
+  background: #007AFF;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.15s, transform 0.1s;
+  flex-shrink: 0;
+  padding: 0;
+  box-shadow: none;
+  font-size: 15px;
 }
-#send-button:hover {
-  background: linear-gradient(135deg, #0E9494 0%, #0C8282 100%);
-  box-shadow: var(--shadow-glow-teal);
-  transform: scale(1.05);
+
+.imessage-send-btn:hover {
+  background: #0066d6;
 }
-#send-button:active {
-  transform: scale(0.95);
+
+.imessage-send-btn:active {
+  transform: scale(0.9);
+}
+
+/* Disclaimer — more subtle */
+.chat-disclaimer {
+  text-align: center;
+  font-size: 0.65rem;
+  color: #c7c7cc;
+  margin: 3px 0 0;
+  line-height: 1.3;
+}
+
+.chat-disclaimer i {
+  margin-right: 3px;
+  opacity: 0.5;
+}
+
+/* Legacy toolbar (hidden — replaced by imessage-tool-btns) */
+.input-toolbar {
+  display: none;
 }
 
 /* Input Tools (Mic, Equation, Attach) */
@@ -437,23 +525,23 @@
   z-index: 9999;
 }
 
-/* Thinking Indicator (iMessage style) */
+/* Thinking Indicator — iMessage typing bubble */
 #thinking-indicator, #parent-thinking-indicator {
   display: none; /* Controlled by JS */
   align-items: center;
-  justify-content: flex-start; /* Aligned left for AI bubble feel */
-  gap: 6px;
-  padding: 8px 16px;
-  margin-left: 15px; /* Indent slightly like an AI bubble */
-  border-radius: 18px; /* Bubble shape, matching new .message styles */
-  border-bottom-left-radius: 4px; /* Match AI bubble */
-  background-color: #e0e0e0; /* AI bubble background */
+  justify-content: flex-start;
+  gap: 5px;
+  padding: 10px 16px;
+  margin-left: 34px; /* Align with AI message bubbles (avatar width + gap) */
+  border-radius: 18px;
+  border-bottom-left-radius: 4px;
+  background-color: #E9E9EB;
   flex-shrink: 0;
-  font-size: 0.95em;
-  color: var(--clr-text-dim);
-  max-width: 75%;
-  align-self: flex-start; /* Align left */
-  box-shadow: 0 1px 3px rgba(0,0,0,0.08); /* Match AI bubble shadow */
+  font-size: 0.9em;
+  color: #8e8e93;
+  max-width: 120px;
+  align-self: flex-start;
+  box-shadow: none;
 }
 /* Corrected dot animation for thinking indicator */
 #thinking-indicator .dot, #parent-thinking-indicator .dot {

--- a/public/css/dark-mode.css
+++ b/public/css/dark-mode.css
@@ -383,7 +383,80 @@
 
 /* Chat disclaimer dark mode */
 [data-theme="dark"] .chat-disclaimer {
-    color: var(--text-secondary);
+    color: #4a5568;
+}
+
+/* iMessage dark mode overrides */
+[data-theme="dark"] #chat-messages-container {
+    background-color: #000;
+}
+
+[data-theme="dark"] .message.ai {
+    background-color: #1c1c1e;
+    color: #f0f0f0;
+}
+
+[data-theme="dark"] .message.user {
+    background: #0b84fe;
+}
+
+[data-theme="dark"] #user-input {
+    background: #1c1c1e;
+    border-color: #38383a;
+    color: #f0f0f0;
+}
+
+[data-theme="dark"] #user-input:empty::before {
+    color: #636366;
+}
+
+[data-theme="dark"] .imessage-tool-btn {
+    color: #0a84ff;
+}
+
+[data-theme="dark"] .imessage-send-btn {
+    background: #0a84ff;
+}
+
+[data-theme="dark"] #thinking-indicator,
+[data-theme="dark"] #parent-thinking-indicator {
+    background-color: #1c1c1e;
+    color: #636366;
+}
+
+[data-theme="dark"] .session-stats-bar {
+    background: #000;
+    border-top-color: #1c1c1e;
+}
+
+[data-theme="dark"] .stat-label {
+    color: #636366;
+}
+
+[data-theme="dark"] .stat-value {
+    color: #0a84ff;
+}
+
+/* Hamburger dropdown dark mode */
+[data-theme="dark"] .header-dropdown-menu {
+    background: #1c1c1e;
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.4);
+}
+
+[data-theme="dark"] .header-menu-item {
+    color: #f0f0f0;
+}
+
+[data-theme="dark"] .header-menu-item:hover {
+    background: #2c2c2e;
+}
+
+[data-theme="dark"] .header-menu-item i {
+    color: #0a84ff;
+}
+
+[data-theme="dark"] .header-menu-divider {
+    background: #38383a;
 }
 
 /* App sidebar in dark mode */

--- a/public/css/mobile-fixes.css
+++ b/public/css/mobile-fixes.css
@@ -237,22 +237,20 @@ input, textarea, select, .math-field {
         opacity: 0.7;
     }
 
-    /* Send button: prominent, tappable */
+    /* Send button: iMessage-style circle */
     #send-button {
-        min-height: 44px;
-        min-width: 48px;
-        font-size: 0.95rem;
-        font-weight: 600;
-        padding: 10px 20px;
-        border-radius: 22px;
-        margin-top: 6px;
-        letter-spacing: 0.01em;
-        transition: transform 100ms ease, opacity 150ms ease;
+        width: 36px;
+        height: 36px;
+        min-width: 36px;
+        min-height: 36px;
+        padding: 0;
+        border-radius: 50%;
+        margin-top: 0;
+        font-size: 15px;
     }
 
     #send-button:active {
-        transform: scale(0.96);
-        opacity: 0.9;
+        transform: scale(0.9);
     }
 
     /* Scrollable toolbar with fade edges */
@@ -1213,17 +1211,20 @@ input, textarea, select, .math-field {
     }
 
     #send-button {
-        min-height: 36px;
-        padding: 6px 14px;
+        width: 32px;
+        height: 32px;
+        min-width: 32px;
+        min-height: 32px;
+        padding: 0;
     }
 
     #chat-messages-container {
-        padding: 4px 8px;
+        padding: 6px 10px;
     }
 
     .message {
         padding: 8px 12px;
-        margin-bottom: 2px;
+        margin-bottom: 1px;
     }
 
     .message-avatar {
@@ -1562,23 +1563,22 @@ body.is-mobile #sidebar-toggle {
         font-size: 0.85rem !important;
     }
 
-    /* Send button */
-    #send-button.send-button-fullwidth {
-        width: 100%;
-        min-height: 42px !important;
-        padding: 10px 16px !important;
-        font-size: 0.9rem !important;
-        font-weight: 600;
-        border-radius: 22px;
-        letter-spacing: 0.02em;
+    /* Send button — iMessage circle */
+    #send-button {
+        width: 36px !important;
+        height: 36px !important;
+        min-width: 36px !important;
+        min-height: 36px !important;
+        padding: 0 !important;
+        border-radius: 50% !important;
     }
 
     /* Text input */
     #user-input {
-        min-height: 42px !important;
-        padding: 10px 16px !important;
-        margin-bottom: 4px !important;
-        border-radius: 22px;
+        min-height: 36px !important;
+        padding: 8px 14px !important;
+        margin-bottom: 0 !important;
+        border-radius: 20px;
         font-size: 16px;
     }
 

--- a/public/style.css
+++ b/public/style.css
@@ -86,6 +86,70 @@
     justify-content: center;
 }
 
+/* ============================================
+   Header Dropdown Menu (Hamburger)
+   ============================================ */
+.header-dropdown-menu {
+    display: none;
+    position: absolute;
+    top: calc(100% + 4px);
+    right: var(--page-horizontal-padding);
+    background: var(--clr-bg-light);
+    border-radius: 12px;
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.12), 0 2px 8px rgba(0, 0, 0, 0.06);
+    padding: 6px 0;
+    min-width: 200px;
+    z-index: var(--z-dropdown);
+    animation: menuDropIn 0.15s ease-out;
+}
+
+.header-dropdown-menu.is-open {
+    display: block;
+}
+
+@keyframes menuDropIn {
+    from { opacity: 0; transform: translateY(-6px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.header-menu-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    padding: 10px 18px;
+    background: none;
+    border: none;
+    font-size: 0.9rem;
+    color: var(--text-primary);
+    cursor: pointer;
+    text-align: left;
+    transition: background 0.12s;
+}
+
+.header-menu-item:hover {
+    background: var(--clr-bg-subtle);
+}
+
+.header-menu-item i {
+    width: 18px;
+    text-align: center;
+    color: #007AFF;
+    font-size: 14px;
+}
+
+.header-menu-divider {
+    height: 1px;
+    background: var(--clr-border-light);
+    margin: 4px 12px;
+}
+
+/* Position header as relative for dropdown */
+.landing-header {
+    position: sticky;
+    top: 0;
+}
+
 main {
     flex-grow: 1;
     overflow-y: auto;
@@ -2784,35 +2848,36 @@ body:not(.landing-page-body) {
     }
 }
 
-/* Session Stats Bar - Bottom of chat */
+/* Session Stats Bar - Minimal bottom strip */
 .session-stats-bar {
     position: sticky;
     bottom: 0;
-    background: linear-gradient(90deg, rgba(102, 126, 234, 0.1) 0%, rgba(118, 75, 162, 0.1) 100%);
-    border-top: 2px solid rgba(102, 126, 234, 0.2);
-    padding: 8px 16px;
+    background: var(--clr-bg-light);
+    border-top: 1px solid rgba(0, 0, 0, 0.06);
+    padding: 4px 16px;
     display: flex;
-    justify-content: space-around;
+    justify-content: center;
     align-items: center;
-    font-size: 0.85rem;
+    gap: 20px;
+    font-size: 0.75rem;
     z-index: 1000;
 }
 
 .stat-item {
     display: flex;
     align-items: center;
-    gap: 6px;
+    gap: 4px;
 }
 
 .stat-label {
-    color: #666;
-    font-weight: 600;
+    color: #8e8e93;
+    font-weight: 500;
 }
 
 .stat-value {
-    color: #667eea;
-    font-weight: 900;
-    font-size: 1rem;
+    color: #007AFF;
+    font-weight: 700;
+    font-size: 0.8rem;
 }
 
 /* Quest Tracker Sidebar Styles */


### PR DESCRIPTION
- Replace full-width send button with compact circular arrow button inline with the text input (iMessage compose bar layout)
- Move toolbar icons (equation, attach, camera, mic) into a subtle row above the input field
- Update message bubbles: tighter spacing, 18px border-radius, grouped consecutive same-sender messages with hidden avatars
- Use iMessage blue (#007AFF) for user bubbles, light gray (#E9E9EB) for AI bubbles, no box-shadows
- Collapse header actions (settings, resources, share, feedback, logout) into a hamburger dropdown menu in the upper right
- Keep TTS playback controls visible only during audio playback
- Minimize session stats bar to a subtle single-line strip
- Add full dark mode support for all new iMessage styles
- Remove border and background tint from chat messages container

https://claude.ai/code/session_01DQsgZ2f3fFD5LPcDQCQhL3