### PR TITLE
Add transcript-level regression tests + fix verifyAnswer numeric guard

### DIFF
--- a/tests/unit/tutorValidation.test.js
+++ b/tests/unit/tutorValidation.test.js
@@ -1,0 +1,517 @@
+/**
+ * TRANSCRIPT-LEVEL REGRESSION TESTS — Tutor Validation
+ *
+ * These tests reproduce the exact scenarios from the bug report where the
+ * tutor falsely rejected correct student answers or dragged students through
+ * unnecessary scaffolding steps.
+ *
+ * Unlike pipelineIntegration.test.js (which mocks mathSolver), these tests
+ * use the REAL math solver to prove end-to-end correctness for calculus
+ * and algebraic answer verification.
+ *
+ * Test categories:
+ *   1. Correct answer given directly (student skips to final answer)
+ *   2. Correct answer embedded in explanation
+ *   3. Correct algebraic expression answer
+ *   4. Correct answer in equivalent form
+ *   5. Correct method but wrong arithmetic (should NOT affirm)
+ *   6. Student self-corrects mid-conversation
+ */
+
+// ── Mocks (LLM + DB only — math solver is REAL) ──
+
+jest.mock('../../utils/llmGateway', () => ({
+  callLLM: jest.fn(),
+  callLLMStream: jest.fn(),
+}));
+
+jest.mock('../../utils/openaiClient', () => ({
+  chat: { completions: { create: jest.fn() } },
+}));
+
+// DO NOT mock mathSolver — we need real verification
+
+jest.mock('../../utils/misconceptionDetector', () => ({
+  analyzeError: jest.fn(() => null),
+  findKnownMisconception: jest.fn(() => null),
+  recordMisconception: jest.fn(() => Promise.resolve()),
+  MISCONCEPTION_LIBRARY: {},
+}));
+
+jest.mock('../../utils/worksheetGuard', () => ({
+  filterAnswerKeyResponse: jest.fn((text) => ({ text, wasFiltered: false })),
+}));
+
+jest.mock('../../utils/readability', () => ({
+  checkReadingLevel: jest.fn(() => ({ passes: true })),
+  buildSimplificationPrompt: jest.fn(() => ''),
+}));
+
+jest.mock('../../utils/visualCommandEnforcer', () => ({
+  enforceVisualTeaching: jest.fn((_userMsg, text) => text),
+  autoVisualizeByTopic: jest.fn((_userMsg, text) => text),
+}));
+
+jest.mock('../../utils/visualTeachingParser', () => ({
+  parseVisualTeaching: jest.fn((text) => ({ cleanedText: text, visualCommands: {}, drawingSequence: null })),
+}));
+
+jest.mock('../../utils/chatBoardParser', () => ({
+  processAIResponse: jest.fn((text) => ({ text, boardContext: null })),
+}));
+
+jest.mock('../../utils/emailService', () => ({
+  sendSafetyConcernAlert: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../../utils/activitySummarizer', () => ({
+  detectTopic: jest.fn(() => 'Calculus'),
+  detectStruggle: jest.fn(() => ({ isStruggling: false })),
+}));
+
+jest.mock('../../utils/unlockTutors', () => ({
+  getTutorsToUnlock: jest.fn(() => []),
+}));
+
+jest.mock('../../utils/promptCompressor', () => ({
+  calculateXpBoostFactor: jest.fn(() => ({ factor: 1.0, isNewUser: false, guidance: 'none' })),
+  determineTier: jest.fn(() => 'tier1'),
+  buildSystemPrompt: jest.fn(() => 'system prompt'),
+}));
+
+const { callLLM } = require('../../utils/llmGateway');
+const { runPipeline } = require('../../utils/pipeline');
+const { observe } = require('../../utils/pipeline/observe');
+const { diagnose } = require('../../utils/pipeline/diagnose');
+const { decide, ACTIONS } = require('../../utils/pipeline/decide');
+
+// ── Helpers ──
+
+function mockUser(overrides = {}) {
+  return {
+    _id: 'user123',
+    firstName: 'Jason',
+    lastName: 'Student',
+    username: 'jason',
+    gradeLevel: '11th',
+    level: 8,
+    xp: 500,
+    iepPlan: null,
+    skillMastery: new Map(),
+    learningProfile: {},
+    learningEngines: {},
+    xpLadderStats: { lifetimeTier1: 0, lifetimeTier2: 0, lifetimeTier3: 0, tier3Behaviors: [] },
+    masteryProgress: null,
+    weeklyAISeconds: 0,
+    totalAISeconds: 0,
+    activeCourseSessionId: null,
+    unlockedItems: [],
+    markModified: jest.fn(),
+    save: jest.fn(() => Promise.resolve()),
+    ...overrides,
+  };
+}
+
+function mockConversation(messages = [], overrides = {}) {
+  return {
+    _id: 'conv123',
+    userId: 'user123',
+    messages: [...messages],
+    problemsAttempted: 0,
+    problemsCorrect: 0,
+    lastActivity: new Date(),
+    currentTopic: null,
+    strugglingWith: null,
+    alerts: [],
+    createdAt: new Date(Date.now() - 5 * 60 * 1000),
+    startDate: new Date(Date.now() - 5 * 60 * 1000),
+    sessionMood: {},
+    save: jest.fn(() => Promise.resolve()),
+    ...overrides,
+  };
+}
+
+function mockLLMResponse(text) {
+  callLLM.mockResolvedValueOnce({
+    choices: [{ message: { content: text } }],
+  });
+}
+
+function buildCtx(user, conversation, extras = {}) {
+  return {
+    user,
+    conversation,
+    systemPrompt: 'You are a friendly math tutor.',
+    formattedMessages: conversation.messages.map(m => ({ role: m.role, content: m.content })),
+    activeSkill: null,
+    phaseState: null,
+    hasRecentUpload: false,
+    stream: false,
+    res: null,
+    aiProcessingStartTime: Date.now(),
+    ...extras,
+  };
+}
+
+/**
+ * Run observe + diagnose + decide (the deterministic stages)
+ * without calling the LLM. This tests the exact pipeline decisions.
+ */
+async function runDeterministicStages(studentMessage, tutorMessages) {
+  const recentAssistantMessages = tutorMessages.map(content => ({
+    content,
+    role: 'assistant',
+    problemResult: null,
+  }));
+
+  const observation = observe(studentMessage, {
+    recentUserMessages: [],
+    recentAssistantMessages,
+    hasRecentUpload: false,
+  });
+
+  const diagnosis = await diagnose(observation, {
+    recentAssistantMessages: recentAssistantMessages.map(msg => ({
+      content: msg.content,
+      problemResult: msg.problemResult,
+    })),
+    recentUserMessages: [],
+    activeSkill: null,
+    user: mockUser(),
+  });
+
+  const decision = decide(observation, diagnosis, {
+    phaseState: null,
+    activeSkill: null,
+  });
+
+  return { observation, diagnosis, decision };
+}
+
+// ============================================================================
+// TRANSCRIPT REGRESSION TESTS
+// ============================================================================
+
+describe('Tutor Validation: Transcript Regression', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // BUG REPORT SCENARIO 1:
+  // Tutor asks: "What is the limit of (x²-4)/(x-2) as x approaches 2?"
+  // Student answers: "4"
+  // EXPECTED: Confirm correct immediately
+  // PREVIOUS BUG: Tutor said "Hmm, that's an interesting answer!"
+  // ────────────────────────────────────────────────────────────────────────
+
+  test('TRANSCRIPT BUG 1: limit answer "4" must be confirmed correct', async () => {
+    const { observation, diagnosis, decision } = await runDeterministicStages(
+      '4',
+      ['Can you tell me what the limit of (x^2-4)/(x-2) is as x approaches 2? What do you think we should do first?']
+    );
+
+    expect(observation.messageType).toBe('answer_attempt');
+    expect(observation.answer.value).toBe('4');
+    expect(diagnosis.isCorrect).toBe(true);
+    expect(diagnosis.correctAnswer).toBe('4');
+    expect(decision.action).toBe(ACTIONS.CONFIRM_CORRECT);
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // BUG REPORT SCENARIO 2:
+  // Student explains: "after I factor and simplify, you get x+2...
+  //   which means the limit is 4"
+  // EXPECTED: Confirm correct AND acknowledge reasoning, then advance
+  // PREVIOUS BUG: Tutor kept dragging through steps
+  // ────────────────────────────────────────────────────────────────────────
+
+  test('TRANSCRIPT BUG 2: explained answer with reasoning must affirm and advance', async () => {
+    const { observation, diagnosis, decision } = await runDeterministicStages(
+      'Yeah, but after I factor and simplify, you get x+2, which means the limit is 4',
+      ['Can you tell me what the limit of (x^2-4)/(x-2) is as x approaches 2? What do you think we should do first?']
+    );
+
+    expect(observation.messageType).toBe('answer_attempt');
+    expect(observation.answer.value).toBe('4');
+    expect(observation.answer.hasExplanation).toBe(true);
+    expect(observation.demonstratedReasoning).toBe(true);
+    expect(diagnosis.isCorrect).toBe(true);
+    expect(diagnosis.demonstratedReasoning).toBe(true);
+    expect(decision.action).toBe(ACTIONS.CONFIRM_CORRECT);
+    // Must include directive to NOT re-walk steps
+    expect(decision.directives.some(d => /DEMONSTRATED UNDERSTANDING/.test(d))).toBe(true);
+    expect(decision.directives.some(d => /do NOT walk them through steps/i.test(d))).toBe(true);
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // BUG REPORT SCENARIO 3:
+  // Tutor asks: "derivative of x³ - 3x + 2?"
+  // Student answers: "3x^2-3"
+  // EXPECTED: Confirm correct immediately
+  // PREVIOUS BUG: Tutor said "Nice try! You got the x³ term right..."
+  // ────────────────────────────────────────────────────────────────────────
+
+  test('TRANSCRIPT BUG 3: derivative answer "3x^2-3" must be confirmed correct', async () => {
+    const { observation, diagnosis, decision } = await runDeterministicStages(
+      '3x^2-3',
+      ['How about we tackle the derivative of x^3 - 3x + 2? What do you think the first step is?']
+    );
+
+    expect(observation.messageType).toBe('answer_attempt');
+    expect(observation.answer.value).toBe('3x^2-3');
+    expect(diagnosis.isCorrect).toBe(true);
+    expect(diagnosis.correctAnswer).toBe('3x^2-3');
+    expect(decision.action).toBe(ACTIONS.CONFIRM_CORRECT);
+    // Must NEVER contain guide/remediation actions
+    expect(decision.action).not.toBe(ACTIONS.GUIDE_INCORRECT);
+    expect(decision.action).not.toBe(ACTIONS.RETEACH_MISCONCEPTION);
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // BUG REPORT SCENARIO 4: Warm-up — derivative of x²
+  // Student answers: "2x"
+  // EXPECTED: Confirm correct
+  // ────────────────────────────────────────────────────────────────────────
+
+  test('TRANSCRIPT BUG 4: derivative of x^2 = 2x must be confirmed correct', async () => {
+    const { observation, diagnosis, decision } = await runDeterministicStages(
+      '2x',
+      ['What is the derivative of x^2? Just a simple one to get us rolling!']
+    );
+
+    expect(observation.messageType).toBe('answer_attempt');
+    expect(diagnosis.isCorrect).toBe(true);
+    expect(decision.action).toBe(ACTIONS.CONFIRM_CORRECT);
+  });
+});
+
+// ============================================================================
+// ADDITIONAL CORRECTNESS SCENARIOS
+// ============================================================================
+
+describe('Tutor Validation: Correct Answer Must Always Be Confirmed', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('bare numeric answer to limit problem', async () => {
+    const { diagnosis, decision } = await runDeterministicStages(
+      '6',
+      ['What is the limit of (x^2-9)/(x-3) as x approaches 3?']
+    );
+
+    expect(diagnosis.isCorrect).toBe(true);
+    expect(decision.action).toBe(ACTIONS.CONFIRM_CORRECT);
+  });
+
+  test('algebraic expression answer to derivative', async () => {
+    const { diagnosis, decision } = await runDeterministicStages(
+      '20x^3+6x-7',
+      ['Find the derivative of 5x^4 + 3x^2 - 7x + 1']
+    );
+
+    expect(diagnosis.isCorrect).toBe(true);
+    expect(decision.action).toBe(ACTIONS.CONFIRM_CORRECT);
+  });
+
+  test('constant derivative answer', async () => {
+    const { diagnosis, decision } = await runDeterministicStages(
+      '4',
+      ['What is the derivative of 4x?']
+    );
+
+    expect(diagnosis.isCorrect).toBe(true);
+    expect(decision.action).toBe(ACTIONS.CONFIRM_CORRECT);
+  });
+
+  test('zero derivative of constant', async () => {
+    const { diagnosis, decision } = await runDeterministicStages(
+      '0',
+      ['What is the derivative of 7?']
+    );
+
+    expect(diagnosis.isCorrect).toBe(true);
+    expect(decision.action).toBe(ACTIONS.CONFIRM_CORRECT);
+  });
+
+  test('limit via direct substitution (no discontinuity)', async () => {
+    const { diagnosis, decision } = await runDeterministicStages(
+      '10',
+      ['What is the limit of x^2 + 3x as x approaches 2?']
+    );
+
+    expect(diagnosis.isCorrect).toBe(true);
+    expect(decision.action).toBe(ACTIONS.CONFIRM_CORRECT);
+  });
+
+  test('student gives answer in longer sentence', async () => {
+    const { observation, diagnosis, decision } = await runDeterministicStages(
+      'I think the answer is 4',
+      ['What is the limit of (x^2-4)/(x-2) as x approaches 2?']
+    );
+
+    expect(observation.answer.value).toBe('4');
+    expect(diagnosis.isCorrect).toBe(true);
+    expect(decision.action).toBe(ACTIONS.CONFIRM_CORRECT);
+  });
+});
+
+// ============================================================================
+// INCORRECT ANSWERS MUST NOT BE FALSELY CONFIRMED
+// ============================================================================
+
+describe('Tutor Validation: Incorrect Answers Must Not Be Confirmed', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('wrong numeric answer to limit', async () => {
+    const { diagnosis, decision } = await runDeterministicStages(
+      '2',
+      ['What is the limit of (x^2-4)/(x-2) as x approaches 2?']
+    );
+
+    expect(diagnosis.isCorrect).toBe(false);
+    expect(decision.action).not.toBe(ACTIONS.CONFIRM_CORRECT);
+  });
+
+  test('wrong derivative answer', async () => {
+    const { diagnosis, decision } = await runDeterministicStages(
+      '3x^2+3',
+      ['What is the derivative of x^3 - 3x + 2?']
+    );
+
+    // Student got the sign wrong on the -3 term
+    expect(diagnosis.isCorrect).toBe(false);
+    expect(decision.action).not.toBe(ACTIONS.CONFIRM_CORRECT);
+  });
+
+  test('partially correct derivative (missing constant rule)', async () => {
+    const { diagnosis, decision } = await runDeterministicStages(
+      '3x^2-3+2',
+      ['What is the derivative of x^3 - 3x + 2?']
+    );
+
+    // Student forgot to drop the constant
+    expect(diagnosis.isCorrect).toBe(false);
+    expect(decision.action).not.toBe(ACTIONS.CONFIRM_CORRECT);
+  });
+});
+
+// ============================================================================
+// FULL PIPELINE: FALSE REJECTION GUARD
+// ============================================================================
+
+describe('Tutor Validation: False Rejection Guard (Full Pipeline)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('LLM hedging on verified-correct answer triggers regeneration', async () => {
+    const user = mockUser();
+    const conversation = mockConversation([
+      { role: 'assistant', content: 'What is the derivative of x^3 - 3x + 2?' },
+      { role: 'user', content: '3x^2-3' },
+    ]);
+
+    // LLM falsely hedges despite the answer being correct
+    mockLLMResponse('Nice try! You got the x^3 term right, but let\'s check the other terms.');
+    // Regeneration call returns proper confirmation
+    mockLLMResponse('That\'s right! The derivative of x^3 - 3x + 2 is indeed 3x^2 - 3. <PROBLEM_RESULT:correct>');
+
+    const result = await runPipeline('3x^2-3', buildCtx(user, conversation));
+
+    expect(result._pipeline.action).toBe('confirm_correct');
+    expect(result._pipeline.flags).toContain('false_rejection_detected');
+    expect(result._pipeline.flags).toContain('false_rejection_regenerated');
+    // Final text should NOT contain false rejection language
+    expect(result.text).not.toMatch(/nice try/i);
+    expect(result.text).not.toMatch(/let's check/i);
+  });
+
+  test('LLM proper confirmation on verified-correct answer passes through', async () => {
+    const user = mockUser();
+    const conversation = mockConversation([
+      { role: 'assistant', content: 'What is the limit of (x^2-4)/(x-2) as x approaches 2?' },
+      { role: 'user', content: '4' },
+    ]);
+
+    mockLLMResponse('Exactly right! The limit is 4. <PROBLEM_RESULT:correct> Nice work on that removable discontinuity.');
+
+    const result = await runPipeline('4', buildCtx(user, conversation));
+
+    expect(result._pipeline.action).toBe('confirm_correct');
+    expect(result._pipeline.flags).not.toContain('false_rejection_detected');
+    // Response should contain confirmation
+    expect(result.text).toMatch(/right|correct/i);
+  });
+});
+
+// ============================================================================
+// ANSWER EXTRACTION EDGE CASES
+// ============================================================================
+
+describe('Tutor Validation: Answer Extraction', () => {
+  test('extracts final answer over intermediate step in explanation', () => {
+    const obs = observe(
+      'Yeah, but after I factor and simplify, you get x+2, which means the limit is 4',
+      { recentUserMessages: [], recentAssistantMessages: [] }
+    );
+    // Must extract 4 (conclusive), NOT x+2 (intermediate)
+    expect(obs.answer.value).toBe('4');
+    expect(obs.answer.hasExplanation).toBe(true);
+    expect(obs.demonstratedReasoning).toBe(true);
+  });
+
+  test('extracts algebraic expression as bare answer', () => {
+    const obs = observe('3x^2-3', { recentUserMessages: [], recentAssistantMessages: [] });
+    expect(obs.messageType).toBe('answer_attempt');
+    expect(obs.answer.value).toBe('3x^2-3');
+  });
+
+  test('extracts answer from "the derivative is ..."', () => {
+    const obs = observe(
+      'Using the power rule, the derivative is 5x^4-1',
+      { recentUserMessages: [], recentAssistantMessages: [] }
+    );
+    expect(obs.answer.value).toBe('5x^4-1');
+    expect(obs.answer.hasExplanation).toBe(true);
+  });
+
+  test('bare number in unrelated sentence is not falsely extracted', () => {
+    // "I'm already at the station. 4" — the "4" has no answer phrase.
+    // Without conversational context, observe cannot know "4" is an answer.
+    // This is fine — the LLM handles ambiguous cases. The important thing
+    // is that when the student says JUST "4" (bare number), it IS extracted.
+    const obs = observe(
+      "I'm already at the station. 4",
+      { recentUserMessages: [], recentAssistantMessages: [] }
+    );
+    // The bare "4" is NOT the full message, so justNumber won't match.
+    // No answer phrase present either. This is correctly ambiguous.
+    // What matters is that "4" alone works:
+    const obs2 = observe('4', { recentUserMessages: [], recentAssistantMessages: [] });
+    expect(obs2.answer).not.toBeNull();
+    expect(obs2.answer.value).toBe('4');
+    expect(obs2.messageType).toBe('answer_attempt');
+  });
+
+  test('does not extract answer from very long off-topic messages', () => {
+    const longMsg = 'I was just thinking about how math is really interesting and ' +
+      'I wonder if we could talk about something else for a while because ' +
+      'I am really tired today and do not feel like doing more problems ' +
+      'right now maybe we could take a break or something what do you think';
+    const obs = observe(longMsg, { recentUserMessages: [], recentAssistantMessages: [] });
+    expect(obs.messageType).not.toBe('answer_attempt');
+  });
+
+  test('student self-corrects: "wait no, it should be 4"', () => {
+    const obs = observe(
+      'wait no, the answer is 4',
+      { recentUserMessages: [], recentAssistantMessages: [] }
+    );
+    expect(obs.answer).not.toBeNull();
+    expect(obs.answer.value).toBe('4');
+  });
+});

--- a/utils/mathSolver.js
+++ b/utils/mathSolver.js
@@ -1875,12 +1875,18 @@ function verifyAnswer(studentAnswer, correctAnswer, tolerance = 0.01) {
     }
 
     // Numeric comparison with tolerance
-    const studentNum = parseFloat(studentStr.replace(/[^\d.\-]/g, ''));
-    const correctNum = parseFloat(correctStr.replace(/[^\d.\-]/g, ''));
+    // Only apply when both answers look like pure numbers (no variables).
+    // Without this guard, "3x^2-3+2" gets stripped to "32-32" → 32 and
+    // falsely matches "3x^2-3" stripped to "32-3" → 32.
+    const hasLetters = /[a-zA-Z]/.test(studentStr) || /[a-zA-Z]/.test(correctStr);
+    if (!hasLetters) {
+        const studentNum = parseFloat(studentStr.replace(/[^\d.\-]/g, ''));
+        const correctNum = parseFloat(correctStr.replace(/[^\d.\-]/g, ''));
 
-    if (!isNaN(studentNum) && !isNaN(correctNum)) {
-        if (Math.abs(studentNum - correctNum) <= tolerance) {
-            return { isCorrect: true, exact: false, difference: Math.abs(studentNum - correctNum) };
+        if (!isNaN(studentNum) && !isNaN(correctNum)) {
+            if (Math.abs(studentNum - correctNum) <= tolerance) {
+                return { isCorrect: true, exact: false, difference: Math.abs(studentNum - correctNum) };
+            }
         }
     }
 

--- a/utils/pipeline/observe.js
+++ b/utils/pipeline/observe.js
@@ -50,11 +50,13 @@ const PATTERNS = {
   // Answer embedded in explanation — two tiers of patterns.
   // "Conclusive" patterns (highest priority): "the limit is 4", "the answer is 3x^2-3"
   // These indicate the student is stating their final answer.
-  embeddedAnswerConclusive: /(?:(?:the\s+)?(?:limit|answer|result|derivative|solution|value)\s+(?:is|equals?|=|would\s+be|comes?\s+(?:out\s+)?to)\s+|(?:so|which\s+means|meaning|therefore|thus)\s+(?:it'?s?|the\s+\w+\s+is)\s+)(-?\d+\.?\d*(?:\s*\/\s*\d+)?|-?\d*[a-z](?:\^[\d{}]+)?(?:\s*[+\-]\s*\d*[a-z]?(?:\^[\d{}]+)?)*)/gi,
+  // NOTE: algebraic alternation MUST come before numeric, so "5x^4-1" matches
+  // before the numeric branch can grab just "5".
+  embeddedAnswerConclusive: /(?:(?:the\s+)?(?:limit|answer|result|derivative|solution|value)\s+(?:is|equals?|=|would\s+be|comes?\s+(?:out\s+)?to)\s+|(?:so|which\s+means|meaning|therefore|thus)\s+(?:it'?s?|the\s+\w+\s+is)\s+)(-?\d*[a-z](?:\^[\d{}]+)?(?:\s*[+\-]\s*\d*[a-z]?(?:\^[\d{}]+)?)*|-?\d+\.?\d*(?:\s*\/\s*\d+)?)/gi,
 
   // "Intermediate" patterns (lower priority): "you get x+2", "gives 3x"
   // These may be intermediate steps, not the final answer.
-  embeddedAnswerIntermediate: /(?:(?:you\s+)?(?:get|gives?)\s+)(-?\d+\.?\d*(?:\s*\/\s*\d+)?|-?\d*[a-z](?:\^[\d{}]+)?(?:\s*[+\-]\s*\d*[a-z]?(?:\^[\d{}]+)?)*)/gi,
+  embeddedAnswerIntermediate: /(?:(?:you\s+)?(?:get|gives?)\s+)(-?\d*[a-z](?:\^[\d{}]+)?(?:\s*[+\-]\s*\d*[a-z]?(?:\^[\d{}]+)?)*|-?\d+\.?\d*(?:\s*\/\s*\d+)?)/gi,
 
   // Reasoning phrases that indicate the student is showing their work
   reasoningIndicators: /\b(because|since|after\s+(?:i\s+)?(?:factor|simplif|cancel|distribut|combin|reduc)|(?:i\s+)?(?:factor|simplif|cancel)(?:ed|ing)?|if\s+(?:you|i)\s+(?:factor|simplif|cancel)|by\s+(?:factoring|simplifying|canceling)|using\s+the\s+(?:power|chain|quotient|product)\s+rule|(?:which|that|so)\s+(?:means|gives|leaves|simplifies?\s+to))\b/i,


### PR DESCRIPTION
Adds 21 transcript-level tests that reproduce the exact bug report scenarios end-to-end through the deterministic pipeline stages (observe → diagnose → decide) using the REAL math solver, not mocks.

Test categories:
- 4 transcript regression tests (the exact bugs from the report)
- 6 additional correct-answer-must-confirm scenarios
- 3 incorrect-answer-must-not-confirm scenarios
- 2 full-pipeline false-rejection guard tests
- 6 answer extraction edge cases

Bugs found and fixed by the tests:

1. verifyAnswer numeric comparison was stripping letters from algebraic expressions before parseFloat, turning "3x^2-3+2" and "3x^2-3" into the same garbage number (32). Fix: skip numeric comparison when either answer contains alphabetic characters.

2. Embedded answer regex had numeric alternation before algebraic, so "the derivative is 5x^4-1" captured "5" instead of "5x^4-1". Fix: reorder alternation so algebraic branch matches first.

943 tests passing across 43 suites.

https://claude.ai/code/session_01LSxLgFmSwohccBUGiQd8ZQ