### PR TITLE
Fix calculator re-opening after every problem for IEP students

### DIFF
--- a/public/js/modules/iep.js
+++ b/public/js/modules/iep.js
@@ -15,6 +15,7 @@ export function createIepSystem({ playAudio, generateSpeakableText, getCurrentUs
     let iepChunkProblemCount = 0;
     const IEP_CHUNK_SIZE = 4; // check in after every 4 problems
     let extendedTimeIndicatorInjected = false;
+    let calculatorAutoOpened = false;
 
     function escapeHtml(text) {
         const div = document.createElement('div');
@@ -83,13 +84,14 @@ export function createIepSystem({ playAudio, generateSpeakableText, getCurrentUs
     function handleIepResponseFeatures(iepFeatures) {
         if (!iepFeatures) return;
 
-        // Auto-show calculator when the accommodation is active
-        if (iepFeatures.showCalculator && window.floatingCalc) {
+        // Auto-show calculator once on first response; respect if student closes it
+        if (iepFeatures.showCalculator && window.floatingCalc && !calculatorAutoOpened) {
             const calcEl = document.getElementById('floating-calculator');
             if (calcEl && calcEl.style.display === 'none') {
                 window.floatingCalc.showCalculator();
                 console.log('[IEP] Auto-opened calculator for calculatorAllowed accommodation');
             }
+            calculatorAutoOpened = true;
         }
 
         // Auto Read-Aloud: trigger TTS automatically on new AI messages


### PR DESCRIPTION
The calculator auto-open logic in handleIepResponseFeatures() ran on
every chat response, so closing the calculator was immediately undone
by the next AI reply. Added a flag so the auto-open only fires once
per session — the sidebar button remains visible per the accommodation,
but students can close the calculator without it popping back up.

https://claude.ai/code/session_01RvQAUnEc7iNsNtLzbev6Rq