### PR TITLE
Fix admin analytics data path mismatches and add mastery distribution

### DIFF
--- a/public/js/admin-analytics.js
+++ b/public/js/admin-analytics.js
@@ -20,15 +20,16 @@
       if (healthRes.ok) {
         const data = await healthRes.json();
         const el = (id) => document.getElementById(id);
+        const avgs = data.averages || {};
 
-        if (data.avgPLearned != null) {
-          el('admin-avg-mastery').textContent = `${(data.avgPLearned * 100).toFixed(0)}%`;
+        if (avgs.bktPLearned != null) {
+          el('admin-avg-mastery').textContent = `${(avgs.bktPLearned * 100).toFixed(0)}%`;
         }
-        if (data.avgRetrievability != null) {
-          el('admin-avg-retention').textContent = `${(data.avgRetrievability * 100).toFixed(0)}%`;
+        if (avgs.fsrsRetrievability != null) {
+          el('admin-avg-retention').textContent = `${(avgs.fsrsRetrievability * 100).toFixed(0)}%`;
         }
-        if (data.avgSmartScore != null) {
-          el('admin-avg-smartscore').textContent = data.avgSmartScore.toFixed(0);
+        if (avgs.smartScore != null) {
+          el('admin-avg-smartscore').textContent = avgs.smartScore.toFixed(0);
         }
 
         // Cognitive Load Zone distribution
@@ -60,9 +61,10 @@
       if (outcomesRes.ok) {
         const data = await outcomesRes.json();
         const el = (id) => document.getElementById(id);
+        const psRate = data.productiveStruggle?.rate;
 
-        if (data.productiveStruggleRate != null) {
-          el('admin-productive-struggle').textContent = `${(data.productiveStruggleRate * 100).toFixed(0)}%`;
+        if (psRate != null) {
+          el('admin-productive-struggle').textContent = `${(psRate * 100).toFixed(0)}%`;
         }
       }
     } catch (err) {

--- a/routes/analytics.js
+++ b/routes/analytics.js
@@ -642,14 +642,19 @@ router.get('/platform/engine-health', isAdmin, async (req, res) => {
     let smartScoreCount = 0;
 
     const cogLevelDistribution = {};
+    // Mastery distribution buckets: [0-20%, 20-40%, 40-60%, 60-80%, 80-100%]
+    const masteryBuckets = [0, 0, 0, 0, 0];
 
     for (const s of students) {
       const engines = s.learningEngines || {};
 
       // BKT
       for (const [, data] of mapEntries(engines.bkt)) {
-        totalBktPLearned += data.pLearned ?? 0;
+        const pL = data.pLearned ?? 0;
+        totalBktPLearned += pL;
         bktCount++;
+        const bucketIdx = Math.min(Math.floor(pL * 5), 4);
+        masteryBuckets[bucketIdx]++;
       }
 
       // FSRS
@@ -685,6 +690,10 @@ router.get('/platform/engine-health', isAdmin, async (req, res) => {
         smartScore: smartScoreCount > 0 ? Math.round((totalSmartScore / smartScoreCount) * 100) / 100 : null,
       },
       cognitiveLoadDistribution: cogLevelDistribution,
+      masteryDistribution: {
+        labels: ['0-20%', '20-40%', '40-60%', '60-80%', '80-100%'],
+        counts: masteryBuckets,
+      },
       counts: {
         bktSkillEntries: bktCount,
         fsrsSkillEntries: fsrsCount,


### PR DESCRIPTION
- admin-analytics.js: read from data.averages.* and data.productiveStruggle.rate instead of non-existent top-level properties
- routes/analytics.js: add masteryDistribution bucket data to engine-health endpoint

https://claude.ai/code/session_01SgZCMydEDQBD3JLNy8aH9h