### PR TITLE
Fix accuracy displaying 3000% instead of correct percentage

### DIFF
--- a/public/js/modules/assessment.js
+++ b/public/js/modules/assessment.js
@@ -286,7 +286,7 @@ ${data.problem.content}`;
 
 You did great! Here's what I learned:
 • **Level**: θ = ${report.theta.toFixed(2)} (${report.percentile}th percentile)
-• **Accuracy**: ${Math.round(report.accuracy * 100)}%
+• **Accuracy**: ${report.accuracy}%
 • **Questions**: ${report.questionsAnswered}${badgeInfo}
 
 I now have a good understanding of where you are. I'll use this to personalize everything for you!


### PR DESCRIPTION
## Summary

- **Bug**: Assessment completion screen showed "Accuracy: 3000%" instead of "30%"
- **Root cause**: Backend (`adaptiveScreener.js:513`) already converts accuracy from decimal to percentage (`accuracy * 100`), but the frontend (`assessment.js:289`) was multiplying by 100 again
- **Fix**: Removed the redundant `* 100` multiplication in the frontend display

## Test plan

- [ ] Complete an assessment and verify accuracy displays correctly (e.g., 30% not 3000%)
- [ ] Verify edge cases: 0% accuracy, 100% accuracy

https://claude.ai/code/session_0157yJxWmiNxiyCFTV69MkBM