### PR TITLE
Fix chat state resetting when switching mobile tabs

### DIFF
--- a/public/css/mobile-redesign.css
+++ b/public/css/mobile-redesign.css
@@ -53,18 +53,19 @@
     display: flex;
 }
 
-/* When a panel is active, hide the main chat area on mobile */
+/* When a panel is active, disable chat interaction but keep DOM intact.
+   Panels overlay via z-index 1750 so chat is hidden visually.
+   Using pointer-events instead of visibility to preserve scroll position
+   and input content across tab switches. */
 @media (max-width: 768px) {
     body.mobile-panel-active #app-layout-wrapper,
     body.mobile-panel-active #input-container {
-        visibility: hidden;
         pointer-events: none;
     }
 
-    /* But chat panel should show the main content */
+    /* Chat tab restores interaction */
     body.mobile-panel-chat #app-layout-wrapper,
     body.mobile-panel-chat #input-container {
-        visibility: visible;
         pointer-events: auto;
     }
 }

--- a/public/js/mobile-chat-nav.js
+++ b/public/js/mobile-chat-nav.js
@@ -23,6 +23,8 @@
 
     var activeTab = 'chat';
     var panelsBuilt = {};
+    var savedScrollPos = null;   // preserve chat scroll across tab switches
+    var savedInputContent = '';  // preserve typed input across tab switches
 
     /* ---- helpers ---- */
 
@@ -85,6 +87,15 @@
 
     function switchTab(action) {
         if (activeTab === action && action === 'chat') return;
+
+        // Save chat state before leaving the chat tab
+        if (activeTab === 'chat') {
+            var box = document.getElementById('chat-messages-container');
+            if (box) savedScrollPos = box.scrollTop;
+            var input = document.getElementById('user-input');
+            if (input) savedInputContent = input.innerHTML;
+        }
+
         activeTab = action;
 
         // Update nav highlight
@@ -103,10 +114,23 @@
         if (action === 'chat') {
             // Show main chat (no panel overlay)
             document.body.classList.add('mobile-panel-chat');
-            var box = document.getElementById('chat-messages-container');
-            if (box) box.scrollTop = box.scrollHeight;
-            var input = document.getElementById('user-input');
-            if (input) input.focus();
+
+            // Restore chat state
+            requestAnimationFrame(function () {
+                var box = document.getElementById('chat-messages-container');
+                if (box) {
+                    // Restore saved position, or scroll to bottom if no saved state
+                    box.scrollTop = savedScrollPos != null ? savedScrollPos : box.scrollHeight;
+                }
+                var input = document.getElementById('user-input');
+                if (input) {
+                    // Restore typed content if it was cleared
+                    if (savedInputContent && !input.innerHTML.trim()) {
+                        input.innerHTML = savedInputContent;
+                    }
+                    input.focus();
+                }
+            });
         } else {
             // Build and show the panel
             document.body.classList.add('mobile-panel-active');


### PR DESCRIPTION
- Save scroll position and input content before leaving chat tab
- Restore both when returning to chat via requestAnimationFrame
- Stop using visibility:hidden on chat container (caused scroll/input loss on mobile browsers); panels already overlay at z-index 1750
- Use pointer-events:none instead to block interaction while keeping DOM state fully intact

https://claude.ai/code/session_01TLNvijZZk4yARhCfQaBFgz