### PR TITLE
Add mobile math keyboard panel for equation input

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -503,29 +503,16 @@
       <div class="equation-section-header">Subscripts and Superscripts</div>
       <div class="subscript-superscript-grid">
         <button class="script-btn" data-latex="#0^{#1}" title="Superscript/Power">
-          <svg viewBox="0 0 40 40" class="script-icon">
-            <rect x="4" y="8" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-dasharray="4,2"/>
-            <rect x="24" y="4" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" stroke-dasharray="4,2"/>
-          </svg>
+          <span class="script-label">x<sup>n</sup></span>
         </button>
         <button class="script-btn" data-latex="#0_{#1}" title="Subscript">
-          <svg viewBox="0 0 40 40" class="script-icon">
-            <rect x="4" y="4" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-dasharray="4,2"/>
-            <rect x="24" y="24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" stroke-dasharray="4,2"/>
-          </svg>
+          <span class="script-label">x<sub>n</sub></span>
         </button>
         <button class="script-btn" data-latex="#0_{#1}^{#2}" title="Subscript and Superscript">
-          <svg viewBox="0 0 40 40" class="script-icon">
-            <rect x="4" y="10" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-dasharray="4,2"/>
-            <rect x="22" y="4" width="10" height="10" fill="none" stroke="currentColor" stroke-width="2" stroke-dasharray="4,2"/>
-            <rect x="22" y="26" width="10" height="10" fill="none" stroke="currentColor" stroke-width="2" stroke-dasharray="4,2"/>
-          </svg>
+          <span class="script-label">x<sub>n</sub><sup>m</sup></span>
         </button>
         <button class="script-btn" data-latex="{}_{#0}#1" title="Left Subscript">
-          <svg viewBox="0 0 40 40" class="script-icon">
-            <rect x="12" y="4" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-dasharray="4,2"/>
-            <rect x="4" y="24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" stroke-dasharray="4,2"/>
-          </svg>
+          <span class="script-label"><sub>n</sub>x</span>
         </button>
       </div>
 

--- a/public/chat.html
+++ b/public/chat.html
@@ -585,21 +585,38 @@
       <div class="imessage-input-row">
         <div id="user-input" contenteditable="true" data-placeholder="Ask a math question..." data-i18n-placeholder="chat.askQuestion" role="textbox" aria-multiline="true"></div>
         <!-- Math-field input (hidden until math mode activated) -->
-        <math-field id="math-keyboard-field" class="math-keyboard-field" virtual-keyboard-mode="off" style="display:none;"></math-field>
+        <div id="math-input-wrapper" class="math-input-wrapper" style="display:none;">
+          <math-field id="math-keyboard-field" class="math-keyboard-field" virtual-keyboard-mode="off"></math-field>
+          <button id="mk-done-btn" class="mk-done-btn" title="Insert equation and return to text">Done</button>
+        </div>
         <button id="send-button" class="imessage-send-btn" title="Send" aria-label="Send message">
           <i class="fas fa-arrow-up"></i>
         </button>
+      </div>
+      <!-- Helper text shown when math mode is active -->
+      <div id="mk-helper-text" class="mk-helper-text" style="display:none;">
+        Type your equation below, then tap <strong>Done</strong> or <strong>Send</strong>
       </div>
     </div>
 
     <!-- Math Keyboard Panel (replaces native keyboard on mobile) -->
     <div id="math-keyboard-panel" class="math-keyboard-panel" style="display:none;">
       <div class="mk-tabs">
-        <button class="mk-tab" data-tab="abc" title="Text keyboard">ABC</button>
-        <button class="mk-tab" data-tab="123" title="Numbers & operations">123</button>
-        <button class="mk-tab mk-tab-active" data-tab="math" title="Math symbols">√x</button>
+        <button class="mk-tab" data-tab="abc" title="Switch to text keyboard">
+          <span class="mk-tab-icon"><i class="fas fa-keyboard"></i></span>
+          <span class="mk-tab-label">Text</span>
+        </button>
+        <button class="mk-tab" data-tab="123" title="Numbers and basic math">
+          <span class="mk-tab-icon">123</span>
+          <span class="mk-tab-label">Numbers</span>
+        </button>
+        <button class="mk-tab mk-tab-active" data-tab="math" title="Math symbols and formulas">
+          <span class="mk-tab-icon">√x</span>
+          <span class="mk-tab-label">Symbols</span>
+        </button>
       </div>
-      <!-- 123 tab: number pad + common operations -->
+
+      <!-- Numbers tab -->
       <div class="mk-page" data-page="123" style="display:none;">
         <div class="mk-grid mk-grid-5">
           <button class="mk-key" data-insert="1">1</button>
@@ -613,44 +630,53 @@
           <button class="mk-key" data-insert="9">9</button>
           <button class="mk-key" data-insert="0">0</button>
           <button class="mk-key" data-insert="+">+</button>
-          <button class="mk-key" data-insert="-">−</button>
-          <button class="mk-key" data-insert="\times">×</button>
-          <button class="mk-key" data-insert="\div">÷</button>
+          <button class="mk-key" data-insert="-">&minus;</button>
+          <button class="mk-key" data-insert="\times">&times;</button>
+          <button class="mk-key" data-insert="\div">&divide;</button>
           <button class="mk-key" data-insert="=">=</button>
           <button class="mk-key" data-insert="(">(</button>
           <button class="mk-key" data-insert=")">)</button>
           <button class="mk-key" data-insert=".">.</button>
           <button class="mk-key" data-insert=",">,</button>
-          <button class="mk-key mk-key-action" data-command="deleteBackward"><i class="fas fa-delete-left"></i></button>
+          <button class="mk-key mk-key-action" data-command="deleteBackward" title="Delete"><i class="fas fa-delete-left"></i></button>
         </div>
       </div>
-      <!-- Math tab: symbols, templates, Greek -->
+
+      <!-- Symbols tab — grouped with clear section headers -->
       <div class="mk-page" data-page="math">
+        <div class="mk-section-label">Common</div>
         <div class="mk-grid mk-grid-5">
-          <!-- Templates -->
-          <button class="mk-key" data-insert="\frac{#0}{#1}" title="Fraction">x/y</button>
-          <button class="mk-key" data-insert="\sqrt{#0}" title="Square root">√</button>
-          <button class="mk-key" data-insert="\sqrt[#1]{#0}" title="Nth root">ⁿ√</button>
-          <button class="mk-key" data-insert="#0^{#1}" title="Superscript">x<sup>n</sup></button>
-          <button class="mk-key" data-insert="#0_{#1}" title="Subscript">x<sub>n</sub></button>
-          <!-- Calculus -->
-          <button class="mk-key" data-insert="\sum_{#0}^{#1}" title="Sum">∑</button>
-          <button class="mk-key" data-insert="\int_{#0}^{#1}" title="Integral">∫</button>
+          <button class="mk-key" data-insert="\frac{#0}{#1}" title="Fraction"><span class="mk-key-main">x/y</span><span class="mk-key-hint">Fraction</span></button>
+          <button class="mk-key" data-insert="\sqrt{#0}" title="Square root"><span class="mk-key-main">&radic;</span><span class="mk-key-hint">Root</span></button>
+          <button class="mk-key" data-insert="#0^{#1}" title="Power / Exponent"><span class="mk-key-main">x<sup>n</sup></span><span class="mk-key-hint">Power</span></button>
+          <button class="mk-key" data-insert="#0_{#1}" title="Subscript"><span class="mk-key-main">x<sub>n</sub></span><span class="mk-key-hint">Sub</span></button>
+          <button class="mk-key mk-key-action" data-command="deleteBackward" title="Delete"><i class="fas fa-delete-left"></i></button>
+        </div>
+        <div class="mk-section-label">Symbols</div>
+        <div class="mk-grid mk-grid-5">
+          <button class="mk-key" data-insert="\pi" title="Pi">&pi;</button>
+          <button class="mk-key" data-insert="\theta" title="Theta">&theta;</button>
+          <button class="mk-key" data-insert="\infty" title="Infinity">&infin;</button>
+          <button class="mk-key" data-insert="\pm" title="Plus or minus">&plusmn;</button>
+          <button class="mk-key" data-insert="\Delta" title="Delta / Change">&Delta;</button>
+          <button class="mk-key" data-insert="\leq" title="Less than or equal">&le;</button>
+          <button class="mk-key" data-insert="\geq" title="Greater than or equal">&ge;</button>
+          <button class="mk-key" data-insert="\neq" title="Not equal">&ne;</button>
+          <button class="mk-key" data-insert="\approx" title="Approximately">&asymp;</button>
+          <button class="mk-key" data-insert="\alpha" title="Alpha">&alpha;</button>
+        </div>
+        <div class="mk-section-label">Advanced</div>
+        <div class="mk-grid mk-grid-5">
+          <button class="mk-key" data-insert="\sum_{#0}^{#1}" title="Summation">&sum;</button>
+          <button class="mk-key" data-insert="\int_{#0}^{#1}" title="Integral">&int;</button>
           <button class="mk-key" data-insert="\lim_{#0 \to #1}" title="Limit">lim</button>
-          <button class="mk-key" data-insert="\log_{#0}" title="Log">log</button>
-          <button class="mk-key" data-insert="\infty" title="Infinity">∞</button>
-          <!-- Greek -->
-          <button class="mk-key" data-insert="\pi" title="Pi">π</button>
-          <button class="mk-key" data-insert="\theta" title="Theta">θ</button>
-          <button class="mk-key" data-insert="\alpha" title="Alpha">α</button>
-          <button class="mk-key" data-insert="\beta" title="Beta">β</button>
-          <button class="mk-key" data-insert="\Delta" title="Delta">Δ</button>
-          <!-- Comparisons & symbols -->
-          <button class="mk-key" data-insert="\leq" title="Less or equal">≤</button>
-          <button class="mk-key" data-insert="\geq" title="Greater or equal">≥</button>
-          <button class="mk-key" data-insert="\neq" title="Not equal">≠</button>
-          <button class="mk-key" data-insert="\approx" title="Approximately">≈</button>
-          <button class="mk-key" data-insert="\pm" title="Plus-minus">±</button>
+          <button class="mk-key" data-insert="\log_{#0}" title="Logarithm">log</button>
+          <button class="mk-key" data-insert="\sqrt[#1]{#0}" title="Nth root"><sup>n</sup>&radic;</button>
+          <button class="mk-key" data-insert="\beta" title="Beta">&beta;</button>
+          <button class="mk-key" data-insert="\gamma" title="Gamma">&gamma;</button>
+          <button class="mk-key" data-insert="\lambda" title="Lambda">&lambda;</button>
+          <button class="mk-key" data-insert="\sigma" title="Sigma">&sigma;</button>
+          <button class="mk-key" data-insert="\phi" title="Phi">&phi;</button>
         </div>
       </div>
     </div>

--- a/public/chat.html
+++ b/public/chat.html
@@ -584,11 +584,77 @@
       </div>
       <div class="imessage-input-row">
         <div id="user-input" contenteditable="true" data-placeholder="Ask a math question..." data-i18n-placeholder="chat.askQuestion" role="textbox" aria-multiline="true"></div>
+        <!-- Math-field input (hidden until math mode activated) -->
+        <math-field id="math-keyboard-field" class="math-keyboard-field" virtual-keyboard-mode="off" style="display:none;"></math-field>
         <button id="send-button" class="imessage-send-btn" title="Send" aria-label="Send message">
           <i class="fas fa-arrow-up"></i>
         </button>
       </div>
     </div>
+
+    <!-- Math Keyboard Panel (replaces native keyboard on mobile) -->
+    <div id="math-keyboard-panel" class="math-keyboard-panel" style="display:none;">
+      <div class="mk-tabs">
+        <button class="mk-tab" data-tab="abc" title="Text keyboard">ABC</button>
+        <button class="mk-tab" data-tab="123" title="Numbers & operations">123</button>
+        <button class="mk-tab mk-tab-active" data-tab="math" title="Math symbols">√x</button>
+      </div>
+      <!-- 123 tab: number pad + common operations -->
+      <div class="mk-page" data-page="123" style="display:none;">
+        <div class="mk-grid mk-grid-5">
+          <button class="mk-key" data-insert="1">1</button>
+          <button class="mk-key" data-insert="2">2</button>
+          <button class="mk-key" data-insert="3">3</button>
+          <button class="mk-key" data-insert="4">4</button>
+          <button class="mk-key" data-insert="5">5</button>
+          <button class="mk-key" data-insert="6">6</button>
+          <button class="mk-key" data-insert="7">7</button>
+          <button class="mk-key" data-insert="8">8</button>
+          <button class="mk-key" data-insert="9">9</button>
+          <button class="mk-key" data-insert="0">0</button>
+          <button class="mk-key" data-insert="+">+</button>
+          <button class="mk-key" data-insert="-">−</button>
+          <button class="mk-key" data-insert="\times">×</button>
+          <button class="mk-key" data-insert="\div">÷</button>
+          <button class="mk-key" data-insert="=">=</button>
+          <button class="mk-key" data-insert="(">(</button>
+          <button class="mk-key" data-insert=")">)</button>
+          <button class="mk-key" data-insert=".">.</button>
+          <button class="mk-key" data-insert=",">,</button>
+          <button class="mk-key mk-key-action" data-command="deleteBackward"><i class="fas fa-delete-left"></i></button>
+        </div>
+      </div>
+      <!-- Math tab: symbols, templates, Greek -->
+      <div class="mk-page" data-page="math">
+        <div class="mk-grid mk-grid-5">
+          <!-- Templates -->
+          <button class="mk-key" data-insert="\frac{#0}{#1}" title="Fraction">x/y</button>
+          <button class="mk-key" data-insert="\sqrt{#0}" title="Square root">√</button>
+          <button class="mk-key" data-insert="\sqrt[#1]{#0}" title="Nth root">ⁿ√</button>
+          <button class="mk-key" data-insert="#0^{#1}" title="Superscript">x<sup>n</sup></button>
+          <button class="mk-key" data-insert="#0_{#1}" title="Subscript">x<sub>n</sub></button>
+          <!-- Calculus -->
+          <button class="mk-key" data-insert="\sum_{#0}^{#1}" title="Sum">∑</button>
+          <button class="mk-key" data-insert="\int_{#0}^{#1}" title="Integral">∫</button>
+          <button class="mk-key" data-insert="\lim_{#0 \to #1}" title="Limit">lim</button>
+          <button class="mk-key" data-insert="\log_{#0}" title="Log">log</button>
+          <button class="mk-key" data-insert="\infty" title="Infinity">∞</button>
+          <!-- Greek -->
+          <button class="mk-key" data-insert="\pi" title="Pi">π</button>
+          <button class="mk-key" data-insert="\theta" title="Theta">θ</button>
+          <button class="mk-key" data-insert="\alpha" title="Alpha">α</button>
+          <button class="mk-key" data-insert="\beta" title="Beta">β</button>
+          <button class="mk-key" data-insert="\Delta" title="Delta">Δ</button>
+          <!-- Comparisons & symbols -->
+          <button class="mk-key" data-insert="\leq" title="Less or equal">≤</button>
+          <button class="mk-key" data-insert="\geq" title="Greater or equal">≥</button>
+          <button class="mk-key" data-insert="\neq" title="Not equal">≠</button>
+          <button class="mk-key" data-insert="\approx" title="Approximately">≈</button>
+          <button class="mk-key" data-insert="\pm" title="Plus-minus">±</button>
+        </div>
+      </div>
+    </div>
+
     <input type="file" name="file" id="file-input" style="display:none;" accept="image/png,image/jpeg,image/jpg,image/webp,image/heic,image/svg+xml,application/pdf" multiple/>
     <p class="chat-disclaimer"><i class="fas fa-info-circle"></i> AI can make mistakes. Always check your work.</p>
 </div>

--- a/public/css/base/chat.css
+++ b/public/css/base/chat.css
@@ -482,6 +482,114 @@
   opacity: 0.5;
 }
 
+/* --- Math Keyboard Panel (inline, no overlay) --- */
+.math-keyboard-panel {
+  background: var(--clr-bg-light, #f8f9fa);
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+  padding: 0;
+  animation: mkSlideUp 0.2s ease-out;
+}
+
+@keyframes mkSlideUp {
+  from { transform: translateY(20px); opacity: 0; }
+  to   { transform: translateY(0); opacity: 1; }
+}
+
+/* Tab bar */
+.mk-tabs {
+  display: flex;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  padding: 0 8px;
+  gap: 0;
+}
+
+.mk-tab {
+  flex: 1;
+  background: none;
+  border: none;
+  padding: 8px 4px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #8e8e93;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.mk-tab-active {
+  color: #007AFF;
+  border-bottom-color: #007AFF;
+}
+
+.mk-tab:active {
+  background: rgba(0, 122, 255, 0.06);
+}
+
+/* Key grid */
+.mk-page {
+  padding: 6px 8px 8px;
+}
+
+.mk-grid {
+  display: grid;
+  gap: 5px;
+}
+
+.mk-grid-5 {
+  grid-template-columns: repeat(5, 1fr);
+}
+
+/* Individual key */
+.mk-key {
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+  padding: 10px 4px;
+  font-size: 1rem;
+  min-height: 42px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.1s, transform 0.1s;
+  color: #333;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.mk-key:active {
+  background: #e8e8ed;
+  transform: scale(0.95);
+}
+
+.mk-key sup, .mk-key sub {
+  font-size: 0.65em;
+}
+
+.mk-key-action {
+  background: #d1d1d6;
+}
+
+/* Math field in compose bar (math mode) */
+.math-keyboard-field {
+  flex: 1;
+  min-height: 36px;
+  max-height: 120px;
+  padding: 4px 14px;
+  border-radius: 20px;
+  border: 1px solid rgba(0, 122, 255, 0.4);
+  font-size: 1rem;
+  background: var(--clr-bg-subtle, #f2f2f7);
+  overflow-y: auto;
+}
+
+/* Active state on the √x tool button when math mode is on */
+.imessage-tool-btn.mk-active {
+  background: rgba(0, 122, 255, 0.15);
+  color: #0055cc;
+}
+
 /* Legacy toolbar (hidden — replaced by imessage-tool-btns) */
 .input-toolbar {
   display: none;

--- a/public/css/base/chat.css
+++ b/public/css/base/chat.css
@@ -499,7 +499,7 @@
 .mk-tabs {
   display: flex;
   border-bottom: 1px solid rgba(0, 0, 0, 0.08);
-  padding: 0 8px;
+  padding: 0 4px;
   gap: 0;
 }
 
@@ -507,17 +507,37 @@
   flex: 1;
   background: none;
   border: none;
-  padding: 8px 4px;
-  font-size: 0.8rem;
-  font-weight: 600;
-  color: #8e8e93;
+  padding: 6px 4px 8px;
   cursor: pointer;
-  border-bottom: 2px solid transparent;
+  border-bottom: 2.5px solid transparent;
   transition: color 0.15s, border-color 0.15s;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1px;
+}
+
+.mk-tab-icon {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #8e8e93;
+  line-height: 1.2;
+}
+
+.mk-tab-label {
+  font-size: 0.6rem;
+  font-weight: 500;
+  color: #8e8e93;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.mk-tab-active .mk-tab-icon,
+.mk-tab-active .mk-tab-label {
+  color: #007AFF;
 }
 
 .mk-tab-active {
-  color: #007AFF;
   border-bottom-color: #007AFF;
 }
 
@@ -525,9 +545,23 @@
   background: rgba(0, 122, 255, 0.06);
 }
 
+/* Section labels inside keyboard pages */
+.mk-section-label {
+  font-size: 0.65rem;
+  font-weight: 600;
+  color: #8e8e93;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 6px 4px 2px;
+}
+
+.mk-page .mk-section-label:first-child {
+  padding-top: 4px;
+}
+
 /* Key grid */
 .mk-page {
-  padding: 6px 8px 8px;
+  padding: 2px 8px 8px;
 }
 
 .mk-grid {
@@ -544,12 +578,14 @@
   background: #fff;
   border: 1px solid rgba(0, 0, 0, 0.1);
   border-radius: 8px;
-  padding: 10px 4px;
+  padding: 8px 4px;
   font-size: 1rem;
   min-height: 42px;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: 1px;
   cursor: pointer;
   transition: background 0.1s, transform 0.1s;
   color: #333;
@@ -571,6 +607,27 @@
   background: #d1d1d6;
 }
 
+/* Two-line key: main symbol + small hint underneath */
+.mk-key-main {
+  font-size: 1.05rem;
+  line-height: 1.1;
+}
+
+.mk-key-hint {
+  font-size: 0.55rem;
+  color: #8e8e93;
+  line-height: 1;
+}
+
+/* Math input wrapper: field + Done button side by side */
+.math-input-wrapper {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
 /* Math field in compose bar (math mode) */
 .math-keyboard-field {
   flex: 1;
@@ -578,16 +635,72 @@
   max-height: 120px;
   padding: 4px 14px;
   border-radius: 20px;
-  border: 1px solid rgba(0, 122, 255, 0.4);
+  border: 2px solid rgba(0, 122, 255, 0.5);
   font-size: 1rem;
   background: var(--clr-bg-subtle, #f2f2f7);
   overflow-y: auto;
+}
+
+/* Done button next to math field */
+.mk-done-btn {
+  background: #007AFF;
+  color: white;
+  border: none;
+  border-radius: 16px;
+  padding: 6px 14px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s, transform 0.1s;
+  touch-action: manipulation;
+}
+
+.mk-done-btn:active {
+  background: #0055cc;
+  transform: scale(0.95);
+}
+
+/* Helper text above the keyboard */
+.mk-helper-text {
+  font-size: 0.72rem;
+  color: #8e8e93;
+  text-align: center;
+  padding: 4px 8px 0;
+  line-height: 1.3;
+}
+
+.mk-helper-text strong {
+  color: #007AFF;
 }
 
 /* Active state on the √x tool button when math mode is on */
 .imessage-tool-btn.mk-active {
   background: rgba(0, 122, 255, 0.15);
   color: #0055cc;
+}
+
+/* First-time onboarding tooltip */
+.mk-tooltip {
+  background: #007AFF;
+  color: white;
+  font-size: 0.78rem;
+  line-height: 1.4;
+  padding: 8px 14px;
+  border-radius: 10px;
+  margin: 4px 8px;
+  animation: mkFadeIn 0.3s ease;
+  cursor: pointer;
+}
+
+.mk-tooltip strong {
+  color: #fff;
+  font-weight: 700;
+}
+
+@keyframes mkFadeIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
 /* Legacy toolbar (hidden — replaced by imessage-tool-btns) */

--- a/public/css/base/modals.css
+++ b/public/css/base/modals.css
@@ -241,6 +241,18 @@
     transition: color 0.2s;
 }
 
+.script-label {
+    font-size: 1.2em;
+    font-family: 'Georgia', 'Times New Roman', serif;
+    color: #e0e0e0;
+    letter-spacing: 0.5px;
+}
+
+.script-label sup,
+.script-label sub {
+    font-size: 0.65em;
+}
+
 /* Palette keyboard tip */
 .palette-tip {
     font-size: 0.75em;

--- a/public/css/dark-mode.css
+++ b/public/css/dark-mode.css
@@ -645,12 +645,19 @@
 [data-theme="dark"] .mk-tabs {
     border-bottom-color: #243040;
 }
-[data-theme="dark"] .mk-tab {
+[data-theme="dark"] .mk-tab-icon,
+[data-theme="dark"] .mk-tab-label {
     color: #8899aa;
 }
-[data-theme="dark"] .mk-tab-active {
+[data-theme="dark"] .mk-tab-active .mk-tab-icon,
+[data-theme="dark"] .mk-tab-active .mk-tab-label {
     color: #5ac8fa;
+}
+[data-theme="dark"] .mk-tab-active {
     border-bottom-color: #5ac8fa;
+}
+[data-theme="dark"] .mk-section-label {
+    color: #667788;
 }
 [data-theme="dark"] .mk-key {
     background: #1A2633;
@@ -664,10 +671,23 @@
 [data-theme="dark"] .mk-key-action {
     background: #243040;
 }
+[data-theme="dark"] .mk-key-hint {
+    color: #667788;
+}
 [data-theme="dark"] .math-keyboard-field {
     background: #1A2633;
-    border-color: rgba(90, 200, 250, 0.4);
+    border-color: rgba(90, 200, 250, 0.5);
     color: var(--text-primary, #e0e0e0);
+}
+[data-theme="dark"] .mk-done-btn {
+    background: #5ac8fa;
+    color: #0a1520;
+}
+[data-theme="dark"] .mk-helper-text {
+    color: #667788;
+}
+[data-theme="dark"] .mk-helper-text strong {
+    color: #5ac8fa;
 }
 
 /* Transition for smooth theme switching */

--- a/public/css/dark-mode.css
+++ b/public/css/dark-mode.css
@@ -637,6 +637,39 @@
     background: #243040;
 }
 
+/* Math Keyboard Panel dark mode */
+[data-theme="dark"] .math-keyboard-panel {
+    background: #141E29;
+    border-top-color: #243040;
+}
+[data-theme="dark"] .mk-tabs {
+    border-bottom-color: #243040;
+}
+[data-theme="dark"] .mk-tab {
+    color: #8899aa;
+}
+[data-theme="dark"] .mk-tab-active {
+    color: #5ac8fa;
+    border-bottom-color: #5ac8fa;
+}
+[data-theme="dark"] .mk-key {
+    background: #1A2633;
+    border-color: #243040;
+    color: var(--text-primary, #e0e0e0);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+[data-theme="dark"] .mk-key:active {
+    background: #243040;
+}
+[data-theme="dark"] .mk-key-action {
+    background: #243040;
+}
+[data-theme="dark"] .math-keyboard-field {
+    background: #1A2633;
+    border-color: rgba(90, 200, 250, 0.4);
+    color: var(--text-primary, #e0e0e0);
+}
+
 /* Transition for smooth theme switching */
 html.theme-transitioning,
 html.theme-transitioning *,

--- a/public/css/mobile-fixes.css
+++ b/public/css/mobile-fixes.css
@@ -1747,7 +1747,25 @@ a {
         max-width: 100% !important;
         height: auto !important;
     }
+}
 
+/* --- 18. FREE-TIME INDICATOR: ABOVE BOTTOM NAV ---
+   The billing time indicator is fixed at bottom:12px.
+   On mobile with the bottom nav (56px + safe-area), push it up. */
+@media (max-width: 768px) {
+    #free-time-indicator {
+        /* 56px nav + safe-area + 10px gap */
+        bottom: calc(56px + env(safe-area-inset-bottom, 0px) + 10px) !important;
+        right: 10px !important;
+        left: 10px !important;
+        max-width: none !important;
+        border-radius: 10px !important;
+        text-align: center !important;
+        font-size: 12px !important;
+    }
+}
+
+@media (max-width: 600px) {
     /* --- Equation Palette: Mobile Bottom Sheet --- */
     .inline-equation-palette {
         position: fixed !important;

--- a/public/css/mobile-fixes.css
+++ b/public/css/mobile-fixes.css
@@ -1882,8 +1882,23 @@ a {
         to   { opacity: 1; }
     }
 
-    /* Hide MathLive's virtual keyboard on mobile — we use our symbol buttons */
+    /* Hide MathLive's virtual keyboard on mobile — we use our own math keyboard */
     .ML__keyboard {
         display: none !important;
+    }
+
+    /* --- Math Keyboard Panel: mobile tuning --- */
+    .math-keyboard-panel {
+        padding-bottom: env(safe-area-inset-bottom, 0);
+    }
+
+    .mk-key {
+        min-height: 44px;
+        font-size: 1.05rem;
+    }
+
+    .math-keyboard-field {
+        min-height: 38px;
+        font-size: 1.05rem;
     }
 }

--- a/public/js/modules/billing.js
+++ b/public/js/modules/billing.js
@@ -54,7 +54,7 @@ export function updateFreeTimeIndicator(usage) {
     if (!indicator) {
         indicator = document.createElement('div');
         indicator.id = 'free-time-indicator';
-        indicator.style.cssText = 'position:fixed;bottom:12px;right:12px;background:#1a1a2e;color:#fff;padding:8px 14px;border-radius:8px;font-size:13px;z-index:9000;cursor:pointer;border:1px solid #333;transition:all 0.3s;';
+        indicator.style.cssText = 'position:fixed;bottom:12px;right:12px;background:#1a1a2e;color:#fff;padding:8px 14px;border-radius:8px;font-size:13px;z-index:1750;cursor:pointer;border:1px solid #333;transition:all 0.3s;';
         indicator.title = 'AI processing time only — reading and thinking time is free';
         indicator.addEventListener('click', () => showUpgradePrompt({}));
         document.body.appendChild(indicator);

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1447,8 +1447,9 @@ document.addEventListener("DOMContentLoaded", () => {
     function sendMessage() {
         // If math keyboard is active, grab its content first
         const mkFieldEl = document.getElementById('math-keyboard-field');
+        const mkWrapperEl = document.getElementById('math-input-wrapper');
         let mathLatex = '';
-        if (mkFieldEl && mkFieldEl.style.display !== 'none') {
+        if (mkFieldEl && mkWrapperEl && mkWrapperEl.style.display !== 'none') {
             mathLatex = (mkFieldEl.value || '').trim();
         }
 
@@ -1466,8 +1467,10 @@ document.addEventListener("DOMContentLoaded", () => {
         if (typeof mathModeOn !== 'undefined' && mathModeOn && mkFieldEl) {
             mkFieldEl.value = ''; // already captured
             const mkPanelEl = document.getElementById('math-keyboard-panel');
+            const mkHelperEl = document.getElementById('mk-helper-text');
             if (mkPanelEl) mkPanelEl.style.display = 'none';
-            mkFieldEl.style.display = 'none';
+            if (mkWrapperEl) mkWrapperEl.style.display = 'none';
+            if (mkHelperEl) mkHelperEl.style.display = 'none';
             userInput.style.display = '';
             if (openEquationBtn) openEquationBtn.classList.remove('mk-active');
             mathModeOn = false;
@@ -2715,29 +2718,34 @@ document.addEventListener("DOMContentLoaded", () => {
     }
     
     // ─── Math Keyboard Panel (inline, no overlay) ─────────────────────
-    const mkPanel     = document.getElementById('math-keyboard-panel');
-    const mkField     = document.getElementById('math-keyboard-field');
-    const mkTabs      = mkPanel ? mkPanel.querySelectorAll('.mk-tab') : [];
-    const mkPages     = mkPanel ? mkPanel.querySelectorAll('.mk-page') : [];
-    let   mathModeOn  = false;
+    const mkPanel      = document.getElementById('math-keyboard-panel');
+    const mkField      = document.getElementById('math-keyboard-field');
+    const mkWrapper    = document.getElementById('math-input-wrapper');
+    const mkDoneBtn    = document.getElementById('mk-done-btn');
+    const mkHelperText = document.getElementById('mk-helper-text');
+    const mkTabs       = mkPanel ? mkPanel.querySelectorAll('.mk-tab') : [];
+    const mkPages      = mkPanel ? mkPanel.querySelectorAll('.mk-page') : [];
+    let   mathModeOn   = false;
 
     function activateMathMode() {
-        if (!mkPanel || !mkField || !userInput) return;
+        if (!mkPanel || !mkField || !mkWrapper || !userInput) return;
         mathModeOn = true;
 
-        // Swap input: hide text input, show math field
+        // Swap input: hide text input, show math field + wrapper
         userInput.style.display = 'none';
-        mkField.style.display = '';
+        mkWrapper.style.display = '';
         mkPanel.style.display = '';
-        mkField.focus();
+        if (mkHelperText) mkHelperText.style.display = '';
 
         // Close old overlay palette if open
         if (typeof closeEquationPalette === 'function') closeEquationPalette();
 
-        // Blur native keyboard on mobile
+        // Blur native keyboard on mobile, then focus math field
         if (window.innerWidth <= 768) {
             document.activeElement?.blur();
             setTimeout(() => mkField.focus(), 50);
+        } else {
+            mkField.focus();
         }
 
         // Highlight the √x tool button
@@ -2745,10 +2753,13 @@ document.addEventListener("DOMContentLoaded", () => {
 
         // Default to math tab
         switchMkTab('math');
+
+        // Show first-time tooltip if never seen before
+        showMathKeyboardTooltip();
     }
 
     function deactivateMathMode() {
-        if (!mkPanel || !mkField || !userInput) return;
+        if (!mkPanel || !mkField || !mkWrapper || !userInput) return;
 
         // If math field has content, insert it into chat input before closing
         const latex = mkField.value?.trim();
@@ -2764,8 +2775,9 @@ document.addEventListener("DOMContentLoaded", () => {
         }
 
         mathModeOn = false;
-        mkField.style.display = 'none';
+        mkWrapper.style.display = 'none';
         mkPanel.style.display = 'none';
+        if (mkHelperText) mkHelperText.style.display = 'none';
         userInput.style.display = '';
         userInput.focus();
         if (openEquationBtn) openEquationBtn.classList.remove('mk-active');
@@ -2778,6 +2790,9 @@ document.addEventListener("DOMContentLoaded", () => {
         if (tabName === 'abc') {
             // Switch back to regular text input
             deactivateMathMode();
+        } else {
+            // Keep focus on math field when switching between 123 and math tabs
+            if (mkField) mkField.focus();
         }
     }
 
@@ -2785,6 +2800,11 @@ document.addEventListener("DOMContentLoaded", () => {
     mkTabs.forEach(tab => {
         tab.addEventListener('click', () => switchMkTab(tab.dataset.tab));
     });
+
+    // Done button: insert equation and return to text mode
+    if (mkDoneBtn) {
+        mkDoneBtn.addEventListener('click', () => deactivateMathMode());
+    }
 
     // √x tool button: toggle math mode
     if (openEquationBtn) {
@@ -2824,6 +2844,31 @@ document.addEventListener("DOMContentLoaded", () => {
                 sendMessage();
             }
         });
+    }
+
+    // First-time tooltip: show once to teach users what the √x button does
+    function showMathKeyboardTooltip() {
+        const storageKey = 'mk-tooltip-seen';
+        try {
+            if (localStorage.getItem(storageKey)) return;
+            localStorage.setItem(storageKey, '1');
+        } catch (e) { return; }
+
+        const tip = document.createElement('div');
+        tip.className = 'mk-tooltip';
+        tip.innerHTML = 'Tap the buttons below to build your equation. ' +
+                        'Use <strong>Numbers</strong> for digits, <strong>Symbols</strong> for math. ' +
+                        'Tap <strong>Done</strong> when finished.';
+
+        // Insert above the math keyboard panel
+        if (mkPanel && mkPanel.parentElement) {
+            mkPanel.parentElement.insertBefore(tip, mkPanel);
+        }
+
+        // Auto-dismiss after 6 seconds or on tap
+        const dismiss = () => { if (tip.parentElement) tip.remove(); };
+        tip.addEventListener('click', dismiss);
+        setTimeout(dismiss, 6000);
     }
 
     if (closeWhiteboardBtn) {

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1445,8 +1445,33 @@ document.addEventListener("DOMContentLoaded", () => {
      * Send a message - uses the message queue to handle back-to-back messages gracefully
      */
     function sendMessage() {
-        const messageText = extractMessageText(userInput).trim();
+        // If math keyboard is active, grab its content first
+        const mkFieldEl = document.getElementById('math-keyboard-field');
+        let mathLatex = '';
+        if (mkFieldEl && mkFieldEl.style.display !== 'none') {
+            mathLatex = (mkFieldEl.value || '').trim();
+        }
+
+        let messageText = extractMessageText(userInput).trim();
+
+        // Append math-field LaTeX (wrapped for rendering)
+        if (mathLatex) {
+            messageText = messageText ? messageText + ' \\(' + mathLatex + '\\)' : '\\(' + mathLatex + '\\)';
+            mkFieldEl.value = '';
+        }
+
         if (!messageText && attachedFiles.length === 0) return;
+
+        // If math mode is on, deactivate without re-inserting (we already captured the value)
+        if (typeof mathModeOn !== 'undefined' && mathModeOn && mkFieldEl) {
+            mkFieldEl.value = ''; // already captured
+            const mkPanelEl = document.getElementById('math-keyboard-panel');
+            if (mkPanelEl) mkPanelEl.style.display = 'none';
+            mkFieldEl.style.display = 'none';
+            userInput.style.display = '';
+            if (openEquationBtn) openEquationBtn.classList.remove('mk-active');
+            mathModeOn = false;
+        }
 
         // Capture response time from ghost timer
         let responseTime = null;
@@ -2689,6 +2714,118 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     }
     
+    // ─── Math Keyboard Panel (inline, no overlay) ─────────────────────
+    const mkPanel     = document.getElementById('math-keyboard-panel');
+    const mkField     = document.getElementById('math-keyboard-field');
+    const mkTabs      = mkPanel ? mkPanel.querySelectorAll('.mk-tab') : [];
+    const mkPages     = mkPanel ? mkPanel.querySelectorAll('.mk-page') : [];
+    let   mathModeOn  = false;
+
+    function activateMathMode() {
+        if (!mkPanel || !mkField || !userInput) return;
+        mathModeOn = true;
+
+        // Swap input: hide text input, show math field
+        userInput.style.display = 'none';
+        mkField.style.display = '';
+        mkPanel.style.display = '';
+        mkField.focus();
+
+        // Close old overlay palette if open
+        if (typeof closeEquationPalette === 'function') closeEquationPalette();
+
+        // Blur native keyboard on mobile
+        if (window.innerWidth <= 768) {
+            document.activeElement?.blur();
+            setTimeout(() => mkField.focus(), 50);
+        }
+
+        // Highlight the √x tool button
+        if (openEquationBtn) openEquationBtn.classList.add('mk-active');
+
+        // Default to math tab
+        switchMkTab('math');
+    }
+
+    function deactivateMathMode() {
+        if (!mkPanel || !mkField || !userInput) return;
+
+        // If math field has content, insert it into chat input before closing
+        const latex = mkField.value?.trim();
+        if (latex) {
+            const mathContainer = document.createElement('span');
+            mathContainer.className = 'math-container';
+            mathContainer.setAttribute('data-latex', latex);
+            mathContainer.textContent = `\\(${latex}\\)`;
+            userInput.appendChild(mathContainer);
+            userInput.appendChild(document.createTextNode(' '));
+            if (typeof renderMathInElement === 'function') renderMathInElement(mathContainer);
+            mkField.value = '';
+        }
+
+        mathModeOn = false;
+        mkField.style.display = 'none';
+        mkPanel.style.display = 'none';
+        userInput.style.display = '';
+        userInput.focus();
+        if (openEquationBtn) openEquationBtn.classList.remove('mk-active');
+    }
+
+    function switchMkTab(tabName) {
+        mkTabs.forEach(t => t.classList.toggle('mk-tab-active', t.dataset.tab === tabName));
+        mkPages.forEach(p => p.style.display = p.dataset.page === tabName ? '' : 'none');
+
+        if (tabName === 'abc') {
+            // Switch back to regular text input
+            deactivateMathMode();
+        }
+    }
+
+    // Tab clicks
+    mkTabs.forEach(tab => {
+        tab.addEventListener('click', () => switchMkTab(tab.dataset.tab));
+    });
+
+    // √x tool button: toggle math mode
+    if (openEquationBtn) {
+        // On mobile, use the new math keyboard instead of the old palette
+        openEquationBtn.addEventListener('click', (e) => {
+            if (window.innerWidth <= 768) {
+                e.stopImmediatePropagation(); // prevent old palette toggle
+                if (mathModeOn) deactivateMathMode();
+                else activateMathMode();
+            }
+        }, true); // capture phase to run before old handler
+    }
+
+    // Key presses on the math keyboard
+    if (mkPanel) {
+        mkPanel.addEventListener('click', (e) => {
+            const key = e.target.closest('.mk-key');
+            if (!key || !mkField) return;
+
+            const insertLatex = key.dataset.insert;
+            const command = key.dataset.command;
+
+            if (command) {
+                mkField.executeCommand(command);
+            } else if (insertLatex) {
+                mkField.executeCommand(['insert', insertLatex]);
+            }
+            mkField.focus();
+        });
+    }
+
+    // Enter on math field = send, Shift+Enter = stay
+    if (mkField) {
+        mkField.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                sendMessage();
+            }
+        });
+    }
+
     if (closeWhiteboardBtn) {
         closeWhiteboardBtn.addEventListener('click', () => {
             const whiteboardPanel = document.getElementById('whiteboard-panel');

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -2406,12 +2406,21 @@ document.addEventListener("DOMContentLoaded", () => {
     const isMobileView = () => window.innerWidth <= 768;
     let eqBackdrop = null;
 
+    // Store the palette's original parent so we can restore it after mobile close
+    const paletteOriginalParent = inlineEquationPalette ? inlineEquationPalette.parentElement : null;
+    const paletteOriginalNextSibling = inlineEquationPalette ? inlineEquationPalette.nextElementSibling : null;
+
     function openEquationPalette() {
         if (!inlineEquationPalette) return;
-        inlineEquationPalette.style.display = 'block';
 
-        // On mobile, show backdrop overlay behind the bottom sheet
+        // On mobile, move palette to body so it escapes #input-container's
+        // stacking context (z-index:100) — otherwise the backdrop (z-index:1000
+        // on body) covers the palette and intercepts all taps.
         if (isMobileView()) {
+            if (inlineEquationPalette.parentElement !== document.body) {
+                document.body.appendChild(inlineEquationPalette);
+            }
+
             if (!eqBackdrop) {
                 eqBackdrop = document.createElement('div');
                 eqBackdrop.className = 'equation-palette-backdrop';
@@ -2428,6 +2437,7 @@ document.addEventListener("DOMContentLoaded", () => {
             });
         }
 
+        inlineEquationPalette.style.display = 'block';
         const field = getActiveMathField();
         if (field) setTimeout(() => field.focus(), 100);
     }
@@ -2436,6 +2446,14 @@ document.addEventListener("DOMContentLoaded", () => {
         if (inlineEquationPalette) inlineEquationPalette.style.display = 'none';
         if (eqBackdrop && eqBackdrop.parentNode) {
             eqBackdrop.parentNode.removeChild(eqBackdrop);
+        }
+        // Restore palette to its original position in the DOM
+        if (inlineEquationPalette && paletteOriginalParent && inlineEquationPalette.parentElement === document.body) {
+            if (paletteOriginalNextSibling) {
+                paletteOriginalParent.insertBefore(inlineEquationPalette, paletteOriginalNextSibling);
+            } else {
+                paletteOriginalParent.appendChild(inlineEquationPalette);
+            }
         }
     }
 
@@ -2476,8 +2494,13 @@ document.addEventListener("DOMContentLoaded", () => {
         }, { passive: true });
 
         inlineEquationPalette.addEventListener('touchend', () => {
+            if (!touchStartY) {
+                // Touch didn't start on the header — ignore
+                return;
+            }
             const dy = touchCurrentY - touchStartY;
             touchStartY = 0;
+            touchCurrentY = 0;
             if (dy > 80) {
                 // Swiped down enough — dismiss
                 closeEquationPalette();


### PR DESCRIPTION
## Summary
Introduces a new inline math keyboard panel for mobile devices, replacing the overlay equation palette with a native-like keyboard interface. This provides a better mobile UX for entering mathematical equations with dedicated symbol buttons, tabs for different input modes, and seamless integration with the chat input.

## Key Changes

### UI Components
- **Math Keyboard Panel**: New inline panel with three tabs (Text, Numbers, Symbols) that appears below the chat input on mobile
- **Math Input Wrapper**: Replaces the text input with a `math-field` element and "Done" button when math mode is active
- **Helper Text**: Contextual guidance shown when math mode is active
- **First-time Tooltip**: Onboarding message displayed on first use (stored in localStorage)

### Styling
- Added comprehensive CSS for the math keyboard panel, tabs, keys, and helper text in `chat.css`
- Dark mode support in `dark-mode.css` with appropriate color adjustments
- Mobile-specific tuning in `mobile-fixes.css` (larger touch targets, safe-area padding)
- Replaced SVG icons with text labels for subscript/superscript buttons in the equation palette

### Functionality
- **Math Mode Toggle**: √x button now activates/deactivates math mode on mobile (≤768px)
- **Tab Switching**: Users can switch between Numbers, Symbols, and Text tabs
- **Key Insertion**: Clicking math keyboard keys inserts LaTeX into the math field
- **Message Sending**: Captures math field content, wraps it in `\(...\)` delimiters, and appends to message text
- **Equation Palette Fix**: Moved palette to `document.body` on mobile to escape stacking context issues; restored to original position on close
- **Touch Handling**: Improved touchend event handling to prevent false dismissals

### Implementation Details
- Math field uses MathLive's `virtual-keyboard-mode="off"` to suppress native keyboard
- Enter key in math field sends message; Shift+Enter creates new line
- Math mode deactivation preserves unsent equations as inline math containers
- Palette backdrop properly positioned with z-index management for mobile
- Safe-area insets respected for notched devices
- Free-time indicator repositioned above bottom nav on mobile

## Files Modified
- `public/css/base/chat.css` - Math keyboard styling
- `public/css/dark-mode.css` - Dark mode support
- `public/css/mobile-fixes.css` - Mobile-specific adjustments
- `public/css/base/modals.css` - Script label styling
- `public/js/script.js` - Math keyboard logic and message handling
- `public/js/modules/billing.js` - Free-time indicator positioning
- `public/chat.html` - Math keyboard panel markup and input wrapper

https://claude.ai/code/session_017GNLLD65vjVBgyBQEqs5gF