### PR TITLE
Add Smart Resume Hero section to returning user modal

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -1462,10 +1462,13 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <div class="modal-content returning-user-content">
       <div class="returning-user-header">
         <h2 id="returning-user-greeting"></h2>
-        <p class="returning-user-subtitle">Where do you want to pick up?</p>
+        <p class="returning-user-subtitle">Ready to jump back in?</p>
       </div>
 
       <div id="returning-user-body" class="returning-user-body">
+        <!-- Smart Resume Hero Section -->
+        <div id="returning-hero-section" style="display: none;"></div>
+
         <!-- Course Sessions Section -->
         <div id="returning-user-courses" style="display: none;">
           <div class="returning-section-label">

--- a/public/css/returning-user-modal.css
+++ b/public/css/returning-user-modal.css
@@ -258,6 +258,141 @@
   padding: 4px 12px 2px;
 }
 
+/* Smart Resume Hero Cards */
+.returning-hero-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: all 0.15s;
+  margin-bottom: 8px;
+}
+
+.returning-hero-primary {
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  color: #fff;
+  box-shadow: 0 3px 12px rgba(102, 126, 234, 0.3);
+}
+
+.returning-hero-primary:hover {
+  box-shadow: 0 4px 16px rgba(102, 126, 234, 0.45);
+  transform: translateY(-1px);
+}
+
+.returning-hero-secondary {
+  background: #f8f9fb;
+  border: 1px solid #e2e8f0;
+  color: #333;
+}
+
+.returning-hero-secondary:hover {
+  background: #f0eeff;
+  border-color: #c7c3e8;
+}
+
+.returning-hero-emoji {
+  font-size: 22px;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  border-radius: 8px;
+}
+
+.returning-hero-primary .returning-hero-emoji {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.returning-hero-secondary .returning-hero-emoji {
+  background: linear-gradient(135deg, #667eea20, #764ba220);
+}
+
+.returning-hero-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.returning-hero-name {
+  font-size: 14px;
+  font-weight: 700;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.returning-hero-meta {
+  font-size: 12px;
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.returning-hero-primary .returning-hero-meta {
+  opacity: 0.85;
+}
+
+.returning-hero-secondary .returning-hero-meta {
+  color: #888;
+}
+
+.returning-hero-action {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.returning-hero-time {
+  font-size: 11px;
+  opacity: 0.75;
+}
+
+.returning-hero-action i {
+  font-size: 13px;
+  opacity: 0.7;
+  transition: transform 0.15s;
+}
+
+.returning-hero-card:hover .returning-hero-action i {
+  transform: translateX(2px);
+  opacity: 1;
+}
+
+#returning-hero-section {
+  margin-bottom: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+/* Dark mode hero cards */
+.dark-mode .returning-hero-secondary {
+  background: #252535;
+  border-color: #333;
+  color: #e0e0e0;
+}
+
+.dark-mode .returning-hero-secondary:hover {
+  background: #2a2a3d;
+  border-color: #555;
+}
+
+.dark-mode .returning-hero-secondary .returning-hero-meta {
+  color: #999;
+}
+
+.dark-mode .returning-hero-secondary .returning-hero-emoji {
+  background: rgba(102, 126, 234, 0.15);
+}
+
+.dark-mode #returning-hero-section {
+  border-bottom-color: #333;
+}
+
 /* "See more" / "Show less" toggle button */
 .returning-see-more-btn {
   display: block;

--- a/public/css/returning-user-modal.css
+++ b/public/css/returning-user-modal.css
@@ -258,6 +258,35 @@
   padding: 4px 12px 2px;
 }
 
+/* "See more" / "Show less" toggle button */
+.returning-see-more-btn {
+  display: block;
+  width: 100%;
+  padding: 8px 12px;
+  margin-top: 4px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: #667eea;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  text-align: center;
+  transition: background 0.15s;
+}
+
+.returning-see-more-btn:hover {
+  background: #f5f3ff;
+}
+
+.dark-mode .returning-see-more-btn {
+  color: #8b9cf7;
+}
+
+.dark-mode .returning-see-more-btn:hover {
+  background: #2a2a3d;
+}
+
 /* Footer */
 .returning-user-footer {
   padding: 12px 20px 16px;

--- a/public/index.html
+++ b/public/index.html
@@ -208,11 +208,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     .lp-section-heading::after {
       content: '';
       display: block;
-      width: 48px;
+      width: 40px;
       height: 3px;
       background: linear-gradient(90deg, var(--clr-primary-teal), var(--clr-accent-hotpink));
-      margin: 0.6rem auto 0;
-      border-radius: 2px;
+      margin: 0.75rem auto 0;
+      border-radius: 3px;
     }
 
     .lp-section-sub {
@@ -226,8 +226,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
     /* ── Hero ───────────────────────────────────────────────── */
     .lp-hero {
-      background: linear-gradient(160deg, #f0fafa 0%, #e4f3f3 40%, #f8fbfb 100%);
-      padding: 4rem var(--page-horizontal-padding) 2.5rem;
+      background: linear-gradient(160deg, #f4fbfb 0%, #eaf6f6 35%, #f9fcfc 70%, #fefefe 100%);
+      padding: 4.5rem var(--page-horizontal-padding) 3rem;
     }
 
     .lp-hero-layout {
@@ -247,13 +247,15 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     }
 
     .lp-hero .lp-hero-sub {
-      font-size: 1.15rem;
-      line-height: 1.65;
+      font-size: 1.1rem;
+      line-height: 1.7;
       color: var(--clr-text-dim);
       margin-bottom: 2rem;
       max-width: 520px;
       margin-left: auto;
       margin-right: auto;
+      font-weight: 400;
+      letter-spacing: 0.005em;
     }
 
     .lp-hero-buttons {
@@ -448,18 +450,21 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
     /* Trust bar */
     .lp-trust-bar {
-      display: flex; justify-content: center; gap: 2rem; flex-wrap: wrap;
-      padding-top: 2rem;
-      border-top: 1px solid rgba(18, 179, 179, 0.12);
-      max-width: 1100px; margin: 0 auto;
+      display: flex; justify-content: center; gap: 1.5rem; flex-wrap: wrap;
+      padding: 1.75rem 2rem;
+      background: rgba(18, 179, 179, 0.03);
+      border-radius: 16px;
+      border: 1px solid rgba(18, 179, 179, 0.08);
+      max-width: 1100px; margin: 2.5rem auto 0;
     }
 
     .lp-trust-item {
       display: flex; align-items: center; gap: 0.5rem;
-      font-size: 0.9rem; font-weight: 500; color: var(--clr-text-dim);
+      font-size: 0.85rem; font-weight: 500; color: var(--clr-text-dim);
+      letter-spacing: 0.01em;
     }
 
-    .lp-trust-item i { color: var(--clr-primary-teal); font-size: 1rem; }
+    .lp-trust-item i { color: var(--clr-primary-teal); font-size: 0.95rem; opacity: 0.85; }
 
     /* Hero side-by-side on desktop */
     @media (min-width: 769px) {
@@ -1480,36 +1485,38 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     }
 
     .lp-hero-eyebrow {
-      font-size: 0.95rem;
+      font-size: 0.85rem;
       font-weight: 600;
       color: var(--clr-primary-teal, #12B3B3);
-      letter-spacing: 0.01em;
-      margin-bottom: 0.5rem;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      margin-bottom: 0.75rem;
     }
 
     .lp-hero-pick-inner h1 {
       font-size: 2.5rem;
-      font-weight: 700;
-      letter-spacing: -0.02em;
+      font-weight: 800;
+      letter-spacing: -0.025em;
       color: var(--clr-text);
-      margin-bottom: 0.5rem;
+      margin-bottom: 0.6rem;
+      line-height: 1.15;
     }
 
     .lp-tutor-grid {
       display: grid;
       grid-template-columns: repeat(4, 1fr);
-      gap: 1.25rem;
+      gap: 1.5rem;
       max-width: 960px;
-      margin: 2rem auto 0;
+      margin: 2.5rem auto 0;
     }
 
     .lp-tutor-card {
       background: var(--clr-bg-light);
-      border: 2px solid #e8ecf0;
-      border-radius: 16px;
-      padding: 1.5rem 1rem 1rem;
+      border: 1px solid rgba(0, 0, 0, 0.06);
+      border-radius: 20px;
+      padding: 2rem 1.25rem 1.25rem;
       cursor: pointer;
-      transition: all 0.25s ease;
+      transition: transform 0.3s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.3s cubic-bezier(0.22, 1, 0.36, 1), border-color 0.3s ease;
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -1517,71 +1524,78 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       position: relative;
       font-family: inherit;
       font-size: inherit;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04), 0 4px 12px rgba(0, 0, 0, 0.03);
     }
 
     .lp-tutor-card:hover {
-      transform: translateY(-6px);
-      box-shadow: 0 12px 32px rgba(18, 179, 179, 0.18);
-      border-color: var(--clr-primary-teal);
+      transform: translateY(-8px);
+      box-shadow: 0 12px 40px rgba(18, 179, 179, 0.14), 0 4px 12px rgba(0, 0, 0, 0.06);
+      border-color: rgba(18, 179, 179, 0.3);
     }
 
     .lp-tutor-card:active {
-      transform: translateY(-2px);
+      transform: translateY(-3px);
+      transition-duration: 0.1s;
     }
 
     .lp-tutor-card-img {
-      width: 100px;
-      height: 100px;
+      width: 96px;
+      height: 96px;
       border-radius: 50%;
       object-fit: cover;
       object-position: top;
-      border: 3px solid #e8ecf0;
-      margin-bottom: 0.75rem;
-      transition: border-color 0.25s ease;
+      border: 3px solid #f0f2f5;
+      margin-bottom: 1rem;
+      transition: border-color 0.3s ease, box-shadow 0.3s ease;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
     }
 
     .lp-tutor-card:hover .lp-tutor-card-img {
-      border-color: var(--clr-primary-teal);
+      border-color: rgba(18, 179, 179, 0.4);
+      box-shadow: 0 4px 16px rgba(18, 179, 179, 0.15);
     }
 
     .lp-tutor-card-info h3 {
       font-size: 1.1rem;
       font-weight: 700;
-      margin: 0 0 0.25rem;
+      margin: 0 0 0.3rem;
       color: var(--clr-text);
+      letter-spacing: -0.01em;
     }
 
     .lp-tutor-card-catch {
-      font-size: 0.82rem;
+      font-size: 0.8rem;
       color: var(--clr-primary-teal);
       font-weight: 600;
-      margin: 0 0 0.2rem;
+      margin: 0 0 0.35rem;
       font-style: italic;
+      line-height: 1.35;
     }
 
     .lp-tutor-card-spec {
       font-size: 0.78rem;
       color: var(--clr-text-dim);
       margin: 0;
-      line-height: 1.4;
+      line-height: 1.5;
     }
 
     .lp-tutor-card-hear {
       display: inline-flex;
       align-items: center;
-      gap: 4px;
-      margin-top: 0.75rem;
+      gap: 5px;
+      margin-top: 0.85rem;
       font-size: 0.75rem;
       color: var(--clr-accent-hotpink);
       font-weight: 600;
-      padding: 4px 10px;
+      padding: 5px 12px;
       border-radius: 20px;
-      background: rgba(255, 59, 127, 0.06);
-      transition: background 0.2s;
+      background: rgba(255, 59, 127, 0.05);
+      transition: background 0.2s, transform 0.2s;
     }
 
     .lp-tutor-card-hear:hover {
-      background: rgba(255, 59, 127, 0.14);
+      background: rgba(255, 59, 127, 0.12);
+      transform: scale(1.04);
     }
 
     /* ── Celebration Overlay ────────────────────────────── */
@@ -1976,7 +1990,19 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
     /* ── Dark mode overrides for trial chat UI ───────── */
     [data-theme="dark"] .lp-tutor-card {
-      border-color: #334155;
+      border-color: rgba(255, 255, 255, 0.08);
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2), 0 4px 12px rgba(0, 0, 0, 0.15);
+    }
+    [data-theme="dark"] .lp-tutor-card:hover {
+      border-color: rgba(18, 179, 179, 0.35);
+      box-shadow: 0 12px 40px rgba(18, 179, 179, 0.12), 0 4px 12px rgba(0, 0, 0, 0.2);
+    }
+    [data-theme="dark"] .lp-tutor-card-img {
+      border-color: rgba(255, 255, 255, 0.1);
+    }
+    [data-theme="dark"] .lp-trust-bar {
+      background: rgba(18, 179, 179, 0.04);
+      border-color: rgba(18, 179, 179, 0.1);
     }
     [data-theme="dark"] .lp-tutor-card:hover {
       box-shadow: 0 12px 32px rgba(18, 179, 179, 0.25);
@@ -2059,9 +2085,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </a>
     </div>
     <nav class="landing-nav">
-      <a href="/pricing.html" class="btn btn-primary-outline" style="border-color: transparent; color: var(--clr-text-dim);">Pricing</a>
-      <a href="/login.html" class="btn btn-primary-outline">Log In</a>
-      <a href="/signup.html" class="btn btn-primary">Start Free Now</a>
+      <a href="/pricing.html" class="btn btn-primary-outline" style="border-color: transparent; color: var(--clr-text-dim); font-weight: 500;">Pricing</a>
+      <a href="/login.html" class="btn btn-primary-outline" style="font-weight: 500;">Log In</a>
+      <a href="/signup.html" class="btn btn-primary" style="font-weight: 600; letter-spacing: 0.01em;">Start Free Now</a>
     </nav>
   </header>
 

--- a/public/index.html
+++ b/public/index.html
@@ -1484,6 +1484,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       text-align: center;
     }
 
+    .lp-hero-pick-inner .lp-hero-sub {
+      margin-left: auto;
+      margin-right: auto;
+    }
+
     .lp-hero-eyebrow {
       font-size: 0.85rem;
       font-weight: 600;

--- a/public/js/returningUserModal.js
+++ b/public/js/returningUserModal.js
@@ -20,6 +20,7 @@ class ReturningUserModal {
      *   { action: 'new-course', courseSessionId: '...' }
      *   { action: 'resume-chat', conversationId: '...' }
      *   { action: 'resume-course', courseSessionId: '...', conversationId: '...' }
+     *   { action: 'browse-courses' }
      *   { action: 'skip' } — if not a returning user
      */
     async show(currentUser) {
@@ -73,6 +74,9 @@ class ReturningUserModal {
                 greeting.textContent = `${timeGreeting}, ${name}!`;
             }
 
+            // Render smart resume hero
+            this.renderHero();
+
             // Render courses
             this.renderCourses();
 
@@ -91,6 +95,100 @@ class ReturningUserModal {
             // Show modal using the is-visible class (matches other modals)
             this.modal.classList.add('is-visible');
         });
+    }
+
+    renderHero() {
+        const section = document.getElementById('returning-hero-section');
+        if (!section) return;
+
+        const sessions = this.data.recentSessions || [];
+        const courses = this.data.courses || [];
+        const latestSession = sessions[0] || null;
+        const latestCourse = courses[0] || null;
+
+        if (!latestSession && !latestCourse) {
+            section.style.display = 'none';
+            return;
+        }
+
+        section.style.display = 'block';
+        section.innerHTML = '';
+
+        const label = document.createElement('div');
+        label.className = 'returning-section-label';
+        label.innerHTML = '<i class="fas fa-bolt"></i> Pick up where you left off';
+        section.appendChild(label);
+
+        // Primary: most recent tutoring session
+        if (latestSession) {
+            const card = document.createElement('div');
+            card.className = 'returning-hero-card returning-hero-primary';
+            card.innerHTML = `
+                <span class="returning-hero-emoji">${latestSession.topicEmoji || '💬'}</span>
+                <div class="returning-hero-info">
+                    <div class="returning-hero-name">${this.escapeHtml(latestSession.name)}</div>
+                    <div class="returning-hero-meta">${this.escapeHtml(latestSession.lastMessage || '')}</div>
+                </div>
+                <div class="returning-hero-action">
+                    <span class="returning-hero-time">${this.formatRelativeTime(latestSession.lastActivity)}</span>
+                    <i class="fas fa-arrow-right"></i>
+                </div>
+            `;
+            card.addEventListener('click', () => {
+                this.close();
+                this.resolveChoice({
+                    action: 'resume-chat',
+                    conversationId: latestSession._id
+                });
+            });
+            section.appendChild(card);
+        }
+
+        // Secondary: most recent course OR browse courses
+        if (latestCourse) {
+            const statusLabel = latestCourse.status === 'paused'
+                ? 'Paused'
+                : latestCourse.currentModuleLabel || 'In Progress';
+
+            const card = document.createElement('div');
+            card.className = 'returning-hero-card returning-hero-secondary';
+            card.innerHTML = `
+                <span class="returning-hero-emoji">📘</span>
+                <div class="returning-hero-info">
+                    <div class="returning-hero-name">${this.escapeHtml(latestCourse.courseName)}</div>
+                    <div class="returning-hero-meta">${this.escapeHtml(statusLabel)} &middot; ${latestCourse.overallProgress}%</div>
+                </div>
+                <div class="returning-hero-action">
+                    <i class="fas fa-arrow-right"></i>
+                </div>
+            `;
+            card.addEventListener('click', () => {
+                this.close();
+                this.resolveChoice({
+                    action: 'new-course',
+                    courseSessionId: latestCourse.courseSessionId
+                });
+            });
+            section.appendChild(card);
+        } else {
+            const card = document.createElement('div');
+            card.className = 'returning-hero-card returning-hero-secondary';
+            card.innerHTML = `
+                <span class="returning-hero-emoji">📚</span>
+                <div class="returning-hero-info">
+                    <div class="returning-hero-name">Browse Courses</div>
+                    <div class="returning-hero-meta">Explore structured lessons and curricula</div>
+                </div>
+                <div class="returning-hero-action">
+                    <i class="fas fa-arrow-right"></i>
+                </div>
+            `;
+            card.addEventListener('click', () => {
+                this.close();
+                this.resolveChoice({ action: 'browse-courses' });
+            });
+            section.appendChild(card);
+        }
     }
 
     renderCourses() {

--- a/public/js/returningUserModal.js
+++ b/public/js/returningUserModal.js
@@ -10,6 +10,7 @@ class ReturningUserModal {
         this.modal = null;
         this.data = null;
         this.resolveChoice = null; // Promise resolver for the user's choice
+        this._sessionsShowAll = false;
     }
 
     /**
@@ -147,7 +148,7 @@ class ReturningUserModal {
                 });
             });
 
-            // Add existing course chats
+            // Add existing course chats (limited with "See more" toggle)
             const chatsContainer = card.querySelector('.returning-course-chats');
             if (course.conversations && course.conversations.length > 0) {
                 const divider = document.createElement('div');
@@ -155,7 +156,12 @@ class ReturningUserModal {
                 divider.textContent = 'Or continue a chat:';
                 chatsContainer.appendChild(divider);
 
-                course.conversations.forEach(conv => {
+                const courseDefaultShow = 3;
+                const courseKey = `_courseChatsShowAll_${course.courseSessionId}`;
+                const showAll = this[courseKey];
+                const convsToShow = showAll ? course.conversations : course.conversations.slice(0, courseDefaultShow);
+
+                convsToShow.forEach(conv => {
                     const chatItem = this.createChatItem(conv, () => {
                         this.close();
                         this.resolveChoice({
@@ -166,6 +172,19 @@ class ReturningUserModal {
                     });
                     chatsContainer.appendChild(chatItem);
                 });
+
+                if (course.conversations.length > courseDefaultShow) {
+                    const seeMoreBtn = document.createElement('button');
+                    seeMoreBtn.className = 'returning-see-more-btn';
+                    seeMoreBtn.textContent = showAll
+                        ? 'Show less'
+                        : `See ${course.conversations.length - courseDefaultShow} more`;
+                    seeMoreBtn.addEventListener('click', () => {
+                        this[courseKey] = !this[courseKey];
+                        this.renderCourses();
+                    });
+                    chatsContainer.appendChild(seeMoreBtn);
+                }
             }
 
             list.appendChild(card);
@@ -186,7 +205,10 @@ class ReturningUserModal {
         section.style.display = 'block';
         list.innerHTML = '';
 
-        sessions.forEach(session => {
+        const defaultShow = 3;
+        const sessionsToShow = this._sessionsShowAll ? sessions : sessions.slice(0, defaultShow);
+
+        sessionsToShow.forEach(session => {
             const chatItem = this.createChatItem(
                 {
                     _id: session._id,
@@ -205,6 +227,20 @@ class ReturningUserModal {
             );
             list.appendChild(chatItem);
         });
+
+        // "See more" / "Show less" toggle
+        if (sessions.length > defaultShow) {
+            const seeMoreBtn = document.createElement('button');
+            seeMoreBtn.className = 'returning-see-more-btn';
+            seeMoreBtn.textContent = this._sessionsShowAll
+                ? 'Show less'
+                : `See ${sessions.length - defaultShow} more`;
+            seeMoreBtn.addEventListener('click', () => {
+                this._sessionsShowAll = !this._sessionsShowAll;
+                this.renderSessions();
+            });
+            list.appendChild(seeMoreBtn);
+        }
     }
 
     createChatItem(conv, onClick) {

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -374,6 +374,13 @@ document.addEventListener("DOMContentLoaded", () => {
                     }
                     modalHandled = true;
 
+                } else if (choice.action === 'browse-courses') {
+                    // Open the course catalogue
+                    modalHandled = false; // Still show welcome flow
+                    if (window.courseManager) {
+                        setTimeout(() => window.courseManager.openCatalog(), 500);
+                    }
+
                 } else if (choice.action === 'new-general') {
                     // Start a fresh general session — fall through to normal welcome flow
                     modalHandled = false;

--- a/public/style.css
+++ b/public/style.css
@@ -26,18 +26,18 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 12px var(--page-horizontal-padding);
-    background-color: rgba(255, 255, 255, 0.92);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-    box-shadow: 0 1px 0 rgba(0, 0, 0, 0.06);
+    padding: 14px var(--page-horizontal-padding);
+    background-color: rgba(255, 255, 255, 0.95);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04), 0 1px 0 rgba(0, 0, 0, 0.03);
     flex-shrink: 0;
     flex-wrap: nowrap;
     z-index: var(--z-header);
     position: sticky;
     top: 0;
     min-height: var(--header-height);
-    gap: var(--space-2);
+    gap: var(--space-3);
 }
 
 .header-logo-container {
@@ -70,7 +70,7 @@
 
 .landing-nav {
     display: flex;
-    gap: var(--space-2);
+    gap: var(--space-3);
     flex-shrink: 0;
     align-items: center;
     flex-wrap: nowrap;


### PR DESCRIPTION
## Summary
This PR enhances the returning user modal with a new "Smart Resume Hero" section that prominently displays the user's most recent tutoring session and course, allowing them to quickly resume where they left off. It also adds "See more" / "Show less" toggles for expanded chat lists.

## Key Changes

### Returning User Modal Enhancements
- **New Smart Resume Hero Section**: Displays the most recent tutoring session as a primary card and the most recent course (or "Browse Courses" fallback) as a secondary card
  - Primary card shows session name, last message preview, and time since last activity
  - Secondary card shows course name, status/progress, and completion percentage
  - Both cards are clickable and trigger appropriate actions
  - Includes smooth hover animations and transitions

- **Collapsible Chat Lists**: Added "See more" / "Show less" toggle buttons for:
  - Recent tutoring sessions (shows 3 by default)
  - Course-specific conversations (shows 3 by default)
  - Maintains toggle state per course using instance properties

- **New Action Type**: Added `browse-courses` action to allow users to explore the course catalog when no courses are in progress

### Styling
- Added comprehensive CSS for hero cards with light and dark mode support
- Gradient backgrounds for primary cards with shadow effects
- Responsive hover states with icon animations
- Styled "See more" toggle buttons with smooth transitions
- Dark mode overrides for secondary cards and toggle buttons

### Landing Page Polish
- Refined hero section gradient and padding
- Updated tutor card styling with improved shadows and transitions
- Enhanced trust bar with background and border styling
- Adjusted typography (font weights, letter spacing) throughout
- Improved header styling with better backdrop blur and shadows
- Updated button styling in navigation with font weight adjustments

### Implementation Details
- Hero section renders before courses in the modal flow
- Uses `escapeHtml()` for XSS protection on user-generated content
- Relative time formatting for session timestamps
- Emoji support for topic identification
- Graceful fallback to "Browse Courses" when no courses exist

https://claude.ai/code/session_011UiHHWrWyZm8PiribPxbDT