### PR TITLE
Disable biology tutor prototype features

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -108,7 +108,7 @@ const demoRoutes = require('../routes/demo');
 const trialChatRoutes = require('../routes/trialChat');
 const supportRoutes = require('../routes/support');
 const imageSearchRoutes = require('../routes/imageSearch');
-const bioRoutes = require('../routes/bio');
+// const bioRoutes = require('../routes/bio'); // Biology tutor prototype — disabled
 
 const TUTOR_CONFIG = require('../utils/tutorConfig');
 
@@ -197,7 +197,7 @@ function registerRoutes(app, { authLimiter, signupLimiter }) {
   app.use('/api/waitlist', waitlistRoutes);
   app.use('/api/demo', demoRoutes);
   app.use('/api/trial-chat', trialChatLimiter, trialChatRoutes);
-  app.use('/api/bio', bioRoutes);
+  // app.use('/api/bio', bioRoutes); // Biology tutor prototype — disabled
 
   app.use('/api/images', isAuthenticated, imageSearchRoutes);
   app.use('/api', isAuthenticated, diagramRoutes);
@@ -558,9 +558,9 @@ function registerHtmlRoutes(app) {
   app.get('/terms.html', sendHtml('terms.html'));
   app.get('/demo.html', sendHtml('demo.html'));
   app.get('/pricing.html', sendHtml('pricing.html'));
-  app.get('/bio.html', sendHtml('bio.html'));
-  app.get('/bio-chat.html', sendHtml('bio-chat.html'));
-  app.get('/bio-chapters.html', sendHtml('bio-chapters.html'));
+  // app.get('/bio.html', sendHtml('bio.html'));           // Biology tutor prototype — disabled
+  // app.get('/bio-chat.html', sendHtml('bio-chat.html')); // Biology tutor prototype — disabled
+  // app.get('/bio-chapters.html', sendHtml('bio-chapters.html')); // Biology tutor prototype — disabled
 
   // Protected HTML routes
   app.get('/affiliate.html', isAuthenticated, sendHtml('affiliate.html'));

--- a/public/chat.html
+++ b/public/chat.html
@@ -156,7 +156,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </div>
 
       <!-- Textbook Mode Toggle -->
-      <div class="textbook-toggle-wrapper" title="Switch between Tutor and Textbook mode">
+      <div class="textbook-toggle-wrapper" title="Switch between Tutor and Textbook mode" style="display: none;">
         <span id="textbook-label-tutor" class="textbook-toggle-label active">Tutor</span>
         <label class="textbook-toggle-switch">
           <input type="checkbox" id="textbook-mode-toggle" aria-label="Toggle textbook mode" />

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -29,8 +29,8 @@ const { processAIResponse } = require('../utils/chatBoardParser');
 const ScreenerSession = require('../models/screenerSession');
 const { needsAssessment } = require('../services/chatService');
 const { buildCourseSystemPrompt, buildCourseGreetingInstruction, loadCourseContext, calculateOverallProgress } = require('../utils/coursePrompt');
-const { buildTextbookContext, generateBioSystemPrompt } = require('../utils/bioPromptCompact');
-const ChapterContent = require('../models/chapterContent');
+// const { buildTextbookContext, generateBioSystemPrompt } = require('../utils/bioPromptCompact'); // Biology tutor prototype — disabled
+// const ChapterContent = require('../models/chapterContent'); // Biology tutor prototype — disabled
 
 // Performance optimizations
 const contextCache = require('../utils/contextCache');
@@ -712,29 +712,29 @@ router.post('/', isAuthenticated, promptInjectionFilter, async (req, res) => {
         let systemPrompt;
         let courseScaffoldCtx = null; // Captured for step-context reminder below
 
-        // TEXTBOOK MODE: When active and student has an active chapter, use biology textbook prompt
-        if (user.textbookMode && user.activeChapterId) {
-            try {
-                const chapter = await ChapterContent.getChapterForRAG(user.activeChapterId);
-                if (chapter && chapter.processingStatus === 'ready') {
-                    const textbookContext = await buildTextbookContext({
-                        chapter,
-                        studentMessage: message,
-                        currentConceptIndex: user.currentConceptIndex || 0,
-                        tokenBudget: 1500
-                    });
-                    systemPrompt = generateBioSystemPrompt({
-                        user: studentProfileForPrompt,
-                        tutorName: currentTutor,
-                        textbookMode: true,
-                        textbookContext
-                    });
-                }
-            } catch (textbookError) {
-                console.error('[Chat] Textbook mode context failed, falling back to default:', textbookError.message);
-                // Fall through to default prompt below
-            }
-        }
+        // TEXTBOOK MODE: Biology tutor prototype — disabled
+        // if (user.textbookMode && user.activeChapterId) {
+        //     try {
+        //         const chapter = await ChapterContent.getChapterForRAG(user.activeChapterId);
+        //         if (chapter && chapter.processingStatus === 'ready') {
+        //             const textbookContext = await buildTextbookContext({
+        //                 chapter,
+        //                 studentMessage: message,
+        //                 currentConceptIndex: user.currentConceptIndex || 0,
+        //                 tokenBudget: 1500
+        //             });
+        //             systemPrompt = generateBioSystemPrompt({
+        //                 user: studentProfileForPrompt,
+        //                 tutorName: currentTutor,
+        //                 textbookMode: true,
+        //                 textbookContext
+        //             });
+        //         }
+        //     } catch (textbookError) {
+        //         console.error('[Chat] Textbook mode context failed, falling back to default:', textbookError.message);
+        //         // Fall through to default prompt below
+        //     }
+        // }
 
         if (!systemPrompt && conversationContextForPrompt?.courseSession && !masteryContext) {
             // COURSE MODE: Use the dedicated instructor-led prompt

--- a/routes/curriculum.js
+++ b/routes/curriculum.js
@@ -794,12 +794,14 @@ function extractObjectives(text) {
 }
 
 // ============================================================================
-// CHAPTER UPLOAD ENDPOINTS (Textbook Mode)
+// CHAPTER UPLOAD ENDPOINTS (Textbook Mode) — Biology tutor prototype — disabled
 // ============================================================================
 
-const ChapterContent = require('../models/chapterContent');
-const { processChapter } = require('../utils/chapterProcessor');
+// const ChapterContent = require('../models/chapterContent');
+// const { processChapter } = require('../utils/chapterProcessor');
 
+/*
+// Biology tutor prototype — disabled
 // Configure multer for chapter PDF uploads (larger limit for textbooks)
 const chapterUpload = multer({
     storage: multer.memoryStorage(),
@@ -813,11 +815,6 @@ const chapterUpload = multer({
     }
 });
 
-/**
- * POST /api/teacher/chapters/upload
- * Upload a single chapter PDF for processing
- * Body: chapterNumber, chapterTitle, subject, weekNumber, curriculumId (optional)
- */
 router.post('/teacher/chapters/upload', isAuthenticated, isTeacher, chapterUpload.single('file'), async (req, res) => {
     try {
         if (!req.file) {
@@ -830,7 +827,6 @@ router.post('/teacher/chapters/upload', isAuthenticated, isTeacher, chapterUploa
             return res.status(400).json({ message: 'chapterNumber and chapterTitle are required' });
         }
 
-        // Create the chapter content document
         const chapterContent = new ChapterContent({
             teacherId: req.user._id,
             curriculumId: curriculumId || null,
@@ -849,7 +845,6 @@ router.post('/teacher/chapters/upload', isAuthenticated, isTeacher, chapterUploa
 
         await chapterContent.save();
 
-        // Kick off processing pipeline as background job
         processChapter(chapterContent._id, req.file.buffer).catch(err => {
             console.error(`[ChapterUpload] Background processing failed for chapter ${chapterContent._id}: ${err.message}`);
         });
@@ -867,10 +862,6 @@ router.post('/teacher/chapters/upload', isAuthenticated, isTeacher, chapterUploa
     }
 });
 
-/**
- * POST /api/teacher/chapters/upload-bulk
- * Upload multiple chapter PDFs at once
- */
 router.post('/teacher/chapters/upload-bulk', isAuthenticated, isTeacher, chapterUpload.array('files', 20), async (req, res) => {
     try {
         if (!req.files || req.files.length === 0) {
@@ -882,7 +873,6 @@ router.post('/teacher/chapters/upload-bulk', isAuthenticated, isTeacher, chapter
 
         for (let i = 0; i < req.files.length; i++) {
             const file = req.files[i];
-            // Derive chapter number from filename or index
             const nameMatch = file.originalname.match(/(?:ch(?:apter)?\.?\s*)?(\d+)/i);
             const chapterNum = nameMatch ? parseInt(nameMatch[1]) : i + 1;
             const chapterTitle = file.originalname.replace(/\.pdf$/i, '').replace(/[-_]/g, ' ').trim();
@@ -904,12 +894,11 @@ router.post('/teacher/chapters/upload-bulk', isAuthenticated, isTeacher, chapter
 
             await chapterContent.save();
 
-            // Kick off processing (staggered to avoid rate limits)
             setTimeout(() => {
                 processChapter(chapterContent._id, file.buffer).catch(err => {
                     console.error(`[ChapterUpload] Background processing failed for chapter ${chapterContent._id}: ${err.message}`);
                 });
-            }, i * 2000); // 2 second stagger between chapters
+            }, i * 2000);
 
             results.push({
                 chapterContentId: chapterContent._id,
@@ -931,10 +920,6 @@ router.post('/teacher/chapters/upload-bulk', isAuthenticated, isTeacher, chapter
     }
 });
 
-/**
- * GET /api/teacher/chapters/status
- * Get processing status for all chapters uploaded by this teacher
- */
 router.get('/teacher/chapters/status', isAuthenticated, isTeacher, async (req, res) => {
     try {
         const chapters = await ChapterContent.getProcessingStatus(req.user._id);
@@ -950,10 +935,6 @@ router.get('/teacher/chapters/status', isAuthenticated, isTeacher, async (req, r
     }
 });
 
-/**
- * GET /api/teacher/chapters/:id
- * Get a specific chapter's details (without embeddings)
- */
 router.get('/teacher/chapters/:id', isAuthenticated, isTeacher, async (req, res) => {
     try {
         const chapter = await ChapterContent.findOne({
@@ -973,10 +954,6 @@ router.get('/teacher/chapters/:id', isAuthenticated, isTeacher, async (req, res)
     }
 });
 
-/**
- * DELETE /api/teacher/chapters/:id
- * Delete a chapter and its processed data
- */
 router.delete('/teacher/chapters/:id', isAuthenticated, isTeacher, async (req, res) => {
     try {
         const result = await ChapterContent.findOneAndDelete({
@@ -999,10 +976,6 @@ router.delete('/teacher/chapters/:id', isAuthenticated, isTeacher, async (req, r
     }
 });
 
-/**
- * GET /api/student/chapters
- * Get available chapters for a student (based on their teacher's uploads)
- */
 router.get('/student/chapters', isAuthenticated, async (req, res) => {
     try {
         const user = await User.findById(req.user._id);
@@ -1029,5 +1002,6 @@ router.get('/student/chapters', isAuthenticated, async (req, res) => {
         res.status(500).json({ message: 'Failed to fetch chapters' });
     }
 });
+*/
 
 module.exports = router;

--- a/routes/settings.js
+++ b/routes/settings.js
@@ -285,9 +285,10 @@ router.get('/upload-retention/:studentId', isAuthenticated, async (req, res) => 
 
 /**
  * @route   PATCH /api/settings/user
- * @desc    Update user settings (textbookMode, preferences, etc.)
+ * @desc    Update user settings — Biology tutor prototype fields disabled
  * @access  Private (Authenticated users)
  */
+/*
 router.patch('/user', isAuthenticated, async (req, res) => {
     try {
         const userId = req.user._id;
@@ -323,5 +324,6 @@ router.patch('/user', isAuthenticated, async (req, res) => {
         });
     }
 });
+*/
 
 module.exports = router;


### PR DESCRIPTION
## Summary
This PR disables the biology tutor prototype features across the codebase by commenting out related imports, route handlers, and UI elements. The changes preserve the code for potential future re-enablement while removing the feature from active use.

## Key Changes

- **routes/chat.js**: Commented out biology textbook mode imports and disabled the textbook context building logic that was conditionally executed when `user.textbookMode` was active
- **routes/curriculum.js**: Disabled all chapter upload endpoints (`/teacher/chapters/upload`, `/teacher/chapters/upload-bulk`, `/teacher/chapters/status`, etc.) and related chapter processing functionality by wrapping them in a multi-line comment block
- **config/routes.js**: Commented out the biology routes registration (`/api/bio`) and disabled three biology-related HTML routes (`/bio.html`, `/bio-chat.html`, `/bio-chapters.html`)
- **routes/settings.js**: Disabled the user settings PATCH endpoint that handled textbook mode preferences and related biology tutor configuration
- **public/chat.html**: Hidden the textbook mode toggle UI element by adding `display: none` style to the wrapper

## Implementation Details

- All disabled code is preserved with inline comments indicating "Biology tutor prototype — disabled" for clarity
- The changes are non-destructive and can be easily reverted if the prototype needs to be re-enabled
- No database migrations or data cleanup is required; the feature is simply deactivated at the application layer
- The textbook mode toggle remains in the DOM but is hidden from users via CSS

https://claude.ai/code/session_01AcrG9zmM1GgKYuj7xc7h2D