### PR TITLE
Fix trial chat not passing user message to LLM pipeline

### DIFF
--- a/routes/trialChat.js
+++ b/routes/trialChat.js
@@ -293,10 +293,13 @@ CRITICAL FOR THIS RESPONSE: You MUST end your response with a question or a next
     }
 
     // ── Build pipeline context ──
-    const { conversation, user } = buildTrialPipelineContext(sanitizedHistory);
+    // Include the current user message so the pipeline and LLM can see it
+    // (mirrors chat.js which pushes to activeConversation.messages before building formattedMessages)
+    const historyWithCurrentMessage = [...sanitizedHistory, { role: 'user', content: sanitizedMessage }];
+    const { conversation, user } = buildTrialPipelineContext(historyWithCurrentMessage);
 
-    // Format messages for LLM (same format as chat.js)
-    const formattedMessages = sanitizedHistory.map(m => ({ role: m.role, content: m.content }));
+    // Format messages for LLM (same format as chat.js — includes current user message)
+    const formattedMessages = historyWithCurrentMessage.map(m => ({ role: m.role, content: m.content }));
 
     // ── Run the full pipeline (observe → diagnose → decide → generate → verify) ──
     // skipPersist=true means no DB writes — everything else runs identically.

--- a/utils/pipeline/observe.js
+++ b/utils/pipeline/observe.js
@@ -55,7 +55,7 @@ const PATTERNS = {
   checkMyWork: /\b(check|verify|grade|review|is\s*this\s*right|is\s*this\s*correct|did\s*i\s*(get|do)\s*(it|this)\s*right|am\s*i\s*right|how'?d\s*i\s*do)\b/i,
 
   // Questions about math
-  question: /^(what|why|how|when|where|can\s*you|could\s*you|is\s*it|does|do|will|would|should|explain)\b/i,
+  question: /^(what|why|how|when|where|can\s*you|could\s*you|is\s*it|does|do|will|would|should|explain|find|solve|calculate|compute|evaluate|determine|simplify|factor|graph|prove|derive|convert|estimate)\b/i,
 
   // Greetings
   greeting: /^(hi|hey|hello|yo|sup|what'?s\s*up|good\s*(morning|afternoon|evening))\b/i,


### PR DESCRIPTION
## Summary

- **Root cause**: Trial chat built `formattedMessages` and `conversation.messages` from `sanitizedHistory` (previous messages only), never including the current user message. The LLM literally never saw what the user typed/clicked, so it responded generically with "What math problem are you working on?"
- **Fix**: Append the current user message to the history before building the pipeline context and formatted messages, mirroring how main chat (`chat.js`) pushes the user message to `activeConversation.messages` before building `formattedMessagesForLLM`
- **Bonus**: Expanded the observe stage's QUESTION regex to recognize imperative math verbs (`find`, `solve`, `calculate`, `factor`, `simplify`, etc.) so suggestion chip prompts like "Find the slope between (2,5) and (6,13)" get classified as `question` (confidence 1.0) instead of falling to the `general_math` default (confidence 0.5)

## Test plan

- [ ] Click each suggestion chip in trial chat and verify the AI responds to the actual math problem
- [ ] Verify typed messages in trial chat still work correctly
- [ ] Verify main chat is unaffected (no changes to chat.js)
- [ ] Check pipeline logs show `question` classification for chip prompts starting with "Find", "Solve", "Factor", etc.

https://claude.ai/code/session_01KsaJ8NJWPdFynQe6zaFE1v