### PR TITLE
Fix voice tutor bugs (hands-free, interrupt, math) + elite UI polish

### DIFF
--- a/public/css/voice-tutor.css
+++ b/public/css/voice-tutor.css
@@ -25,10 +25,11 @@ html, body {
   position: absolute;
   top: 0; right: 0; bottom: 0; left: 0;
   background:
-    radial-gradient(ellipse 80% 60% at 20% 80%, rgba(18, 179, 179, 0.08) 0%, transparent 60%),
-    radial-gradient(ellipse 60% 50% at 80% 20%, rgba(102, 126, 234, 0.06) 0%, transparent 50%),
-    radial-gradient(ellipse 50% 40% at 50% 50%, rgba(255, 59, 127, 0.03) 0%, transparent 50%),
-    linear-gradient(180deg, #0a0a1a 0%, #0d1025 50%, #0a0a1a 100%);
+    radial-gradient(ellipse 90% 70% at 15% 85%, rgba(18, 179, 179, 0.1) 0%, transparent 55%),
+    radial-gradient(ellipse 70% 60% at 85% 15%, rgba(102, 126, 234, 0.08) 0%, transparent 50%),
+    radial-gradient(ellipse 60% 50% at 50% 60%, rgba(118, 75, 162, 0.05) 0%, transparent 50%),
+    radial-gradient(ellipse 40% 30% at 70% 70%, rgba(255, 59, 127, 0.03) 0%, transparent 40%),
+    linear-gradient(180deg, #080818 0%, #0c0f28 40%, #0a0d22 70%, #080818 100%);
 }
 
 #vt-particle-canvas {
@@ -85,6 +86,17 @@ html, body {
   color: #8892b0;
   letter-spacing: 0.5px;
   text-transform: uppercase;
+}
+
+.vt-session-timer {
+  font-size: 12px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: #5a6380;
+  background: rgba(255, 255, 255, 0.04);
+  padding: 3px 10px;
+  border-radius: 10px;
+  letter-spacing: 1px;
 }
 
 .vt-header-actions {
@@ -149,30 +161,27 @@ html, body {
 
 .vt-canvas-placeholder {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 16px;
-  opacity: 0.3;
+  justify-content: center;
+  opacity: 0.25;
   transition: opacity 0.6s;
+  padding-top: 60px;
 }
 
 .vt-canvas-placeholder.hidden { opacity: 0; pointer-events: none; }
 
-.vt-canvas-icon {
-  width: 80px;
-  height: 80px;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.04);
+.vt-canvas-placeholder p {
+  font-size: 13px;
+  color: #5a6380;
+  letter-spacing: 0.5px;
   display: flex;
   align-items: center;
-  justify-content: center;
-  font-size: 32px;
-  color: rgba(18, 179, 179, 0.4);
+  gap: 8px;
 }
 
-.vt-canvas-placeholder p {
-  font-size: 15px;
-  color: #7a84a0;
+.vt-canvas-placeholder p i {
+  font-size: 14px;
+  color: rgba(18, 179, 179, 0.3);
 }
 
 /* Math display area */
@@ -260,8 +269,8 @@ html, body {
 /* --- Rings (behind the avatar) --- */
 .vt-presence-rings {
   position: absolute;
-  width: 180px;
-  height: 180px;
+  width: 240px;
+  height: 240px;
   top: 50%;
   left: 50%;
   transform: translate(-50%, calc(-50% - 8px)); /* offset for status text */
@@ -277,18 +286,18 @@ html, body {
   transition: border-color 0.5s, box-shadow 0.5s, transform 0.5s;
 }
 
-.vt-ring-inner  { width: 140px; height: 140px; }
-.vt-ring-mid    { width: 160px; height: 160px; }
-.vt-ring-outer  { width: 180px; height: 180px; }
+.vt-ring-inner  { width: 184px; height: 184px; }
+.vt-ring-mid    { width: 210px; height: 210px; }
+.vt-ring-outer  { width: 240px; height: 240px; }
 
 /* --- Avatar circle (photo + waveform overlay) --- */
 .vt-avatar-circle {
   position: relative;
-  width: 120px;
-  height: 120px;
+  width: 160px;
+  height: 160px;
   border-radius: 50%;
   overflow: hidden;
-  border: 3px solid rgba(255, 255, 255, 0.08);
+  border: 3px solid rgba(255, 255, 255, 0.1);
   background: #0d0d20;
   transition: border-color 0.4s, box-shadow 0.4s, transform 0.4s;
   z-index: 2;
@@ -316,8 +325,8 @@ html, body {
 /* --- Glow (behind everything) --- */
 .vt-presence-glow {
   position: absolute;
-  width: 260px;
-  height: 260px;
+  width: 340px;
+  height: 340px;
   top: 50%;
   left: 50%;
   transform: translate(-50%, calc(-50% - 8px));
@@ -379,23 +388,25 @@ html, body {
    STATE: LISTENING — teal pulse rings
    ═══════════════════════════════════════ */
 .vt-presence[data-state="listening"] .vt-avatar-circle {
-  border-color: rgba(18, 179, 179, 0.5);
-  box-shadow: 0 0 20px rgba(18, 179, 179, 0.15), 0 0 60px rgba(18, 179, 179, 0.05);
+  border-color: rgba(18, 179, 179, 0.6);
+  box-shadow: 0 0 30px rgba(18, 179, 179, 0.2), 0 0 80px rgba(18, 179, 179, 0.08);
   animation: none;
 }
 .vt-presence[data-state="listening"] .vt-tutor-face {
   filter: brightness(1) saturate(1);
 }
 .vt-presence[data-state="listening"] .vt-ring-inner {
-  border-color: rgba(18, 179, 179, 0.35);
+  border-width: 3px;
+  border-color: rgba(18, 179, 179, 0.4);
   animation: vt-listen-ring 2s ease-out infinite;
 }
 .vt-presence[data-state="listening"] .vt-ring-mid {
-  border-color: rgba(18, 179, 179, 0.2);
+  border-width: 2px;
+  border-color: rgba(18, 179, 179, 0.25);
   animation: vt-listen-ring 2s ease-out 0.4s infinite;
 }
 .vt-presence[data-state="listening"] .vt-ring-outer {
-  border-color: rgba(18, 179, 179, 0.1);
+  border-color: rgba(18, 179, 179, 0.12);
   animation: vt-listen-ring 2s ease-out 0.8s infinite;
 }
 .vt-presence[data-state="listening"] .vt-presence-glow {
@@ -461,8 +472,8 @@ html, body {
    STATE: SPEAKING — indigo/purple glow + pulse
    ═══════════════════════════════════════ */
 .vt-presence[data-state="speaking"] .vt-avatar-circle {
-  border-color: rgba(102, 126, 234, 0.5);
-  box-shadow: 0 0 25px rgba(102, 126, 234, 0.2), 0 0 80px rgba(102, 126, 234, 0.06);
+  border-color: rgba(102, 126, 234, 0.6);
+  box-shadow: 0 0 30px rgba(102, 126, 234, 0.25), 0 0 100px rgba(102, 126, 234, 0.1), 0 0 160px rgba(118, 75, 162, 0.05);
   animation: vt-speak-pulse 1.5s ease-in-out infinite;
 }
 .vt-presence[data-state="speaking"] .vt-tutor-face {
@@ -540,10 +551,11 @@ html, body {
   min-width: 300px;
   display: flex;
   flex-direction: column;
-  background: rgba(15, 17, 35, 0.7);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-  border-left: 1px solid rgba(255, 255, 255, 0.04);
+  background: rgba(12, 14, 30, 0.85);
+  backdrop-filter: blur(30px) saturate(1.2);
+  -webkit-backdrop-filter: blur(30px) saturate(1.2);
+  border-left: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: -8px 0 40px rgba(0, 0, 0, 0.3);
   transition: transform 0.4s cubic-bezier(0.22, 1, 0.36, 1), width 0.4s;
 }
 
@@ -713,14 +725,29 @@ html, body {
   position: relative;
   z-index: 10;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
-  gap: 24px;
-  padding: 16px 20px;
-  background: rgba(10, 10, 26, 0.8);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
+  gap: 32px;
+  padding: 16px 20px 20px;
+  background: rgba(8, 8, 22, 0.85);
+  backdrop-filter: blur(30px) saturate(1.2);
+  -webkit-backdrop-filter: blur(30px) saturate(1.2);
   border-top: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.vt-control-group {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.vt-control-label {
+  font-size: 10px;
+  font-weight: 500;
+  color: #5a6380;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
 }
 
 .vt-control-btn {
@@ -934,12 +961,12 @@ html, body {
     backdrop-filter: blur(10px);
   }
 
-  .vt-avatar-circle { width: 90px; height: 90px; }
-  .vt-ring-inner  { width: 110px !important; height: 110px !important; }
-  .vt-ring-mid    { width: 126px !important; height: 126px !important; }
-  .vt-ring-outer  { width: 142px !important; height: 142px !important; }
-  .vt-presence-rings { width: 142px; height: 142px; }
-  .vt-presence-glow { width: 200px; height: 200px; }
+  .vt-avatar-circle { width: 110px; height: 110px; }
+  .vt-ring-inner  { width: 134px !important; height: 134px !important; }
+  .vt-ring-mid    { width: 154px !important; height: 154px !important; }
+  .vt-ring-outer  { width: 176px !important; height: 176px !important; }
+  .vt-presence-rings { width: 176px; height: 176px; }
+  .vt-presence-glow { width: 240px; height: 240px; }
 
   .vt-mic-btn { width: 60px; height: 60px; font-size: 22px; }
   .vt-end-btn, .vt-mute-btn { width: 44px; height: 44px; }
@@ -953,7 +980,8 @@ html, body {
 @media (max-width: 480px) {
   .vt-header { padding: 10px 14px; }
   .vt-session-label { display: none; }
-  .vt-controls { gap: 16px; padding: 12px 16px; }
+  .vt-controls { gap: 20px; padding: 12px 16px 16px; }
+  .vt-control-label { font-size: 9px; }
 }
 
 /* --- Reduced motion --- */

--- a/public/js/voice-tutor-session.js
+++ b/public/js/voice-tutor-session.js
@@ -28,9 +28,14 @@
     vadTimer: null,
     maxRecordTimer: null,
     isSpeaking: false,
+    silenceFrames: 0,      // consecutive silent frames for hysteresis
     speechStartTime: null,
     waveformRAF: null,
     particleRAF: null,
+    playResolve: null,     // resolve fn for current playResponse promise
+    sessionStart: null,    // session start time for timer
+    timerInterval: null,   // session timer interval
+    processing: false,     // guard against double processVoiceInput
   };
 
   // --- DOM refs ---
@@ -68,6 +73,7 @@
     dom.tutorName = $('#vt-tutor-name');
     dom.tutorStatus = $('#vt-tutor-status');
     dom.particleCanvas = $('#vt-particle-canvas');
+    dom.sessionTimer = $('#vt-session-timer');
   }
 
   // ═══════════════════════════════════════
@@ -81,12 +87,24 @@
     setupParticles();
     drawIdleWaveform();
     setMode('idle');
+    startSessionTimer();
     addSystemMessage('Voice session started. Tap the mic or just say something.');
 
     // Auto-start listening if hands-free
     if (state.handsFree) {
       setTimeout(() => startListening(), 800);
     }
+  }
+
+  function startSessionTimer() {
+    state.sessionStart = Date.now();
+    state.timerInterval = setInterval(() => {
+      if (!dom.sessionTimer) return;
+      const elapsed = Math.floor((Date.now() - state.sessionStart) / 1000);
+      const mins = Math.floor(elapsed / 60).toString().padStart(2, '0');
+      const secs = (elapsed % 60).toString().padStart(2, '0');
+      dom.sessionTimer.textContent = `${mins}:${secs}`;
+    }, 1000);
   }
 
   async function loadUserData() {
@@ -283,35 +301,58 @@
 
     const buffer = new Uint8Array(analyser.frequencyBinCount);
 
+    // Hysteresis: require N consecutive silent frames before triggering silence
+    const SILENCE_FRAMES_REQUIRED = 8; // ~130ms at 60fps
+    const SPEECH_THRESHOLD_DB = -45;   // Slightly more sensitive
+
+    state.isSpeaking = false;
+    state.silenceFrames = 0;
+
     const check = () => {
       if (state.mode !== 'listening') return;
 
       analyser.getByteFrequencyData(buffer);
-      const avg = buffer.reduce((a, b) => a + b, 0) / buffer.length;
+
+      // Use RMS of the top frequency bins (voice range ~300-3000Hz)
+      const voiceBins = buffer.slice(4, 80); // Approximate voice frequency range
+      const sum = voiceBins.reduce((a, b) => a + b, 0);
+      const avg = sum / voiceBins.length;
       const db = avg > 0 ? 20 * Math.log10(avg / 255) : -Infinity;
-      const speaking = db > -50;
+      const speaking = db > SPEECH_THRESHOLD_DB;
 
       // Draw waveform
       drawListeningWaveform(buffer);
 
-      if (speaking && !state.isSpeaking) {
-        state.isSpeaking = true;
-        state.speechStartTime = Date.now();
-        clearTimeout(state.vadTimer);
-      } else if (!speaking && state.isSpeaking) {
-        const duration = Date.now() - (state.speechStartTime || Date.now());
-        if (duration < 400) {
-          // Too brief, ignore
-          state.isSpeaking = false;
-          state.speechStartTime = null;
-        } else {
-          // Silence after speech — wait then auto-send
+      if (speaking) {
+        state.silenceFrames = 0;
+
+        if (!state.isSpeaking) {
+          state.isSpeaking = true;
+          state.speechStartTime = Date.now();
           clearTimeout(state.vadTimer);
-          state.vadTimer = setTimeout(() => {
-            if (state.mode === 'listening') {
-              stopListening();
+        }
+      } else {
+        state.silenceFrames++;
+
+        // Only react to silence if we had meaningful speech AND enough consecutive silent frames
+        if (state.isSpeaking && state.silenceFrames >= SILENCE_FRAMES_REQUIRED) {
+          const duration = Date.now() - (state.speechStartTime || Date.now());
+
+          if (duration < 500) {
+            // Speech was too brief — reset and keep listening
+            state.isSpeaking = false;
+            state.speechStartTime = null;
+          } else {
+            // Real speech followed by confirmed silence — start countdown
+            if (!state.vadTimer) {
+              state.vadTimer = setTimeout(() => {
+                state.vadTimer = null;
+                if (state.mode === 'listening') {
+                  stopListening();
+                }
+              }, state.silenceTimeout);
             }
-          }, state.silenceTimeout);
+          }
         }
       }
 
@@ -325,6 +366,8 @@
   // ═══════════════════════════════════════
 
   async function processVoiceInput(audioBlob) {
+    if (state.processing) return; // Guard against double-processing
+    state.processing = true;
     setMode('thinking');
 
     try {
@@ -356,9 +399,14 @@
         addMessage(data.response, 'ai');
       }
 
-      // Render math visuals
-      if (data.mathSteps && data.mathSteps.length > 0 && state.showVisuals) {
-        renderMathSteps(data.mathSteps);
+      // Render math visuals — use backend mathSteps or extract from response
+      if (state.showVisuals) {
+        const steps = (data.mathSteps && data.mathSteps.length > 0)
+          ? data.mathSteps
+          : extractEquationsFromText(data.response || '');
+        if (steps.length > 0) {
+          renderMathSteps(steps);
+        }
       }
 
       // Play audio response (unless muted)
@@ -377,6 +425,8 @@
       console.error('[VoiceTutor] Processing error:', err);
       addSystemMessage('Something went wrong. Try again.');
       setMode('idle');
+    } finally {
+      state.processing = false;
     }
   }
 
@@ -402,8 +452,11 @@
       const data = await res.json();
 
       if (data.response) addMessage(data.response, 'ai');
-      if (data.mathSteps && data.mathSteps.length > 0 && state.showVisuals) {
-        renderMathSteps(data.mathSteps);
+      if (state.showVisuals) {
+        const steps = (data.mathSteps && data.mathSteps.length > 0)
+          ? data.mathSteps
+          : extractEquationsFromText(data.response || '');
+        if (steps.length > 0) renderMathSteps(steps);
       }
 
       if (data.audioUrl && !state.muted) {
@@ -432,59 +485,60 @@
     }
 
     return new Promise((resolve) => {
+      // Store resolver so interrupt can resolve this promise
+      state.playResolve = resolve;
+
       const audio = new Audio(audioUrl);
       state.currentAudio = audio;
 
-      // Draw speaking waveform from audio
-      {
-        const audioCtx = state.audioContext || new (window.AudioContext || window.webkitAudioContext)();
-        state.audioContext = audioCtx;
+      // Draw speaking waveform — use a FRESH AudioContext to avoid
+      // conflicts with the mic AudioContext
+      try {
+        const playCtx = new (window.AudioContext || window.webkitAudioContext)();
+        const source = playCtx.createMediaElementSource(audio);
+        const analyser = playCtx.createAnalyser();
+        analyser.fftSize = 256;
+        source.connect(analyser);
+        analyser.connect(playCtx.destination);
 
-        audio.addEventListener('canplay', () => {
-          try {
-            const source = audioCtx.createMediaElementSource(audio);
-            const analyser = audioCtx.createAnalyser();
-            analyser.fftSize = 256;
-            source.connect(analyser);
-            analyser.connect(audioCtx.destination);
-
-            const buffer = new Uint8Array(analyser.frequencyBinCount);
-            const drawSpeaking = () => {
-              if (state.mode !== 'speaking') return;
-              analyser.getByteFrequencyData(buffer);
-              drawSpeakingWaveform(buffer);
-              requestAnimationFrame(drawSpeaking);
-            };
-            drawSpeaking();
-          } catch (e) {
-            audio.volume = 1;
+        const buffer = new Uint8Array(analyser.frequencyBinCount);
+        const drawSpeaking = () => {
+          if (state.mode !== 'speaking') {
+            playCtx.close().catch(() => {});
+            return;
           }
-        }, { once: true });
+          analyser.getByteFrequencyData(buffer);
+          drawSpeakingWaveform(buffer);
+          requestAnimationFrame(drawSpeaking);
+        };
+        audio.addEventListener('canplay', drawSpeaking, { once: true });
+
+        // Store for cleanup
+        audio._playCtx = playCtx;
+      } catch (e) {
+        // Fallback: play without waveform visualization
       }
 
-      audio.onended = () => {
+      const done = (startNext) => {
+        if (audio._playCtx) {
+          audio._playCtx.close().catch(() => {});
+        }
         state.currentAudio = null;
+        state.playResolve = null;
         hideTranscript();
 
-        if (state.handsFree && state.autoListen) {
+        if (startNext && state.handsFree && state.autoListen) {
           setTimeout(() => startListening(), 400);
-        } else {
+        } else if (startNext) {
           setMode('idle');
         }
         resolve();
       };
 
-      audio.onerror = () => {
-        state.currentAudio = null;
-        hideTranscript();
-        setMode('idle');
-        resolve();
-      };
+      audio.onended = () => done(true);
+      audio.onerror = () => done(true);
 
-      audio.play().catch(() => {
-        setMode('idle');
-        resolve();
-      });
+      audio.play().catch(() => done(true));
     });
   }
 
@@ -493,10 +547,23 @@
       state.currentAudio.onended = null;
       state.currentAudio.onerror = null;
       state.currentAudio.pause();
-      state.currentAudio.currentTime = 0;
+      if (state.currentAudio._playCtx) {
+        state.currentAudio._playCtx.close().catch(() => {});
+      }
       state.currentAudio = null;
     }
     hideTranscript();
+
+    // Resolve the pending playResponse promise so processVoiceInput doesn't hang
+    if (state.playResolve) {
+      const resolve = state.playResolve;
+      state.playResolve = null;
+      resolve();
+    }
+
+    // Reset processing guard so next voice input can proceed
+    state.processing = false;
+
     setMode('idle');
   }
 
@@ -508,6 +575,14 @@
     }
 
     stopSpeaking();
+
+    // Close existing AudioContext so startListening gets a fresh one
+    // (avoids conflicts with the playback MediaElementSource)
+    if (state.audioContext && state.audioContext.state !== 'closed') {
+      state.audioContext.close().catch(() => {});
+      state.audioContext = null;
+    }
+
     startListening();
   }
 
@@ -1006,6 +1081,60 @@
   }
 
   // ═══════════════════════════════════════
+  // CLIENT-SIDE EQUATION EXTRACTION
+  // ═══════════════════════════════════════
+
+  /**
+   * Fallback: if backend didn't return mathSteps, extract equations from the response.
+   * Looks for LaTeX display/inline math, or patterns like "x = 5", "2x + 3 = 7", etc.
+   */
+  function extractEquationsFromText(text) {
+    const steps = [];
+
+    // 1. Extract display math: \[ ... \] or $$ ... $$
+    const displayPatterns = [
+      /\\\[(.+?)\\\]/gs,
+      /\$\$(.+?)\$\$/gs,
+    ];
+    for (const pat of displayPatterns) {
+      let m;
+      while ((m = pat.exec(text)) !== null) {
+        steps.push({ latex: m[1].trim() });
+      }
+    }
+
+    // 2. Extract inline math: \( ... \) or $ ... $ (only if contains math-like chars)
+    const inlinePatterns = [
+      /\\\((.+?)\\\)/g,
+      /(?<!\$)\$([^$\n]+?)\$(?!\$)/g,
+    ];
+    for (const pat of inlinePatterns) {
+      let m;
+      while ((m = pat.exec(text)) !== null) {
+        const latex = m[1].trim();
+        // Only include if it looks like an equation (has =, +, -, frac, etc.)
+        if (/[=+\-*/^_\\]/.test(latex) && latex.length > 2) {
+          steps.push({ latex });
+        }
+      }
+    }
+
+    // 3. Heuristic: find plain-text equations like "x = 5" or "2x + 3 = 7"
+    if (steps.length === 0) {
+      const eqPattern = /(?:^|[.!?]\s+)([^.!?\n]*?(?:\d+[a-z]|[a-z])\s*[+\-*/^]\s*[^.!?\n]*?=\s*[^.!?\n]+)/gi;
+      let m;
+      while ((m = eqPattern.exec(text)) !== null) {
+        const eq = m[1].trim();
+        if (eq.length > 3 && eq.length < 120) {
+          steps.push({ text: eq });
+        }
+      }
+    }
+
+    return steps;
+  }
+
+  // ═══════════════════════════════════════
   // UTILITIES
   // ═══════════════════════════════════════
 
@@ -1041,6 +1170,7 @@
     cancelAnimationFrame(state.particleRAF);
     clearTimeout(state.vadTimer);
     clearTimeout(state.maxRecordTimer);
+    clearInterval(state.timerInterval);
 
     // Stop MediaRecorder and prevent onstop from firing processVoiceInput
     if (state.mediaRecorder) {

--- a/public/voice-tutor.html
+++ b/public/voice-tutor.html
@@ -27,6 +27,7 @@
     <div class="vt-header-center">
       <img src="/images/mathmatix-ai-logo.png" alt="Mathmatix" class="vt-logo" />
       <span class="vt-session-label">Voice Session</span>
+      <span class="vt-session-timer" id="vt-session-timer">00:00</span>
     </div>
     <div class="vt-header-actions">
       <button id="vt-settings-btn" class="vt-icon-btn" title="Settings" aria-label="Settings">
@@ -42,10 +43,7 @@
       <!-- Math visualization canvas -->
       <div class="vt-canvas-area" id="vt-canvas-area">
         <div class="vt-canvas-placeholder" id="vt-canvas-placeholder">
-          <div class="vt-canvas-icon">
-            <i class="fas fa-wand-magic-sparkles"></i>
-          </div>
-          <p>Math will appear here as you talk</p>
+          <p><i class="fas fa-function"></i> Equations appear here as you talk</p>
         </div>
         <!-- Rendered math steps appear here -->
         <div id="vt-math-display" class="vt-math-display"></div>
@@ -105,16 +103,24 @@
 
   <!-- Bottom controls -->
   <footer class="vt-controls">
-    <button id="vt-end-btn" class="vt-control-btn vt-end-btn" title="End session" aria-label="End session">
-      <i class="fas fa-phone-slash"></i>
-    </button>
-    <button id="vt-mic-btn" class="vt-control-btn vt-mic-btn" title="Tap to speak" aria-label="Tap to speak">
-      <div class="vt-mic-ripple"></div>
-      <i class="fas fa-microphone"></i>
-    </button>
-    <button id="vt-mute-btn" class="vt-control-btn vt-mute-btn" title="Mute tutor" aria-label="Mute tutor">
-      <i class="fas fa-volume-up"></i>
-    </button>
+    <div class="vt-control-group">
+      <button id="vt-end-btn" class="vt-control-btn vt-end-btn" title="End session" aria-label="End session">
+        <i class="fas fa-phone-slash"></i>
+      </button>
+      <span class="vt-control-label">End</span>
+    </div>
+    <div class="vt-control-group">
+      <button id="vt-mic-btn" class="vt-control-btn vt-mic-btn" title="Tap to speak" aria-label="Tap to speak">
+        <div class="vt-mic-ripple"></div>
+        <i class="fas fa-microphone"></i>
+      </button>
+    </div>
+    <div class="vt-control-group">
+      <button id="vt-mute-btn" class="vt-control-btn vt-mute-btn" title="Mute tutor" aria-label="Mute tutor">
+        <i class="fas fa-volume-up"></i>
+      </button>
+      <span class="vt-control-label">Mute</span>
+    </div>
   </footer>
 
   <!-- Settings drawer -->


### PR DESCRIPTION
BUGS FIXED:
- Hands-free: VAD now uses voice-range frequency bins with hysteresis (8 consecutive silent frames required) to prevent noise spikes from resetting the silence countdown. Threshold tuned to -45dB.
- Interrupt: playResponse now stores a resolver so stopSpeaking can resolve the pending promise. Interrupt creates a fresh AudioContext to avoid conflicts with playback MediaElementSource. Processing guard prevents double processVoiceInput calls.
- Math steps: Added client-side extractEquationsFromText fallback that pulls LaTeX (display/inline) and plain-text equations from the AI response when backend returns no mathSteps.

UI UPGRADES:
- Avatar circle enlarged from 120px to 160px (110px mobile)
- Rings enlarged proportionally (184/210/240px)
- Listening rings thicker (3px inner, 2px mid) with stronger glow
- Speaking state: triple-layer box-shadow for dramatic depth
- Session timer in header (MM:SS, tabular-nums)
- Control button labels (End, Mute) like FaceTime/Zoom
- Richer ambient gradient (4 radial layers + deeper base)
- Chat panel deeper glassmorphism (blur 30px, saturate, shadow)
- Math placeholder simplified to single-line minimal design

https://claude.ai/code/session_01HD7dAQUQbDVBecHdRc7kwu