### PR TITLE
Increase spotlight photo height and adjust image positioning

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1145,13 +1145,13 @@
     .lp-spotlight-photo {
       border-radius: 14px;
       overflow: hidden;
-      max-height: 340px;
+      max-height: 420px;
     }
 
     .lp-spotlight-photo img {
       width: 100%;
       height: 100%;
-      max-height: 340px;
+      max-height: 420px;
       object-fit: cover;
       display: block;
       border-radius: 14px;
@@ -1550,8 +1550,8 @@
       .lp-spotlight { padding: 2.5rem var(--page-horizontal-padding); }
       .lp-spotlight-layout { grid-template-columns: 1fr; gap: 1.5rem; }
       .lp-spotlight--reverse .lp-spotlight-layout { direction: ltr; }
-      .lp-spotlight-photo { max-height: 260px; }
-      .lp-spotlight-photo img { max-height: 260px; }
+      .lp-spotlight-photo { max-height: 340px; }
+      .lp-spotlight-photo img { max-height: 340px; }
       .lp-spotlight-content { text-align: center; }
       .lp-spotlight-content h2 { font-size: 1.45rem; }
       .lp-spotlight-content p { font-size: 0.92rem; }
@@ -2060,7 +2060,7 @@
     <section class="lp-spotlight lp-reveal">
       <div class="lp-spotlight-layout lp-inner">
         <div class="lp-spotlight-photo">
-          <img src="/images/tabletBoy.png" alt="Student using a tablet to learn math with Mathmatix AI" style="object-position: top;" />
+          <img src="/images/tabletBoy.png" alt="Student using a tablet to learn math with Mathmatix AI" style="object-position: center 40%;" />
         </div>
         <div class="lp-spotlight-content">
           <h2>A Tutor That Never Sleeps</h2>


### PR DESCRIPTION
## Summary
Updated the spotlight section styling to display larger images and adjusted the image positioning for better visual presentation on the landing page.

## Key Changes
- Increased `.lp-spotlight-photo` max-height from 340px to 420px on desktop view
- Increased `.lp-spotlight-photo img` max-height from 340px to 420px on desktop view
- Updated mobile/tablet responsive breakpoint max-height from 260px to 340px for both `.lp-spotlight-photo` and `.lp-spotlight-photo img`
- Changed image object-position from `top` to `center 40%` for the tablet boy image to better center the subject within the frame

## Implementation Details
These changes improve the visual hierarchy of the spotlight section by giving featured images more vertical space while maintaining the responsive design across different screen sizes. The object-position adjustment ensures the image content is better framed when displayed at the new larger dimensions.

https://claude.ai/code/session_019UjyiqESE1SJy9gxna3gon