### PR TITLE
Fix language not clearing on logout; add language settings to parent …

### DIFF
--- a/public/js/auto-logout.js
+++ b/public/js/auto-logout.js
@@ -38,6 +38,9 @@
       }
     }
 
+    // Clear UI language cache so next user on shared device gets a clean state
+    try { localStorage.removeItem('mathmatix_ui_lang'); } catch (e) { /* */ }
+
     // Use the CSRF-exempt /api/session/end endpoint (sendBeacon can't send CSRF headers).
     // This endpoint destroys the express session on the server side.
     const payload = JSON.stringify({ reason: 'auto_logout', destroySession: true });

--- a/public/js/logout.js
+++ b/public/js/logout.js
@@ -32,6 +32,8 @@ document.addEventListener('DOMContentLoaded', () => {
               StorageUtils.local.clear();
               StorageUtils.session.clear();
             }
+            // Clear UI language cache so next user gets a clean state
+            try { localStorage.removeItem('mathmatix_ui_lang'); } catch (e) { /* */ }
             window.location.href = '/login.html';
           } else {
             const errorText = await res.text();

--- a/public/js/parent-dashboard.js
+++ b/public/js/parent-dashboard.js
@@ -1012,11 +1012,12 @@ document.addEventListener("DOMContentLoaded", async () => {
             e.preventDefault();
             settingsSaveMessage.textContent = '';
 
+            const selectedLang = document.getElementById('parentLanguage').value;
             const formData = {
                 reportFrequency: document.getElementById('reportFrequency').value,
                 goalViewPreference: document.getElementById('goalViewPreference').value,
                 parentTone: document.getElementById('parentTone').value,
-                parentLanguage: document.getElementById('parentLanguage').value
+                parentLanguage: selectedLang
             };
 
             try {
@@ -1027,8 +1028,20 @@ document.addEventListener("DOMContentLoaded", async () => {
                     body: JSON.stringify(formData)
                 });
 
+                // Also sync to preferredLanguage so the i18n system picks it up
+                await csrfFetch('/api/user/settings', {
+                    method: 'PATCH',
+                    headers: { 'Content-Type': 'application/json' },
+                    credentials: 'include',
+                    body: JSON.stringify({ preferredLanguage: selectedLang })
+                });
+
                 const data = await res.json();
                 if (data.success) {
+                    // Update UI language in real time
+                    if (window.MathmatixI18n) {
+                        window.MathmatixI18n.setLanguage(selectedLang);
+                    }
                     settingsSaveMessage.className = "mt-2 text-sm text-green-600";
                     settingsSaveMessage.textContent = data.message;
                     showToast("Settings saved!", "success", 3500);

--- a/public/js/sessionManager.js
+++ b/public/js/sessionManager.js
@@ -387,6 +387,9 @@ class SessionManager {
       console.error('[SessionManager] Logout error:', error);
     }
 
+    // Clear UI language cache so the next user on this device gets a clean state
+    try { localStorage.removeItem('mathmatix_ui_lang'); } catch (e) { /* private mode */ }
+
     // Redirect to login
     window.location.href = '/login.html';
   }

--- a/public/js/teacher-ai-settings.js
+++ b/public/js/teacher-ai-settings.js
@@ -215,6 +215,25 @@ document.addEventListener('DOMContentLoaded', () => {
                     </div>
                 </div>
 
+                <!-- Dashboard Language -->
+                <div class="ai-settings-section">
+                    <h3><i class="fas fa-language"></i> Dashboard Language</h3>
+                    <div class="setting-group">
+                        <label>Choose the language for your dashboard interface.</label>
+                        <select id="teacher-preferred-language">
+                            <option value="English">English</option>
+                            <option value="Spanish">Spanish (Español)</option>
+                            <option value="Russian">Russian (Русский)</option>
+                            <option value="Chinese">Chinese (中文)</option>
+                            <option value="Vietnamese">Vietnamese (Tiếng Việt)</option>
+                            <option value="Arabic">Arabic (العربية)</option>
+                            <option value="Somali">Somali (Soomaali)</option>
+                            <option value="French">French (Français)</option>
+                            <option value="German">German (Deutsch)</option>
+                        </select>
+                    </div>
+                </div>
+
                 <div class="modal-footer">
                     <button class="btn btn-secondary" id="cancel-ai-settings">Cancel</button>
                     <button class="btn btn-primary" id="save-ai-settings"><i class="fas fa-save"></i> Save Settings</button>
@@ -223,6 +242,17 @@ document.addEventListener('DOMContentLoaded', () => {
         `;
 
         document.body.appendChild(modal);
+
+        // Pre-select current dashboard language from the user record
+        fetch('/user', { credentials: 'include' })
+            .then(r => r.ok ? r.json() : null)
+            .then(data => {
+                if (data && data.user && data.user.preferredLanguage) {
+                    const langSelect = document.getElementById('teacher-preferred-language');
+                    if (langSelect) langSelect.value = data.user.preferredLanguage;
+                }
+            })
+            .catch(() => {});
 
         // Event listeners
         document.getElementById('close-ai-settings').onclick = () => modal.remove();
@@ -319,6 +349,25 @@ document.addEventListener('DOMContentLoaded', () => {
             const result = await response.json();
 
             if (result.success) {
+                // Save dashboard language preference
+                const langSelect = document.getElementById('teacher-preferred-language');
+                if (langSelect) {
+                    const selectedLang = langSelect.value;
+                    try {
+                        await csrfFetch('/api/user/settings', {
+                            method: 'PATCH',
+                            headers: { 'Content-Type': 'application/json' },
+                            credentials: 'include',
+                            body: JSON.stringify({ preferredLanguage: selectedLang })
+                        });
+                        if (window.MathmatixI18n) {
+                            window.MathmatixI18n.setLanguage(selectedLang);
+                        }
+                    } catch (langErr) {
+                        console.error('Error saving language preference:', langErr);
+                    }
+                }
+
                 if (typeof showToast === 'function') {
                     showToast('AI Settings saved successfully!', 'success');
                 } else {

--- a/public/parent-dashboard.html
+++ b/public/parent-dashboard.html
@@ -1263,6 +1263,8 @@
       return window.loadScript('https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js');
     };
   </script>
+  <script src="/js/i18n-translations.js"></script>
+  <script src="/js/i18n.js"></script>
 </head>
 <body>
   <a href="#main-content" class="skip-to-content">Skip to main content</a>
@@ -1505,8 +1507,18 @@
               <label for="parentLanguage">
                 <i class="fas fa-language"></i> Language
               </label>
-              <input type="text" id="parentLanguage" name="parentLanguage" placeholder="English">
-              <p class="text-xs text-gray-500 mt-2">Preferred language for reports</p>
+              <select id="parentLanguage" name="parentLanguage">
+                <option value="English">English</option>
+                <option value="Spanish">Spanish (Español)</option>
+                <option value="Russian">Russian (Русский)</option>
+                <option value="Chinese">Chinese (中文)</option>
+                <option value="Vietnamese">Vietnamese (Tiếng Việt)</option>
+                <option value="Arabic">Arabic (العربية)</option>
+                <option value="Somali">Somali (Soomaali)</option>
+                <option value="French">French (Français)</option>
+                <option value="German">German (Deutsch)</option>
+              </select>
+              <p class="text-xs text-gray-500 mt-2">Preferred language for reports and dashboard</p>
             </div>
 
             <!-- Save Button -->
@@ -1657,8 +1669,18 @@
 
         <div class="drawer-section">
           <div class="drawer-section-title"><i class="fas fa-language" style="color: #3498db;"></i> Language</div>
-          <input type="text" id="mobile-parentLanguage" placeholder="English" style="width: 100%; padding: 10px; border: 1.5px solid #ddd; border-radius: 8px; font-size: 16px;">
-          <p style="font-size: 0.75em; color: #999; margin-top: 6px;">Preferred language for reports</p>
+          <select id="mobile-parentLanguage" style="width: 100%; padding: 10px; border: 1.5px solid #ddd; border-radius: 8px; font-size: 16px;">
+            <option value="English">English</option>
+            <option value="Spanish">Spanish (Español)</option>
+            <option value="Russian">Russian (Русский)</option>
+            <option value="Chinese">Chinese (中文)</option>
+            <option value="Vietnamese">Vietnamese (Tiếng Việt)</option>
+            <option value="Arabic">Arabic (العربية)</option>
+            <option value="Somali">Somali (Soomaali)</option>
+            <option value="French">French (Français)</option>
+            <option value="German">German (Deutsch)</option>
+          </select>
+          <p style="font-size: 0.75em; color: #999; margin-top: 6px;">Preferred language for reports and dashboard</p>
         </div>
 
         <button type="submit" class="btn btn-primary main-action-btn" style="width: 100%;">

--- a/public/student-dashboard.html
+++ b/public/student-dashboard.html
@@ -716,11 +716,11 @@
     document.getElementById('logoutBtn').addEventListener('click', async () => {
       try {
         await csrfFetch('/logout', { method: 'POST' });
-        window.location.href = '/login.html';
       } catch (error) {
         console.error('Logout error:', error);
-        window.location.href = '/login.html';
       }
+      try { localStorage.removeItem('mathmatix_ui_lang'); } catch (e) { /* */ }
+      window.location.href = '/login.html';
     });
 
     // ============================================

--- a/public/teacher-dashboard.html
+++ b/public/teacher-dashboard.html
@@ -3920,6 +3920,8 @@
   </style>
   <link rel="stylesheet" href="/css/dashboard-mobile.css" />
   <link rel="stylesheet" href="/css/demo-mode.css" />
+  <script src="/js/i18n-translations.js"></script>
+  <script src="/js/i18n.js"></script>
 </head>
 <body>
   <!-- Full-page loading overlay -->


### PR DESCRIPTION
…and teacher dashboards

Logout cleanup:
- sessionManager.logout() now removes mathmatix_ui_lang from localStorage
- logout.js fallback path also clears the key
- auto-logout.js performLogout() clears it for inactivity timeouts
- student-dashboard inline logout handler clears it too

Parent dashboard:
- Replace free-text language input with proper 9-language dropdown (desktop + mobile)
- Save parentLanguage AND preferredLanguage together so i18n picks it up
- Trigger live UI re-translation on settings save
- Include i18n scripts

Teacher dashboard:
- Add "Dashboard Language" dropdown to the AI Settings modal
- Pre-populate from user's preferredLanguage
- Save to preferredLanguage on save and trigger live i18n
- Include i18n scripts

https://claude.ai/code/session_01XF2gqZ2hSUXym853qupxDA