### PR TITLE
Fix VAD: loop was dead on arrival due to mode race condition

### DIFF
--- a/public/js/voice-tutor-session.js
+++ b/public/js/voice-tutor-session.js
@@ -363,7 +363,8 @@
 
       requestAnimationFrame(check);
     };
-    check();
+    // Defer first check so setMode('listening') runs first
+    requestAnimationFrame(check);
   }
 
   // ═══════════════════════════════════════


### PR DESCRIPTION
Root cause: setupVAD() was called while state.mode was still 'starting', but the VAD check() function immediately returns when mode !== 'listening'. Since check() was called synchronously, it exited before requestAnimationFrame could schedule the next iteration — killing the entire VAD loop permanently.

setMode('listening') ran 3 lines later but the loop was already dead. Students had to manually press stop because auto-send never fired.

Fix: defer the first check() to requestAnimationFrame so setMode('listening') executes first on the same synchronous tick.

https://claude.ai/code/session_01HD7dAQUQbDVBecHdRc7kwu