### PR TITLE
Fix settings API 401 by saving session before redirect/response

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -263,10 +263,21 @@ router.post('/complete-oauth-enrollment', async (req, res) => {
       }
 
       console.log(`LOG: OAuth user ${newUser.username} logged in, redirecting to ${redirect}`);
-      return res.json({
-        success: true,
-        message: 'Account created successfully!',
-        redirect
+
+      // Persist session to MongoDB before responding to prevent race condition
+      req.session.save((saveErr) => {
+        if (saveErr) {
+          console.error('ERROR: Failed to save session after OAuth enrollment:', saveErr);
+          return res.status(500).json({
+            success: false,
+            message: 'Account created but session save failed. Please try logging in.'
+          });
+        }
+        return res.json({
+          success: true,
+          message: 'Account created successfully!',
+          redirect
+        });
       });
     });
 

--- a/routes/login.js
+++ b/routes/login.js
@@ -56,8 +56,15 @@ router.post('/', loginValidation, handleValidationErrors, (req, res, next) => {
                 redirectUrl = "/pick-avatar.html";
             }
 
-            // Send success response with redirect URL (frontend will handle redirect)
-            return res.status(200).json({ success: true, message: 'Logged in successfully!', redirect: redirectUrl });
+            // Persist session to MongoDB before responding to prevent race condition
+            // where the frontend navigates before the session is saved
+            req.session.save((saveErr) => {
+                if (saveErr) {
+                    console.error("ERROR: Failed to save session after login:", saveErr);
+                    return res.status(500).json({ success: false, message: 'Login successful, but session save failed.' });
+                }
+                return res.status(200).json({ success: true, message: 'Logged in successfully!', redirect: redirectUrl });
+            });
         });
     })(req, res, next); // Ensure passport.authenticate is called with req, res, next
 });

--- a/routes/signup.js
+++ b/routes/signup.js
@@ -304,7 +304,15 @@ router.post('/', ensureNotAuthenticated, signupValidation, handleValidationError
             // Other roles redirect to their dashboards if profile completion not needed
             // (though needsProfileCompletion should handle most of this flow)
             console.log(`LOG: New user ${newUser.username} signed up and logged in. Redirecting to: ${redirectUrl}`);
-            res.status(201).json({ success: true, message: 'Account created successfully!', redirect: redirectUrl });
+
+            // Persist session to MongoDB before responding to prevent race condition
+            req.session.save((saveErr) => {
+                if (saveErr) {
+                    console.error("ERROR: Failed to save session after signup:", saveErr);
+                    return res.status(500).json({ success: true, message: 'Account created, but session save failed. Please try logging in.' });
+                }
+                res.status(201).json({ success: true, message: 'Account created successfully!', redirect: redirectUrl });
+            });
         });
 
     } catch (error) {

--- a/server.js
+++ b/server.js
@@ -385,11 +385,17 @@ app.get('/auth/google/callback', authLimiter, (req, res, next) => {
             } catch (updateErr) {
                 console.error("ERROR: Failed to update lastLogin:", updateErr);
             }
-            if (user.needsProfileCompletion) return res.redirect('/complete-profile.html');
-            if (user.role === 'student' && !user.selectedTutorId) return res.redirect('/pick-tutor.html');
-            if (user.role === 'student' && !user.selectedAvatarId) return res.redirect('/pick-avatar.html');
-            const dashboardMap = { student: '/chat.html', teacher: '/teacher-dashboard.html', admin: '/admin-dashboard.html', parent: '/parent-dashboard.html' };
-            res.redirect(dashboardMap[user.role] || '/login.html');
+
+            // Persist session to MongoDB before redirecting to prevent race condition
+            // where the browser follows the redirect before the session is saved
+            req.session.save((saveErr) => {
+                if (saveErr) { return next(saveErr); }
+                if (user.needsProfileCompletion) return res.redirect('/complete-profile.html');
+                if (user.role === 'student' && !user.selectedTutorId) return res.redirect('/pick-tutor.html');
+                if (user.role === 'student' && !user.selectedAvatarId) return res.redirect('/pick-avatar.html');
+                const dashboardMap = { student: '/chat.html', teacher: '/teacher-dashboard.html', admin: '/admin-dashboard.html', parent: '/parent-dashboard.html' };
+                res.redirect(dashboardMap[user.role] || '/login.html');
+            });
         });
     })(req, res, next);
 });
@@ -420,11 +426,16 @@ app.get('/auth/microsoft/callback', authLimiter, (req, res, next) => {
             } catch (updateErr) {
                 console.error("ERROR: Failed to update lastLogin:", updateErr);
             }
-            if (user.needsProfileCompletion) return res.redirect('/complete-profile.html');
-            if (user.role === 'student' && !user.selectedTutorId) return res.redirect('/pick-tutor.html');
-            if (user.role === 'student' && !user.selectedAvatarId) return res.redirect('/pick-avatar.html');
-            const dashboardMap = { student: '/chat.html', teacher: '/teacher-dashboard.html', admin: '/admin-dashboard.html', parent: '/parent-dashboard.html' };
-            res.redirect(dashboardMap[user.role] || '/login.html');
+
+            // Persist session to MongoDB before redirecting to prevent race condition
+            req.session.save((saveErr) => {
+                if (saveErr) { return next(saveErr); }
+                if (user.needsProfileCompletion) return res.redirect('/complete-profile.html');
+                if (user.role === 'student' && !user.selectedTutorId) return res.redirect('/pick-tutor.html');
+                if (user.role === 'student' && !user.selectedAvatarId) return res.redirect('/pick-avatar.html');
+                const dashboardMap = { student: '/chat.html', teacher: '/teacher-dashboard.html', admin: '/admin-dashboard.html', parent: '/parent-dashboard.html' };
+                res.redirect(dashboardMap[user.role] || '/login.html');
+            });
         });
     })(req, res, next);
 });
@@ -478,11 +489,16 @@ if (process.env.CLEVER_CLIENT_ID && process.env.CLEVER_CLIENT_SECRET) {
                     } catch (updateErr) {
                         console.error("ERROR: Failed to update lastLogin:", updateErr);
                     }
-                    if (user.needsProfileCompletion) return res.redirect('/complete-profile.html');
-                    if (user.role === 'student' && !user.selectedTutorId) return res.redirect('/pick-tutor.html');
-                    if (user.role === 'student' && !user.selectedAvatarId) return res.redirect('/pick-avatar.html');
-                    const dashboardMap = { student: '/chat.html', teacher: '/teacher-dashboard.html', admin: '/admin-dashboard.html', parent: '/parent-dashboard.html' };
-                    res.redirect(dashboardMap[user.role] || '/login.html');
+
+                    // Persist session to MongoDB before redirecting to prevent race condition
+                    req.session.save((saveErr) => {
+                        if (saveErr) { return next(saveErr); }
+                        if (user.needsProfileCompletion) return res.redirect('/complete-profile.html');
+                        if (user.role === 'student' && !user.selectedTutorId) return res.redirect('/pick-tutor.html');
+                        if (user.role === 'student' && !user.selectedAvatarId) return res.redirect('/pick-avatar.html');
+                        const dashboardMap = { student: '/chat.html', teacher: '/teacher-dashboard.html', admin: '/admin-dashboard.html', parent: '/parent-dashboard.html' };
+                        res.redirect(dashboardMap[user.role] || '/login.html');
+                    });
                 });
             });
         })(req, res, next);


### PR DESCRIPTION
After req.logIn(), the session was not explicitly persisted to MongoDB
before sending redirects or JSON responses. This caused a race condition
where the browser would follow the redirect (or the frontend would
navigate) before the session was saved, resulting in 401 Unauthorized
on the next request (e.g., PATCH /api/user/settings).

Added req.session.save() calls in all auth flows:
- Google, Microsoft, and Clever OAuth callbacks (server.js)
- Local login (routes/login.js)
- Signup (routes/signup.js)
- OAuth enrollment completion (routes/auth.js)

https://claude.ai/code/session_01T4LjjVRfmNYHAyyJKqNgWo