### PR TITLE
Improve JSON parsing resilience for LaTeX-containing AI responses

### DIFF
--- a/routes/gradeWork.js
+++ b/routes/gradeWork.js
@@ -145,11 +145,26 @@ function parseAnalysisResponse(raw) {
         jsonStr = fenceMatch[1].trim();
     }
 
-    // LLMs often produce bare LaTeX backslashes (\(, \frac, \[, etc.)
-    // that are invalid JSON escapes. Fix them before parsing.
-    jsonStr = jsonStr.replace(/\\(?!["\\/bfnrtu])/g, '\\\\');
+    let parsed;
 
-    const parsed = JSON.parse(jsonStr);
+    // First try: parse as-is (works when AI returns properly escaped JSON)
+    try {
+        parsed = JSON.parse(jsonStr);
+    } catch (_) {
+        // Second try: fix bare LaTeX backslashes that are invalid JSON escapes.
+        // The prompt requires LaTeX like \( and \frac inside JSON string values,
+        // which are not valid JSON escape sequences. We double-escape them while
+        // preserving valid sequences like \", \\, \n, \/, \uXXXX, etc.
+        const fixed = jsonStr.replace(
+            /\\(["\\/bfnrt])|\\u([0-9a-fA-F]{4})|\\(.)/g,
+            (match, validEsc, unicodeHex, other) => {
+                if (validEsc !== undefined) return match;   // e.g. \", \\, \n
+                if (unicodeHex !== undefined) return match;  // e.g. \u00A0
+                return '\\\\' + other;                       // e.g. \( → \\(
+            }
+        );
+        parsed = JSON.parse(fixed);
+    }
 
     if (!parsed.problems || !Array.isArray(parsed.problems)) {
         throw new Error('AI response missing problems array');
@@ -182,6 +197,7 @@ router.post('/',
     upload.single('file'),
     validateUpload,
     async (req, res) => {
+    let aiResponse = '';
     try {
         const file = req.file;
         const user = await User.findById(req.user._id);
@@ -201,7 +217,6 @@ router.post('/',
 
         console.log(`[gradeWork] Analyzing work for user: ${user.firstName} ${user.lastName} (${isPDF ? 'PDF' : 'image'})`);
 
-        let aiResponse;
 
         if (isPDF) {
             // PDF path: Extract text via Mathpix, then use text-based analysis
@@ -262,7 +277,7 @@ router.post('/',
             });
         }
 
-        console.log('[gradeWork] AI analysis received');
+        console.log('[gradeWork] AI analysis received, length:', aiResponse.length);
 
         // Parse structured JSON
         const parsed = parseAnalysisResponse(aiResponse);
@@ -395,6 +410,7 @@ router.post('/',
         }
 
         if (error instanceof SyntaxError) {
+            console.error('[gradeWork] JSON parse failure. Raw AI response (first 500 chars):', (aiResponse || '').substring(0, 500));
             return res.status(502).json({
                 success: false,
                 message: 'The AI returned an unexpected format. Please try again.'


### PR DESCRIPTION
## Summary
Enhanced the `parseAnalysisResponse` function to more robustly handle JSON responses from the AI that contain LaTeX expressions. The parser now uses a two-stage approach: first attempting to parse the JSON as-is, then falling back to intelligent backslash escaping only when needed.

## Key Changes
- **Two-stage JSON parsing**: Tries parsing the raw response first, then applies selective backslash escaping only on failure
- **Improved escape sequence handling**: Uses a more precise regex pattern that preserves valid JSON escape sequences (`\"`, `\\`, `\n`, `\/`, `\uXXXX`, etc.) while only double-escaping invalid LaTeX sequences like `\(`, `\frac`, `\[`
- **Better error diagnostics**: Added logging of AI response length and first 500 characters on JSON parse failures to aid debugging
- **Variable scope fix**: Moved `aiResponse` variable declaration to the top of the route handler to ensure it's accessible in error handling blocks

## Implementation Details
The new regex pattern `/(\\(["\\/bfnrt])|\\u([0-9a-fA-F]{4})|\\(.)/g` uses capture groups to distinguish between:
- Valid JSON escape sequences (preserved as-is)
- Unicode escapes (preserved as-is)
- Other backslash sequences like LaTeX (double-escaped)

This approach is more efficient than the previous blanket replacement and reduces unnecessary modifications to the JSON string.

https://claude.ai/code/session_0183zkqZVzPhKQHY8cbTBVqe