### PR TITLE
Improve session UX: limit to 3 with see-more, rename to My Chats

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -258,7 +258,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <!-- My Courses (always visible — primary navigation for enrolled students) -->
     <div class="sidebar-section" id="sidebar-courses-section">
       <button class="courses-toggle" id="courses-toggle-btn">
-        <span data-i18n="chat.myCourses">My Courses</span>
+        <span><i class="fas fa-graduation-cap" style="margin-right: 6px; font-size: 13px; color: #764ba2;"></i><span data-i18n="chat.myCourses">My Courses</span></span>
         <i class="fas fa-chevron-down"></i>
       </button>
 
@@ -310,10 +310,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
     <!-- ═══ GENERAL CHAT CONTEXT (hidden when in a course) ═══ -->
 
-    <!-- My Sessions -->
+    <!-- My Chats (renamed from "My Sessions" to differentiate from course lessons) -->
     <div class="sidebar-section sidebar-ctx-general">
       <button class="sessions-toggle">
-        <span data-i18n="chat.mySessions">My Sessions</span>
+        <span><i class="fas fa-comments" style="margin-right: 6px; font-size: 13px; color: var(--clr-primary-teal, #12B3B3);"></i>My Chats</span>
         <i class="fas fa-chevron-down"></i>
       </button>
 
@@ -321,12 +321,12 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <!-- Session Search -->
         <div class="session-search-container">
           <i class="fas fa-search session-search-icon"></i>
-          <input type="text" id="session-search-input" class="session-search-input" placeholder="Search sessions..." data-i18n-placeholder="chat.searchSessions">
+          <input type="text" id="session-search-input" class="session-search-input" placeholder="Search chats..." data-i18n-placeholder="chat.searchSessions">
         </div>
 
         <button id="new-session-btn" class="sidebar-tool-btn special">
           <i class="fas fa-plus-circle"></i>
-          <span data-i18n="chat.newSession">New Session</span>
+          <span data-i18n="chat.newSession">New Chat</span>
         </button>
         <div id="sessions-list">
           <!-- Sessions loaded dynamically by sidebar.js -->
@@ -1477,7 +1477,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <!-- Recent Sessions Section -->
         <div id="returning-user-sessions" style="display: none;">
           <div class="returning-section-label">
-            <i class="fas fa-comments"></i> Recent Sessions
+            <i class="fas fa-comments"></i> Recent Chats
           </div>
           <div id="returning-sessions-list" class="returning-sessions-list">
             <!-- Populated dynamically -->

--- a/public/css/sidebar-layout.css
+++ b/public/css/sidebar-layout.css
@@ -1314,7 +1314,7 @@ footer {
     background: #e8e0ff;
 }
 
-/* "See all" link button (leaderboard) */
+/* "See all" / "See more" link buttons */
 .sidebar-see-all-btn {
     display: block;
     width: 100%;
@@ -1331,4 +1331,13 @@ footer {
 
 .sidebar-see-all-btn:hover {
     text-decoration: underline;
+}
+
+/* Distinct section accents for Courses vs Chats */
+#sidebar-courses-section {
+    border-left: 3px solid #764ba2;
+}
+
+.sidebar-ctx-general:has(.sessions-toggle) {
+    border-left: 3px solid var(--clr-primary-teal, #12B3B3);
 }

--- a/public/js/i18n-translations.js
+++ b/public/js/i18n-translations.js
@@ -353,16 +353,16 @@ window.I18N_TRANSLATIONS = {
     Vietnamese: 'Tải lên bài làm', Arabic: 'رفع العمل', Somali: 'Soo geli shaqada', French: 'Télécharger le travail', German: 'Arbeit hochladen'
   },
   'chat.mySessions': {
-    English: 'My Sessions', Spanish: 'Mis sesiones', Russian: 'Мои сессии', Chinese: '我的会话',
-    Vietnamese: 'Phiên của tôi', Arabic: 'جلساتي', Somali: 'Fadhiyaadkayga', French: 'Mes sessions', German: 'Meine Sitzungen'
+    English: 'My Chats', Spanish: 'Mis chats', Russian: 'Мои чаты', Chinese: '我的聊天',
+    Vietnamese: 'Trò chuyện của tôi', Arabic: 'محادثاتي', Somali: 'Wada-sheekeysiyadayda', French: 'Mes discussions', German: 'Meine Chats'
   },
   'chat.searchSessions': {
-    English: 'Search sessions...', Spanish: 'Buscar sesiones...', Russian: 'Поиск сессий...', Chinese: '搜索会话…',
-    Vietnamese: 'Tìm kiếm phiên...', Arabic: 'البحث في الجلسات...', Somali: 'Raadi fadhiyaadka...', French: 'Rechercher des sessions…', German: 'Sitzungen suchen…'
+    English: 'Search chats...', Spanish: 'Buscar chats...', Russian: 'Поиск чатов...', Chinese: '搜索聊天…',
+    Vietnamese: 'Tìm kiếm trò chuyện...', Arabic: 'البحث في المحادثات...', Somali: 'Raadi wada-sheekeysiyo...', French: 'Rechercher des discussions…', German: 'Chats suchen…'
   },
   'chat.newSession': {
-    English: 'New Session', Spanish: 'Nueva sesión', Russian: 'Новая сессия', Chinese: '新会话',
-    Vietnamese: 'Phiên mới', Arabic: 'جلسة جديدة', Somali: 'Fadhiyaad cusub', French: 'Nouvelle session', German: 'Neue Sitzung'
+    English: 'New Chat', Spanish: 'Nuevo chat', Russian: 'Новый чат', Chinese: '新聊天',
+    Vietnamese: 'Trò chuyện mới', Arabic: 'محادثة جديدة', Somali: 'Wada-sheekeysiga cusub', French: 'Nouvelle discussion', German: 'Neuer Chat'
   },
   'chat.askQuestion': {
     English: 'Ask a math question...', Spanish: 'Haz una pregunta de matemáticas...', Russian: 'Задайте вопрос по математике...', Chinese: '问一个数学问题…',

--- a/public/js/sidebar.js
+++ b/public/js/sidebar.js
@@ -404,6 +404,7 @@ class Sidebar {
 
         // Cache conversations for search
         this.conversations = conversations;
+        this._sessionsShowAll = false;
 
         // Clear existing
         sessionsList.innerHTML = '';
@@ -427,7 +428,7 @@ class Sidebar {
             pinnedSessions.forEach(conv => this.renderSessionItem(conv, sessionsList, true));
         }
 
-        // Add regular sessions
+        // Add regular sessions (show only 3 by default)
         if (regularSessions.length > 0) {
             if (pinnedSessions.length > 0) {
                 const recentHeader = document.createElement('div');
@@ -436,7 +437,17 @@ class Sidebar {
                 sessionsList.appendChild(recentHeader);
             }
 
-            regularSessions.forEach(conv => this.renderSessionItem(conv, sessionsList, false));
+            const defaultShow = 3;
+            regularSessions.slice(0, defaultShow).forEach(conv => this.renderSessionItem(conv, sessionsList, false));
+
+            // "See more" button if there are more than 3 regular sessions
+            if (regularSessions.length > defaultShow) {
+                const seeMoreBtn = document.createElement('button');
+                seeMoreBtn.className = 'sidebar-see-all-btn sessions-see-more-btn';
+                seeMoreBtn.textContent = `See ${regularSessions.length - defaultShow} more`;
+                seeMoreBtn.addEventListener('click', () => this.toggleAllSessions());
+                sessionsList.appendChild(seeMoreBtn);
+            }
         }
 
         // Show empty state if no conversations
@@ -445,10 +456,57 @@ class Sidebar {
             emptyState.className = 'session-empty-state';
             emptyState.innerHTML = `
                 <span style="color: #888; font-size: 13px; padding: 12px; display: block; text-align: center;">
-                    No sessions yet. Click <strong>New Session</strong> to start!
+                    No chats yet. Click <strong>New Chat</strong> to start!
                 </span>
             `;
             sessionsList.appendChild(emptyState);
+        }
+    }
+
+    /**
+     * Toggle between showing 3 sessions and all sessions
+     */
+    toggleAllSessions() {
+        this._sessionsShowAll = !this._sessionsShowAll;
+
+        const sessionsList = document.getElementById('sessions-list');
+        if (!sessionsList) return;
+
+        sessionsList.innerHTML = '';
+
+        const chatConversations = this.conversations.filter(c =>
+            c.conversationType === 'general' || c.conversationType === 'topic'
+        );
+        const pinnedSessions = chatConversations.filter(c => c.isPinned);
+        const regularSessions = chatConversations.filter(c => !c.isPinned);
+
+        if (pinnedSessions.length > 0) {
+            const pinnedHeader = document.createElement('div');
+            pinnedHeader.className = 'session-divider';
+            pinnedHeader.innerHTML = '<span><i class="fas fa-thumbtack"></i> Pinned</span>';
+            sessionsList.appendChild(pinnedHeader);
+            pinnedSessions.forEach(conv => this.renderSessionItem(conv, sessionsList, true));
+        }
+
+        if (regularSessions.length > 0) {
+            if (pinnedSessions.length > 0) {
+                const recentHeader = document.createElement('div');
+                recentHeader.className = 'session-divider';
+                recentHeader.innerHTML = '<span>Recent</span>';
+                sessionsList.appendChild(recentHeader);
+            }
+
+            const defaultShow = 3;
+            const showCount = this._sessionsShowAll ? regularSessions.length : defaultShow;
+            regularSessions.slice(0, showCount).forEach(conv => this.renderSessionItem(conv, sessionsList, false));
+
+            if (regularSessions.length > defaultShow) {
+                const seeMoreBtn = document.createElement('button');
+                seeMoreBtn.className = 'sidebar-see-all-btn sessions-see-more-btn';
+                seeMoreBtn.textContent = this._sessionsShowAll ? 'Show less' : `See ${regularSessions.length - defaultShow} more`;
+                seeMoreBtn.addEventListener('click', () => this.toggleAllSessions());
+                sessionsList.appendChild(seeMoreBtn);
+            }
         }
     }
 


### PR DESCRIPTION
- Show only 3 recent chats by default with "See N more" / "Show less" toggle
- Rename "My Sessions" → "My Chats" to clearly differentiate from "My Courses"
- Add distinct icons (💬 comments for chats, 🎓 graduation cap for courses)
- Add colored left-border accents (teal for chats, purple for courses)
- Update i18n translations for all supported languages
- Update welcome screen to say "Recent Chats" instead of "Recent Sessions"

https://claude.ai/code/session_01WhdaFuZHYdCT1GZ3VLQmE4