### PR TITLE
Fix z-index stacking for chat messages and reactions

### DIFF
--- a/public/css/base/chat.css
+++ b/public/css/base/chat.css
@@ -38,6 +38,8 @@
     font-size: 0.94em;
     box-shadow: none;
     animation: messageIn 0.25s ease-out;
+    position: relative;
+    z-index: 1;
 }
 
 @keyframes messageIn {
@@ -205,6 +207,11 @@
 .message.user .message-timestamp {
     color: rgba(255, 255, 255, 0.6);
     text-align: left;
+}
+
+.message:hover,
+.message:has(.reaction-display.has-reaction) {
+    z-index: 2;
 }
 
 /* ===== EMOJI REACTION SYSTEM ===== */


### PR DESCRIPTION
## Summary
This PR fixes z-index layering issues in the chat message system to ensure proper stacking of messages and their associated reaction displays.

## Key Changes
- Added `position: relative` and `z-index: 1` to base `.message` elements to establish a stacking context
- Added hover and reaction state styling that elevates messages to `z-index: 2` when:
  - The message is hovered
  - The message contains reactions (`.reaction-display.has-reaction`)

## Implementation Details
The changes ensure that when users interact with messages (hover) or when reactions are present, those messages appear above other messages in the chat. This prevents reaction displays and interactive elements from being obscured by adjacent messages, improving the visual hierarchy and user experience when managing emoji reactions.

https://claude.ai/code/session_01VGirHGaUkvWXVAKKAHEnnk