### PR TITLE
Fix premature rounding in quiz grading that caused incorrect scores

### DIFF
--- a/routes/gradeWork.js
+++ b/routes/gradeWork.js
@@ -67,6 +67,14 @@ A blank worksheet with solved answers is CHEATING — you would be doing their h
 Before reviewing the student's work, solve each attempted problem from scratch.
 You need verified answers to check their work, but NEVER include your solutions for problems the student left blank.
 
+⚠️ PRECISION RULES — avoid premature rounding:
+- Keep FULL precision in every intermediate step (use fractions or many decimal places).
+- Only round at the VERY END, and only if the problem asks for a rounded answer.
+- When comparing your answer to the student's, accept answers that match to reasonable precision.
+  For example: if the exact answer is 14.2857… accept 14.29, 14.3, or 14.286.
+- If the student rounded to fewer decimal places than you, that is NOT an error unless the problem specifically required more precision.
+- Common trap: if a problem involves division (e.g., 100 ÷ 7), do NOT round the quotient before using it in later steps. Carry the full value forward.
+
 ## 2. COMPARE — then GUIDE
 For correct problems: quick, specific praise. Keep it short — name what they did well in one sentence.
 
@@ -258,7 +266,7 @@ router.post('/',
 
             // Use callLLM for text-based analysis (no vision needed)
             const { callLLM } = require('../utils/llmGateway');
-            const completion = await callLLM('gpt-4o-mini', [
+            const completion = await callLLM('gpt-4o', [
                 { role: 'user', content: pdfPrompt }
             ], { max_tokens: 4000, temperature: 0.2 });
 

--- a/services/assessmentService.js
+++ b/services/assessmentService.js
@@ -282,11 +282,13 @@ function checkAnswer(userAnswer, question) {
   const cleanAnswer = userAnswer.trim().toLowerCase();
   const correctAnswer = String(question.correctAnswer).toLowerCase();
 
-  // Number answers
+  // Number answers — use relative tolerance to accept reasonable rounding
   if (question.type === 'number') {
     const userNum = parseFloat(cleanAnswer.replace(/[^\d.-]/g, ''));
     const correctNum = parseFloat(correctAnswer);
-    return Math.abs(userNum - correctNum) < 0.01;
+    if (isNaN(userNum) || isNaN(correctNum)) return false;
+    if (correctNum === 0) return Math.abs(userNum) < 0.01;
+    return Math.abs(userNum - correctNum) / Math.abs(correctNum) < 0.015;
   }
 
   // Fraction answers


### PR DESCRIPTION
Three changes to prevent correct answers from being marked wrong:

1. Add precision rules to the grading prompt instructing the LLM to carry full precision through intermediate steps and accept reasonably rounded student answers (e.g. 14.3 when exact answer is 14.2857…).

2. Upgrade PDF grading from gpt-4o-mini to gpt-4o — the smaller model is significantly weaker at multi-step arithmetic and was a major source of miscounted scores on uploaded PDF quizzes.

3. Switch checkAnswer from a fixed ±0.01 absolute tolerance to a 1.5% relative tolerance, so answers like 14.3 vs 14.29 are no longer penalized. Also guards against NaN comparisons.

https://claude.ai/code/session_01FTaDAxWUX19CgxvZQouEs3