### PR TITLE
Fix TypeError: Assignment to constant variable in chat route

### DIFF
--- a/routes/chat.js
+++ b/routes/chat.js
@@ -521,7 +521,7 @@ router.post('/', isAuthenticated, promptInjectionFilter, async (req, res) => {
         const mathResult = processMathMessage(message);
 
         // Execute all fetches in parallel
-        const [curriculumContext, teacherAISettings, resourceContext, recentUploads, recentGradingResults, errorPatterns] = await Promise.all(contextPromises);
+        let [curriculumContext, teacherAISettings, resourceContext, recentUploads, recentGradingResults, errorPatterns] = await Promise.all(contextPromises);
 
         // Log teacher settings if loaded
         if (teacherAISettings) {


### PR DESCRIPTION
The resourceContext variable was declared via const destructuring at line 524 but reassigned at line 548 when a resource mention is detected but not found in the database. This caused a 500 error on every chat message where the student mentioned a resource name not in the DB.

Changed const to let for the Promise.all destructuring.

https://claude.ai/code/session_01XNz1oEqZF7F6wYd4dCRKUD