### PR TITLE
Add pricing page, freemium feature tasting, and upgrade access points

### DIFF
--- a/middleware/usageGate.js
+++ b/middleware/usageGate.js
@@ -18,6 +18,10 @@ const SchoolLicense = require('../models/schoolLicense');
 const BILLING_ENABLED = process.env.BILLING_ENABLED === 'true';
 const FREE_WEEKLY_SECONDS = 10 * 60; // 10 minutes per week for ALL students
 
+// Freemium taste limits — free users get a sample before upgrade prompt
+const FREE_UPLOAD_LIMIT = 1;     // 1 free upload, then upgrade required
+const FREE_GRADE_LIMIT  = 1;     // 1 free Show My Work, then upgrade required
+
 // In-memory cache for school license lookups (avoids DB hit on every request)
 // Key: licenseId.toString(), Value: { license: object|null, checkedAt: number }
 const licenseCache = new Map();
@@ -157,13 +161,19 @@ async function usageGate(req, res, next) {
     }
 
     // --- Free-tier student, no pack, free minutes exhausted ---
+    // Calculate when free minutes reset
+    const resetDate = new Date(lastReset.getTime() + 7 * 24 * 60 * 60 * 1000);
+    const msUntilReset = resetDate - now;
+    const daysUntilReset = Math.max(0, Math.ceil(msUntilReset / (1000 * 60 * 60 * 24)));
+
     return res.status(402).json({
-      message: "You've used your 10 free minutes this week. Ask your teacher about a school license for unlimited access, or come back next week!",
+      message: `You've used your 10 free minutes this week. Your minutes reset in ${daysUntilReset} day${daysUntilReset !== 1 ? 's' : ''}. Upgrade for more time, or ask your teacher about a school license!`,
       usageLimitReached: true,
       tier: 'free',
       freeMinutesUsed: Math.floor(weeklyAIUsed / 60),
       freeMinutesTotal: 10,
       freeSecondsRemaining: 0,
+      nextResetAt: resetDate.toISOString(),
       upgradeRequired: true
     });
   } catch (error) {
@@ -174,8 +184,10 @@ async function usageGate(req, res, next) {
 }
 
 /**
- * Feature gate for premium-only features (voice, OCR, uploads).
- * School-licensed students and unlimited subscribers get access.
+ * Feature gate for premium-only features (voice, uploads, Show My Work).
+ * School-licensed students and unlimited subscribers get full access.
+ * Free users get a limited taste: 1 free upload and 1 free Show My Work,
+ * then they see an upgrade prompt. Voice chat has no free taste (too expensive).
  */
 function premiumFeatureGate(featureName) {
   return async (req, res, next) => {
@@ -200,12 +212,34 @@ function premiumFeatureGate(featureName) {
       if (valid) return next();
     }
 
+    // --- Freemium taste: allow limited free uses of uploads and Show My Work ---
+    if (featureName === 'File uploads' && (user.freeUploadsUsed || 0) < FREE_UPLOAD_LIMIT) {
+      // Allow this upload, increment counter
+      await User.findByIdAndUpdate(user._id, { $inc: { freeUploadsUsed: 1 } });
+      return next();
+    }
+
+    if (featureName === 'Work grading' && (user.freeGradesUsed || 0) < FREE_GRADE_LIMIT) {
+      // Allow this grading, increment counter
+      await User.findByIdAndUpdate(user._id, { $inc: { freeGradesUsed: 1 } });
+      return next();
+    }
+
+    // Determine the message based on whether user already used their free taste
+    const usedFreeTaste = (featureName === 'File uploads' && (user.freeUploadsUsed || 0) >= FREE_UPLOAD_LIMIT) ||
+                          (featureName === 'Work grading' && (user.freeGradesUsed || 0) >= FREE_GRADE_LIMIT);
+
+    const message = usedFreeTaste
+      ? `You've used your free ${featureName.toLowerCase()} trial! Upgrade to the Unlimited plan ($19.95/month) for unlimited access.`
+      : `${featureName} requires the Unlimited plan ($19.95/month) or a school license.`;
+
     return res.status(402).json({
-      message: `${featureName} requires the Unlimited plan ($19.95/month) or a school license.`,
+      message,
       premiumFeatureBlocked: true,
       feature: featureName,
       tier: user.subscriptionTier || 'free',
-      upgradeRequired: true
+      upgradeRequired: true,
+      freeTrialUsed: usedFreeTaste
     });
   };
 }

--- a/models/user.js
+++ b/models/user.js
@@ -612,6 +612,11 @@ const userSchema = new Schema({
   // Minute-pack fields (60-min and 120-min packs)
   packSecondsRemaining: { type: Number, default: 0 },
   packExpiresAt: { type: Date, default: null },
+  // Freemium taste — free users get 1 free upload and 1 free Show My Work before upgrade prompt
+  freeUploadsUsed: { type: Number, default: 0 },
+  freeGradesUsed: { type: Number, default: 0 },
+  // Tracks whether user has seen the pricing page (shown once after signup)
+  hasSeenPricing: { type: Boolean, default: false },
 
   /* Timestamps */
   lastLogin:  { type: Date },

--- a/public/chat.html
+++ b/public/chat.html
@@ -163,6 +163,9 @@
       <button class="header-menu-item" data-trigger="open-feedback-modal-btn" data-i18n="nav.feedback">
         <i class="fas fa-comment-dots"></i> Feedback
       </button>
+      <a href="/pricing.html" class="header-menu-item" id="upgrade-plan-link" style="display:none;text-decoration:none;color:inherit;">
+        <i class="fas fa-arrow-up" style="color:#00d4ff;"></i> <span style="color:#00d4ff;">Upgrade Plan</span>
+      </a>
       <div class="header-menu-divider"></div>
       <button class="header-menu-item" id="logoutBtn" data-i18n="nav.logOut">
         <i class="fas fa-sign-out-alt"></i> Log Out

--- a/public/css/pricing.css
+++ b/public/css/pricing.css
@@ -1,0 +1,247 @@
+/* pricing.css — Pricing page styles */
+
+.pricing-page {
+  min-height: 100dvh;
+  background: #0d0d1a;
+  color: #fff;
+  padding: 40px 20px 60px;
+  font-family: var(--font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif);
+}
+
+/* Header */
+.pricing-header {
+  text-align: center;
+  max-width: 600px;
+  margin: 0 auto 40px;
+}
+
+.pricing-back-link {
+  display: inline-block;
+  color: #888;
+  text-decoration: none;
+  font-size: 14px;
+  margin-bottom: 20px;
+  transition: color 0.2s;
+}
+.pricing-back-link:hover { color: #00d4ff; }
+
+.pricing-title {
+  font-size: 32px;
+  font-weight: 700;
+  margin: 0 0 12px;
+}
+
+.pricing-subtitle {
+  color: #999;
+  font-size: 15px;
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* Cards Grid */
+.pricing-cards {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+/* Individual Card */
+.pricing-card {
+  background: #1a1a2e;
+  border: 1px solid #333;
+  border-radius: 16px;
+  padding: 28px 24px;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  transition: border-color 0.25s, transform 0.2s;
+}
+.pricing-card:hover {
+  border-color: #555;
+  transform: translateY(-2px);
+}
+
+/* Featured card (Best Value) */
+.pricing-card-featured {
+  border-color: #7b2ff7;
+  box-shadow: 0 0 24px rgba(123, 47, 247, 0.15);
+}
+.pricing-card-featured:hover {
+  border-color: #9b5ff7;
+}
+
+/* Active tier highlight */
+.pricing-card-active {
+  border-color: #00d4ff;
+  box-shadow: 0 0 20px rgba(0, 212, 255, 0.1);
+}
+
+/* Badge */
+.card-badge {
+  position: absolute;
+  top: -10px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #333;
+  color: #aaa;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 3px 12px;
+  border-radius: 20px;
+}
+.card-badge-featured {
+  background: #7b2ff7;
+  color: #fff;
+}
+.card-badge-premium {
+  background: linear-gradient(135deg, #00d4ff, #7b2ff7);
+  color: #fff;
+}
+
+/* Plan Name */
+.card-plan-name {
+  font-size: 20px;
+  font-weight: 600;
+  margin: 12px 0 8px;
+  text-align: center;
+}
+
+/* Price */
+.card-price {
+  font-size: 40px;
+  font-weight: 700;
+  text-align: center;
+  color: #00d4ff;
+}
+.card-price-cents {
+  font-size: 22px;
+}
+.card-price-mo {
+  font-size: 16px;
+  color: #888;
+  font-weight: 400;
+}
+
+.card-period {
+  text-align: center;
+  color: #666;
+  font-size: 13px;
+  margin-bottom: 20px;
+}
+
+/* Feature List */
+.card-features {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 24px;
+  flex: 1;
+}
+.card-features li {
+  font-size: 14px;
+  padding: 6px 0;
+  color: #ccc;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.card-features li i.fa-check { color: #00d4ff; font-size: 12px; }
+.card-features li i.fa-lock  { color: #555; font-size: 12px; }
+.card-features .feature-locked {
+  color: #555;
+}
+
+/* CTA Buttons */
+.card-cta {
+  width: 100%;
+  padding: 12px 20px;
+  border: none;
+  border-radius: 10px;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+.card-cta-current {
+  background: #2a2a3e;
+  color: #666;
+  cursor: default;
+}
+.card-cta-buy {
+  background: #1e1e3a;
+  color: #00d4ff;
+  border: 1px solid #00d4ff;
+}
+.card-cta-buy:hover:not(:disabled) {
+  background: #00d4ff;
+  color: #0d0d1a;
+}
+.card-cta-premium {
+  background: linear-gradient(135deg, #00d4ff, #7b2ff7);
+  color: #fff;
+}
+.card-cta-premium:hover:not(:disabled) {
+  background: linear-gradient(135deg, #33dfff, #9b5ff7);
+  transform: scale(1.02);
+}
+.card-cta:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+/* School Banner */
+.pricing-school-banner {
+  max-width: 600px;
+  margin: 40px auto 0;
+  background: #1a1a2e;
+  border: 1px solid #333;
+  border-radius: 12px;
+  padding: 16px 20px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  color: #aaa;
+  font-size: 14px;
+}
+.pricing-school-banner i {
+  font-size: 24px;
+  color: #7b2ff7;
+}
+.pricing-school-banner strong {
+  color: #fff;
+  display: block;
+  margin-bottom: 2px;
+}
+
+/* Skip link */
+.pricing-skip {
+  text-align: center;
+  margin-top: 24px;
+}
+.pricing-skip-link {
+  color: #666;
+  font-size: 13px;
+  text-decoration: none;
+  transition: color 0.2s;
+}
+.pricing-skip-link:hover { color: #aaa; }
+
+/* Responsive: 2-col on tablet, 1-col on mobile */
+@media (max-width: 900px) {
+  .pricing-cards {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px;
+  }
+}
+@media (max-width: 560px) {
+  .pricing-cards {
+    grid-template-columns: 1fr;
+    max-width: 360px;
+    gap: 16px;
+  }
+  .pricing-title { font-size: 26px; }
+  .pricing-page { padding: 24px 16px 40px; }
+}

--- a/public/js/courseCatalog.js
+++ b/public/js/courseCatalog.js
@@ -833,7 +833,18 @@ class CourseManager {
 
             const data = await res.json();
             if (!data.success) {
-                this.showToast(data.message || 'Enrollment failed');
+                // If enrollment blocked by billing gate, show upgrade prompt
+                if (res.status === 402 && data.upgradeRequired) {
+                    this.closeCatalog();
+                    if (window.showUpgradePrompt) {
+                        window.showUpgradePrompt(data);
+                    } else {
+                        // Fallback: redirect to pricing page
+                        window.location.href = '/pricing.html';
+                    }
+                } else {
+                    this.showToast(data.message || 'Enrollment failed');
+                }
                 if (btnEl) {
                     btnEl.disabled = false;
                     btnEl.textContent = 'Enroll';

--- a/public/js/modules/billing.js
+++ b/public/js/modules/billing.js
@@ -17,10 +17,21 @@ export async function checkBillingStatus() {
         // When billing is off (pre-launch), skip all UI
         if (data.billingEnabled === false) return data;
 
+        // Show "Upgrade Plan" link in nav for free/pack students
+        if (data.tier !== 'unlimited') {
+            const upgradeLink = document.getElementById('upgrade-plan-link');
+            if (upgradeLink) upgradeLink.style.display = '';
+        }
+
         // Show time indicator for students on free/pack tiers only.
         // Teachers, parents, and admins have unlimited access (Infinity) — skip indicator for them.
         if (data.tier !== 'unlimited' && data.usage && data.usage.secondsRemaining !== null && isFinite(data.usage.secondsRemaining)) {
             updateFreeTimeIndicator(data.usage);
+        }
+
+        // Post-signup pricing prompt: redirect new free users to pricing page once
+        if (data.tier === 'free' && data.hasSeenPricing === false) {
+            showNewUserPricingPrompt();
         }
 
         return data;
@@ -49,16 +60,35 @@ export function updateFreeTimeIndicator(usage) {
     const remaining = usage.secondsRemaining || 0;
     const mins = Math.floor(remaining / 60);
 
+    // Calculate human-readable reset time
+    let resetText = '';
+    if (usage.nextResetAt) {
+        const resetDate = new Date(usage.nextResetAt);
+        const msUntilReset = resetDate - Date.now();
+        if (msUntilReset > 0) {
+            const daysUntil = Math.floor(msUntilReset / (1000 * 60 * 60 * 24));
+            const hoursUntil = Math.floor((msUntilReset % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+            if (daysUntil > 0) {
+                resetText = `Resets in ${daysUntil}d ${hoursUntil}h`;
+            } else if (hoursUntil > 0) {
+                resetText = `Resets in ${hoursUntil}h`;
+            } else {
+                resetText = 'Resets soon';
+            }
+        }
+    }
+
     const subtitle = '<div style="font-size:10px;color:#888;margin-top:2px;">Only counts when the tutor is responding — your reading time is free</div>';
+    const resetLine = resetText ? `<div style="font-size:10px;color:#7b2ff7;margin-top:2px;">${resetText}</div>` : '';
 
     if (usage.limitReached || remaining <= 0) {
-        indicator.innerHTML = '<strong>No AI time left</strong> &mdash; <span style="color:#00d4ff;text-decoration:underline">Buy Pack</span>' + subtitle;
+        indicator.innerHTML = '<strong>No AI time left</strong> &mdash; <span style="color:#00d4ff;text-decoration:underline">Buy Pack</span>' + resetLine + subtitle;
         indicator.style.borderColor = '#ff4444';
     } else if (remaining <= 300) {
-        indicator.innerHTML = `<strong>${mins} min</strong> AI time left &mdash; <span style="color:#00d4ff;text-decoration:underline">Buy More</span>` + subtitle;
+        indicator.innerHTML = `<strong>${mins} min</strong> AI time left &mdash; <span style="color:#00d4ff;text-decoration:underline">Buy More</span>` + resetLine + subtitle;
         indicator.style.borderColor = '#ffaa00';
     } else {
-        indicator.innerHTML = `<strong>${mins} min</strong> AI time left` + subtitle;
+        indicator.innerHTML = `<strong>${mins} min</strong> AI time left` + resetLine + subtitle;
         indicator.style.borderColor = '#333';
     }
 }
@@ -135,4 +165,49 @@ export async function initiateUpgrade(pack) {
         console.error('[Billing] Upgrade error:', e);
         showToast('Something went wrong. Please try again.');
     }
+}
+
+/**
+ * Show a one-time welcome prompt for new free users, inviting them to see pricing.
+ * Displayed as a non-blocking banner at the top of chat, not a full-page redirect.
+ */
+export function showNewUserPricingPrompt() {
+    const existing = document.getElementById('new-user-pricing-banner');
+    if (existing) return;
+
+    const banner = document.createElement('div');
+    banner.id = 'new-user-pricing-banner';
+    banner.style.cssText = 'position:fixed;top:60px;left:50%;transform:translateX(-50%);background:#1a1a2e;border:1px solid #7b2ff7;border-radius:12px;padding:16px 24px;z-index:9500;max-width:440px;width:90%;text-align:center;color:#fff;box-shadow:0 8px 32px rgba(0,0,0,0.4);animation:slideDown 0.3s ease;';
+    banner.innerHTML = `
+        <div style="font-size:16px;font-weight:600;margin-bottom:6px;">Welcome to Mathmatix!</div>
+        <div style="font-size:13px;color:#aaa;margin-bottom:14px;line-height:1.5;">You have <strong style="color:#00d4ff;">10 free minutes</strong> of AI tutoring this week. Want to unlock more?</div>
+        <div style="display:flex;gap:10px;justify-content:center;">
+            <a href="/pricing.html" style="background:linear-gradient(135deg,#00d4ff,#7b2ff7);color:#fff;border:none;padding:8px 20px;border-radius:8px;font-size:13px;font-weight:600;cursor:pointer;text-decoration:none;">View Plans</a>
+            <button id="dismiss-pricing-banner" style="background:transparent;color:#666;border:1px solid #333;padding:8px 16px;border-radius:8px;font-size:13px;cursor:pointer;">Maybe Later</button>
+        </div>`;
+    document.body.appendChild(banner);
+
+    // Add slide-down animation
+    if (!document.getElementById('pricing-banner-anim')) {
+        const style = document.createElement('style');
+        style.id = 'pricing-banner-anim';
+        style.textContent = '@keyframes slideDown{from{opacity:0;transform:translateX(-50%) translateY(-20px);}to{opacity:1;transform:translateX(-50%) translateY(0);}}';
+        document.head.appendChild(style);
+    }
+
+    document.getElementById('dismiss-pricing-banner').addEventListener('click', () => {
+        banner.remove();
+        // Mark as seen so it doesn't show again
+        csrfFetch('/api/billing/seen-pricing', { method: 'POST', credentials: 'include' }).catch(() => {});
+    });
+
+    // Auto-dismiss after 15 seconds
+    setTimeout(() => {
+        if (banner.parentNode) {
+            banner.style.transition = 'opacity 0.3s';
+            banner.style.opacity = '0';
+            setTimeout(() => banner.remove(), 300);
+            csrfFetch('/api/billing/seen-pricing', { method: 'POST', credentials: 'include' }).catch(() => {});
+        }
+    }, 15000);
 }

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -12,6 +12,9 @@ import { createIepSystem } from './modules/iep.js';
 import { createAssessmentSystem } from './modules/assessment.js';
 // Whiteboard is shelved for beta — see modules/whiteboard.js to re-enable
 
+// Expose showUpgradePrompt globally so courseCatalog.js (non-module) can call it
+window.showUpgradePrompt = showUpgradePrompt;
+
 // --- Global Variables ---
 let currentUser = null;
 let isPlaying = false;

--- a/public/pricing.html
+++ b/public/pricing.html
@@ -1,0 +1,185 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pricing | Mathmatix AI</title>
+  <link rel="stylesheet" href="/style.css" />
+  <link rel="stylesheet" href="/css/dark-mode.css" />
+  <link rel="stylesheet" href="/css/mobile-fixes.css" />
+  <link rel="stylesheet" href="/css/ux-enhancements.css" />
+  <link rel="stylesheet" href="/css/pricing.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" referrerpolicy="no-referrer" />
+  <script src="/js/csrf.js"></script>
+</head>
+<body>
+  <div class="pricing-page">
+    <!-- Header -->
+    <header class="pricing-header">
+      <a href="/chat.html" class="pricing-back-link"><i class="fas fa-arrow-left"></i> Back to Chat</a>
+      <h1 class="pricing-title">Choose Your Plan</h1>
+      <p class="pricing-subtitle">Start free, upgrade when you're ready. Minutes only count while the AI tutor is responding&mdash;your reading and thinking time is always free.</p>
+    </header>
+
+    <!-- Plan Cards -->
+    <div class="pricing-cards">
+
+      <!-- Free Tier -->
+      <div class="pricing-card" data-tier="free">
+        <div class="card-badge">Current</div>
+        <h2 class="card-plan-name">Free</h2>
+        <div class="card-price">$0</div>
+        <div class="card-period">forever</div>
+        <ul class="card-features">
+          <li><i class="fas fa-check"></i> 10 min/week AI tutoring</li>
+          <li><i class="fas fa-check"></i> 1 free file upload</li>
+          <li><i class="fas fa-check"></i> 1 free Show My Work</li>
+          <li><i class="fas fa-check"></i> Browse course catalog</li>
+          <li><i class="fas fa-check"></i> Mastery Mode &amp; Fact Fluency</li>
+          <li class="feature-locked"><i class="fas fa-lock"></i> Voice chat</li>
+          <li class="feature-locked"><i class="fas fa-lock"></i> Course enrollment</li>
+          <li class="feature-locked"><i class="fas fa-lock"></i> Unlimited uploads &amp; grading</li>
+        </ul>
+        <button class="card-cta card-cta-current" disabled>Your Current Plan</button>
+      </div>
+
+      <!-- 60-Min Pack -->
+      <div class="pricing-card" data-tier="pack_60">
+        <h2 class="card-plan-name">60-Minute Pack</h2>
+        <div class="card-price">$9<span class="card-price-cents">.95</span></div>
+        <div class="card-period">one-time &middot; expires in 90 days</div>
+        <ul class="card-features">
+          <li><i class="fas fa-check"></i> 60 min AI tutoring</li>
+          <li><i class="fas fa-check"></i> $0.17/min</li>
+          <li><i class="fas fa-check"></i> 1 free file upload</li>
+          <li><i class="fas fa-check"></i> 1 free Show My Work</li>
+          <li><i class="fas fa-check"></i> + 10 free min/week on top</li>
+          <li class="feature-locked"><i class="fas fa-lock"></i> Voice chat</li>
+          <li class="feature-locked"><i class="fas fa-lock"></i> Course enrollment</li>
+        </ul>
+        <button class="card-cta card-cta-buy" data-pack="pack_60">Get 60 Minutes</button>
+      </div>
+
+      <!-- 120-Min Pack -->
+      <div class="pricing-card pricing-card-featured" data-tier="pack_120">
+        <div class="card-badge card-badge-featured">Best Value</div>
+        <h2 class="card-plan-name">120-Minute Pack</h2>
+        <div class="card-price">$14<span class="card-price-cents">.95</span></div>
+        <div class="card-period">one-time &middot; expires in 180 days</div>
+        <ul class="card-features">
+          <li><i class="fas fa-check"></i> 120 min AI tutoring</li>
+          <li><i class="fas fa-check"></i> $0.12/min</li>
+          <li><i class="fas fa-check"></i> 1 free file upload</li>
+          <li><i class="fas fa-check"></i> 1 free Show My Work</li>
+          <li><i class="fas fa-check"></i> + 10 free min/week on top</li>
+          <li class="feature-locked"><i class="fas fa-lock"></i> Voice chat</li>
+          <li class="feature-locked"><i class="fas fa-lock"></i> Course enrollment</li>
+        </ul>
+        <button class="card-cta card-cta-buy" data-pack="pack_120">Get 120 Minutes</button>
+      </div>
+
+      <!-- Unlimited -->
+      <div class="pricing-card" data-tier="unlimited">
+        <div class="card-badge card-badge-premium">Everything</div>
+        <h2 class="card-plan-name">Unlimited</h2>
+        <div class="card-price">$19<span class="card-price-cents">.95</span><span class="card-price-mo">/mo</span></div>
+        <div class="card-period">cancel anytime</div>
+        <ul class="card-features">
+          <li><i class="fas fa-check"></i> Unlimited 24/7 AI tutoring</li>
+          <li><i class="fas fa-check"></i> Unlimited file uploads</li>
+          <li><i class="fas fa-check"></i> Unlimited Show My Work</li>
+          <li><i class="fas fa-check"></i> Voice chat</li>
+          <li><i class="fas fa-check"></i> Enroll in full courses</li>
+          <li><i class="fas fa-check"></i> All features unlocked</li>
+        </ul>
+        <button class="card-cta card-cta-premium" data-pack="unlimited">Go Unlimited</button>
+      </div>
+
+    </div>
+
+    <!-- School License Banner -->
+    <div class="pricing-school-banner">
+      <i class="fas fa-school"></i>
+      <div>
+        <strong>School or District?</strong>
+        <span>Ask your school about a Mathmatix site license for unlimited access for all students.</span>
+      </div>
+    </div>
+
+    <!-- Skip link for new signups -->
+    <div class="pricing-skip">
+      <a href="/chat.html" class="pricing-skip-link">Skip for now &mdash; start with 10 free minutes</a>
+    </div>
+  </div>
+
+  <script>
+  (function() {
+    // Fetch billing status and update card states
+    async function initPricing() {
+      try {
+        const res = await csrfFetch('/api/billing/status', { credentials: 'include' });
+        if (!res.ok) return;
+        const data = await res.json();
+
+        // If billing is disabled, show everything as available
+        if (data.billingEnabled === false) {
+          document.querySelector('.pricing-page').innerHTML =
+            '<div style="text-align:center;padding:80px 20px;color:#aaa;"><h2>All features are currently free!</h2><p>Billing is not enabled yet. Enjoy unlimited access.</p><a href="/chat.html" style="color:#00d4ff;">Back to Chat</a></div>';
+          return;
+        }
+
+        // Highlight current tier
+        const currentTier = data.tier || 'free';
+        document.querySelectorAll('.pricing-card').forEach(card => {
+          const tier = card.dataset.tier;
+          const badge = card.querySelector('.card-badge');
+          const cta = card.querySelector('.card-cta');
+
+          if (tier === currentTier) {
+            card.classList.add('pricing-card-active');
+            if (badge) { badge.textContent = 'Current'; badge.style.display = ''; }
+            if (cta) { cta.textContent = 'Your Current Plan'; cta.disabled = true; cta.classList.add('card-cta-current'); }
+          } else if (tier === 'free' && currentTier !== 'free') {
+            // Hide "Current" badge from free card if user is on a higher tier
+            if (badge && badge.textContent === 'Current') badge.style.display = 'none';
+            if (cta) { cta.textContent = 'Free Tier'; cta.disabled = true; }
+          }
+        });
+
+        // Mark pricing as seen
+        await csrfFetch('/api/billing/seen-pricing', { method: 'POST', credentials: 'include' }).catch(() => {});
+      } catch (e) {
+        console.error('[Pricing] Failed to load billing status:', e);
+      }
+    }
+
+    // Handle buy buttons
+    document.querySelectorAll('.card-cta-buy, .card-cta-premium').forEach(btn => {
+      btn.addEventListener('click', async function() {
+        const pack = this.dataset.pack;
+        if (!pack) return;
+        this.disabled = true;
+        this.textContent = 'Redirecting...';
+        try {
+          const res = await csrfFetch('/api/billing/create-checkout-session', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ pack }),
+            credentials: 'include'
+          });
+          if (!res.ok) throw new Error('Failed to create checkout session');
+          const data = await res.json();
+          window.location.href = data.url;
+        } catch (e) {
+          console.error('[Pricing] Checkout error:', e);
+          this.disabled = false;
+          this.textContent = 'Try Again';
+        }
+      });
+    });
+
+    initPricing();
+  })();
+  </script>
+</body>
+</html>

--- a/routes/billing.js
+++ b/routes/billing.js
@@ -390,22 +390,45 @@ router.get('/status', isAuthenticated, async (req, res) => {
     const freeRemaining = Math.max(0, FREE_WEEKLY_SECONDS - weeklyAIUsed);
     const limitReached = freeRemaining <= 0;
 
+    // Calculate when free minutes reset (7 days from lastWeeklyReset)
+    const lastResetDate = weeklyAIUsed === 0 && (now - lastReset) / (1000 * 60 * 60 * 24) >= 7
+      ? now  // Reset just happened, next reset is 7 days from now
+      : lastReset;
+    const nextReset = new Date(lastResetDate.getTime() + 7 * 24 * 60 * 60 * 1000);
+
     res.json({
       success: true,
       billingEnabled: true,
       tier: 'free',
       hasAccess: !limitReached,
+      hasSeenPricing: user.hasSeenPricing || false,
       usage: {
         secondsRemaining: freeRemaining,
         minutesRemaining: Math.floor(freeRemaining / 60),
         weeklyAISecondsUsed: weeklyAIUsed,
         freeWeeklySeconds: FREE_WEEKLY_SECONDS,
-        limitReached
+        limitReached,
+        nextResetAt: nextReset.toISOString()
       }
     });
   } catch (error) {
     console.error('[Billing] Status check error:', error);
     res.status(500).json({ message: 'Failed to fetch billing status' });
+  }
+});
+
+/* ============================================================
+   POST /api/billing/seen-pricing
+   Mark that the user has seen the pricing page (shown once after signup)
+   ============================================================ */
+router.post('/seen-pricing', async (req, res) => {
+  try {
+    if (req.user) {
+      await User.findByIdAndUpdate(req.user._id, { hasSeenPricing: true });
+    }
+    res.json({ success: true });
+  } catch (error) {
+    res.status(500).json({ message: 'Failed to update' });
   }
 });
 

--- a/routes/courseSession.js
+++ b/routes/courseSession.js
@@ -11,6 +11,9 @@ const Conversation = require('../models/conversation');
 const User = require('../models/user');
 const { calculateOverallProgress } = require('../utils/coursePrompt');
 const { buildProgressUpdate } = require('../utils/progressState');
+const { isLicenseValid } = require('../middleware/usageGate');
+
+const BILLING_ENABLED = process.env.BILLING_ENABLED === 'true';
 
 /* ============================================================
    GET /api/course-sessions/catalog
@@ -135,6 +138,24 @@ router.post('/enroll', async (req, res) => {
     const { courseId } = req.body;
     if (!courseId) {
       return res.status(400).json({ success: false, message: 'courseId is required' });
+    }
+
+    // Courses require Unlimited plan or school license (when billing is enabled)
+    if (BILLING_ENABLED && req.user.role === 'student') {
+      const hasUnlimited = req.user.subscriptionTier === 'unlimited';
+      let hasSchoolLicense = false;
+      if (req.user.schoolLicenseId) {
+        hasSchoolLicense = await isLicenseValid(req.user.schoolLicenseId);
+      }
+      if (!hasUnlimited && !hasSchoolLicense) {
+        return res.status(402).json({
+          success: false,
+          message: 'Courses require the Unlimited plan ($19.95/month) or a school license.',
+          premiumFeatureBlocked: true,
+          feature: 'Courses',
+          upgradeRequired: true
+        });
+      }
     }
 
     // Check for existing session in this course (active OR paused)

--- a/server.js
+++ b/server.js
@@ -815,6 +815,9 @@ app.get("/privacy.html", (req, res) => res.sendFile(path.join(__dirname, "public
 app.get("/terms.html", (req, res) => res.sendFile(path.join(__dirname, "public", "terms.html")));
 app.get("/demo.html", (req, res) => res.sendFile(path.join(__dirname, "public", "demo.html")));
 
+// Pricing page (accessible to authenticated users)
+app.get("/pricing.html", isAuthenticated, (req, res) => res.sendFile(path.join(__dirname, "public", "pricing.html")));
+
 // Protected HTML routes (require authentication)
 app.get("/complete-profile.html", isAuthenticated, (req, res) => res.sendFile(path.join(__dirname, "public", "complete-profile.html")));
 app.get("/pick-tutor.html", isAuthenticated, (req, res) => res.sendFile(path.join(__dirname, "public", "pick-tutor.html")));


### PR DESCRIPTION
- Create /pricing.html with 4-tier comparison (Free/60min/120min/Unlimited)
- Add "Upgrade Plan" link in chat nav menu for free/pack users
- Show one-time welcome banner for new signups prompting them to view plans
- Allow 1 free upload and 1 free Show My Work for free users before requiring upgrade
- Gate course enrollment behind Unlimited plan or school license
- Show weekly reset countdown in free time indicator (e.g. "Resets in 3d 5h")
- Include reset timing in 402 error messages when free minutes exhausted
- Add /api/billing/seen-pricing endpoint to track first-visit pricing dismissal
- Add freeUploadsUsed, freeGradesUsed, hasSeenPricing fields to user model

https://claude.ai/code/session_01Pwxd3nJeBFqKUadMbbcBfP