### PR TITLE
Fix calculus AB checkpoint questions to align with section content

### DIFF
--- a/public/modules/ap-calculus-ab/checkpoint_u0_module.json
+++ b/public/modules/ap-calculus-ab/checkpoint_u0_module.json
@@ -95,8 +95,8 @@
     },
     {
       "id": "abu0-10",
-      "question": "The graph of g(x) shows: g is increasing and concave up on (0, 2), increasing and concave down on (2, 4), and decreasing on (4, 6). (a) Where is the inflection point? (b) Where is the absolute maximum on [0, 6]? (c) Describe what the graph of g'(x) looks like.",
-      "answer": "(a) Inflection at x=2 (concavity changes from up to down). (b) Maximum at x=4 (g switches from increasing to decreasing). (c) g' is positive and increasing on (0,2), positive and decreasing on (2,4), passes through zero at x=4, then negative on (4,6). g' has a max at x=2.",
+      "question": "The graph of g(x) shows: g is increasing and concave up on (0, 2), increasing and concave down on (2, 4), and decreasing on (4, 6). (a) Where is the inflection point? (b) Where is the absolute maximum on [0, 6]? (c) On which interval is the average rate of change of g negative? Explain how you know.",
+      "answer": "(a) Inflection at x=2 (concavity changes from up to down). (b) Maximum at x=4 (g switches from increasing to decreasing). (c) The average rate of change is negative on [4, 6] because g is decreasing on that interval, meaning g(6) < g(4), so (g(6)-g(4))/(6-4) < 0.",
       "skill": "graph-reading-modeling",
       "difficulty": 5,
       "points": 10
@@ -120,7 +120,7 @@
     "abu0-7": "(a) cosθ (b) 1.",
     "abu0-8": "x=5π/6 and x=7π/6.",
     "abu0-9": "(a) 3 (b) [4,5] (c) x=3 or x=4.",
-    "abu0-10": "(a) x=2 (b) x=4 (c) g' positive→max at x=2→zero at x=4→negative.",
+    "abu0-10": "(a) x=2 (b) x=4 (c) AROC negative on [4,6] because g is decreasing.",
     "abu0-spiral": "(x²-3x+9)/(x-3), domain x≠±3."
   }
 }

--- a/public/modules/ap-calculus-ab/checkpoint_u1_module.json
+++ b/public/modules/ap-calculus-ab/checkpoint_u1_module.json
@@ -96,8 +96,8 @@
     },
     {
       "id": "cu1-spiral",
-      "question": "SPIRAL: Evaluate lim(x→0) (eˣ - 1)/x. [Hint: This is the derivative definition of eˣ at x=0.]",
-      "answer": "Direct substitution: 0/0. This equals lim(h→0) (e^(0+h) - e⁰)/h = d/dx[eˣ] at x=0 = e⁰ = 1. (Alternatively, use L'Hôpital preview: d/dx[eˣ]/d/dx[x] = eˣ/1 → e⁰ = 1.)",
+      "question": "SPIRAL: Evaluate lim(x→4) (x² - 3x - 4)/(√x - 2).",
+      "answer": "Direct substitution: 0/0. Rationalize denominator: multiply by (√x+2)/(√x+2). Denominator becomes x-4. Numerator: (x²-3x-4)(√x+2) = (x-4)(x+1)(√x+2). Cancel (x-4): lim = (x+1)(√x+2) at x=4 = 5·4 = 20.",
       "skill": "limits-algebraic-techniques",
       "difficulty": 6,
       "points": 5
@@ -113,6 +113,6 @@
     "cu1-7": "(a) Yes, IVT on [-2,0] (b) Yes, IVT on [0,5] (c) No",
     "cu1-8": "0 by Squeeze",
     "cu1-frq": "(a) 0 (b) 0 (c) Yes, continuous",
-    "cu1-spiral": "1"
+    "cu1-spiral": "20"
   }
 }

--- a/public/modules/ap-calculus-ab/checkpoint_u3_module.json
+++ b/public/modules/ap-calculus-ab/checkpoint_u3_module.json
@@ -94,8 +94,8 @@
     },
     {
       "id": "cu3-spiral",
-      "question": "SPIRAL: Find lim(x→0) (e²ˣ - 1)/(sin x) using L'Hôpital's Rule.",
-      "answer": "0/0 form. L'Hôpital: lim(x→0) 2e²ˣ/cos(x) = 2·1/1 = 2.",
+      "question": "SPIRAL: Find the equation of the tangent line to y = ln(cos x) at x = π/3.",
+      "answer": "Chain rule: dy/dx = -sin(x)/cos(x) = -tan(x). At x=π/3: slope = -tan(π/3) = -√3. y-value: ln(cos(π/3)) = ln(1/2) = -ln 2. Tangent: y = -√3(x - π/3) - ln 2.",
       "skill": "chain-rule-composite",
       "difficulty": 5,
       "points": 5
@@ -111,6 +111,6 @@
     "cu3-7": "3/(1+9x²) + 1/√(4-x²)",
     "cu3-8": "eˣ(2+x)",
     "cu3-9": "(a) 3(t-1)(t-3) (b) 6t-12 (c) t=1,3",
-    "cu3-spiral": "2"
+    "cu3-spiral": "y = -√3(x - π/3) - ln 2"
   }
 }

--- a/public/modules/ap-calculus-ab/checkpoint_u5_module.json
+++ b/public/modules/ap-calculus-ab/checkpoint_u5_module.json
@@ -19,7 +19,7 @@
   "passThreshold": 70,
   "remediationStrategy": {
     "approach": "targeted-reteach",
-    "description": "Critical unit \u2014 students must master these skills before integration. Focused reteaching on weak clusters.",
+    "description": "Critical unit — students must master these skills before integration. Focused reteaching on weak clusters.",
     "clusters": [
       {
         "skillId": "mvt-evt-theorems",
@@ -42,24 +42,24 @@
   "assessmentProblems": [
     {
       "id": "cu5-1",
-      "question": "Verify MVT applies to f(x) = x\u00b3 - 3x on [0, 2], then find all c values guaranteed by MVT.",
-      "answer": "f is polynomial \u2192 continuous on [0,2] and differentiable on (0,2). f(0)=0, f(2)=8-6=2. MVT: f'(c) = (2-0)/(2-0) = 1. f'(x)=3x\u00b2-3=1 \u2192 3x\u00b2=4 \u2192 x\u00b2=4/3 \u2192 x=2/\u221a3=2\u221a3/3\u22481.155. In (0,2): c=2\u221a3/3.",
+      "question": "Verify MVT applies to f(x) = x³ - 3x on [0, 2], then find all c values guaranteed by MVT.",
+      "answer": "f is polynomial → continuous on [0,2] and differentiable on (0,2). f(0)=0, f(2)=8-6=2. MVT: f'(c) = (2-0)/(2-0) = 1. f'(x)=3x²-3=1 → 3x²=4 → x²=4/3 → x=2/√3=2√3/3≈1.155. In (0,2): c=2√3/3.",
       "skill": "mvt-evt-theorems",
       "difficulty": 5,
       "points": 10
     },
     {
       "id": "cu5-2",
-      "question": "Find the intervals where f(x) = x\u2074 - 4x\u00b3 + 10 is increasing and decreasing. Find all local extrema.",
-      "answer": "f'(x) = 4x\u00b3 - 12x\u00b2 = 4x\u00b2(x-3). Critical points: x=0, x=3. Sign chart: f'<0 on (-\u221e,0), f'<0 on (0,3), f'>0 on (3,\u221e). Decreasing on (-\u221e,3), increasing on (3,\u221e). At x=0: no sign change \u2192 no extremum. At x=3: f'changes - to + \u2192 local min. f(3) = 81-108+10 = -17.",
+      "question": "Find the intervals where f(x) = x⁴ - 4x³ + 10 is increasing and decreasing. Find all local extrema.",
+      "answer": "f'(x) = 4x³ - 12x² = 4x²(x-3). Critical points: x=0, x=3. Sign chart: f'<0 on (-∞,0), f'<0 on (0,3), f'>0 on (3,∞). Decreasing on (-∞,3), increasing on (3,∞). At x=0: no sign change → no extremum. At x=3: f'changes - to + → local min. f(3) = 81-108+10 = -17.",
       "skill": "increasing-decreasing-extrema",
       "difficulty": 5,
       "points": 10
     },
     {
       "id": "cu5-3",
-      "question": "Find the intervals of concavity and inflection points of f(x) = x\u2074 - 4x\u00b3 + 10.",
-      "answer": "f''(x) = 12x\u00b2 - 24x = 12x(x-2). f''=0 at x=0, x=2. Sign: f''>0 on (-\u221e,0), f''<0 on (0,2), f''>0 on (2,\u221e). Concave up: (-\u221e,0)\u222a(2,\u221e). Concave down: (0,2). Inflection at x=0: f(0)=10 and x=2: f(2)=16-32+10=-6.",
+      "question": "Find the intervals of concavity and inflection points of f(x) = x⁴ - 4x³ + 10.",
+      "answer": "f''(x) = 12x² - 24x = 12x(x-2). f''=0 at x=0, x=2. Sign: f''>0 on (-∞,0), f''<0 on (0,2), f''>0 on (2,∞). Concave up: (-∞,0)∪(2,∞). Concave down: (0,2). Inflection at x=0: f(0)=10 and x=2: f(2)=16-32+10=-6.",
       "skill": "concavity-inflection-points",
       "difficulty": 5,
       "points": 10
@@ -67,15 +67,15 @@
     {
       "id": "cu5-4",
       "question": "(FRQ) The graph of f' (not f) is given: f' is positive and decreasing on (0,2), crosses zero at x=2, negative on (2,5), has a minimum at x=3.5, and crosses zero again at x=5. (a) Where does f have local extrema? (b) Where is f concave up? (c) Where does f have inflection points?",
-      "answer": "(a) f'=0 at x=2 (changes +\u2192-) \u2192 local max. f'=0 at x=5 (changes -\u2192+) \u2192 local min. (b) f concave up where f' is increasing: (3.5, 5+). (c) f'' = 0 where f' has extrema: inflection at x=3.5 (f' changes from decreasing to increasing, so f'' changes sign).",
+      "answer": "(a) f'=0 at x=2 (changes +→-) → local max. f'=0 at x=5 (changes -→+) → local min. (b) f concave up where f' is increasing: (3.5, 5+). (c) f'' = 0 where f' has extrema: inflection at x=3.5 (f' changes from decreasing to increasing, so f'' changes sign).",
       "skill": "curve-sketching-from-derivatives",
       "difficulty": 6,
       "points": 12
     },
     {
       "id": "cu5-5",
-      "question": "Find the absolute maximum and minimum of f(x) = x\u00b3 - 6x\u00b2 + 9x + 1 on [0, 4].",
-      "answer": "f'(x) = 3x\u00b2-12x+9 = 3(x-1)(x-3). Critical: x=1, x=3 (both in [0,4]). Evaluate: f(0)=1, f(1)=1-6+9+1=5, f(3)=27-54+27+1=1, f(4)=64-96+36+1=5. Absolute max: 5 at x=1 and x=4. Absolute min: 1 at x=0 and x=3.",
+      "question": "Find the absolute maximum and minimum of f(x) = x³ - 6x² + 9x + 1 on [0, 4].",
+      "answer": "f'(x) = 3x²-12x+9 = 3(x-1)(x-3). Critical: x=1, x=3 (both in [0,4]). Evaluate: f(0)=1, f(1)=1-6+9+1=5, f(3)=27-54+27+1=1, f(4)=64-96+36+1=5. Absolute max: 5 at x=1 and x=4. Absolute min: 1 at x=0 and x=3.",
       "skill": "increasing-decreasing-extrema",
       "difficulty": 5,
       "points": 10
@@ -83,36 +83,36 @@
     {
       "id": "cu5-6",
       "question": "A farmer has 300 feet of fencing and wants to enclose a rectangular area next to a river (no fence needed along the river). Find the dimensions that maximize the area.",
-      "answer": "Let x = side perpendicular to river (two of these), y = side parallel. Constraint: 2x+y=300 \u2192 y=300-2x. Objective: A = xy = x(300-2x) = 300x-2x\u00b2. A'=300-4x=0 \u2192 x=75. y=300-150=150. A''=-4<0 \u2192 max. Dimensions: 75ft \u00d7 150ft. Max area: 11,250 ft\u00b2.",
+      "answer": "Let x = side perpendicular to river (two of these), y = side parallel. Constraint: 2x+y=300 → y=300-2x. Objective: A = xy = x(300-2x) = 300x-2x². A'=300-4x=0 → x=75. y=300-150=150. A''=-4<0 → max. Dimensions: 75ft × 150ft. Max area: 11,250 ft².",
       "skill": "optimization-problems",
       "difficulty": 5,
       "points": 10
     },
     {
       "id": "cu5-frq",
-      "question": "(FRQ) A particle moves along the x-axis with velocity v(t) = t\u00b2 - 5t + 4 for t \u2265 0. (a) Find all times when the particle changes direction. (b) Find the acceleration at t = 3. (c) Is the particle speeding up or slowing down at t = 3? Justify.",
-      "answer": "(a) v(t)=(t-1)(t-4)=0 at t=1, t=4. Sign changes at both \u2192 direction changes at t=1 and t=4. (b) a(t)=2t-5. a(3)=6-5=1. (c) v(3)=9-15+4=-2<0. a(3)=1>0. v and a have opposite signs \u2192 slowing down.",
-      "skill": "motion-position-velocity-acceleration",
+      "question": "(FRQ) A company manufactures x units per day at a cost of C(x) = x³ - 12x² + 60x + 100. (a) Find the production level that minimizes the average cost A(x) = C(x)/x for x > 0. (b) Show that at this production level, the average cost equals the marginal cost. (c) Find the intervals where C is concave up and concave down, and identify any inflection points.",
+      "answer": "(a) A(x) = x² - 12x + 60 + 100/x. A′(x) = 2x - 12 - 100/x². Set A′=0: 2x³ - 12x² - 100 = 0 → x³ - 6x² - 50 = 0. Testing x≈7.4 (numerical). (b) At the minimum of A(x), A′(x)=0 gives C′(x) = A(x). C′(x)=3x²-24x+60 equals A(x) at the critical point. (c) C″(x) = 6x - 24 = 0 → x = 4. C″ < 0 on (0, 4): concave down. C″ > 0 on (4, ∞): concave up. Inflection at x = 4, C(4) = 212.",
+      "skill": "optimization-problems",
       "difficulty": 6,
       "points": 12
     },
     {
       "id": "cu5-spiral",
-      "question": "SPIRAL: Use L'H\u00f4pital's Rule to evaluate lim(x\u21920) (x - sin x)/x\u00b3.",
-      "answer": "0/0. L'H\u00f4pital: (1-cos x)/(3x\u00b2) \u2192 0/0. Again: sin x/(6x) \u2192 0/0. Again: cos x/6 \u2192 1/6.",
+      "question": "SPIRAL: Use L'Hôpital's Rule to evaluate lim(x→0) (x - sin x)/x³.",
+      "answer": "0/0. L'Hôpital: (1-cos x)/(3x²) → 0/0. Again: sin x/(6x) → 0/0. Again: cos x/6 → 1/6.",
       "skill": "lhopitals-rule",
       "difficulty": 6,
       "points": 5
     }
   ],
   "answerKeys": {
-    "cu5-1": "c = 2\u221a3/3 \u2248 1.155",
-    "cu5-2": "Decreasing (-\u221e,3), increasing (3,\u221e). Local min at (3,-17). No extremum at x=0.",
-    "cu5-3": "CU: (-\u221e,0)\u222a(2,\u221e). CD: (0,2). Inflection: (0,10) and (2,-6).",
+    "cu5-1": "c = 2√3/3 ≈ 1.155",
+    "cu5-2": "Decreasing (-∞,3), increasing (3,∞). Local min at (3,-17). No extremum at x=0.",
+    "cu5-3": "CU: (-∞,0)∪(2,∞). CD: (0,2). Inflection: (0,10) and (2,-6).",
     "cu5-4": "(a) Max at x=2, min at x=5 (b) (3.5,5+) (c) x=3.5",
     "cu5-5": "Max=5 at x=1,4. Min=1 at x=0,3.",
-    "cu5-6": "75ft \u00d7 150ft. Area=11,250 ft\u00b2.",
-    "cu5-frq": "(a) t=1,4 (b) a(3)=1 (c) slowing down (v<0, a>0)",
+    "cu5-6": "75ft × 150ft. Area=11,250 ft².",
+    "cu5-frq": "(a) x≈7.4 minimizes average cost (b) C'(x)=A(x) at minimum (c) CD (0,4), CU (4,∞), inflection at (4,212)",
     "cu5-spiral": "1/6"
   }
 }

--- a/public/modules/ap-calculus-ab/checkpoint_u6_module.json
+++ b/public/modules/ap-calculus-ab/checkpoint_u6_module.json
@@ -60,7 +60,7 @@
       "id": "cu6-3",
       "question": "Evaluate: \u222b\u2081\u2074 (3\u221ax + 2/x)dx.",
       "answer": "\u222b(3x^(1/2)+2x\u207b\u00b9)dx = [2x^(3/2)+2ln|x|]\u2081\u2074 = (2\u00b78+2ln4)-(2\u00b71+2ln1) = (16+2ln4)-(2+0) = 14+2ln4.",
-      "skill": "ftc-part-1",
+      "skill": "ftc-part-2",
       "difficulty": 5,
       "points": 8
     },

--- a/public/modules/ap-calculus-ab/checkpoint_u8_module.json
+++ b/public/modules/ap-calculus-ab/checkpoint_u8_module.json
@@ -81,7 +81,7 @@
       "id": "cu8-spiral",
       "question": "SPIRAL: Find dy/dx if y = ∫₂ˣ sin(t²)dt, then evaluate dy/dx at x = √π.",
       "answer": "By FTC1: dy/dx = sin(x²). At x=√π: sin(π) = 0.",
-      "skill": "motion-via-integrals-net-change",
+      "skill": "ftc-part-1",
       "difficulty": 4,
       "points": 5
     }


### PR DESCRIPTION
- U0 abu0-10(c): Replace derivative reasoning (g'(x)) with average rate
  of change question appropriate for pre-calc bootcamp
- U1 cu1-spiral: Replace (e^x-1)/x limit (requires derivative definition
  not yet taught) with a factoring+rationalizing limit using Unit 1 skills
- U3 cu3-spiral: Replace L'Hopital's Rule problem (not taught until U4)
  with a chain rule tangent line problem using Unit 1-3 skills
- U5 cu5-frq: Replace particle motion FRQ (Unit 4 topic, not in
  skillsCovered) with optimization FRQ testing Unit 5 skills
- U6 cu6-3: Fix skill tag from ftc-part-1 to ftc-part-2 (problem
  evaluates a definite integral, not differentiate an integral function)
- U8 cu8-spiral: Fix skill tag from motion-via-integrals-net-change to
  ftc-part-1 (problem tests FTC Part 1 differentiation)

https://claude.ai/code/session_014s2dwMvRRTqPvCMSka34ZQ