### PR TITLE
Fix session destruction on page navigation

### DIFF
--- a/public/js/sessionManager.js
+++ b/public/js/sessionManager.js
@@ -493,12 +493,14 @@ class SessionManager {
         navigator.sendBeacon('/api/session/save-mastery', masteryBlob);
       }
 
-      // Send session end AND destroy the server-side session.
-      // destroySession: true tells the server to call req.session.destroy()
-      // so the user is actually logged out (not just summarized).
+      // Send session end for summary/tracking only — do NOT destroy the session.
+      // beforeunload and pagehide fire on BOTH browser close AND same-origin
+      // navigation (e.g. clicking "Change Tutor" in settings). Destroying the
+      // session here would log the user out whenever they navigate between pages.
+      // Stale sessions are cleaned up server-side by destroyIdleExpressSessions().
       const payload = {
         reason,
-        destroySession: true,
+        destroySession: false,
         sessionData: {
           ...this.sessionData,
           timeSpent: Date.now() - this.sessionStartTime
@@ -510,7 +512,7 @@ class SessionManager {
       console.log(`[SessionManager] Session end beacon sent: ${reason}`);
     };
 
-    // 1. beforeunload - fires when user is leaving the page
+    // 1. beforeunload - fires when user is leaving the page (navigation OR tab close)
     window.addEventListener('beforeunload', () => {
       sendSessionEnd('browser_close');
     });


### PR DESCRIPTION
## Summary
Changed session handling to prevent users from being logged out when navigating between pages within the application. The session is now only summarized on page exit events, with server-side idle cleanup handling stale session destruction.

## Key Changes
- Set `destroySession: false` in the session end beacon payload to prevent immediate server-side session destruction
- Updated comments to clarify that `beforeunload` and `pagehide` events fire on both browser close AND same-origin navigation (e.g., clicking "Change Tutor" in settings)
- Added explanation that stale sessions are cleaned up server-side by `destroyIdleExpressSessions()` rather than on every page exit

## Implementation Details
The previous implementation would destroy the session whenever a `beforeunload` or `pagehide` event fired, which occurs not only when closing the browser/tab but also during normal same-origin navigation within the application. This caused users to be unexpectedly logged out when navigating between pages.

The fix maintains session tracking and summary data collection while deferring actual session destruction to server-side idle session cleanup, allowing users to navigate freely within the application without losing their session.

https://claude.ai/code/session_012m6hj2MGV7TSK34pCFhPqX