### PR TITLE
Complete spec ed frontend: auto-calculator, high contrast, extended time

### DIFF
--- a/public/css/iep-accommodations.css
+++ b/public/css/iep-accommodations.css
@@ -51,31 +51,88 @@
     --clr-text-dim: #333333;
     --clr-border: #000000;
     --clr-bg: #ffffff;
-    font-size: 118%;
+
+    /* Large Print: scale up base font and use age-adaptive custom properties */
+    font-size: 125%;
+    --brand-base-font-size: 1.25rem;
+    --brand-h1-font-size: clamp(2.2rem, 6vw, 3rem);
+    --brand-h2-font-size: clamp(1.8rem, 5vw, 2.4rem);
+    --brand-h3-font-size: clamp(1.3rem, 3.5vw, 1.6rem);
+    --line-height-normal: 1.8;
+    --line-height-relaxed: 2;
+    line-height: 1.8;
+    letter-spacing: 0.02em;
 }
 
 .iep-high-contrast .message {
-    font-size: 1.1em;
-    line-height: 1.7;
+    font-size: 1.15em;
+    line-height: 1.8;
     border: 2px solid var(--clr-border);
+    padding: 16px 18px;
 }
 
 .iep-high-contrast .message.ai {
     background: #fffff0;
 }
 
+.iep-high-contrast .message .message-text {
+    font-size: 1.1em;
+    line-height: 1.8;
+}
+
+/* Enlarge math rendering (KaTeX / MathJax) */
+.iep-high-contrast .katex {
+    font-size: 1.25em;
+}
+
+.iep-high-contrast .MathJax {
+    font-size: 125% !important;
+}
+
 .iep-high-contrast button,
 .iep-high-contrast .btn {
-    font-size: 1.05em;
+    font-size: 1.1em;
     font-weight: 600;
     border-width: 2px;
     min-height: 48px;
+    padding: 10px 18px;
 }
 
 .iep-high-contrast #user-input {
-    font-size: 1.15em;
-    line-height: 1.6;
+    font-size: 1.2em;
+    line-height: 1.7;
     border-width: 2px;
+    padding: 12px 14px;
+}
+
+/* Sidebar tools — larger labels and icons */
+.iep-high-contrast .sidebar-tool-btn {
+    font-size: 1.05em;
+    padding: 10px;
+}
+
+.iep-high-contrast .sidebar-tool-btn i {
+    font-size: 1.2em;
+}
+
+/* Chat header */
+.iep-high-contrast .chat-title,
+.iep-high-contrast .chat-header {
+    font-size: 1.1em;
+}
+
+/* Answer choices, hints, and feedback text */
+.iep-high-contrast .hint-text,
+.iep-high-contrast .feedback-text,
+.iep-high-contrast .answer-choice {
+    font-size: 1.1em;
+    line-height: 1.7;
+}
+
+/* Ensure focus outlines are extra visible */
+.iep-high-contrast *:focus-visible {
+    outline: 3px solid #1a237e;
+    outline-offset: 2px;
 }
 
 /* -----------------------------------------------------------

--- a/public/css/iep-accommodations.css
+++ b/public/css/iep-accommodations.css
@@ -52,7 +52,8 @@
     --clr-border: #000000;
     --clr-bg: #ffffff;
 
-    /* Large Print: scale up base font and use age-adaptive custom properties */
+    /* Large Print: scale up base font and use age-adaptive custom properties.
+       Use rem for overrides to avoid em-compounding in nested elements. */
     font-size: 125%;
     --brand-base-font-size: 1.25rem;
     --brand-h1-font-size: clamp(2.2rem, 6vw, 3rem);
@@ -65,7 +66,7 @@
 }
 
 .iep-high-contrast .message {
-    font-size: 1.15em;
+    font-size: 1.15rem;
     line-height: 1.8;
     border: 2px solid var(--clr-border);
     padding: 16px 18px;
@@ -76,13 +77,13 @@
 }
 
 .iep-high-contrast .message .message-text {
-    font-size: 1.1em;
+    font-size: inherit;
     line-height: 1.8;
 }
 
-/* Enlarge math rendering (KaTeX / MathJax) */
+/* Enlarge math rendering — use rem to avoid em-compounding inside messages */
 .iep-high-contrast .katex {
-    font-size: 1.25em;
+    font-size: 1.3rem;
 }
 
 .iep-high-contrast .MathJax {
@@ -91,7 +92,7 @@
 
 .iep-high-contrast button,
 .iep-high-contrast .btn {
-    font-size: 1.1em;
+    font-size: 1.05rem;
     font-weight: 600;
     border-width: 2px;
     min-height: 48px;
@@ -99,7 +100,7 @@
 }
 
 .iep-high-contrast #user-input {
-    font-size: 1.2em;
+    font-size: 1.15rem;
     line-height: 1.7;
     border-width: 2px;
     padding: 12px 14px;
@@ -107,25 +108,25 @@
 
 /* Sidebar tools — larger labels and icons */
 .iep-high-contrast .sidebar-tool-btn {
-    font-size: 1.05em;
+    font-size: 0.95rem;
     padding: 10px;
 }
 
 .iep-high-contrast .sidebar-tool-btn i {
-    font-size: 1.2em;
+    font-size: 1.1rem;
 }
 
 /* Chat header */
 .iep-high-contrast .chat-title,
 .iep-high-contrast .chat-header {
-    font-size: 1.1em;
+    font-size: 1.05rem;
 }
 
 /* Answer choices, hints, and feedback text */
 .iep-high-contrast .hint-text,
 .iep-high-contrast .feedback-text,
 .iep-high-contrast .answer-choice {
-    font-size: 1.1em;
+    font-size: 1.05rem;
     line-height: 1.7;
 }
 

--- a/public/css/iep-accommodations.css
+++ b/public/css/iep-accommodations.css
@@ -113,6 +113,103 @@
 }
 
 /* -----------------------------------------------------------
+   EXTENDED TIME INDICATOR
+   Reassuring badge that lets the student know they have
+   extended time on timed activities. Auto-collapses after 8s.
+   ----------------------------------------------------------- */
+.iep-extended-time-indicator {
+    position: fixed;
+    top: 12px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 8999;
+    background: linear-gradient(135deg, #667eea, #5a67d8);
+    color: white;
+    border: none;
+    border-radius: 20px;
+    padding: 8px 16px;
+    font-size: 13px;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    box-shadow: 0 2px 12px rgba(102, 126, 234, 0.35);
+    cursor: pointer;
+    transition: all 0.4s cubic-bezier(0.22, 1, 0.36, 1);
+    white-space: nowrap;
+    user-select: none;
+}
+
+.iep-extended-time-indicator i {
+    font-size: 14px;
+    flex-shrink: 0;
+}
+
+.iep-extended-time-indicator.collapsed {
+    padding: 6px 10px;
+    border-radius: 50%;
+    background: rgba(102, 126, 234, 0.7);
+    box-shadow: 0 2px 8px rgba(102, 126, 234, 0.2);
+}
+
+.iep-extended-time-indicator.collapsed span {
+    width: 0;
+    opacity: 0;
+    overflow: hidden;
+    margin: 0;
+    padding: 0;
+}
+
+.iep-extended-time-indicator.collapsed:hover {
+    padding: 8px 16px;
+    border-radius: 20px;
+    background: linear-gradient(135deg, #667eea, #5a67d8);
+    box-shadow: 0 2px 12px rgba(102, 126, 234, 0.35);
+}
+
+.iep-extended-time-indicator.collapsed:hover span {
+    width: auto;
+    opacity: 1;
+}
+
+.iep-extended-time-indicator span {
+    transition: width 0.3s, opacity 0.3s;
+}
+
+/* Dark mode */
+.dark-mode .iep-extended-time-indicator {
+    background: linear-gradient(135deg, #5a67d8, #4c51bf);
+}
+
+.dark-mode .iep-extended-time-indicator.collapsed {
+    background: rgba(90, 103, 216, 0.6);
+}
+
+/* High contrast override */
+.iep-high-contrast .iep-extended-time-indicator {
+    background: #1a237e;
+    color: #ffffff;
+    border: 2px solid #000;
+    font-size: 15px;
+}
+
+@media (max-width: 600px) {
+    .iep-extended-time-indicator {
+        top: auto;
+        bottom: 70px;
+        left: auto;
+        right: 10px;
+        transform: none;
+        font-size: 12px;
+        padding: 6px 12px;
+    }
+
+    .iep-extended-time-indicator.collapsed {
+        padding: 6px 8px;
+    }
+}
+
+/* -----------------------------------------------------------
    BREAK BUTTON
    Persistent "Take a Break" button for breaksAsNeeded.
    Positioned in bottom-left, always accessible.

--- a/public/js/modules/iep.js
+++ b/public/js/modules/iep.js
@@ -14,6 +14,7 @@
 export function createIepSystem({ playAudio, generateSpeakableText, getCurrentUser }) {
     let iepChunkProblemCount = 0;
     const IEP_CHUNK_SIZE = 4; // check in after every 4 problems
+    let extendedTimeIndicatorInjected = false;
 
     function escapeHtml(text) {
         const div = document.createElement('div');
@@ -38,11 +39,16 @@ export function createIepSystem({ playAudio, generateSpeakableText, getCurrentUs
             console.log('[IEP] Reduced distraction mode enabled');
         }
 
-        // Large Print / High Contrast: force high-contrast theme
+        // Large Print / High Contrast: force high-contrast theme and override ThemeToggle
         if (accom.largePrintHighContrast) {
             document.body.classList.remove('dark-mode');
             document.body.classList.add('iep-high-contrast');
-            console.log('[IEP] High contrast mode enabled (dark mode overridden)');
+            // Override the theme system so dark mode can't re-engage
+            if (window.ThemeToggle) {
+                window.ThemeToggle.setTheme('light');
+            }
+            document.documentElement.setAttribute('data-theme', 'light');
+            console.log('[IEP] High contrast mode enabled (dark mode overridden, theme locked to light)');
         }
 
         // Calculator Always Available
@@ -65,12 +71,26 @@ export function createIepSystem({ playAudio, generateSpeakableText, getCurrentUs
         if (accom.mathAnxietySupport) {
             document.body.classList.add('iep-anxiety-support');
         }
+
+        // Extended Time: show reassuring indicator so student knows they have extra time
+        if (accom.extendedTime && !extendedTimeIndicatorInjected) {
+            injectExtendedTimeIndicator();
+        }
     }
 
     // --- Per-response IEP features (from chat API response) ---
 
     function handleIepResponseFeatures(iepFeatures) {
         if (!iepFeatures) return;
+
+        // Auto-show calculator when the accommodation is active
+        if (iepFeatures.showCalculator && window.floatingCalc) {
+            const calcEl = document.getElementById('floating-calculator');
+            if (calcEl && calcEl.style.display === 'none') {
+                window.floatingCalc.showCalculator();
+                console.log('[IEP] Auto-opened calculator for calculatorAllowed accommodation');
+            }
+        }
 
         // Auto Read-Aloud: trigger TTS automatically on new AI messages
         if (iepFeatures.autoReadAloud) {
@@ -542,6 +562,30 @@ export function createIepSystem({ playAudio, generateSpeakableText, getCurrentUs
         }
 
         render();
+    }
+
+    // --- Extended Time Indicator ---
+
+    function injectExtendedTimeIndicator() {
+        if (document.getElementById('iep-extended-time-indicator')) return;
+        extendedTimeIndicatorInjected = true;
+
+        const indicator = document.createElement('div');
+        indicator.id = 'iep-extended-time-indicator';
+        indicator.className = 'iep-extended-time-indicator';
+        indicator.innerHTML = '<i class="fas fa-clock"></i> <span>Extended Time (1.5x)</span>';
+        indicator.title = 'You have extended time on timed activities';
+        indicator.setAttribute('aria-label', 'Extended time accommodation active: 1.5x time on timed activities');
+        document.body.appendChild(indicator);
+
+        // Auto-hide after 8 seconds, then show only on hover of the icon
+        setTimeout(() => {
+            indicator.classList.add('collapsed');
+        }, 8000);
+
+        indicator.addEventListener('click', () => {
+            indicator.classList.toggle('collapsed');
+        });
     }
 
     // --- Multiplication Chart ---


### PR DESCRIPTION
## Summary

- **Auto-open calculator**: When the backend sends `showCalculator: true` in chat responses, the floating calculator now auto-opens for students with the `calculatorAllowed` IEP accommodation
- **High contrast theme lock**: The `largePrintHighContrast` accommodation now properly overrides ThemeToggle, locking the theme to light mode so dark mode can't re-engage and break high contrast styles
- **Extended time visual indicator**: Students with `extendedTime` accommodation see a reassuring "Extended Time (1.5x)" badge on session start that auto-collapses after 8 seconds into a subtle clock icon (click/hover to expand)

## Files changed

- `public/js/modules/iep.js` — Added auto-calculator logic in `handleIepResponseFeatures`, ThemeToggle override in `applyIepAccommodations`, extended time indicator injection
- `public/css/iep-accommodations.css` — Full CSS for extended time indicator (dark mode, high contrast, mobile responsive)

## Test plan

- [ ] Log in as student with `calculatorAllowed` accommodation, send a message, verify calculator auto-opens
- [ ] Log in as student with `largePrintHighContrast`, verify high contrast is applied and dark mode toggle doesn't override it
- [ ] Log in as student with `extendedTime`, verify badge appears at top center, collapses after ~8s, expands on hover/click
- [ ] Test on mobile viewport — verify extended time indicator repositions to bottom-right
- [ ] Verify no regressions on existing IEP accommodations (breaks, multiplication chart, reduced distraction, math anxiety)

https://claude.ai/code/session_01EKGTs3KH6KednhiqRiF7wp