### PR TITLE
Fix CORS middleware causing 500s on all fetch/module requests

### DIFF
--- a/config/middleware.js
+++ b/config/middleware.js
@@ -81,22 +81,10 @@ function configureMiddleware(app) {
     });
   }
 
-  // CORS — whitelist known origins
-  const allowedOrigins = (process.env.CORS_ORIGINS || process.env.CLIENT_URL || 'http://localhost:3000')
-    .split(',')
-    .map(o => o.trim());
-
+  // CORS — match original production config
   app.use(cors({
-    origin: (origin, callback) => {
-      // Allow requests with no origin (server-to-server, curl, mobile apps)
-      if (!origin) return callback(null, true);
-      if (allowedOrigins.includes(origin)) return callback(null, true);
-      callback(new Error(`Origin ${origin} not allowed by CORS`));
-    },
+    origin: process.env.CLIENT_URL || 'http://localhost:3000',
     credentials: true,
-    methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
-    allowedHeaders: ['Content-Type', 'Authorization', 'X-CSRF-Token', 'X-Request-Id'],
-    maxAge: 86400, // Cache preflight for 24h
   }));
 
   // Stripe webhook needs raw body — MUST be before express.json()


### PR DESCRIPTION
The refactored CORS config threw Error() for unknown origins, which Express caught and returned as 500. This broke all fetch/XHR requests AND all type="module" script loads (which send Origin headers).

Reverted to the original simple CORS config from main that doesn't throw errors.

https://claude.ai/code/session_01X5QWhLNUgt8CS4FHmdVQTr