### PR TITLE
Fix tutors not loading due to CSP blocking inline script injection

### DIFF
--- a/public/js/pick-tutor.js
+++ b/public/js/pick-tutor.js
@@ -10,13 +10,9 @@ document.addEventListener('DOMContentLoaded', () => {
   /* -------- INITIAL DATA LOAD -------- */
   async function fetchData() {
     try {
-      const [userRes, tutorConfigRes] = await Promise.all([
-        fetch('/user',           { credentials: 'include' }),
-        fetch('/js/tutor-config-data.js')
-      ]);
+      const userRes = await fetch('/user', { credentials: 'include' });
 
       if (!userRes.ok) return window.location.href = '/login.html';
-      if (!tutorConfigRes.ok) throw new Error('Failed to load tutor configuration.');
 
       const userData   = await userRes.json();
       currentUser      = userData.user;
@@ -26,15 +22,9 @@ document.addEventListener('DOMContentLoaded', () => {
         currentUser.unlockedItems = ['mr-nappier', 'maya', 'ms-maria', 'bob'];
       }
 
-      /* Inject tutor config into page scope if not already present */
-      const scriptText = await tutorConfigRes.text();
-      if (!window.TUTOR_CONFIG) {
-        const s = document.createElement('script');
-        s.textContent = scriptText;
-        document.body.appendChild(s);
-      }
-
       const tutorsData = window.TUTOR_CONFIG;
+      if (!tutorsData) throw new Error('Tutor configuration not loaded.');
+
       allTutors = Object.keys(tutorsData)
         .filter(key => key !== 'default')
         .map(key => ({ id: key, ...tutorsData[key] }));

--- a/public/pick-tutor.html
+++ b/public/pick-tutor.html
@@ -67,6 +67,7 @@
 
   <script src="/js/logout.js"></script>
   <script src="/js/csrf.js"></script>
+  <script src="/js/tutor-config-data.js"></script>
   <script type="module" src="/js/pick-tutor.js"></script>
   <script src="/js/ux-enhancements.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/js/all.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>


### PR DESCRIPTION
The tutor config was being fetched and injected as an inline script,
which CSP blocked because it lacked a nonce. Load it as an external
<script src> tag instead (matching the avatar-config-data.js pattern).

https://claude.ai/code/session_01QbqhkE5bE3mN1JFnKFervf