### PR TITLE
Fix checkpoint modal showing for all users — CSS display override bug

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -1486,7 +1486,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
     <div class="checkpoint-body">
       <!-- Instruction Screen -->
-      <div id="checkpoint-instruction-screen" class="checkpoint-screen active">
+      <div id="checkpoint-instruction-screen" class="checkpoint-screen">
         <h2 id="checkpoint-module-title">Checkpoint</h2>
         <p class="subtitle">Show what you know. No hints, no help — just you and the problems.</p>
         <div class="checkpoint-info-card">

--- a/public/css/floating-checkpoint.css
+++ b/public/css/floating-checkpoint.css
@@ -17,7 +17,6 @@
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
   z-index: 10000;
   overflow: hidden;
-  display: flex;
   flex-direction: column;
 }
 


### PR DESCRIPTION
The .floating-checkpoint CSS rule had two display declarations: display:none (line 7) was overridden by display:flex (line 20), making the checkpoint widget visible to ALL users regardless of course enrollment. Also removed the default 'active' class from the instruction screen HTML so it doesn't render content before open() is called.

https://claude.ai/code/session_01WJCN4136mpekBqaxKRQinh