### PR TITLE
Fix Stripe webhook 3xx redirect failure by skipping HTTPS/www redirec…

### DIFF
--- a/server.js
+++ b/server.js
@@ -146,6 +146,10 @@ app.set("trust proxy", 1);
 // Enforce HTTPS and redirect www to apex domain in production
 if (isProduction) {
   app.use((req, res, next) => {
+    // Skip redirects for Stripe webhook — Stripe treats any redirect as a failure
+    if (req.originalUrl === '/api/billing/webhook') {
+      return next();
+    }
     // Force HTTPS (Render terminates TLS at the proxy, so check x-forwarded-proto)
     if (req.headers['x-forwarded-proto'] !== 'https') {
       return res.redirect(301, `https://${req.hostname}${req.originalUrl}`);


### PR DESCRIPTION
…t middleware

The HTTPS enforcement and www-to-apex redirect middleware was intercepting Stripe webhook POST requests and returning 301 redirects. Stripe treats any redirect as a delivery failure, causing 25/25 webhook deliveries to fail.

Skip the redirect middleware for /api/billing/webhook so Stripe events are processed directly.

https://claude.ai/code/session_01BcuibqejC5AEF1BP8NnAbt