### PR TITLE
Stop background polling on 401 and redirect to login

### DIFF
--- a/public/js/csrf.js
+++ b/public/js/csrf.js
@@ -71,6 +71,23 @@ function addCsrfTokenToForm(formData) {
 }
 
 /**
+ * Handle 401 — session has expired. Stop all background polling and
+ * redirect to the login page (once).
+ */
+function handleSessionExpired() {
+  if (window.__sessionExpired) return;
+  window.__sessionExpired = true;
+
+  console.warn('[Auth] Session expired — stopping background requests');
+  window.dispatchEvent(new CustomEvent('session-expired'));
+
+  // Don't redirect if already on the login page
+  if (!window.location.pathname.includes('login')) {
+    setTimeout(() => { window.location.href = '/login.html'; }, 100);
+  }
+}
+
+/**
  * Enhanced fetch wrapper with automatic CSRF token injection
  * Drop-in replacement for fetch() that handles CSRF automatically
  *
@@ -85,6 +102,11 @@ function addCsrfTokenToForm(formData) {
  * @returns {Promise} Fetch promise
  */
 async function csrfFetch(url, options = {}) {
+  // If session already expired, return a synthetic 401 to avoid network noise
+  if (window.__sessionExpired) {
+    return new Response(null, { status: 401, statusText: 'Session Expired' });
+  }
+
   // Only add CSRF token for state-changing methods
   const method = (options.method || 'GET').toUpperCase();
   const needsCsrf = ['POST', 'PUT', 'DELETE', 'PATCH'].includes(method);
@@ -93,7 +115,13 @@ async function csrfFetch(url, options = {}) {
     options = addCsrfToken(options);
   }
 
-  return fetch(url, options);
+  const response = await fetch(url, options);
+
+  if (response.status === 401) {
+    handleSessionExpired();
+  }
+
+  return response;
 }
 
 // Export for use in other modules (if using ES6 modules)

--- a/public/js/impersonationBanner.js
+++ b/public/js/impersonationBanner.js
@@ -27,6 +27,7 @@
 
   function schedulePoll() {
     if (pollTimer) clearTimeout(pollTimer);
+    if (window.__sessionExpired) return;
     const interval = Math.min(
       POLL_INTERVAL * Math.pow(2, consecutiveFailures),
       MAX_POLL_INTERVAL
@@ -41,9 +42,15 @@
    * Check current impersonation status from server
    */
   async function checkImpersonationStatus() {
+    if (window.__sessionExpired) return;
     try {
       const response = await fetch('/api/impersonation/status');
       if (!response.ok) {
+        if (response.status === 401) {
+          cleanup();
+          if (typeof handleSessionExpired === 'function') handleSessionExpired();
+          return;
+        }
         if (response.status === 429) consecutiveFailures++;
         return;
       }

--- a/public/js/modules/session.js
+++ b/public/js/modules/session.js
@@ -39,8 +39,9 @@ export function initSessionTracking(getCurrentUser) {
         }
     });
 
-    // Send heartbeat on a dynamic schedule (backs off on 429)
+    // Send heartbeat on a dynamic schedule (backs off on 429, stops on 401)
     function scheduleHeartbeat() {
+        if (window.__sessionExpired) return;
         const interval = Math.min(
             sessionTracker.baseInterval * Math.pow(2, sessionTracker.consecutiveFailures),
             sessionTracker.maxInterval
@@ -50,6 +51,12 @@ export function initSessionTracking(getCurrentUser) {
         }, interval);
     }
     scheduleHeartbeat();
+
+    // Stop scheduling if session expires
+    window.addEventListener('session-expired', () => {
+        clearTimeout(sessionTracker.heartbeatTimer);
+        sessionTracker.heartbeatTimer = null;
+    });
 
     // Send final time on page unload
     window.addEventListener('beforeunload', () => {
@@ -75,6 +82,7 @@ export function getActiveSeconds() {
 }
 
 export async function sendTimeHeartbeat(getCurrentUser, isFinal = false) {
+    if (window.__sessionExpired) return;
     const currentUser = getCurrentUser();
     if (!currentUser || !currentUser._id) return;
 

--- a/public/js/sessionManager.js
+++ b/public/js/sessionManager.js
@@ -39,6 +39,7 @@ class SessionManager {
       masteryProgress: null
     };
 
+    this.stopped = false;
     this.init();
   }
 
@@ -60,6 +61,9 @@ class SessionManager {
     } else {
       console.log('[SessionManager] Initialized (idle timeout deferred to auto-logout.js)');
     }
+
+    // Stop all timers if session expires (401 detected by csrfFetch)
+    window.addEventListener('session-expired', () => this.stop());
 
     // Handle page unload (tab/browser close)
     this.setupUnloadHandler();
@@ -133,7 +137,17 @@ class SessionManager {
     this.scheduleNextHeartbeat();
   }
 
+  stop() {
+    this.stopped = true;
+    clearTimeout(this.heartbeatTimer);
+    clearInterval(this.idleCheckTimer);
+    clearTimeout(this.warningTimer);
+    this.heartbeatTimer = null;
+    console.log('[SessionManager] Stopped (session expired)');
+  }
+
   scheduleNextHeartbeat() {
+    if (this.stopped) return;
     if (this.heartbeatTimer) clearTimeout(this.heartbeatTimer);
     this.heartbeatTimer = setTimeout(() => {
       this.checkAndUpdateActiveTime();
@@ -163,6 +177,7 @@ class SessionManager {
   }
 
   async sendHeartbeat() {
+    if (this.stopped) return;
     try {
       // Check active time one more time before sending
       this.checkAndUpdateActiveTime();

--- a/public/js/student-announcements.js
+++ b/public/js/student-announcements.js
@@ -30,6 +30,7 @@
 
     function schedulePoll() {
         if (pollTimer) clearTimeout(pollTimer);
+        if (window.__sessionExpired) return;
         const interval = Math.min(
             BASE_POLL_INTERVAL * Math.pow(2, consecutiveFailures),
             MAX_POLL_INTERVAL
@@ -228,9 +229,15 @@
 
     // Load unread count
     async function loadUnreadCount() {
+        if (window.__sessionExpired) return;
         try {
             const response = await fetch('/api/announcements/student/unread-count');
             if (!response.ok) {
+                if (response.status === 401) {
+                    if (pollTimer) clearTimeout(pollTimer);
+                    if (typeof handleSessionExpired === 'function') handleSessionExpired();
+                    return;
+                }
                 if (response.status === 429) consecutiveFailures++;
                 return;
             }


### PR DESCRIPTION
When a user's session expires, all background pollers (heartbeat, time tracking, announcements, impersonation status) kept firing indefinitely, flooding the console with 401 errors.

Fix: add a central session-expired handler in csrfFetch that sets a global flag, fires a 'session-expired' event, and redirects to login. Each polling system now checks this flag before scheduling its next request and listens for the event to clean up timers.

Files using raw fetch() (announcements, impersonation) also detect 401 directly and call the same handler.

https://claude.ai/code/session_0183zkqZVzPhKQHY8cbTBVqe