### PR TITLE
Add Pi Day launch promo: $3.14 off all plans + themed quests & mini-lessons

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -310,9 +310,128 @@
       50% { opacity: 0.3; }
     }
 
-    /* Hide banner after launch */
+    /* Hide banner after launch window ends */
     .lp-countdown-banner.lp-countdown-launched {
       display: none;
+    }
+
+    /* ── Pi Day Promo Banner (replaces countdown on 3/14) ── */
+    .lp-piday-promo {
+      background: linear-gradient(135deg, #1a1a2e 0%, #0f3460 40%, #16213e 100%);
+      padding: 1rem var(--page-horizontal-padding);
+      text-align: center;
+      position: relative;
+      overflow: hidden;
+      border-bottom: 2px solid #ff6b9d;
+    }
+
+    .lp-piday-promo::before {
+      content: '';
+      position: absolute;
+      top: 0; left: 0; right: 0; bottom: 0;
+      background: radial-gradient(circle at 20% 50%, rgba(255, 107, 157, 0.15) 0%, transparent 50%),
+                  radial-gradient(circle at 80% 50%, rgba(0, 212, 255, 0.1) 0%, transparent 50%);
+      pointer-events: none;
+    }
+
+    .lp-piday-inner {
+      max-width: 900px;
+      margin: 0 auto;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+      position: relative;
+      z-index: 1;
+    }
+
+    .lp-piday-icon {
+      font-size: 2rem;
+      line-height: 1;
+    }
+
+    .lp-piday-text {
+      color: #fff;
+    }
+
+    .lp-piday-headline {
+      font-size: 1.15rem;
+      font-weight: 700;
+      margin: 0 0 0.2rem;
+    }
+
+    .lp-piday-headline .lp-piday-pink {
+      color: #ff6b9d;
+    }
+
+    .lp-piday-sub {
+      font-size: 0.85rem;
+      color: rgba(255, 255, 255, 0.7);
+      margin: 0;
+    }
+
+    .lp-piday-prices {
+      display: flex;
+      gap: 1rem;
+      align-items: center;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+
+    .lp-piday-price-chip {
+      background: rgba(255, 255, 255, 0.08);
+      border: 1px solid rgba(255, 107, 157, 0.3);
+      border-radius: 8px;
+      padding: 0.5rem 1rem;
+      text-align: center;
+      color: #fff;
+      min-width: 100px;
+    }
+
+    .lp-piday-price-chip .lp-piday-plan-name {
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: rgba(255, 255, 255, 0.6);
+    }
+
+    .lp-piday-price-chip .lp-piday-original {
+      font-size: 0.75rem;
+      color: #888;
+      text-decoration: line-through;
+    }
+
+    .lp-piday-price-chip .lp-piday-deal {
+      font-size: 1.1rem;
+      font-weight: 700;
+      color: #00d4ff;
+    }
+
+    .lp-piday-cta {
+      background: linear-gradient(135deg, #ff6b9d, #c850c0);
+      color: #fff;
+      border: none;
+      padding: 0.6rem 1.5rem;
+      border-radius: 8px;
+      font-weight: 700;
+      font-size: 0.95rem;
+      cursor: pointer;
+      text-decoration: none;
+      white-space: nowrap;
+      transition: transform 0.2s, box-shadow 0.2s;
+    }
+
+    .lp-piday-cta:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 4px 16px rgba(255, 107, 157, 0.4);
+    }
+
+    @media (max-width: 768px) {
+      .lp-piday-inner { flex-direction: column; gap: 0.8rem; }
+      .lp-piday-prices { gap: 0.5rem; }
+      .lp-piday-price-chip { min-width: 80px; padding: 0.4rem 0.7rem; }
     }
 
     /* ── Waitlist Forms ──────────────────────────────────── */
@@ -2498,13 +2617,49 @@
 
       /* ── Pi Day Launch Auto-Switch ─────────────────────── */
       // At midnight EST on March 14 2026, swap waitlist CTAs → sign-up CTAs
+      // and show the Pi Day promo banner with $3.14 off pricing
       (function piDayLaunchSwitch() {
         var launchDate = new Date('2026-03-14T05:00:00Z'); // midnight EST = UTC-5
+        var promoEnd   = new Date('2026-03-16T04:59:59Z'); // end of March 15 EST
         if (new Date() < launchDate) return;
 
         // Hide countdown banner
         var countdown = document.getElementById('lp-countdown');
         if (countdown) countdown.style.display = 'none';
+
+        // Show Pi Day promo banner (only during the promo window)
+        if (new Date() <= promoEnd) {
+          var promoBanner = document.createElement('div');
+          promoBanner.className = 'lp-piday-promo';
+          promoBanner.innerHTML = '<div class="lp-piday-inner">' +
+            '<div class="lp-piday-icon">\u03C0</div>' +
+            '<div class="lp-piday-text">' +
+              '<div class="lp-piday-headline">Happy Pi Day! <span class="lp-piday-pink">$3.14 off</span> every plan</div>' +
+              '<div class="lp-piday-sub">Celebrate 3.14 with us \u2014 limited-time launch pricing through March 15</div>' +
+            '</div>' +
+            '<div class="lp-piday-prices">' +
+              '<div class="lp-piday-price-chip">' +
+                '<div class="lp-piday-plan-name">60 min</div>' +
+                '<div class="lp-piday-original">$9.95</div>' +
+                '<div class="lp-piday-deal">$6.81</div>' +
+              '</div>' +
+              '<div class="lp-piday-price-chip">' +
+                '<div class="lp-piday-plan-name">120 min</div>' +
+                '<div class="lp-piday-original">$14.95</div>' +
+                '<div class="lp-piday-deal">$11.81</div>' +
+              '</div>' +
+              '<div class="lp-piday-price-chip">' +
+                '<div class="lp-piday-plan-name">Unlimited</div>' +
+                '<div class="lp-piday-original">$19.95/mo</div>' +
+                '<div class="lp-piday-deal">$16.81/mo</div>' +
+              '</div>' +
+            '</div>' +
+            '<a href="/signup.html" class="lp-piday-cta">Sign Up &amp; Save</a>' +
+          '</div>';
+          // Insert at the top of main
+          var main = document.getElementById('lp-main');
+          if (main) main.insertBefore(promoBanner, main.firstChild);
+        }
 
         // Swap nav "Join Waitlist" → "Sign Up"
         var navLinks = document.querySelectorAll('.landing-nav .btn');
@@ -2521,7 +2676,7 @@
           var link = document.createElement('a');
           link.href = '/signup.html';
           link.className = 'btn btn-primary';
-          link.textContent = 'Get Started — It\'s Free';
+          link.textContent = 'Get Started \u2014 It\'s Free';
           form.parentNode.replaceChild(link, form);
         });
 

--- a/public/js/dailyQuests.js
+++ b/public/js/dailyQuests.js
@@ -6,6 +6,7 @@ class DailyQuestManager {
     this.streak = 0;
     this.longestStreak = 0;
     this.totalCompleted = 0;
+    this.piDay = false;
   }
 
   async loadQuests() {
@@ -18,6 +19,7 @@ class DailyQuestManager {
         this.streak = data.streak;
         this.longestStreak = data.longestStreak;
         this.totalCompleted = data.totalCompleted;
+        this.piDay = data.piDay || false;
         this.render();
       }
     } catch (error) {
@@ -59,13 +61,21 @@ class DailyQuestManager {
     const allCompleted = this.quests.every(q => q.completed);
     const completedCount = this.quests.filter(q => q.completed).length;
 
+    const questTitle = this.piDay ? 'Pi Day Quests' : 'Daily Quests';
+    const questIcon = this.piDay ? '\u03C0' : '\uD83D\uDCCB';
+    const piDayBanner = this.piDay ? `
+          <div style="background:linear-gradient(135deg,#ff6b9d22,#c850c022);border:1px solid #ff6b9d44;border-radius:8px;padding:8px 12px;margin-bottom:12px;text-align:center;">
+            <div style="font-weight:700;color:#ff6b9d;">Happy Pi Day! 3.14x XP Multiplier Active</div>
+            <div style="font-size:12px;color:#888;">Complete all quests for bonus rewards</div>
+          </div>` : '';
+
     container.innerHTML = `
-      <div class="daily-quests-widget">
+      <div class="daily-quests-widget${this.piDay ? ' pi-day-theme' : ''}">
         <!-- Header -->
         <div class="quest-header">
           <h3>
-            <span class="quest-icon">📋</span>
-            Daily Quests
+            <span class="quest-icon">${questIcon}</span>
+            ${questTitle}
             <span class="quest-counter">${completedCount}/${this.quests.length}</span>
           </h3>
 
@@ -75,6 +85,8 @@ class DailyQuestManager {
             <span class="streak-label">day${this.streak !== 1 ? 's' : ''}</span>
           </div>
         </div>
+
+        ${piDayBanner}
 
         ${allCompleted ? `
           <div class="all-quests-complete">
@@ -136,7 +148,8 @@ class DailyQuestManager {
         </div>
 
         <div class="quest-reward">
-          <span class="xp-badge">+${quest.xpReward} XP</span>
+          <span class="xp-badge">${quest.bonusMultiplier > 1 ? `+${Math.round(quest.xpReward * quest.bonusMultiplier)} XP` : `+${quest.xpReward} XP`}</span>
+          ${quest.piDay ? '<span style="font-size:10px;color:#ff6b9d;display:block;">3.14x</span>' : ''}
         </div>
       </div>
     `;
@@ -152,7 +165,7 @@ class DailyQuestManager {
     container.innerHTML = `
       <div class="quests-compact">
         <div class="compact-header">
-          <span>📋 Daily: ${completedCount}/${this.quests.length}</span>
+          <span>${this.piDay ? '\u03C0 Pi Day' : '\uD83D\uDCCB Daily'}: ${completedCount}/${this.quests.length}</span>
           <span class="streak-compact">🔥 ${this.streak}</span>
         </div>
         <div class="compact-progress">

--- a/public/js/modules/billing.js
+++ b/public/js/modules/billing.js
@@ -62,46 +62,75 @@ export function updateFreeTimeIndicator(usage) {
 }
 
 /**
- * Show the upgrade/pricing modal
+ * Show the upgrade/pricing modal (with Pi Day promo support)
  */
-export function showUpgradePrompt(errorData) {
+export async function showUpgradePrompt(errorData) {
     const existing = document.getElementById('upgrade-modal');
     if (existing) existing.remove();
 
+    // Check for active Pi Day promo
+    let promo = null;
+    try {
+        const promoRes = await fetch('/api/billing/promo');
+        if (promoRes.ok) {
+            const promoData = await promoRes.json();
+            if (promoData.active) promo = promoData;
+        }
+    } catch (_) { /* promo check is best-effort */ }
+
     const isFeatureBlock = errorData.premiumFeatureBlocked;
-    const title = isFeatureBlock ? `${errorData.feature} Requires Unlimited` : 'Choose a Tutoring Pack';
-    const subtitle = isFeatureBlock
-        ? `Unlock ${errorData.feature.toLowerCase()}, unlimited 24/7 tutoring, voice, courses, and more.`
-        : 'Purchase minutes to continue learning with your AI tutor.';
+    const title = promo
+        ? 'Pi Day Launch Special — $3.14 Off!'
+        : isFeatureBlock ? `${errorData.feature} Requires Unlimited` : 'Choose a Tutoring Pack';
+    const subtitle = promo
+        ? 'Celebrate Pi Day with $3.14 off any plan. Limited time only!'
+        : isFeatureBlock
+            ? `Unlock ${errorData.feature.toLowerCase()}, unlimited 24/7 tutoring, voice, courses, and more.`
+            : 'Purchase minutes to continue learning with your AI tutor.';
 
     const packBtnStyle = 'background:#1e1e3a;border:1px solid #444;border-radius:10px;padding:16px;cursor:pointer;text-align:center;color:#fff;transition:border-color 0.2s;';
     const packBtnHover = 'onmouseover="this.style.borderColor=\'#00d4ff\'" onmouseout="this.style.borderColor=\'#444\'"';
+
+    function formatPrice(pack, originalCents, label, perMin, extra) {
+        if (promo && promo.prices[pack]) {
+            const promoCents = promo.prices[pack].promo;
+            const promoPrice = (promoCents / 100).toFixed(2);
+            const originalPrice = (originalCents / 100).toFixed(2);
+            return `<div style="font-size:14px;color:#888;text-decoration:line-through;margin-bottom:2px;">$${originalPrice}${label}</div>
+                    <div style="font-size:24px;font-weight:bold;color:#00d4ff;margin:4px 0;">$${promoPrice}${label}</div>
+                    <div style="color:#ff6b9d;font-size:11px;font-weight:bold;margin-bottom:4px;">Save $3.14 — Pi Day Special!</div>
+                    <div style="color:#888;font-size:12px;">${extra}</div>`;
+        }
+        const price = (originalCents / 100).toFixed(2);
+        return `<div style="font-size:24px;font-weight:bold;color:#00d4ff;margin:4px 0;">$${price}${label}</div>
+                <div style="color:#888;font-size:12px;">${extra}</div>`;
+    }
+
+    const promoBadge = promo ? '<div style="background:linear-gradient(135deg,#ff6b9d,#c850c0);color:#fff;font-size:11px;padding:4px 12px;border-radius:20px;font-weight:bold;text-align:center;margin-bottom:16px;">Limited Time — Ends March 15!</div>' : '';
 
     const modal = document.createElement('div');
     modal.id = 'upgrade-modal';
     modal.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,0.7);display:flex;align-items:center;justify-content:center;z-index:10000;';
     modal.innerHTML = `
-        <div style="background:#1a1a2e;border-radius:16px;padding:32px;max-width:480px;width:92%;color:#fff;border:1px solid #333;">
+        <div style="background:#1a1a2e;border-radius:16px;padding:32px;max-width:480px;width:92%;color:#fff;border:1px solid ${promo ? '#ff6b9d' : '#333'};">
             <h2 style="margin:0 0 8px;font-size:22px;text-align:center;">${title}</h2>
-            <p style="color:#aaa;margin:0 0 24px;text-align:center;line-height:1.5;">${subtitle}</p>
+            <p style="color:#aaa;margin:0 0 16px;text-align:center;line-height:1.5;">${subtitle}</p>
+            ${promoBadge}
             <div style="display:flex;flex-direction:column;gap:12px;">
                 <div class="pack-option" data-pack="pack_60" style="${packBtnStyle}" ${packBtnHover}>
                     <div style="font-size:20px;font-weight:bold;">60 Minutes</div>
-                    <div style="font-size:24px;font-weight:bold;color:#00d4ff;margin:4px 0;">$9.95</div>
-                    <div style="color:#888;font-size:12px;">$0.17/min &middot; Expires in 90 days</div>
+                    ${formatPrice('pack_60', 995, '', '$0.17/min', '$0.17/min \u00b7 Expires in 90 days')}
                 </div>
                 <div class="pack-option" data-pack="pack_120" style="${packBtnStyle};border-color:#7b2ff7;" ${packBtnHover}>
                     <div style="display:flex;justify-content:center;align-items:center;gap:8px;">
                         <span style="font-size:20px;font-weight:bold;">120 Minutes</span>
                         <span style="background:#7b2ff7;color:#fff;font-size:10px;padding:2px 8px;border-radius:4px;font-weight:bold;">BEST VALUE</span>
                     </div>
-                    <div style="font-size:24px;font-weight:bold;color:#00d4ff;margin:4px 0;">$14.95</div>
-                    <div style="color:#888;font-size:12px;">$0.12/min &middot; Expires in 180 days</div>
+                    ${formatPrice('pack_120', 1495, '', '$0.12/min', '$0.12/min \u00b7 Expires in 180 days')}
                 </div>
                 <div class="pack-option" data-pack="unlimited" style="${packBtnStyle}" ${packBtnHover}>
                     <div style="font-size:20px;font-weight:bold;">Unlimited Monthly</div>
-                    <div style="font-size:24px;font-weight:bold;color:#00d4ff;margin:4px 0;">$19.95<span style="font-size:14px;color:#aaa;font-weight:normal">/mo</span></div>
-                    <div style="color:#888;font-size:12px;">24/7 tutoring, voice, PDF upload, courses, Show My Work &middot; Cancel anytime</div>
+                    ${formatPrice('unlimited', 1995, '<span style="font-size:14px;color:#aaa;font-weight:normal">/mo</span>', '', '24/7 tutoring, voice, PDF upload, courses, Show My Work \u00b7 Cancel anytime')}
                 </div>
             </div>
             <button id="upgrade-dismiss" style="background:transparent;color:#666;border:none;padding:10px;cursor:pointer;font-size:13px;width:100%;margin-top:16px;">Maybe later</button>

--- a/routes/billing.js
+++ b/routes/billing.js
@@ -48,6 +48,28 @@ const PACKS = {
   }
 };
 
+// ---- Pi Day Promo ($3.14 off all plans) ----
+const PI_DAY_DISCOUNT_CENTS = 314; // $3.14 in cents
+
+/**
+ * Check if the Pi Day promo is currently active.
+ * Active from March 14, 2026 00:00 EST through March 15, 2026 23:59 EST.
+ */
+function isPiDayPromoActive() {
+  const now = new Date();
+  const start = new Date('2026-03-14T05:00:00Z'); // midnight EST
+  const end   = new Date('2026-03-16T04:59:59Z'); // end of March 15 EST
+  return now >= start && now <= end;
+}
+
+/**
+ * Return promo-adjusted price (in cents) if Pi Day promo is active, otherwise original price.
+ */
+function getPromoPrice(originalPriceCents) {
+  if (!isPiDayPromoActive()) return originalPriceCents;
+  return Math.max(originalPriceCents - PI_DAY_DISCOUNT_CENTS, 100); // floor at $1.00
+}
+
 // Defer Stripe init — only create client when billing is enabled and key exists
 let stripe;
 if (BILLING_ENABLED && process.env.STRIPE_SECRET_KEY) {
@@ -92,15 +114,21 @@ router.post('/create-checkout-session', isAuthenticated, async (req, res) => {
       await user.save();
     }
 
-    // Build line item
+    // Build line item — apply Pi Day promo discount if active
+    const promoActive = isPiDayPromoActive();
+    const finalPrice = promoActive ? getPromoPrice(packConfig.price) : packConfig.price;
+    const productName = promoActive
+      ? `${packConfig.name} (Pi Day Special — $3.14 off!)`
+      : packConfig.name;
+
     const lineItem = {
       price_data: {
         currency: 'usd',
         product_data: {
-          name: packConfig.name,
+          name: productName,
           description: packConfig.description
         },
-        unit_amount: packConfig.price
+        unit_amount: finalPrice
       },
       quantity: 1
     };
@@ -407,6 +435,29 @@ router.get('/status', isAuthenticated, async (req, res) => {
     console.error('[Billing] Status check error:', error);
     res.status(500).json({ message: 'Failed to fetch billing status' });
   }
+});
+
+// =====================================================
+// GET /promo
+// Returns current promo status and adjusted prices
+// =====================================================
+router.get('/promo', (req, res) => {
+  const active = isPiDayPromoActive();
+  if (!active) {
+    return res.json({ active: false });
+  }
+
+  res.json({
+    active: true,
+    name: 'Pi Day Launch Special',
+    discount: '$3.14 off',
+    prices: {
+      pack_60:   { original: PACKS.pack_60.price,   promo: getPromoPrice(PACKS.pack_60.price) },
+      pack_120:  { original: PACKS.pack_120.price,   promo: getPromoPrice(PACKS.pack_120.price) },
+      unlimited: { original: PACKS.unlimited.price, promo: getPromoPrice(PACKS.unlimited.price) }
+    },
+    endsAt: '2026-03-16T04:59:59Z'
+  });
 });
 
 module.exports = router;

--- a/routes/dailyQuests.js
+++ b/routes/dailyQuests.js
@@ -88,10 +88,108 @@ const QUEST_TEMPLATES = {
   }
 };
 
+// ── Pi Day Special Quest Templates (March 14) ──────────────────────
+const PI_DAY_QUEST_TEMPLATES = {
+  piDigitChallenge: {
+    id: 'piDigitChallenge',
+    name: 'Pi Digit Challenge',
+    description: 'Solve 3 problems about circles, circumference, or area',
+    icon: '\u03C0',
+    target: 'problemsCorrect',
+    countOptions: [3],
+    xpReward: 100,
+    piDay: true
+  },
+  piMinilesson: {
+    id: 'piMinilesson',
+    name: 'Pi Day Mini-Lesson',
+    description: 'Ask your tutor to teach you something amazing about pi!',
+    icon: '\u03C0',
+    target: 'dailyPractice',
+    countOptions: [1],
+    xpReward: 75,
+    piDay: true
+  },
+  circleExplorer: {
+    id: 'circleExplorer',
+    name: 'Circle Explorer',
+    description: 'Practice a circle-related skill (area, circumference, or arc length)',
+    icon: '\u{1F4D0}',
+    target: 'skillsPracticed',
+    countOptions: [1],
+    xpReward: 75,
+    piDay: true
+  }
+};
+
+// Pi Day mini-lesson topics the AI tutor can teach
+const PI_DAY_MINILESSONS = [
+  {
+    title: 'Why Pi Never Ends',
+    prompt: 'Teach me a fun mini-lesson about why pi is an irrational number and its decimal digits never end or repeat. Use examples a student would find mind-blowing.',
+    gradeBand: 'all'
+  },
+  {
+    title: 'Pi in the Real World',
+    prompt: 'Give me a mini-lesson about where pi shows up in real life — wheels, planets, sound waves, GPS, and more. Make it surprising and fun.',
+    gradeBand: 'all'
+  },
+  {
+    title: 'The History of Pi',
+    prompt: 'Teach me a mini-lesson about the history of pi — from ancient Egyptians and Archimedes to modern supercomputers calculating trillions of digits.',
+    gradeBand: 'all'
+  },
+  {
+    title: 'Pi vs Tau Debate',
+    prompt: 'Teach me a fun mini-lesson about the pi vs tau (2pi) debate. Why do some mathematicians think we should use tau instead? Present both sides!',
+    gradeBand: '5-8'
+  },
+  {
+    title: 'Buffon\'s Needle: Finding Pi by Dropping Sticks',
+    prompt: 'Teach me about Buffon\'s Needle experiment — how dropping sticks on lined paper can actually calculate pi. Walk me through the math!',
+    gradeBand: '8-12'
+  },
+  {
+    title: 'Pi and Infinite Series',
+    prompt: 'Teach me a mini-lesson about how you can calculate pi using infinite series like Leibniz or Gregory series. Show me the pattern!',
+    gradeBand: '8-12'
+  }
+];
+
+/**
+ * Check if today is Pi Day (March 14)
+ */
+function isPiDay() {
+  const now = new Date();
+  return now.getMonth() === 2 && now.getDate() === 14; // month is 0-indexed
+}
+
 // Generate daily quests for a user based on their level and progress
 function generateDailyQuests(user) {
   const userLevel = user.level || 1;
   const quests = [];
+
+  // On Pi Day, use special Pi Day quests instead of regular ones
+  if (isPiDay()) {
+    const piTemplates = Object.values(PI_DAY_QUEST_TEMPLATES);
+    piTemplates.forEach(template => {
+      quests.push({
+        id: `${template.id}-${Date.now()}`,
+        templateId: template.id,
+        name: template.name,
+        description: template.description,
+        icon: template.icon,
+        target: template.target,
+        targetCount: template.countOptions[0],
+        progress: 0,
+        completed: false,
+        xpReward: template.xpReward,
+        bonusMultiplier: 3.14, // Pi Day XP multiplier!
+        piDay: true
+      });
+    });
+    return quests;
+  }
 
   // Select 3 random quest types
   const templateKeys = Object.keys(QUEST_TEMPLATES);
@@ -204,6 +302,7 @@ router.get('/daily-quests', isAuthenticated, async (req, res) => {
 
     res.json({
       success: true,
+      piDay: isPiDay(),
       quests: user.dailyQuests.quests,
       streak: user.dailyQuests.currentStreak || 0,
       longestStreak: user.dailyQuests.longestStreak || 0,
@@ -373,6 +472,20 @@ router.get('/daily-quests/stats', isAuthenticated, async (req, res) => {
     console.error('Error fetching quest stats:', error);
     res.status(500).json({ success: false, error: error.message });
   }
+});
+
+// GET /api/daily-quests/pi-day-lessons - Get Pi Day mini-lesson topics
+router.get('/daily-quests/pi-day-lessons', isAuthenticated, (req, res) => {
+  if (!isPiDay()) {
+    return res.json({ success: true, active: false, lessons: [] });
+  }
+
+  // Return all mini-lessons — frontend can filter by grade band
+  res.json({
+    success: true,
+    active: true,
+    lessons: PI_DAY_MINILESSONS
+  });
 });
 
 module.exports = router;


### PR DESCRIPTION
- Backend: time-limited Pi Day discount ($3.14 off) active 3/14-3/15,
  applied automatically at Stripe checkout with GET /api/billing/promo endpoint
- Landing page: countdown transforms into promo banner on Pi Day showing
  struck-through prices ($6.81 / $11.81 / $16.81/mo) with sign-up CTA
- Upgrade modal: fetches promo status and displays promotional pricing
  with visual struck-through original prices and "Save $3.14" callouts
- Daily quests: Pi Day themed quests (Pi Digit Challenge, Pi Day
  Mini-Lesson, Circle Explorer) with 3.14x XP multiplier
- Mini-lessons: 6 pi-themed topics (Why Pi Never Ends, Pi in the Real
  World, History of Pi, Pi vs Tau, Buffon's Needle, Infinite Series)
  served via GET /api/daily-quests/pi-day-lessons

https://claude.ai/code/session_01De44cAQaY3rG4AbPiDj2dh