### PR TITLE
Fix 10→30 minutes on login page and make thinking indicator single-line

### DIFF
--- a/public/css/base/chat.css
+++ b/public/css/base/chat.css
@@ -796,7 +796,8 @@
   flex-shrink: 0;
   font-size: 0.9em;
   color: #8e8e93;
-  max-width: 120px;
+  max-width: fit-content;
+  white-space: nowrap;
   align-self: flex-start;
   box-shadow: none;
 }

--- a/public/login.html
+++ b/public/login.html
@@ -140,7 +140,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           No account needed. Explore as a teacher, parent, or student.
         </p>
         <p class="lp-post-launch" style="display:none; font-size: 0.85rem; color: var(--clr-text-dim, #5B6876);">
-          <a href="/signup.html" style="color: #7C3AED; font-weight: 600; text-decoration: none;">Sign up free</a> — get 10 minutes of AI tutoring every week.
+          <a href="/signup.html" style="color: #7C3AED; font-weight: 600; text-decoration: none;">Sign up free</a> — get 30 minutes of AI tutoring every week.
         </p>
       </div>
     </div>


### PR DESCRIPTION
- Updated login.html signup CTA from "10 minutes" to "30 minutes"
- Changed thinking indicator max-width from 120px to fit-content with white-space: nowrap so dots + text display on one line

https://claude.ai/code/session_01Sp7sp4SeRmPD6GwCgy7pnf