### PR TITLE
Fix showToast ReferenceError in gamification.js

### DIFF
--- a/public/js/modules/gamification.js
+++ b/public/js/modules/gamification.js
@@ -1,7 +1,7 @@
 // modules/gamification.js
 // XP system, level celebrations, leaderboard, quests, tutor unlocks
 
-import { triggerConfetti } from './helpers.js';
+import { triggerConfetti, showToast } from './helpers.js';
 
 /**
  * Show level-up celebration modal with tutor video


### PR DESCRIPTION
Add missing showToast import from helpers.js module, which was causing an uncaught ReferenceError in showUnlockProximityTeaser.

https://claude.ai/code/session_01Jz8f7YQzfr85JtR5jKDxx2