### PR TITLE
Center the hero subheader text

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -248,6 +248,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       color: var(--clr-text-dim);
       margin-bottom: 2rem;
       max-width: 520px;
+      margin-left: auto;
+      margin-right: auto;
     }
 
     .lp-hero-buttons {


### PR DESCRIPTION
Add auto left/right margins to .lp-hero-sub so the max-width constrained paragraph is horizontally centered within its parent.

https://claude.ai/code/session_01YEyQsyjv6uD8XaXVbwNBAj