### PR TITLE
Fix CSP blocking inline scripts on static HTML pages

### DIFF
--- a/public/oauth-enrollment.html
+++ b/public/oauth-enrollment.html
@@ -21,13 +21,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
   <header class="landing-header">
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-WDF79L47');</script>
-<!-- End Google Tag Manager -->
     <div class="header-logo-container">
       <img src="/images/mathmatix-ai-logo.png" alt="Mathmatix AI Logo" class="main-logo-hero" />
     </div>

--- a/server.js
+++ b/server.js
@@ -937,6 +937,23 @@ app.get("/fact-fluency-practice.html", (req, res) => res.redirect(301, "/fact-fl
 // IMPORTANT: This must come AFTER all HTML route definitions to ensure authentication checks run first
 // Cache static assets (JS, CSS, images, fonts) so browsers don't re-download on every page load
 const staticCacheOptions = { maxAge: '1d', etag: true, lastModified: true };
+// Serve HTML files via res.sendFile() so the CSP nonce middleware can inject nonces
+// into inline <script> tags. express.static bypasses res.sendFile(), so without this,
+// inline scripts in static HTML files are blocked by the CSP nonce policy.
+app.use((req, res, next) => {
+  if (req.method === 'GET' && req.path.endsWith('.html')) {
+    const publicDir = path.join(__dirname, 'public');
+    const filePath = path.resolve(publicDir, req.path.replace(/^\/+/, ''));
+    // Prevent path traversal — ensure resolved path stays within public/
+    if (!filePath.startsWith(publicDir + path.sep)) return next();
+    fs.access(filePath, fs.constants.F_OK, (err) => {
+      if (err) return next(); // File doesn't exist, fall through
+      res.sendFile(filePath);
+    });
+  } else {
+    next();
+  }
+});
 app.use(express.static(path.join(__dirname, "public"), staticCacheOptions));
 app.use('/images', express.static(path.join(__dirname, 'public', 'images'), staticCacheOptions));
 


### PR DESCRIPTION
## Summary

- **Root cause:** `express.static()` bypasses `res.sendFile()`, so the CSP nonce injection middleware never ran for static HTML files like `oauth-enrollment.html`. Since a nonce is present in the CSP header, browsers ignore `unsafe-inline`, blocking all inline scripts — causing the page to get stuck on the loading spinner.
- **Fix:** Added a middleware before `express.static` that intercepts `.html` requests and serves them via `res.sendFile()`, ensuring nonces are properly injected into all inline `<script>` tags. Includes path traversal protection.
- **Cleanup:** Removed duplicate Google Tag Manager snippet from `oauth-enrollment.html` (was in both `<head>` and `<header>`).

## Test plan

- [ ] Visit `/oauth-enrollment.html` and verify the page loads past the spinner (no longer stuck on loading screen)
- [ ] Open browser DevTools console and confirm no CSP `script-src` violations
- [ ] Verify inline scripts execute correctly (OAuth profile fetch, form submission, cancel button)
- [ ] Check other static HTML pages (e.g., `/login.html`, `/signup.html`) still work correctly
- [ ] Inspect response headers to confirm nonce is present in both the CSP header and inline `<script>` tags

https://claude.ai/code/session_01QZ2nhHbjL5xA7fWLMxn57k