### PR TITLE
Update Pi Day 2026 launch time from EST to EDT

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2334,8 +2334,8 @@
 
         if (!banner || !daysEl || !hoursEl || !minsEl || !secsEl) return;
 
-        // Target: March 14, 2026 at midnight EST (UTC-5)
-        var target = new Date('2026-03-14T05:00:00Z');
+        // Target: March 14, 2026 at midnight EDT (UTC-4, daylight saving in effect)
+        var target = new Date('2026-03-14T04:00:00Z');
 
         function pad(n) { return n < 10 ? '0' + n : String(n); }
 
@@ -2630,8 +2630,8 @@
       // At midnight EST on March 14 2026, swap waitlist CTAs → sign-up CTAs
       // and show the Pi Day promo banner with $3.14 off pricing
       (function piDayLaunchSwitch() {
-        var launchDate = new Date('2026-03-14T05:00:00Z'); // midnight EST = UTC-5
-        var promoEnd   = new Date('2026-03-16T04:59:59Z'); // end of March 15 EST
+        var launchDate = new Date('2026-03-14T04:00:00Z'); // midnight EDT = UTC-4
+        var promoEnd   = new Date('2026-03-16T03:59:59Z'); // end of March 15 EDT
         if (new Date() < launchDate) return;
 
         // Hide countdown banner

--- a/public/login.html
+++ b/public/login.html
@@ -135,7 +135,7 @@
 
   <script>
     // Swap demo → signup after launch date (March 14, 2026 midnight EST)
-    if (new Date() >= new Date('2026-03-14T05:00:00Z')) {
+    if (new Date() >= new Date('2026-03-14T04:00:00Z')) {
       document.querySelectorAll('.lp-pre-launch').forEach(function (el) { el.style.display = 'none'; });
       document.querySelectorAll('.lp-post-launch').forEach(function (el) { el.style.display = ''; });
     }

--- a/routes/billing.js
+++ b/routes/billing.js
@@ -53,12 +53,12 @@ const PI_DAY_DISCOUNT_CENTS = 314; // $3.14 in cents
 
 /**
  * Check if the Pi Day promo is currently active.
- * Active from March 14, 2026 00:00 EST through March 15, 2026 23:59 EST.
+ * Active from March 14, 2026 00:00 EDT through March 15, 2026 23:59 EDT.
  */
 function isPiDayPromoActive() {
   const now = new Date();
-  const start = new Date('2026-03-14T05:00:00Z'); // midnight EST
-  const end   = new Date('2026-03-16T04:59:59Z'); // end of March 15 EST
+  const start = new Date('2026-03-14T04:00:00Z'); // midnight EDT
+  const end   = new Date('2026-03-16T03:59:59Z'); // end of March 15 EDT
   return now >= start && now <= end;
 }
 
@@ -456,7 +456,7 @@ router.get('/promo', (req, res) => {
       pack_120:  { original: PACKS.pack_120.price,   promo: getPromoPrice(PACKS.pack_120.price) },
       unlimited: { original: PACKS.unlimited.price, promo: getPromoPrice(PACKS.unlimited.price) }
     },
-    endsAt: '2026-03-16T04:59:59Z'
+    endsAt: '2026-03-16T03:59:59Z'
   });
 });
 


### PR DESCRIPTION
## Summary
Corrected the Pi Day 2026 launch date and promo period timestamps to account for Daylight Saving Time (EDT, UTC-4) instead of Standard Time (EST, UTC-5). This ensures the countdown timer, launch switch, and promo eligibility logic all trigger at the correct moment.

## Key Changes
- **Countdown timer** (`public/index.html`): Updated target from `2026-03-14T05:00:00Z` (EST) to `2026-03-14T04:00:00Z` (EDT)
- **Launch switch** (`public/index.html`): Updated launch date and promo end time to EDT equivalents
- **Promo validation** (`routes/billing.js`): Updated `isPiDayPromoActive()` function to use EDT timestamps for start and end dates
- **Promo API endpoint** (`routes/billing.js`): Updated `endsAt` response field to reflect EDT end time
- **Login page** (`public/login.html`): Updated launch date check to use EDT timestamp

## Implementation Details
All timestamps were shifted one hour earlier (from UTC-5 to UTC-4) to reflect that March 14, 2026 falls during Daylight Saving Time in the Eastern timezone. The promo period remains 2 days (March 14-15) but with corrected UTC times:
- Start: `2026-03-14T04:00:00Z` (midnight EDT)
- End: `2026-03-16T03:59:59Z` (end of March 15 EDT)

https://claude.ai/code/session_01REPEd7QMVEfBhEa9CzNRcf