### PR TITLE
Add "Explain Like I'm in 3rd Grade" feature for parents

### DIFF
--- a/public/js/guided-tour.js
+++ b/public/js/guided-tour.js
@@ -679,6 +679,12 @@ window.parentDashboardTour = [
         position: 'top'
     },
     {
+        element: '#parent-learning-center',
+        title: 'Parent Courses',
+        content: 'Enroll in free mini-courses designed to help you understand the math your child is learning. Lessons are short, conversational, and built for busy parents.',
+        position: 'right'
+    },
+    {
         element: '[data-tab="messages"]',
         title: 'Teacher Communication',
         content: 'Send and receive messages from your child\'s teacher. Stay informed about their progress.',

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1285,7 +1285,8 @@ document.addEventListener("DOMContentLoaded", () => {
         const defaultSuggestions = [
             { text: "💡 Give me a hint", message: "Can you give me a hint?" },
             { text: "📝 Show me an example", message: "Can you show me an example problem?" },
-            { text: "🔄 Explain differently", message: "Can you explain that a different way?" }
+            { text: "🔄 Explain differently", message: "Can you explain that a different way?" },
+            { text: "🧒 Explain like I'm in 3rd grade", message: "Explain this like I'm in 3rd grade. Use simple words, fun examples, and make it really easy to understand." }
         ];
         showSuggestions(defaultSuggestions);
     }

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -2121,7 +2121,10 @@ document.addEventListener("DOMContentLoaded", () => {
             }
         } finally {
             showThinkingIndicator(false);
-            setTimeout(() => showDefaultSuggestions(), 500);
+            if (!window._serverSuggestionsProvided) {
+                setTimeout(() => showDefaultSuggestions(), 500);
+            }
+            window._serverSuggestionsProvided = false;
         }
     }
 

--- a/public/parent-dashboard.html
+++ b/public/parent-dashboard.html
@@ -1415,6 +1415,9 @@
             <button class="helper-btn" data-message="What are my child's strengths in math? What are they doing well?">
               <i class="fas fa-star"></i> Strengths
             </button>
+            <button class="helper-btn" data-message="Explain the math concept my child is working on right now like I'm in 3rd grade. Use simple words, fun examples, and make it really easy to understand.">
+              <i class="fas fa-child"></i> Explain Like I'm in 3rd Grade
+            </button>
           </div>
 
           <style>


### PR DESCRIPTION
## Summary
This PR adds a new simplified explanation feature to help parents understand math concepts at a basic level. The feature includes a new quick-action button on the parent dashboard and a corresponding suggestion prompt in the chat interface.

## Key Changes
- **Parent Dashboard**: Added "Explain Like I'm in 3rd Grade" helper button that sends a pre-formatted message requesting simplified explanations with simple words and fun examples
- **Chat Suggestions**: Added a new default suggestion prompt ("🧒 Explain like I'm in 3rd grade") to the suggestion list shown to users
- **Suggestion Logic**: Improved suggestion handling to prevent default suggestions from appearing when the server has already provided custom suggestions via a new `_serverSuggestionsProvided` flag
- **Guided Tour**: Added a new tour step for the Parent Learning Center section to help users discover the educational resources available to them

## Implementation Details
- The new helper button uses the `helper-btn` class and follows the existing pattern of other quick-action buttons
- The suggestion flag (`window._serverSuggestionsProvided`) is reset after each message to ensure proper suggestion display on subsequent interactions
- The guided tour step is positioned to the right of the Parent Learning Center element for optimal visibility

https://claude.ai/code/session_01LG57LMKbsBwCK92WEBhfZq