### PR TITLE
Fix pdf-parse usage: PDFParse is a named class export, not a default …

### DIFF
--- a/utils/chapterProcessor.js
+++ b/utils/chapterProcessor.js
@@ -91,20 +91,20 @@ async function processChapter(chapterContentId, pdfBuffer) {
  * @returns {Promise<{text: string, pageCount: number}>}
  */
 async function extractTextFromPDF(pdfBuffer) {
-  // pdf-parse is a lightweight PDF text extraction library
-  // It's already available via pdfjs-dist in package.json
-  let pdfParse;
+  let PDFParse;
   try {
-    pdfParse = require('pdf-parse');
+    ({ PDFParse } = require('pdf-parse'));
   } catch {
     // Fallback: use pdfjs-dist if pdf-parse isn't installed
     return extractTextWithPdfjs(pdfBuffer);
   }
 
-  const data = await pdfParse(pdfBuffer);
+  const parser = new PDFParse({ data: pdfBuffer });
+  const result = await parser.getText();
+  const text = (result.pages || []).map(p => p.text).join('\n\n');
   return {
-    text: data.text || '',
-    pageCount: data.numpages || 0
+    text,
+    pageCount: result.total || 0
   };
 }
 


### PR DESCRIPTION
…function

The pdf-parse package exports { PDFParse } (a class), not a default function. Updated extractTextFromPDF to instantiate PDFParse and use getText() API.

https://claude.ai/code/session_01WJCN4136mpekBqaxKRQinh