### PR TITLE
Add ChatGPT-style auto-visualization for math topics

### DIFF
--- a/tests/unit/autoVisualize.test.js
+++ b/tests/unit/autoVisualize.test.js
@@ -1,0 +1,199 @@
+const { autoVisualizeByTopic } = require('../../utils/visualCommandEnforcer');
+
+describe('autoVisualizeByTopic', () => {
+    // ── Skip when visual already present ──
+    it('should NOT inject if response already contains a visual command', () => {
+        const msg = 'what is the pythagorean theorem?';
+        const resp = 'The Pythagorean theorem states a² + b² = c².\n\n[PYTHAGOREAN:a=3,b=4]';
+        expect(autoVisualizeByTopic(msg, resp)).toBe(resp);
+    });
+
+    // ── Pythagorean theorem ──
+    it('should inject PYTHAGOREAN for "what is the pythagorean theorem"', () => {
+        const result = autoVisualizeByTopic(
+            'what is the pythagorean theorem?',
+            'The Pythagorean theorem states that a² + b² = c².'
+        );
+        expect(result).toContain('[PYTHAGOREAN:');
+        expect(result).toContain('proof=true');
+    });
+
+    it('should extract side lengths for Pythagorean when mentioned', () => {
+        const result = autoVisualizeByTopic(
+            'pythagorean theorem with sides 5 and 12',
+            'Let me show you.'
+        );
+        expect(result).toContain('a=5,b=12');
+    });
+
+    // ── Unit circle ──
+    it('should inject UNIT_CIRCLE for "explain the unit circle"', () => {
+        const result = autoVisualizeByTopic(
+            'explain the unit circle',
+            'The unit circle is a circle with radius 1 centered at the origin.'
+        );
+        expect(result).toContain('[UNIT_CIRCLE:');
+    });
+
+    // ── Trig functions ──
+    it('should inject FUNCTION_GRAPH + UNIT_CIRCLE for trig function questions', () => {
+        const result = autoVisualizeByTopic(
+            'what are trig functions?',
+            'Trigonometric functions relate angles to side ratios.'
+        );
+        expect(result).toContain('[FUNCTION_GRAPH:');
+        expect(result).toContain('[UNIT_CIRCLE:');
+    });
+
+    it('should use cos(x) when cosine is mentioned', () => {
+        const result = autoVisualizeByTopic(
+            'explain the cosine function',
+            'The cosine function gives the x-coordinate on the unit circle.'
+        );
+        expect(result).toContain('fn=cos(x)');
+    });
+
+    it('should use tan(x) when tangent is mentioned', () => {
+        const result = autoVisualizeByTopic(
+            'what is the tangent function?',
+            'Tangent is sin/cos.'
+        );
+        expect(result).toContain('fn=tan(x)');
+    });
+
+    // ── Quadratic / Parabola ──
+    it('should inject SLIDER_GRAPH for quadratic questions', () => {
+        const result = autoVisualizeByTopic(
+            'what is a quadratic function?',
+            'A quadratic function has the form y = ax² + bx + c.'
+        );
+        expect(result).toContain('[SLIDER_GRAPH:');
+        expect(result).toContain('a*x^2');
+    });
+
+    it('should detect "parabola"', () => {
+        const result = autoVisualizeByTopic(
+            'what does a parabola look like?',
+            'A parabola is a U-shaped curve.'
+        );
+        expect(result).toContain('[SLIDER_GRAPH:');
+    });
+
+    // ── Slope / Linear ──
+    it('should inject SLIDER_GRAPH for slope-intercept form', () => {
+        const result = autoVisualizeByTopic(
+            'what is slope intercept form?',
+            'Slope-intercept form is y = mx + b.'
+        );
+        expect(result).toContain('[SLIDER_GRAPH:');
+        expect(result).toContain('m*x+b');
+    });
+
+    it('should detect "rise over run"', () => {
+        const result = autoVisualizeByTopic(
+            'what is rise over run?',
+            'Rise over run describes the slope of a line.'
+        );
+        expect(result).toContain('[SLIDER_GRAPH:');
+    });
+
+    // ── Angle types ──
+    it('should inject ANGLE for "what is an acute angle"', () => {
+        const result = autoVisualizeByTopic(
+            'what is an acute angle?',
+            'An acute angle is less than 90 degrees.'
+        );
+        expect(result).toContain('[ANGLE:');
+    });
+
+    it('should use 120 degrees for obtuse angle', () => {
+        const result = autoVisualizeByTopic(
+            'what is an obtuse angle?',
+            'An obtuse angle is between 90 and 180 degrees.'
+        );
+        expect(result).toContain('degrees=120');
+    });
+
+    // ── Fractions ──
+    it('should inject FRACTION for "what are fractions"', () => {
+        const result = autoVisualizeByTopic(
+            'what are fractions?',
+            'A fraction represents a part of a whole.'
+        );
+        expect(result).toContain('[FRACTION:');
+    });
+
+    it('should extract fraction from message', () => {
+        const result = autoVisualizeByTopic(
+            'explain fractions using 2/5',
+            'Let me explain fractions.'
+        );
+        expect(result).toContain('numerator=2');
+        expect(result).toContain('denominator=5');
+    });
+
+    // ── Inequality ──
+    it('should inject INEQUALITY for inequality questions', () => {
+        const result = autoVisualizeByTopic(
+            'how do I graph an inequality?',
+            'To graph an inequality, first solve for the variable.'
+        );
+        expect(result).toContain('[INEQUALITY:');
+    });
+
+    it('should extract specific inequality expression', () => {
+        const result = autoVisualizeByTopic(
+            'solve x > 7',
+            'The solution is x > 7.'
+        );
+        expect(result).toContain('x>7');
+    });
+
+    // ── Area model ──
+    it('should inject AREA_MODEL for area model questions', () => {
+        const result = autoVisualizeByTopic(
+            'what is the area model for multiplication?',
+            'The area model breaks numbers into parts.'
+        );
+        expect(result).toContain('[AREA_MODEL:');
+    });
+
+    it('should extract numbers for area model', () => {
+        const result = autoVisualizeByTopic(
+            'use area model for 23 x 15',
+            'Let me show you.'
+        );
+        expect(result).toContain('a=23,b=15');
+    });
+
+    // ── No false positives ──
+    it('should NOT inject visuals for generic math questions', () => {
+        const msg = 'what is 2 + 2?';
+        const resp = '2 + 2 = 4.';
+        expect(autoVisualizeByTopic(msg, resp)).toBe(resp);
+    });
+
+    it('should NOT inject visuals for word problems', () => {
+        const msg = 'If Sally has 5 apples and gives away 2, how many does she have?';
+        const resp = 'Sally has 3 apples left.';
+        expect(autoVisualizeByTopic(msg, resp)).toBe(resp);
+    });
+
+    it('should NOT inject visuals for simple arithmetic', () => {
+        const msg = 'help me multiply 6 times 7';
+        const resp = '6 × 7 = 42.';
+        expect(autoVisualizeByTopic(msg, resp)).toBe(resp);
+    });
+
+    // ── First-match-wins ──
+    it('should match most specific topic first (unit circle before trig)', () => {
+        const result = autoVisualizeByTopic(
+            'show me the unit circle with trig functions',
+            'The unit circle shows all trig function values.'
+        );
+        // Unit circle comes before trig in the topic list, so it should match
+        expect(result).toContain('[UNIT_CIRCLE:');
+        // Should NOT also have FUNCTION_GRAPH from trig topic
+        expect(result).not.toContain('[FUNCTION_GRAPH:');
+    });
+});

--- a/utils/pipeline/verify.js
+++ b/utils/pipeline/verify.js
@@ -12,7 +12,7 @@
 
 const { filterAnswerKeyResponse } = require('../worksheetGuard');
 const { checkReadingLevel, buildSimplificationPrompt } = require('../readability');
-const { enforceVisualTeaching } = require('../visualCommandEnforcer');
+const { enforceVisualTeaching, autoVisualizeByTopic } = require('../visualCommandEnforcer');
 const { parseVisualTeaching } = require('../visualTeachingParser');
 const { processAIResponse } = require('../chatBoardParser');
 const { callLLM } = require('../llmGateway');
@@ -233,6 +233,8 @@ async function verify(responseText, context = {}) {
   // ── 4. Visual teaching enforcement ──
   if (context.userMessage) {
     text = enforceVisualTeaching(context.userMessage, text);
+    // Auto-inject visualizations for recognized math topics (ChatGPT-style)
+    text = autoVisualizeByTopic(context.userMessage, text);
   }
 
   // ── 5. Parse visual commands ──

--- a/utils/visualCommandEnforcer.js
+++ b/utils/visualCommandEnforcer.js
@@ -915,6 +915,153 @@ function shortenResponse(response) {
     return shortened.trim();
 }
 
+// ============================================
+// AUTO-VISUALIZE BY TOPIC
+// ChatGPT-style: automatically inject interactive
+// visualizations when the student asks about certain
+// math concepts — no explicit "show me" needed.
+// ============================================
+
+/**
+ * Topic definitions: order matters (most specific first).
+ * Each entry has:
+ *   name    – for logging
+ *   detect  – regex tested against combined student + AI text
+ *   build   – returns the visual command string to append
+ */
+const TOPIC_VISUALS = [
+    {
+        name: 'Pythagorean theorem',
+        detect: /\b(pythag\w*|a\s*²\s*\+\s*b\s*²|a\s*\^\s*2\s*\+\s*b\s*\^\s*2)/i,
+        build(studentMsg, aiResponse) {
+            const combined = studentMsg + ' ' + aiResponse;
+            // Try to extract side lengths from context
+            const sideMatch = combined.match(/(?:sides?|legs?)\s+(\d+)\s+(?:and\s+)?(\d+)/i)
+                || combined.match(/a\s*=\s*(\d+)[\s,]+b\s*=\s*(\d+)/i);
+            const a = sideMatch ? parseInt(sideMatch[1]) : 3;
+            const b = sideMatch ? parseInt(sideMatch[2]) : 4;
+            return `\n\n[PYTHAGOREAN:a=${a},b=${b},proof=true]`;
+        }
+    },
+    {
+        name: 'Unit circle',
+        // Only match when the STUDENT asks about unit circle (not just AI mentioning it)
+        detect: null,
+        detectFn(studentMsg) {
+            return /\bunit\s*circle\b/i.test(studentMsg);
+        },
+        build(studentMsg) {
+            const angle = extractAngleFromMessage(studentMsg);
+            return `\n\n[UNIT_CIRCLE:angle=${angle}]`;
+        }
+    },
+    {
+        name: 'Trig functions',
+        detect: /\b(trig(onometr\w*)?|sine\s+function|cosine\s+function|tangent\s+function|sin\s*\(x\)|cos\s*\(x\)|tan\s*\(x\)|sinusoidal|trig\s+function)/i,
+        build(studentMsg) {
+            const lower = studentMsg.toLowerCase();
+            let fn = 'sin(x)';
+            let title = 'Sine Function';
+            if (/\bcos(ine)?\b/i.test(lower)) { fn = 'cos(x)'; title = 'Cosine Function'; }
+            if (/\btan(gent)?\b/i.test(lower)) { fn = 'tan(x)'; title = 'Tangent Function'; }
+            return `\n\n[FUNCTION_GRAPH:fn=${fn},xMin=-6.28,xMax=6.28,yMin=-3,yMax=3,title="${title}"]\n\n[UNIT_CIRCLE:angle=45]`;
+        }
+    },
+    {
+        name: 'Quadratic / Parabola',
+        detect: /\b(quadratic|parabola|vertex\s*form|standard\s*form.*ax|completing\s*the\s*square|a\s*x\s*²|ax\^2)\b/i,
+        build() {
+            return `\n\n[SLIDER_GRAPH:fn=a*x^2+b*x+c,params=a:1:-3:3,b:0:-5:5,c:0:-5:5,title="Explore: y = ax² + bx + c"]`;
+        }
+    },
+    {
+        name: 'Slope / Linear equations',
+        detect: /\b(slope|rise\s*(over|and)\s*run|y\s*=\s*m\s*x\s*\+\s*b|slope.?intercept|linear\s+(equation|function))\b/i,
+        build() {
+            return `\n\n[SLIDER_GRAPH:fn=m*x+b,params=m:1:-5:5,b:0:-5:5,title="Explore: y = mx + b (slope-intercept form)"]`;
+        }
+    },
+    {
+        name: 'Angle types',
+        detect: /\b(acute\s+angle|obtuse\s+angle|right\s+angle|complementary\s+angle|supplementary\s+angle|angle\s+measure|types?\s+of\s+angle)/i,
+        build(studentMsg) {
+            const lower = studentMsg.toLowerCase();
+            let degrees = 45;
+            if (/obtuse/i.test(lower)) degrees = 120;
+            else if (/right/i.test(lower)) degrees = 90;
+            else if (/supplementary/i.test(lower)) degrees = 135;
+            else if (/complementary/i.test(lower)) degrees = 60;
+            // Try to pull a specific degree from the message
+            const degMatch = lower.match(/(\d+)\s*(?:°|degree|deg)/i);
+            if (degMatch) degrees = parseInt(degMatch[1]);
+            return `\n\n[ANGLE:degrees=${degrees}]`;
+        }
+    },
+    {
+        name: 'Fractions',
+        detect: /\b(what\s+(is|are)\s+fraction|explain\s+fraction|understand\s+fraction|numerator\s+and\s+denominator|improper\s+fraction|mixed\s+number|equivalent\s+fraction)/i,
+        build(studentMsg) {
+            const frac = extractFractionFromMessage(studentMsg);
+            const num = frac ? frac.num : 3;
+            const denom = frac ? frac.denom : 4;
+            return `\n\n[FRACTION:numerator=${num},denominator=${denom},type=circle]`;
+        }
+    },
+    {
+        name: 'Inequality',
+        detect: /\b(inequalit\w*|solve.*[<>]|graph.*(greater|less\s+than|[<>]))/i,
+        build(studentMsg) {
+            // Try to extract inequality expression
+            const ineqMatch = studentMsg.match(/([x])\s*([<>]=?)\s*(-?\d+)/);
+            if (ineqMatch) {
+                return `\n\n[INEQUALITY:expression=${ineqMatch[1]}${ineqMatch[2]}${ineqMatch[3]},variable=x]`;
+            }
+            return `\n\n[INEQUALITY:expression=x>3,variable=x]`;
+        }
+    },
+    {
+        name: 'Area model / Box method',
+        detect: /\b(area\s+model|box\s+method|partial\s+product|lattice\s+multipli)/i,
+        build(studentMsg) {
+            const numMatch = studentMsg.match(/(\d{2,})\s*[×x*]\s*(\d{2,})/);
+            const a = numMatch ? parseInt(numMatch[1]) : 23;
+            const b = numMatch ? parseInt(numMatch[2]) : 15;
+            return `\n\n[AREA_MODEL:a=${a},b=${b}]`;
+        }
+    }
+];
+
+/**
+ * Auto-inject interactive visualizations based on detected math topics.
+ * Runs AFTER enforceVisualTeaching — only adds visuals if none are present.
+ *
+ * @param {string} studentMessage - The student's question
+ * @param {string} aiResponse - The AI's (possibly already enhanced) response
+ * @returns {string} Response with visual command appended (or unchanged)
+ */
+function autoVisualizeByTopic(studentMessage, aiResponse) {
+    // Skip if the response already has visual commands
+    if (hasInlineVisualCommands(aiResponse)) {
+        return aiResponse;
+    }
+
+    const combined = (studentMessage + ' ' + aiResponse).toLowerCase();
+
+    for (const topic of TOPIC_VISUALS) {
+        const matches = topic.detectFn
+            ? topic.detectFn(studentMessage, aiResponse)
+            : topic.detect.test(combined);
+        if (matches) {
+            const visual = topic.build(studentMessage, aiResponse);
+            console.log(`[AutoVisualize] 🎨 Topic detected: "${topic.name}" — injecting visualization`);
+            return aiResponse + visual;
+        }
+    }
+
+    return aiResponse;
+}
+
 module.exports = {
-    enforceVisualTeaching
+    enforceVisualTeaching,
+    autoVisualizeByTopic
 };


### PR DESCRIPTION
## Summary

- Adds `autoVisualizeByTopic()` — a topic-detection system that auto-injects interactive visualizations when students ask about key math concepts, without needing to say "show me" or "graph this"
- Covers 9 topic areas: Pythagorean theorem, unit circle, trig functions, quadratics/parabolas, slope/linear equations, angle types, fractions, inequalities, and area model
- Integrates into the existing verify pipeline (runs after `enforceVisualTeaching`), respects existing visuals — only adds when the AI didn't already include one
- Extracts context from the student message (e.g. specific side lengths, angles, fraction values) for relevant visualizations

## Test plan

- [x] 23 unit tests passing covering all 9 topics, number extraction, no false positives, and first-match-wins ordering
- [x] Existing 105 pipeline tests still passing
- [ ] Manual test: ask "what is the pythagorean theorem?" → should see interactive triangle proof
- [ ] Manual test: ask "explain trig functions" → should see function graph + unit circle
- [ ] Manual test: ask "what is slope intercept form?" → should see interactive slider graph
- [ ] Manual test: ask "what is 2+2?" → should NOT inject any visualization

https://claude.ai/code/session_011eqcULA29WEM3XTFzS3AXT