### PR TITLE
Add false-affirmation guard to prevent confusing student feedback

### DIFF
--- a/utils/pipeline/generate.js
+++ b/utils/pipeline/generate.js
@@ -65,15 +65,17 @@ function buildActionPrompt(decision) {
       parts.push('2. Then ask them to apply the same method to their problem');
       parts.push('3. If STILL stuck, offer to skip and move on');
       parts.push('NEVER reveal the answer. The answer stays hidden. Always.');
+      parts.push('Do NOT say "That\'s right", "Correct", or any affirmation — the student did not answer correctly.');
       break;
 
     case ACTIONS.SCAFFOLD_DOWN:
-      parts.push('Student needs more support. Lower the barrier:');
+      parts.push('The student said they don\'t know or needs more support. Lower the barrier:');
       if (decision.scaffoldLevel >= 5) {
         parts.push('Rephrase as a yes/no or multiple-choice question.');
       } else {
         parts.push('Break the problem into a simpler sub-question.');
       }
+      parts.push('CRITICAL: The student did NOT answer the question. Do NOT say "That\'s right", "Correct", "Exactly", "Great job", or any affirmation. They did not provide an answer to affirm.');
       break;
 
     case ACTIONS.HINT:

--- a/utils/pipeline/index.js
+++ b/utils/pipeline/index.js
@@ -212,6 +212,8 @@ async function runPipeline(message, ctx) {
     firstName: ctx.user.firstName,
     isStreaming: ctx.stream || false,
     res: ctx.res || null,
+    action: decision.action,
+    messageType: observation.messageType,
   });
 
   console.log(`[Pipeline] Verify: ${verified.flags.length > 0 ? verified.flags.join(', ') : 'clean'}`);

--- a/utils/pipeline/verify.js
+++ b/utils/pipeline/verify.js
@@ -16,6 +16,8 @@ const { enforceVisualTeaching } = require('../visualCommandEnforcer');
 const { parseVisualTeaching } = require('../visualTeachingParser');
 const { processAIResponse } = require('../chatBoardParser');
 const { callLLM } = require('../llmGateway');
+const { ACTIONS } = require('./decide');
+const { MESSAGE_TYPES } = require('./observe');
 
 const PRIMARY_CHAT_MODEL = 'gpt-4o-mini';
 
@@ -168,6 +170,30 @@ async function verify(responseText, context = {}) {
       try {
         context.res.write(`data: ${JSON.stringify({ type: 'replacement', content: text })}\n\n`);
       } catch (e) { /* client disconnected */ }
+    }
+  }
+
+  // ── 2b. False-affirmation guard ──
+  // When the student didn't answer (IDK, give-up, etc.), the AI must NOT
+  // say "That's right!", "Correct!", etc. — it confuses students into
+  // thinking they answered correctly. Strip the leading affirmation.
+  if (context.action && context.messageType) {
+    const noAnswerActions = [ACTIONS.SCAFFOLD_DOWN, ACTIONS.EXIT_RAMP, ACTIONS.HINT, ACTIONS.ACKNOWLEDGE_FRUSTRATION];
+    const noAnswerTypes = [MESSAGE_TYPES.IDK, MESSAGE_TYPES.GIVE_UP, MESSAGE_TYPES.HELP_REQUEST, MESSAGE_TYPES.FRUSTRATION];
+
+    if (noAnswerActions.includes(context.action) || noAnswerTypes.includes(context.messageType)) {
+      const falseAffirmation = /^(that'?s\s+right[.!]*|correct[.!]*|exactly[.!]*|great\s+job[.!]*|perfect[.!]*|well\s+done[.!]*|yes[.!]*|you\s+got\s+it[.!]*|right\s+on[.!]*|bingo[.!]*)\s*/i;
+      if (falseAffirmation.test(text.trim())) {
+        text = text.trim().replace(falseAffirmation, '').trim();
+        flags.push('false_affirmation_stripped');
+        console.log(`[Verify] Stripped false affirmation (action: ${context.action}, messageType: ${context.messageType})`);
+
+        if (context.isStreaming && context.res) {
+          try {
+            context.res.write(`data: ${JSON.stringify({ type: 'replacement', content: text })}\n\n`);
+          } catch (e) { /* client disconnected */ }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
This PR adds a "false-affirmation guard" to the verification pipeline that strips misleading positive feedback when students haven't actually answered a question. This prevents confusing students into thinking they answered correctly when they said "I don't know," gave up, asked for help, or expressed frustration.

## Key Changes

- **verify.js**: Added a new verification step (2b) that detects and removes false affirmations (e.g., "That's right!", "Correct!", "Great job!") when:
  - The student's action indicates they need support (SCAFFOLD_DOWN, EXIT_RAMP, HINT, ACKNOWLEDGE_FRUSTRATION)
  - The student's message type indicates no answer was provided (IDK, GIVE_UP, HELP_REQUEST, FRUSTRATION)
  - Uses regex pattern matching to identify common affirmation phrases (case-insensitive)
  - Logs the removal and flags it as `false_affirmation_stripped`
  - For streaming responses, sends a replacement message to the client with the corrected text

- **generate.js**: Enhanced action prompts to explicitly instruct the LLM not to use affirmations:
  - Added guidance to HINT action to never reveal the answer and avoid affirmations
  - Updated SCAFFOLD_DOWN action description to clarify the student didn't answer
  - Added critical instruction to avoid affirmations when scaffolding down

- **index.js**: Updated pipeline context to pass decision action and observation messageType to the verify function, enabling the false-affirmation guard to make informed decisions

## Implementation Details
The false-affirmation detection uses a comprehensive regex pattern covering common positive phrases: "that's right", "correct", "exactly", "great job", "perfect", "well done", "yes", "you got it", "right on", and "bingo". The guard operates as a safety net after LLM generation, ensuring student confusion is prevented regardless of prompt adherence.

https://claude.ai/code/session_017iQ6Brb69sz9WeLJYLDDZC