### PR TITLE
Add preserveAspectRatio to SVG sanitization allowlist

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -651,7 +651,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 ALLOWED_ATTR: [
                     'href', 'class', 'target', 'rel', 'id', 'style', 'title', 'alt', 'src',
                     // SVG attributes
-                    'viewBox', 'width', 'height', 'fill', 'stroke', 'stroke-width', 'stroke-dasharray',
+                    'viewBox', 'width', 'height', 'fill', 'stroke', 'stroke-width', 'stroke-dasharray', 'preserveAspectRatio',
                     'x', 'y', 'x1', 'y1', 'x2', 'y2', 'cx', 'cy', 'r', 'rx', 'ry', 'd', 'points',
                     'text-anchor', 'font-size', 'font-weight', 'transform', 'transform-origin',
                     // Form/interactive attributes


### PR DESCRIPTION
## Summary
Added `preserveAspectRatio` to the list of allowed SVG attributes in the DOMPurify configuration to enable proper SVG aspect ratio preservation during sanitization.

## Changes
- Added `preserveAspectRatio` to the `ALLOWED_ATTR` array in the DOMPurify configuration
- This attribute is now permitted when sanitizing SVG content, allowing SVGs to maintain their intended aspect ratio behavior

## Details
The `preserveAspectRatio` attribute is a standard SVG attribute that controls how an SVG scales to fit its container. By adding it to the allowlist, SVG elements can now be properly rendered with their aspect ratio preservation settings intact during the sanitization process.

https://claude.ai/code/session_018GRUYzF8148ytPiJ2AjqJp