### PR TITLE
Fix classroom image too big and tabletBoy head cutoff

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1083,10 +1083,12 @@
     .lp-mission-photo {
       border-radius: 14px;
       overflow: hidden;
+      max-height: 340px;
     }
 
     .lp-mission-photo img {
       width: 100%; height: 100%;
+      max-height: 340px;
       object-fit: cover; display: block;
       border-radius: 14px;
     }
@@ -2058,7 +2060,7 @@
     <section class="lp-spotlight lp-reveal">
       <div class="lp-spotlight-layout lp-inner">
         <div class="lp-spotlight-photo">
-          <img src="/images/tabletBoy.png" alt="Student using a tablet to learn math with Mathmatix AI" />
+          <img src="/images/tabletBoy.png" alt="Student using a tablet to learn math with Mathmatix AI" style="object-position: top;" />
         </div>
         <div class="lp-spotlight-content">
           <h2>A Tutor That Never Sleeps</h2>


### PR DESCRIPTION
- Add max-height: 340px to mission photo container to match spotlight sections
- Add object-position: top to tabletBoy so the boy's head isn't cropped off

https://claude.ai/code/session_01VMiEHGa77MoJkLXNeMrmNm