### PR TITLE
Fix mobile formatting in Grade My Work results

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -999,7 +999,7 @@
         </div>
 
         <!-- Action Buttons -->
-        <div style="display: flex; gap: 10px; justify-content: space-between; margin-top: 20px;">
+        <div class="syw-result-actions">
           <button id="syw-try-again-btn" class="btn btn-secondary">
             <i class="fas fa-redo"></i> Check Another
           </button>

--- a/public/css/show-your-work.css
+++ b/public/css/show-your-work.css
@@ -372,6 +372,25 @@
     background: #e5e7eb;
 }
 
+/* ---- Result Action Buttons ---- */
+.syw-result-actions {
+    display: flex;
+    gap: 10px;
+    justify-content: space-between;
+    margin-top: 20px;
+}
+
+@media (max-width: 480px) {
+    .syw-result-actions {
+        flex-direction: column;
+    }
+
+    .syw-result-actions .btn {
+        width: 100%;
+        text-align: center;
+    }
+}
+
 /* ---- Camera Overlay ---- */
 .syw-live-camera-overlay {
     position: fixed;

--- a/public/js/show-your-work.js
+++ b/public/js/show-your-work.js
@@ -393,7 +393,7 @@ class ShowYourWorkManager {
                     ${correct ? 'Got it' : 'Take another look'}
                 </span>
             </div>
-            ${problem.problemStatement ? `<div class="syw-problem-statement">${this.escapeHtml(problem.problemStatement)}</div>` : ''}
+            ${problem.problemStatement ? `<div class="syw-problem-statement">${problem.problemStatement}</div>` : ''}
 
             <!-- Tutor feedback is the main content (not escaped — may contain LaTeX) -->
             ${problem.feedback ? `<div class="syw-problem-feedback">${problem.feedback}</div>` : ''}
@@ -404,7 +404,7 @@ class ShowYourWorkManager {
             <div class="syw-problem-answers">
                 <div class="syw-answer-row">
                     <span class="syw-answer-label">Your answer:</span>
-                    <span class="syw-answer-value">${this.escapeHtml(problem.studentAnswer || '—')}</span>
+                    <span class="syw-answer-value">${problem.studentAnswer || '—'}</span>
                 </div>
                 ${!correct ? `<div class="syw-answer-row">
                     <span class="syw-answer-label">Hint:</span>


### PR DESCRIPTION
- Allow LaTeX rendering in studentAnswer and problemStatement fields by removing escapeHtml() (matching treatment of feedback field which already renders LaTeX correctly)
- Fix bottom action buttons (Check Another / Ask My Tutor) getting truncated on mobile by replacing inline flex styles with a CSS class that stacks buttons vertically on screens ≤480px

https://claude.ai/code/session_011V2aXQ6ZXcPLQa7o2dFCqL