### PR TITLE
Add Math Showdown navigation links to badge map, sidebar, and dashboard

### DIFF
--- a/public/badge-map.html
+++ b/public/badge-map.html
@@ -1055,16 +1055,16 @@
 
       <!-- CENTER: Badge Map -->
       <section class="center-content">
-        <!-- ARCADE CARD - FLOATING UPPER RIGHT -->
+        <!-- MATH SHOWDOWN CARD - FLOATING UPPER RIGHT -->
         <div class="arcade-floating-card">
-          <a href="/mastery-arcade.html" class="featured-game-card" style="background: linear-gradient(135deg, #ff00ff 0%, #00ffff 100%); margin-bottom: 0;">
-            <div class="featured-game-badge">🎮 ARCADE</div>
-            <div class="featured-game-icon">🕹️</div>
-            <h3 class="featured-game-title">M∆STERY.∆RC∆DE</h3>
-            <p class="featured-game-subtitle">Two arcade games • Master facts • Build streaks</p>
+          <a href="/math-showdown.html" class="featured-game-card" style="background: linear-gradient(135deg, #e94560 0%, #f5a623 100%); margin-bottom: 0;">
+            <div class="featured-game-badge">⚔️ CHALLENGE</div>
+            <div class="featured-game-icon">🏆</div>
+            <h3 class="featured-game-title">M∆TH SHOWDOWN</h3>
+            <p class="featured-game-subtitle">Challenge classmates • Speed & accuracy • Earn XP</p>
             <div class="featured-game-cta">
-              <i class="fas fa-gamepad"></i>
-              <span>Enter Arcade</span>
+              <i class="fas fa-bolt"></i>
+              <span>Enter Showdown</span>
               <i class="fas fa-arrow-right"></i>
             </div>
           </a>

--- a/public/chat.html
+++ b/public/chat.html
@@ -340,6 +340,15 @@
           </button>
           <div id="weekly-challenges-container" style="display: none;"></div>
         </div>
+
+        <!-- Math Showdown Quick Link -->
+        <div style="margin-top: 12px; padding-top: 10px; border-top: 1px solid rgba(255,255,255,0.06);">
+          <a href="/math-showdown.html" style="display: flex; align-items: center; gap: 10px; padding: 10px 12px; background: linear-gradient(135deg, rgba(233,69,96,0.15), rgba(245,166,35,0.1)); border: 1px solid rgba(233,69,96,0.2); border-radius: 10px; text-decoration: none; color: #ccd6f6; font-weight: 600; font-size: 13px; transition: all 0.2s;">
+            <span style="font-size: 18px;">⚔️</span>
+            <span>Math Showdown</span>
+            <i class="fas fa-chevron-right" style="margin-left: auto; font-size: 10px; color: #8892b0;"></i>
+          </a>
+        </div>
       </div>
     </div>
 

--- a/public/student-dashboard.html
+++ b/public/student-dashboard.html
@@ -554,6 +554,10 @@
           <i class="fas fa-chalkboard-teacher"></i>
           <span data-i18n="dash.joinAClass">Join a Class</span>
         </button>
+        <a href="/math-showdown.html" class="quick-action-btn interactive-press" style="border:1.5px solid #e94560; background: linear-gradient(135deg, #fff5f7, #fff8f0);">
+          <i class="fas fa-bolt" style="color: #e94560;"></i>
+          <span>Math Showdown</span>
+        </a>
       </div>
     </div>
   </main>


### PR DESCRIPTION
- Badge map: Replace shelved Mastery Arcade card with Math Showdown card
- Chat sidebar: Add Showdown quick link below weekly challenges
- Student dashboard: Add Showdown to quick actions row

https://claude.ai/code/session_01GY7XAZTwnKU2VfsF5rHCUj