### PR TITLE
Fix SSL certificate error: add custom domains to Render and normalize…

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,23 +10,23 @@
   <meta name="keywords" content="math tutor, AI tutoring, online math help, personalized learning, math education, K-12 math, homework help, adaptive learning, math equity, affordable math tutor, free math help, step-by-step math" />
   <meta name="author" content="Mathmatix AI" />
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.mathmatix.ai/" />
+  <link rel="canonical" href="https://mathmatix.ai/" />
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://www.mathmatix.ai/" />
+  <meta property="og:url" content="https://mathmatix.ai/" />
   <meta property="og:title" content="Mathmatix AI | A Math Tutor That Actually Knows Your Child" />
   <meta property="og:description" content="Personalized, AI-powered math tutoring that adapts to your child's learning style. Get one-on-one help anytime, anywhere." />
-  <meta property="og:image" content="https://www.mathmatix.ai/images/mathmatix-ai-logo.png" />
+  <meta property="og:image" content="https://mathmatix.ai/images/mathmatix-ai-logo.png" />
   <meta property="og:site_name" content="Mathmatix AI" />
   <meta property="og:locale" content="en_US" />
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:url" content="https://www.mathmatix.ai/" />
+  <meta name="twitter:url" content="https://mathmatix.ai/" />
   <meta name="twitter:title" content="Mathmatix AI | A Math Tutor That Actually Knows Your Child" />
   <meta name="twitter:description" content="Personalized, AI-powered math tutoring that adapts to your child's learning style. Get one-on-one help anytime, anywhere." />
-  <meta name="twitter:image" content="https://www.mathmatix.ai/images/mathmatix-ai-logo.png" />
+  <meta name="twitter:image" content="https://mathmatix.ai/images/mathmatix-ai-logo.png" />
 
   <!-- JSON-LD Structured Data -->
   <script type="application/ld+json">
@@ -35,8 +35,8 @@
     "@type": "EducationalOrganization",
     "name": "Mathmatix AI",
     "description": "An intelligent math tutoring platform that provides personalized, one-on-one learning for students of all levels.",
-    "url": "https://www.mathmatix.ai",
-    "logo": "https://www.mathmatix.ai/images/mathmatix-ai-logo.png",
+    "url": "https://mathmatix.ai",
+    "logo": "https://mathmatix.ai/images/mathmatix-ai-logo.png",
     "sameAs": [],
     "contactPoint": {
       "@type": "ContactPoint",
@@ -55,11 +55,11 @@
     "@context": "https://schema.org",
     "@type": "WebSite",
     "name": "Mathmatix AI",
-    "url": "https://www.mathmatix.ai",
+    "url": "https://mathmatix.ai",
     "description": "Affordable AI math tutor for every child",
     "potentialAction": {
       "@type": "SearchAction",
-      "target": "https://www.mathmatix.ai/search?q={search_term_string}",
+      "target": "https://mathmatix.ai/search?q={search_term_string}",
       "query-input": "required name=search_term_string"
     }
   }

--- a/public/login.html
+++ b/public/login.html
@@ -8,21 +8,21 @@
 
   <!-- SEO Meta Tags -->
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.mathmatix.ai/login.html" />
+  <link rel="canonical" href="https://mathmatix.ai/login.html" />
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://www.mathmatix.ai/login.html" />
+  <meta property="og:url" content="https://mathmatix.ai/login.html" />
   <meta property="og:title" content="Login | Mathmatix AI" />
   <meta property="og:description" content="Log in to Mathmatix AI to continue your personalized math learning journey." />
-  <meta property="og:image" content="https://www.mathmatix.ai/images/mathmatix-ai-logo.png" />
+  <meta property="og:image" content="https://mathmatix.ai/images/mathmatix-ai-logo.png" />
   <meta property="og:site_name" content="Mathmatix AI" />
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:title" content="Login | Mathmatix AI" />
   <meta name="twitter:description" content="Log in to continue your personalized math learning journey." />
-  <meta name="twitter:image" content="https://www.mathmatix.ai/images/mathmatix-ai-logo.png" />
+  <meta name="twitter:image" content="https://mathmatix.ai/images/mathmatix-ai-logo.png" />
 
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="css/dark-mode.css" />

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -8,14 +8,14 @@
 
   <!-- SEO Meta Tags -->
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.mathmatix.ai/privacy.html" />
+  <link rel="canonical" href="https://mathmatix.ai/privacy.html" />
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://www.mathmatix.ai/privacy.html" />
+  <meta property="og:url" content="https://mathmatix.ai/privacy.html" />
   <meta property="og:title" content="Privacy Policy | Mathmatix AI" />
   <meta property="og:description" content="Learn how Mathmatix AI protects your privacy and handles your data. COPPA and FERPA compliant." />
-  <meta property="og:image" content="https://www.mathmatix.ai/images/mathmatix-ai-logo.png" />
+  <meta property="og:image" content="https://mathmatix.ai/images/mathmatix-ai-logo.png" />
   <meta property="og:site_name" content="Mathmatix AI" />
 
   <!-- Twitter Card -->

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,5 @@
 # Robots.txt for Mathmatix AI
-# https://www.mathmatix.ai
+# https://mathmatix.ai
 
 User-agent: *
 Allow: /
@@ -30,4 +30,4 @@ Disallow: /api/
 Disallow: /auth/
 
 # Sitemap location
-Sitemap: https://www.mathmatix.ai/sitemap.xml
+Sitemap: https://mathmatix.ai/sitemap.xml

--- a/public/signup.html
+++ b/public/signup.html
@@ -8,21 +8,21 @@
 
   <!-- SEO Meta Tags -->
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.mathmatix.ai/signup.html" />
+  <link rel="canonical" href="https://mathmatix.ai/signup.html" />
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://www.mathmatix.ai/signup.html" />
+  <meta property="og:url" content="https://mathmatix.ai/signup.html" />
   <meta property="og:title" content="Sign Up | Mathmatix AI" />
   <meta property="og:description" content="Create your account and get started with personalized AI math tutoring. Perfect for students, parents, and teachers." />
-  <meta property="og:image" content="https://www.mathmatix.ai/images/mathmatix-ai-logo.png" />
+  <meta property="og:image" content="https://mathmatix.ai/images/mathmatix-ai-logo.png" />
   <meta property="og:site_name" content="Mathmatix AI" />
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:title" content="Sign Up | Mathmatix AI" />
   <meta name="twitter:description" content="Create your account and start learning math with AI tutoring." />
-  <meta name="twitter:image" content="https://www.mathmatix.ai/images/mathmatix-ai-logo.png" />
+  <meta name="twitter:image" content="https://mathmatix.ai/images/mathmatix-ai-logo.png" />
 
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="css/dark-mode.css" />

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://www.mathmatix.ai/</loc>
+    <loc>https://mathmatix.ai/</loc>
     <lastmod>2025-01-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://www.mathmatix.ai/login.html</loc>
+    <loc>https://mathmatix.ai/login.html</loc>
     <lastmod>2025-01-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.mathmatix.ai/signup.html</loc>
+    <loc>https://mathmatix.ai/signup.html</loc>
     <lastmod>2025-01-25</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://www.mathmatix.ai/privacy.html</loc>
+    <loc>https://mathmatix.ai/privacy.html</loc>
     <lastmod>2025-05-31</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://www.mathmatix.ai/terms.html</loc>
+    <loc>https://mathmatix.ai/terms.html</loc>
     <lastmod>2025-05-31</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.5</priority>

--- a/public/terms.html
+++ b/public/terms.html
@@ -8,14 +8,14 @@
 
   <!-- SEO Meta Tags -->
   <meta name="robots" content="index, follow" />
-  <link rel="canonical" href="https://www.mathmatix.ai/terms.html" />
+  <link rel="canonical" href="https://mathmatix.ai/terms.html" />
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://www.mathmatix.ai/terms.html" />
+  <meta property="og:url" content="https://mathmatix.ai/terms.html" />
   <meta property="og:title" content="Terms of Use | Mathmatix AI" />
   <meta property="og:description" content="Terms of Use for Mathmatix AI math tutoring platform." />
-  <meta property="og:image" content="https://www.mathmatix.ai/images/mathmatix-ai-logo.png" />
+  <meta property="og:image" content="https://mathmatix.ai/images/mathmatix-ai-logo.png" />
   <meta property="og:site_name" content="Mathmatix AI" />
 
   <!-- Twitter Card -->

--- a/render.yaml
+++ b/render.yaml
@@ -8,6 +8,11 @@ services:
     buildCommand: npm install
     startCommand: npm start
 
+    # Custom domain with SSL (Render auto-provisions Let's Encrypt certs)
+    customDomains:
+      - name: mathmatix.ai
+      - name: www.mathmatix.ai
+
     # Puppeteer needs this
     envVars:
       - key: NODE_VERSION

--- a/server.js
+++ b/server.js
@@ -137,6 +137,17 @@ const PORT = process.env.PORT || 3000;
 app.set("trust proxy", 1);
 
 // --- 6. MIDDLEWARE ---
+
+// Redirect www to apex domain in production (ensures consistent domain + valid SSL cert)
+if (isProduction) {
+  app.use((req, res, next) => {
+    if (req.hostname === 'www.mathmatix.ai') {
+      return res.redirect(301, `https://mathmatix.ai${req.originalUrl}`);
+    }
+    next();
+  });
+}
+
 app.use(cors({
   origin: process.env.CLIENT_URL || "http://localhost:3000",
   credentials: true


### PR DESCRIPTION
… to apex domain

The site was returning 403 (host_not_allowed) from Render's proxy because custom domains were not declared in render.yaml, so Render never provisioned an SSL certificate for mathmatix.ai. This caused browsers to see a certificate mismatch, and HSTS (preload) prevented any bypass.

Changes:
- Add customDomains (mathmatix.ai + www.mathmatix.ai) to render.yaml
- Add www→apex 301 redirect middleware in server.js for consistent URLs
- Update canonical URLs, OG tags, sitemap, and robots.txt to use mathmatix.ai

https://claude.ai/code/session_018kTabTCJQJ2DJjrR14uM67