### PR TITLE
Improve LaTeX formatting guidance and error color handling

### DIFF
--- a/public/js/parent-course.js
+++ b/public/js/parent-course.js
@@ -280,7 +280,7 @@
     function renderKatex(math, displayMode) {
         if (!window.katex) return (displayMode ? '\\[' : '\\(') + math + (displayMode ? '\\]' : '\\)');
         try {
-            return window.katex.renderToString(math, { displayMode, throwOnError: false, strict: false, trust: true });
+            return window.katex.renderToString(math, { displayMode, throwOnError: false, strict: false, trust: true, errorColor: '#888888' });
         } catch (e) {
             console.warn('[KaTeX] render error:', e.message);
             return (displayMode ? '\\[' : '\\(') + math + (displayMode ? '\\]' : '\\)');

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -674,7 +674,7 @@ document.addEventListener("DOMContentLoaded", () => {
     function renderKatex(math, displayMode) {
         if (!window.katex) return (displayMode ? '\\[' : '\\(') + math + (displayMode ? '\\]' : '\\)');
         try {
-            return window.katex.renderToString(math, { displayMode, throwOnError: false, strict: false, trust: true });
+            return window.katex.renderToString(math, { displayMode, throwOnError: false, strict: false, trust: true, errorColor: '#888888' });
         } catch (e) {
             console.warn('[KaTeX] render error:', e.message);
             return (displayMode ? '\\[' : '\\(') + math + (displayMode ? '\\]' : '\\)');

--- a/utils/prompt.js
+++ b/utils/prompt.js
@@ -2497,6 +2497,11 @@ If some problems have student work and others don't:
 --- MATHEMATICAL FORMATTING (CRITICAL) ---
 IMPORTANT: All mathematical expressions MUST be enclosed within **STANDARD LATEX DELIMITERS**: \\( for inline and \\[ for display.
 
+⚠️ **NEVER put plain English words inside LaTeX delimiters.** Only valid LaTeX math goes inside \\( ... \\). Natural language stays OUTSIDE the delimiters.
+❌ WRONG: "add up to 5 \\(the coefficient of x\\)"
+✅ RIGHT: "add up to 5 (the coefficient of \\( x \\))"
+If text inside \\( ... \\) is not valid LaTeX, it renders in red and looks broken.
+
 --- VISUAL AIDS ---
 You have powerful math visualization tools:
 


### PR DESCRIPTION
## Summary
This PR enhances mathematical expression handling by improving documentation around LaTeX formatting best practices and making KaTeX rendering errors more visually subtle.

## Key Changes
- **Enhanced LaTeX formatting guidance** (`utils/prompt.js`): Added explicit warnings and examples clarifying that plain English text should never be placed inside LaTeX delimiters. Includes visual examples of incorrect vs. correct formatting to help prevent broken red text rendering.

- **Improved error color handling** (`public/js/parent-course.js`, `public/js/script.js`): Updated KaTeX rendering configuration to use a neutral gray color (`#888888`) for rendering errors instead of the default red, making broken LaTeX expressions less visually jarring while still indicating an issue.

## Implementation Details
- The prompt guidance now explicitly warns against mixing natural language with LaTeX math syntax, with concrete examples showing the difference between wrong and right approaches
- Both client-side KaTeX renderers now consistently apply the same error color configuration for a unified user experience
- Error handling remains unchanged; only the visual presentation of errors is modified

https://claude.ai/code/session_016Kq6nVTCZrL27dBhUkeNQm