### PR TITLE
Fix join class card appearing mandatory for new students

### DIFF
--- a/public/signup.html
+++ b/public/signup.html
@@ -124,10 +124,11 @@
           </select>
         </div>
 
-        <div class="form-group" style="display:flex;align-items:center;gap:8px;margin:8px 0 4px;">
+        <div class="form-group" style="display:flex;align-items:center;gap:8px;margin:8px 0 0;">
           <input type="checkbox" id="hasCodeCheckbox" style="min-width:16px;" />
           <label for="hasCodeCheckbox" id="hasCodeLabel" style="font-size:0.875rem;cursor:pointer;">I have a code to enter</label>
         </div>
+        <p id="codeHint" class="note" style="margin:2px 0 4px 24px;font-size:0.8rem;color:#888;">Optional — you can sign up without a code and join a class later.</p>
 
         <div id="codeInputGroup" style="display: none;">
           <div id="enrollmentCodeGroup" class="form-group" style="display: none;">
@@ -195,11 +196,14 @@
       const isChecked = hasCodeCheckbox.checked;
       const role = roleSelect.value;
 
-      // Update label text based on role
+      // Update label + hint text based on role
+      const codeHint = document.getElementById("codeHint");
       if (role === "parent") {
         hasCodeLabel.textContent = "I have my child's invite code";
+        if (codeHint) codeHint.textContent = "Optional — you can link to your child later from your dashboard.";
       } else {
         hasCodeLabel.textContent = "I have a code to enter";
+        if (codeHint) codeHint.textContent = "Optional — you can sign up without a code and join a class later.";
       }
 
       // Show/hide the code input area

--- a/public/student-dashboard.html
+++ b/public/student-dashboard.html
@@ -534,6 +534,9 @@
           </button>
         </div>
         <div class="join-class-status" id="join-class-status"></div>
+        <button id="skip-join-class-btn" class="btn-secondary" style="display:none;margin-top:10px;width:auto;padding:8px 20px;font-size:0.9rem;opacity:0.85;">
+          <i class="fas fa-arrow-right"></i> Skip for Now
+        </button>
       </div>
 
       <!-- Quick Actions (consolidated to 4) -->
@@ -741,12 +744,19 @@
         const confirmBtn = document.getElementById('confirm-join-btn');
         const statusEl = document.getElementById('join-class-status');
 
-        // Show section if student has no teacher (mandatory) or show toggle
+        // Show section if student has no teacher (optional) or show toggle
+        const skipBtn = document.getElementById('skip-join-class-btn');
         if (!user.teacherId) {
             section.style.display = 'block';
-            document.getElementById('join-class-title').textContent = 'Join Your Class';
+            document.getElementById('join-class-title').textContent = 'Join a Class';
             document.getElementById('join-class-description').textContent =
-                'Enter the class code from your teacher to get started.';
+                'Have a class code from your teacher? Enter it below. You can also skip this and join a class later.';
+            if (skipBtn) {
+                skipBtn.style.display = 'inline-block';
+                skipBtn.addEventListener('click', () => {
+                    section.style.display = 'none';
+                });
+            }
         } else {
             // Has a teacher - show current class info and toggle
             section.style.display = 'none';


### PR DESCRIPTION
Students signing up without an enrollment code were seeing a prominent
"Join Your Class" card with no way to dismiss it, making it seem like
a code was required to use the platform. Updated the wording to clarify
that joining a class is optional and added a "Skip for Now" button.

https://claude.ai/code/session_01BtLUfRWu5jaBCE6ppohK6C