### PR TITLE
Fix parent course mini courses not advancing past practice phases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "winston-daily-rotate-file": "^4.7.1"
       },
       "devDependencies": {
-        "dotenv": "^17.2.4",
+        "dotenv": "^17.3.1",
         "jest": "^29.7.0",
         "nodemon": "^3.1.11",
         "supertest": "^7.0.0",
@@ -6633,9 +6633,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.2.4",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.4.tgz",
-      "integrity": "sha512-mudtfb4zRB4bVvdj0xRo+e6duH1csJRM8IukBqfTRvHotn9+LBXB8ynAidP9zHqoRC/fsllXgk4kCKlR21fIhw==",
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "winston-daily-rotate-file": "^4.7.1"
   },
   "devDependencies": {
-    "dotenv": "^17.2.4",
+    "dotenv": "^17.3.1",
     "jest": "^29.7.0",
     "nodemon": "^3.1.11",
     "supertest": "^7.0.0",

--- a/routes/courseChat.js
+++ b/routes/courseChat.js
@@ -357,7 +357,7 @@ router.post('/', async (req, res) => {
                         console.log(`🎓 [CourseChat] ${user.firstName} completed module ${courseProgressUpdate.moduleId} — progress: ${courseSession.overallProgress}%`);
 
                     } else if (ext.scaffoldAdvance) {
-                        courseProgressUpdate = processScaffoldAdvance(courseSession, moduleData, conversation, wasCorrect);
+                        courseProgressUpdate = processScaffoldAdvance(courseSession, moduleData, conversation, wasCorrect, { isParentCourse });
                         if (courseProgressUpdate) {
                             await courseSession.save();
                             console.log(`📈 [CourseChat] ${user.firstName} advanced scaffold → step ${courseProgressUpdate.scaffoldIndex + 1}/${courseProgressUpdate.scaffoldTotal}`);

--- a/tests/unit/coursePersist.test.js
+++ b/tests/unit/coursePersist.test.js
@@ -205,6 +205,19 @@ describe('coursePersist: processScaffoldAdvance', () => {
     expect(conversation.messages[0].scaffoldAdvanced).toBe(true);
   });
 
+  test('skips practice gating for parent courses', () => {
+    const session = mockCourseSession({ currentScaffoldIndex: 2 }); // Step 2 is guided_practice
+    const moduleData = mockModuleData(4);
+    const conversation = mockConversation(3, 0); // No correct answers
+
+    // Without isParentCourse, this would be blocked
+    const result = processScaffoldAdvance(session, moduleData, conversation, false, { isParentCourse: true });
+
+    expect(result).not.toBeNull();
+    expect(result.event).toBe('scaffold_advance');
+    expect(result.scaffoldIndex).toBe(3);
+  });
+
   test('returns null if module not found', () => {
     const session = mockCourseSession({ currentModuleId: 'nonexistent' });
     const result = processScaffoldAdvance(session, mockModuleData(), mockConversation(), false);

--- a/utils/pipeline/coursePersist.js
+++ b/utils/pipeline/coursePersist.js
@@ -97,9 +97,11 @@ function detectGraphTool(responseText, options = {}) {
  * @param {Object} moduleData - Loaded module JSON (with scaffold array)
  * @param {Object} conversation - Mongoose conversation document
  * @param {boolean} wasCorrect - Whether the last answer was correct
+ * @param {Object} [options] - Additional options
+ * @param {boolean} [options.isParentCourse] - If true, skip practice-phase gating
  * @returns {Object|null} courseProgressUpdate object, or null if blocked/failed
  */
-function processScaffoldAdvance(courseSession, moduleData, conversation, wasCorrect) {
+function processScaffoldAdvance(courseSession, moduleData, conversation, wasCorrect, options = {}) {
   const scaffold = moduleData?.scaffold || [];
   const totalSteps = scaffold.length || 1;
   const currentIdx = courseSession.currentScaffoldIndex || 0;
@@ -125,7 +127,7 @@ function processScaffoldAdvance(courseSession, moduleData, conversation, wasCorr
     if (wasCorrect) correctSinceLastAdvance++;
   }
 
-  if (isPracticePhase && correctSinceLastAdvance < MIN_CORRECT_FOR_ADVANCE) {
+  if (isPracticePhase && !options.isParentCourse && correctSinceLastAdvance < MIN_CORRECT_FOR_ADVANCE) {
     console.log(`[CoursePersist] SCAFFOLD_ADVANCE blocked — "${stepType}" needs ${MIN_CORRECT_FOR_ADVANCE} correct, got ${correctSinceLastAdvance}`);
     return null;
   }


### PR DESCRIPTION
The practice-phase gating in processScaffoldAdvance required
MIN_CORRECT_FOR_ADVANCE (2) correct answers before allowing
advancement, even for parent courses. Parents have conversations
rather than formally graded problems, so they never accumulate
"correct" answers and get permanently stuck on guided_practice steps.

Pass isParentCourse flag through to processScaffoldAdvance and skip
the practice-phase gate when true.

https://claude.ai/code/session_012uyoZJDZkwnnWmSJp11xut