### PR TITLE
Name course conversations after their module, not the course

### DIFF
--- a/routes/conversations.js
+++ b/routes/conversations.js
@@ -3,6 +3,8 @@
 
 const express = require('express');
 const router = express.Router();
+const fs = require('fs');
+const path = require('path');
 const { isAuthenticated } = require('../middleware/auth');
 const { validateObjectId } = require('../middleware/validateObjectId');
 const {
@@ -109,11 +111,23 @@ router.get('/returning-user-data', isAuthenticated, async (req, res) => {
         };
       });
 
-      // Format current module name
-      const modLabel = (cs.currentModuleId || '')
-        .replace(/^mod-/, '')
-        .replace(/-/g, ' ')
-        .replace(/\b\w/g, c => c.toUpperCase());
+      // Resolve current module title from pathway file
+      let modLabel = '';
+      try {
+        const pwFile = path.join(__dirname, '../public/resources', `${cs.courseId}-pathway.json`);
+        if (fs.existsSync(pwFile)) {
+          const pw = JSON.parse(fs.readFileSync(pwFile, 'utf8'));
+          const mod = (pw.modules || []).find(m => m.moduleId === cs.currentModuleId);
+          if (mod?.title) modLabel = mod.title;
+        }
+      } catch (e) { /* non-critical */ }
+      // Fallback: convert moduleId to a readable label
+      if (!modLabel) {
+        modLabel = (cs.currentModuleId || '')
+          .replace(/^mod-/, '')
+          .replace(/[_-]/g, ' ')
+          .replace(/\b\w/g, c => c.toUpperCase());
+      }
 
       courses.push({
         courseSessionId: cs._id,
@@ -190,11 +204,24 @@ router.post('/new-course-session', isAuthenticated, async (req, res) => {
       return res.status(404).json({ message: 'Course session not found' });
     }
 
+    // Resolve the current module title for a meaningful conversation name
+    let moduleName = courseSession.courseName;
+    try {
+      const pathwayFile = path.join(__dirname, '../public/resources', `${courseSession.courseId}-pathway.json`);
+      if (fs.existsSync(pathwayFile)) {
+        const pathway = JSON.parse(fs.readFileSync(pathwayFile, 'utf8'));
+        const mod = (pathway.modules || []).find(m => m.moduleId === courseSession.currentModuleId);
+        if (mod?.title) moduleName = mod.title;
+      }
+    } catch (e) {
+      // Fall back to course name — non-critical
+    }
+
     // Create a fresh conversation for this course
     const newConversation = new Conversation({
       userId,
       conversationType: 'course',
-      conversationName: courseSession.courseName,
+      conversationName: moduleName,
       topic: courseSession.courseName,
       messages: []
     });

--- a/routes/courseChat.js
+++ b/routes/courseChat.js
@@ -117,9 +117,11 @@ router.post('/', async (req, res) => {
         }
         if (!conversation) {
             // Create a fresh conversation for this course
+            // Name it after the current module so sessions are distinguishable
+            const moduleName = currentPathwayModule.title || courseSession.courseName;
             conversation = new Conversation({
                 userId: user._id,
-                conversationName: courseSession.courseName,
+                conversationName: moduleName,
                 topic: courseSession.courseName,
                 topicEmoji: '📚',
                 conversationType: 'topic'


### PR DESCRIPTION
Course conversations were all named "AP Calculus AB" (or whatever the course name was), making it impossible to tell them apart. Now:

- courseChat.js: new conversations get the current module title (e.g. "Limits & Continuity") instead of the course name
- conversations.js new-course-session: same module-title naming
- returning-user-data: currentModuleLabel now resolves the real pathway title instead of hackily converting the moduleId string

Existing conversations keep their old names; new ones going forward will be distinguishable in the sidebar and returning user modal.

https://claude.ai/code/session_011UiHHWrWyZm8PiribPxbDT