### PR TITLE
Enable drag-and-drop of resource files into chat

### DIFF
--- a/public/js/file-upload.js
+++ b/public/js/file-upload.js
@@ -37,9 +37,10 @@ class FileUploadManager {
             document.body.addEventListener(eventName, this.preventDefaults, false);
         });
 
-        // Show overlay on drag enter
+        // Show overlay on drag enter (OS files OR resource cards)
         chatContainer.addEventListener('dragenter', (e) => {
-            if (e.dataTransfer.types.includes('Files')) {
+            if (e.dataTransfer.types.includes('Files') ||
+                e.dataTransfer.types.includes('application/x-teacher-resource-id')) {
                 this.showDragOverlay();
             }
         });
@@ -51,10 +52,20 @@ class FileUploadManager {
             }
         });
 
-        // Handle drop
+        // Handle drop (OS files OR resource cards dragged from the resources panel)
         this.dragDropOverlay.addEventListener('drop', (e) => {
             this.preventDefaults(e);
             this.hideDragOverlay();
+
+            // Check for teacher-resource drag from the resources panel
+            const resourceId = e.dataTransfer.getData('application/x-teacher-resource-id');
+            if (resourceId) {
+                const resourceName = e.dataTransfer.getData('application/x-teacher-resource-name') || 'Resource';
+                if (typeof fetchAndUploadTeacherResource === 'function') {
+                    fetchAndUploadTeacherResource(resourceId, resourceName);
+                }
+                return;
+            }
 
             const files = [...e.dataTransfer.files];
             if (files.length > 0) {

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -3231,7 +3231,7 @@ document.addEventListener("DOMContentLoaded", () => {
      * Fetch a teacher resource by ID and feed it into the file upload pipeline,
      * exactly as if the student had dragged the PDF file from their computer.
      */
-    async function fetchAndUploadTeacherResource(resourceId, resourceName) {
+    window.fetchAndUploadTeacherResource = async function fetchAndUploadTeacherResource(resourceId, resourceName) {
         showToast(`Loading "${resourceName}"...`, 2500);
         try {
             const response = await fetch(`/api/teacher-resources/download/${resourceId}`);

--- a/public/js/student-resources.js
+++ b/public/js/student-resources.js
@@ -66,7 +66,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
-    // Drag-to-chat
+    // Drag-to-chat: close modal so the chat drop-zone is visible
     resourcesContent?.addEventListener('dragstart', (e) => {
         const card = e.target.closest('[data-resource-id]');
         if (!card) return;
@@ -77,6 +77,10 @@ document.addEventListener('DOMContentLoaded', () => {
         e.dataTransfer.effectAllowed = 'copy';
 
         card.style.opacity = '0.5';
+
+        // Collapse the modal after a tiny delay so the drag image is captured first
+        setTimeout(() => closeModal(), 50);
+
         card.addEventListener('dragend', () => { card.style.opacity = ''; }, { once: true });
     });
 


### PR DESCRIPTION
## Summary
- **Closes the resources modal on drag start** so the chat drop-zone becomes visible as a target
- **Shows the drag overlay for resource card drags**, not just OS file drops — gives students visual feedback ("Drop your files here")
- **Handles resource drops in the overlay** by fetching the file via `/api/teacher-resources/download/:id`, converting it to a `File` object, and feeding it into the existing `handleFileUpload` pipeline
- **Exposes `fetchAndUploadTeacherResource` on `window`** so `file-upload.js` can call it (was previously scoped inside the script.js IIFE)

## How it works
1. Student opens Resources panel and starts dragging a resource card
2. Modal auto-closes after 50ms (delay lets browser capture the drag image first)
3. Drag overlay appears over the chat area with drop target visual
4. On drop, the resource file is fetched from the server, wrapped as a `File`, and attached to chat — identical to dragging a file from the desktop

## Test plan
- [ ] Open resources modal, drag a teacher resource card toward the chat area
- [ ] Verify the modal closes and the drop overlay appears
- [ ] Drop the resource and confirm it attaches as a file pill in the chat input
- [ ] Verify the "Ask Tutor About This" button still works independently
- [ ] Verify regular OS file drag-and-drop still works as before
- [ ] Test on mobile (drag-to-chat is desktop-only; modal should still function normally)

https://claude.ai/code/session_01SbJ5b5Cj7ebhc1gQVayjFg