### PR TITLE
Fix Algebra 1 checkpoint alignment with section content

### DIFF
--- a/public/modules/algebra-1/checkpoint_u10_module.json
+++ b/public/modules/algebra-1/checkpoint_u10_module.json
@@ -16,10 +16,34 @@
   ],
   "passThreshold": 70,
   "remediationResources": [
-    { "skillId": "simplifying-radicals", "reteachFocus": "Identifying perfect square factors, applying the product property √(ab) = √a·√b, simplifying radicals with variables, expressing results in simplest radical form", "resources": ["radicals_geometry_module.json - scaffold phases 1-2"] },
-    { "skillId": "operations-with-radicals", "reteachFocus": "Simplifying each radical before combining, adding and subtracting like radicals (same radicand), multiplying radical expressions", "resources": ["radicals_geometry_module.json - scaffold phases 2-3"] },
-    { "skillId": "pythagorean-theorem", "reteachFocus": "Applying a² + b² = c² to find missing sides, recognizing Pythagorean triples, identifying the hypotenuse in word problems, solving real-world right triangle problems", "resources": ["radicals_geometry_module.json - scaffold phases 4-6"] },
-    { "skillId": "distance-formula", "reteachFocus": "Using d = √((x₂ − x₁)² + (y₂ − y₁)²) to find distances between points, applying the midpoint formula, connecting the distance formula to the Pythagorean theorem", "resources": ["radicals_geometry_module.json - scaffold phases 7-8"] }
+    {
+      "skillId": "simplifying-radicals",
+      "reteachFocus": "Identifying perfect square factors, applying the product property √(ab) = √a·√b, simplifying radicals with variables, expressing results in simplest radical form",
+      "resources": [
+        "radicals_geometry_module.json - scaffold phases 1-2"
+      ]
+    },
+    {
+      "skillId": "operations-with-radicals",
+      "reteachFocus": "Simplifying each radical before combining, adding and subtracting like radicals (same radicand), multiplying radical expressions",
+      "resources": [
+        "radicals_geometry_module.json - scaffold phases 2-3"
+      ]
+    },
+    {
+      "skillId": "pythagorean-theorem",
+      "reteachFocus": "Applying a² + b² = c² to find missing sides, recognizing Pythagorean triples, identifying the hypotenuse in word problems, solving real-world right triangle problems",
+      "resources": [
+        "radicals_geometry_module.json - scaffold phases 4-6"
+      ]
+    },
+    {
+      "skillId": "distance-formula",
+      "reteachFocus": "Using d = √((x₂ − x₁)² + (y₂ − y₁)²) to find distances between points, applying the midpoint formula, connecting the distance formula to the Pythagorean theorem",
+      "resources": [
+        "radicals_geometry_module.json - scaffold phases 7-8"
+      ]
+    }
   ],
   "assessmentProblems": [
     {
@@ -80,9 +104,9 @@
     },
     {
       "id": "a1u10-8",
-      "question": "Solve: √(2x + 3) = 7.",
-      "answer": "Square both sides: (√(2x + 3))² = 7². 2x + 3 = 49. 2x = 46. x = 23. Check: √(2(23) + 3) = √(46 + 3) = √49 = 7 ✓. The solution is x = 23.",
-      "skill": "simplifying-radicals",
+      "question": "Simplify: (3√2 + √6)(√2).",
+      "answer": "Distribute √2 to each term: 3√2 · √2 + √6 · √2 = 3·√4 + √12 = 3·2 + √(4·3) = 6 + 2√3.",
+      "skill": "operations-with-radicals",
       "difficulty": 4,
       "points": 10
     },
@@ -131,7 +155,7 @@
     "a1u10-5": "12. b² = 400 − 256 = 144. Triple: 12-16-20 (3-4-5 × 4).",
     "a1u10-6": "5 units. d = √(16+9) = √25 = 5.",
     "a1u10-7": "Midpoint: (-1, -1). Distance: 10 units. d = √(64+36) = √100 = 10.",
-    "a1u10-8": "x = 23. Square both sides: 2x + 3 = 49 → x = 23. Check: √49 = 7 ✓.",
+    "a1u10-8": "6 + 2√3. Distribute: 3√2·√2 + √6·√2 = 3(2) + √12 = 6 + 2√3.",
     "a1u10-9": "60 inches. 48² + 36² = 2304 + 1296 = 3600. √3600 = 60. Triple: 3-4-5 × 12.",
     "a1u10-10": "Student is wrong. √(a² + b²) ≠ a + b. Counterexample: √(9+16) = √25 = 5 ≠ 3+4 = 7. The square root does not distribute over addition. The hypotenuse is always shorter than the sum of the legs (triangle inequality).",
     "a1u10-spiral-1": "P ≈ 7,934 after 6 years. P = 5000(1.08)⁶.",

--- a/public/modules/algebra-1/checkpoint_u1_module.json
+++ b/public/modules/algebra-1/checkpoint_u1_module.json
@@ -17,11 +17,41 @@
   ],
   "passThreshold": 70,
   "remediationResources": [
-    { "skillId": "variable-expressions", "reteachFocus": "Defining variables, translating verbal phrases to algebraic expressions, evaluating expressions by substitution", "resources": ["foundations_algebra_module.json - scaffold phases 1, 3"] },
-    { "skillId": "order-of-operations", "reteachFocus": "GEMS hierarchy, left-to-right rule for equal-priority operations, nested grouping symbols", "resources": ["foundations_algebra_module.json - scaffold phase 2"] },
-    { "skillId": "algebraic-properties", "reteachFocus": "Commutative property (addition/multiplication), associative property (regrouping), identifying which property justifies a given step", "resources": ["foundations_algebra_module.json - scaffold phase 4"] },
-    { "skillId": "combining-like-terms", "reteachFocus": "Identifying like terms (same variable, same exponent), combining coefficients, recognizing terms that cannot be combined (e.g., x vs x²)", "resources": ["foundations_algebra_module.json - scaffold phases 5-6"] },
-    { "skillId": "distributive-property", "reteachFocus": "Distributing positive and negative factors over addition and subtraction, distributing then combining like terms, multi-group distribution", "resources": ["foundations_algebra_module.json - scaffold phases 5-6"] }
+    {
+      "skillId": "variable-expressions",
+      "reteachFocus": "Defining variables, translating verbal phrases to algebraic expressions, evaluating expressions by substitution",
+      "resources": [
+        "foundations_algebra_module.json - scaffold phases 1, 3"
+      ]
+    },
+    {
+      "skillId": "order-of-operations",
+      "reteachFocus": "GEMS hierarchy, left-to-right rule for equal-priority operations, nested grouping symbols",
+      "resources": [
+        "foundations_algebra_module.json - scaffold phase 2"
+      ]
+    },
+    {
+      "skillId": "algebraic-properties",
+      "reteachFocus": "Commutative property (addition/multiplication), associative property (regrouping), identifying which property justifies a given step",
+      "resources": [
+        "foundations_algebra_module.json - scaffold phase 4"
+      ]
+    },
+    {
+      "skillId": "combining-like-terms",
+      "reteachFocus": "Identifying like terms (same variable, same exponent), combining coefficients, recognizing terms that cannot be combined (e.g., x vs x²)",
+      "resources": [
+        "foundations_algebra_module.json - scaffold phases 5-6"
+      ]
+    },
+    {
+      "skillId": "distributive-property",
+      "reteachFocus": "Distributing positive and negative factors over addition and subtraction, distributing then combining like terms, multi-group distribution",
+      "resources": [
+        "foundations_algebra_module.json - scaffold phases 5-6"
+      ]
+    }
   ],
   "assessmentProblems": [
     {
@@ -98,8 +128,8 @@
     },
     {
       "id": "a1u1-10",
-      "question": "ANALYSIS: The perimeter of a rectangle is given by 2(3x + 4) + 2(x - 1). (a) Simplify this expression completely. (b) Evaluate the perimeter when x = 5. (c) If the perimeter equals 54, find the value of x.",
-      "answer": "(a) Distribute: 6x + 8 + 2x - 2. Combine like terms: 8x + 6. (b) Substitute x = 5: 8(5) + 6 = 40 + 6 = 46. (c) Set 8x + 6 = 54: 8x = 48, so x = 6. Check: 8(6) + 6 = 48 + 6 = 54. Confirmed.",
+      "question": "ANALYSIS: The perimeter of a rectangle is given by 2(3x + 4) + 2(x - 1). (a) Simplify this expression completely. (b) Evaluate the perimeter when x = 5. (c) If x = 8, find the length of each side and verify the perimeter formula.",
+      "answer": "(a) Distribute: 6x + 8 + 2x - 2. Combine like terms: 8x + 6. (b) Substitute x = 5: 8(5) + 6 = 40 + 6 = 46. (c) When x = 8: length = 3(8) + 4 = 28, width = 8 - 1 = 7. Perimeter = 2(28) + 2(7) = 56 + 14 = 70. Check with simplified expression: 8(8) + 6 = 64 + 6 = 70. Confirmed.",
       "skill": "distributive-property",
       "difficulty": 6,
       "points": 14
@@ -115,6 +145,6 @@
     "a1u1-7": "3x² + 4x - 6",
     "a1u1-8": "-12x + 21",
     "a1u1-9": "5x + 26",
-    "a1u1-10": "(a) 8x + 6 (b) 46 (c) x = 6"
+    "a1u1-10": "(a) 8x + 6 (b) 46 (c) length=28, width=7, perimeter=70"
   }
 }

--- a/public/modules/algebra-1/checkpoint_u3_module.json
+++ b/public/modules/algebra-1/checkpoint_u3_module.json
@@ -9,24 +9,64 @@
   "type": "assessment",
   "description": "Summative checkpoint assessing mastery of function identification (domain, range, vertical line test), slope calculation from points and graphs, graphing and writing linear equations in slope-intercept, point-slope, and standard form, and determining parallel and perpendicular line relationships using slope.",
   "skillsCovered": [
-    "graphing-linear-equations-slope-intercept",
-    "writing-linear-equations-slope-intercept",
+    "understanding-functions",
     "slope-from-points",
+    "graphing-linear-equations-slope-intercept",
+    "writing-linear-equations-point-slope",
+    "standard-form-equations",
     "parallel-perpendicular-lines"
   ],
   "passThreshold": 70,
   "remediationResources": [
-    { "skillId": "graphing-linear-equations-slope-intercept", "reteachFocus": "Identifying slope and y-intercept from y = mx + b, plotting the y-intercept, using slope triangles to find additional points, drawing the line with correct direction", "resources": ["functions_graphs_module.json - scaffold phases 1, 3"] },
-    { "skillId": "writing-linear-equations-slope-intercept", "reteachFocus": "Point-slope form y - y1 = m(x - x1), converting to slope-intercept form, converting between slope-intercept and standard form, finding intercepts from standard form", "resources": ["functions_graphs_module.json - scaffold phases 4, 5, 6"] },
-    { "skillId": "slope-from-points", "reteachFocus": "Slope formula m = (y2 - y1) / (x2 - x1), interpreting positive/negative/zero/undefined slope, slope as rate of change, reading slope from a graph", "resources": ["functions_graphs_module.json - scaffold phases 2, 3, 6"] },
-    { "skillId": "parallel-perpendicular-lines", "reteachFocus": "Parallel lines have equal slopes, perpendicular lines have negative reciprocal slopes, writing equations of parallel/perpendicular lines through a given point", "resources": ["functions_graphs_module.json - scaffold phases 7, 8"] }
+    {
+      "skillId": "understanding-functions",
+      "reteachFocus": "Function definition (each input maps to exactly one output), domain and range identification, vertical line test, f(x) notation",
+      "resources": [
+        "functions_graphs_module.json - scaffold phases 1-2"
+      ]
+    },
+    {
+      "skillId": "slope-from-points",
+      "reteachFocus": "Slope formula m = (y2 - y1) / (x2 - x1), interpreting positive/negative/zero/undefined slope, slope as rate of change, reading slope from a graph",
+      "resources": [
+        "functions_graphs_module.json - scaffold phases 2, 3, 6"
+      ]
+    },
+    {
+      "skillId": "graphing-linear-equations-slope-intercept",
+      "reteachFocus": "Identifying slope and y-intercept from y = mx + b, plotting the y-intercept, using slope triangles to find additional points, drawing the line with correct direction",
+      "resources": [
+        "functions_graphs_module.json - scaffold phases 1, 3"
+      ]
+    },
+    {
+      "skillId": "writing-linear-equations-point-slope",
+      "reteachFocus": "Point-slope form y - y1 = m(x - x1), writing equations from slope and a point or two points, converting to slope-intercept form",
+      "resources": [
+        "functions_graphs_module.json - scaffold phases 4, 5"
+      ]
+    },
+    {
+      "skillId": "standard-form-equations",
+      "reteachFocus": "Converting between standard form (Ax + By = C) and slope-intercept form, finding x- and y-intercepts from standard form",
+      "resources": [
+        "functions_graphs_module.json - scaffold phase 6"
+      ]
+    },
+    {
+      "skillId": "parallel-perpendicular-lines",
+      "reteachFocus": "Parallel lines have equal slopes, perpendicular lines have negative reciprocal slopes, writing equations of parallel/perpendicular lines through a given point",
+      "resources": [
+        "functions_graphs_module.json - scaffold phases 7, 8"
+      ]
+    }
   ],
   "assessmentProblems": [
     {
       "id": "a1u3-1",
       "question": "Determine whether the relation {(1, 4), (2, 7), (3, 10), (4, 13)} is a function. If so, state the domain and range.",
       "answer": "Yes, it is a function — each input (x-value) maps to exactly one output (y-value). No x-value is repeated. Domain: {1, 2, 3, 4}. Range: {4, 7, 10, 13}.",
-      "skill": "graphing-linear-equations-slope-intercept",
+      "skill": "understanding-functions",
       "difficulty": 2,
       "points": 6
     },
@@ -58,7 +98,7 @@
       "id": "a1u3-5",
       "question": "Write the equation of the line with slope 2 that passes through the point (3, 7). Give your answer in slope-intercept form.",
       "answer": "Start with point-slope form: y - 7 = 2(x - 3). Distribute: y - 7 = 2x - 6. Add 7 to both sides: y = 2x + 1. Check: when x = 3, y = 2(3) + 1 = 7. Correct.",
-      "skill": "writing-linear-equations-slope-intercept",
+      "skill": "writing-linear-equations-point-slope",
       "difficulty": 3,
       "points": 8
     },
@@ -66,7 +106,7 @@
       "id": "a1u3-6",
       "question": "A line passes through the points (1, -2) and (4, 7). Write the equation of the line in slope-intercept form.",
       "answer": "Step 1 — Find slope: m = (7 - (-2)) / (4 - 1) = 9 / 3 = 3. Step 2 — Use point-slope with (1, -2): y - (-2) = 3(x - 1) becomes y + 2 = 3x - 3. Step 3 — Solve for y: y = 3x - 5. Check: when x = 4, y = 3(4) - 5 = 7. Correct.",
-      "skill": "writing-linear-equations-slope-intercept",
+      "skill": "writing-linear-equations-point-slope",
       "difficulty": 4,
       "points": 10
     },
@@ -74,7 +114,7 @@
       "id": "a1u3-7",
       "question": "Convert 3x + 2y = 12 to slope-intercept form. State the slope and y-intercept, then find the x-intercept.",
       "answer": "Solve for y: 2y = -3x + 12, so y = (-3/2)x + 6. Slope = -3/2, y-intercept = (0, 6). For the x-intercept, set y = 0: 3x + 2(0) = 12, so 3x = 12, x = 4. The x-intercept is (4, 0).",
-      "skill": "writing-linear-equations-slope-intercept",
+      "skill": "standard-form-equations",
       "difficulty": 4,
       "points": 10
     },

--- a/public/modules/algebra-1/checkpoint_u4_module.json
+++ b/public/modules/algebra-1/checkpoint_u4_module.json
@@ -12,14 +12,46 @@
     "systems-of-equations-graphing",
     "systems-of-equations-substitution",
     "systems-of-equations-elimination",
+    "systems-special-cases",
     "systems-word-problems"
   ],
   "passThreshold": 70,
   "remediationResources": [
-    { "skillId": "systems-of-equations-graphing", "reteachFocus": "Graphing two lines on the same plane, reading intersection point, verifying the solution in both equations", "resources": ["systems_equations_module.json - scaffold phases 1-2"] },
-    { "skillId": "systems-of-equations-substitution", "reteachFocus": "Isolating a variable in one equation, substituting into the other, solving the resulting single-variable equation", "resources": ["systems_equations_module.json - scaffold phases 1-2"] },
-    { "skillId": "systems-of-equations-elimination", "reteachFocus": "Adding/subtracting equations to eliminate a variable, multiplying to create opposite coefficients, special cases (no solution, infinite solutions)", "resources": ["systems_equations_module.json - scaffold phases 3-5"] },
-    { "skillId": "systems-word-problems", "reteachFocus": "Defining variables, translating two conditions into two equations, choosing a solution method, interpreting the answer in context", "resources": ["systems_equations_module.json - scaffold phases 6-8"] }
+    {
+      "skillId": "systems-of-equations-graphing",
+      "reteachFocus": "Graphing two lines on the same plane, reading intersection point, verifying the solution in both equations",
+      "resources": [
+        "systems_equations_module.json - scaffold phases 1-2"
+      ]
+    },
+    {
+      "skillId": "systems-of-equations-substitution",
+      "reteachFocus": "Isolating a variable in one equation, substituting into the other, solving the resulting single-variable equation",
+      "resources": [
+        "systems_equations_module.json - scaffold phases 1-2"
+      ]
+    },
+    {
+      "skillId": "systems-of-equations-elimination",
+      "reteachFocus": "Adding/subtracting equations to eliminate a variable, multiplying to create opposite coefficients, special cases (no solution, infinite solutions)",
+      "resources": [
+        "systems_equations_module.json - scaffold phases 3-5"
+      ]
+    },
+    {
+      "skillId": "systems-special-cases",
+      "reteachFocus": "Recognizing no-solution (false statement like 0 = 13, parallel lines) vs. infinitely many solutions (true statement like 0 = 0, same line); consistent/inconsistent/dependent classification",
+      "resources": [
+        "systems_equations_module.json - scaffold phases 4-5"
+      ]
+    },
+    {
+      "skillId": "systems-word-problems",
+      "reteachFocus": "Defining variables, translating two conditions into two equations, choosing a solution method, interpreting the answer in context",
+      "resources": [
+        "systems_equations_module.json - scaffold phases 6-8"
+      ]
+    }
   ],
   "assessmentProblems": [
     {
@@ -66,7 +98,7 @@
       "id": "a1u4-6",
       "question": "Classify the system and explain your reasoning:\n2x + 6y = 10\nx + 3y = 5",
       "answer": "Multiply equation 2 by 2: 2x + 6y = 10. This is identical to equation 1. Subtracting: 0 = 0, a true statement. Both variables cancel, and we get a true statement, so the system has **infinitely many solutions**. The system is **consistent and dependent** — both equations represent the same line (y = -x/3 + 5/3). Every point on the line is a solution.",
-      "skill": "systems-of-equations-elimination",
+      "skill": "systems-special-cases",
       "difficulty": 4,
       "points": 10
     },
@@ -74,7 +106,7 @@
       "id": "a1u4-7",
       "question": "Classify the system and explain your reasoning:\n3x - y = 4\n-6x + 2y = 5",
       "answer": "Multiply equation 1 by 2: 6x - 2y = 8. Add to equation 2: (6x - 2y) + (-6x + 2y) = 8 + 5 → 0 = 13. This is a **false statement**. Both variables canceled and we got a contradiction, so the system has **no solution**. The system is **inconsistent**. The lines are parallel: equation 1 gives y = 3x - 4 and equation 2 gives y = 3x + 5/2 — same slope (3), different y-intercepts.",
-      "skill": "systems-of-equations-elimination",
+      "skill": "systems-special-cases",
       "difficulty": 4,
       "points": 10
     },
@@ -98,7 +130,7 @@
       "id": "a1u4-10",
       "question": "ANALYSIS: A student solves the following system and says there is no solution:\n5x + 2y = 8\n10x + 4y = 16\nIs the student correct? Solve the system, classify it, and explain what the solution set looks like graphically.",
       "answer": "The student is **incorrect**. Multiply equation 1 by 2: 10x + 4y = 16. This is identical to equation 2. Subtracting: 0 = 0, a true statement. The system has **infinitely many solutions**, not no solution. The system is **consistent and dependent**. Both equations represent the same line: 5x + 2y = 8, or equivalently y = -5x/2 + 4. Graphically, the two equations produce the **exact same line** — they overlap completely. Every point on this line (there are infinitely many) is a solution. The student likely confused 'same line' (infinitely many solutions, 0 = 0) with 'parallel lines' (no solution, 0 = nonzero). The key distinction: if both variables cancel and you get a TRUE statement → same line; if you get a FALSE statement → parallel lines.",
-      "skill": "systems-of-equations-elimination",
+      "skill": "systems-special-cases",
       "difficulty": 6,
       "points": 16
     }

--- a/public/modules/algebra-1/checkpoint_u5_module.json
+++ b/public/modules/algebra-1/checkpoint_u5_module.json
@@ -9,30 +9,64 @@
   "type": "assessment",
   "description": "Summative checkpoint assessing mastery of exponent rules (product, quotient, power, zero, and negative), adding and subtracting polynomials, multiplying polynomials (monomial-by-polynomial and FOIL), factoring using GCF, factoring trinomials of the form x² + bx + c, factoring difference of squares, and factoring completely by combining strategies.",
   "skillsCovered": [
-    "exponent-rules-multiplication",
-    "exponent-rules-division",
+    "exponent-rules",
     "polynomial-addition-subtraction",
-    "polynomial-multiplication-monomial",
+    "polynomial-multiplication",
     "factoring-gcf",
     "factoring-trinomials",
     "factoring-difference-of-squares"
   ],
   "passThreshold": 70,
   "remediationResources": [
-    { "skillId": "exponent-rules-multiplication", "reteachFocus": "Product rule (add exponents), power rule (multiply exponents), zero and negative exponent rules, raising a product to a power", "resources": ["polynomials_module.json - scaffold phases 1-2"] },
-    { "skillId": "exponent-rules-division", "reteachFocus": "Quotient rule (subtract exponents), simplifying fractions with exponents, negative exponent results", "resources": ["polynomials_module.json - scaffold phases 1-2"] },
-    { "skillId": "polynomial-addition-subtraction", "reteachFocus": "Identifying like terms, combining coefficients, distributing the negative sign when subtracting polynomials", "resources": ["polynomials_module.json - scaffold phases 3-4"] },
-    { "skillId": "polynomial-multiplication-monomial", "reteachFocus": "Distributing a monomial across a polynomial, FOIL for binomial multiplication, combining like terms in the product", "resources": ["polynomials_module.json - scaffold phases 4-5"] },
-    { "skillId": "factoring-gcf", "reteachFocus": "Finding the GCF of coefficients and variables, dividing each term by the GCF, verifying by distributing back", "resources": ["polynomials_module.json - scaffold phases 6-8"] },
-    { "skillId": "factoring-trinomials", "reteachFocus": "Finding two numbers that multiply to c and add to b, writing the factored form, checking by FOIL", "resources": ["polynomials_module.json - scaffold phases 7-8"] },
-    { "skillId": "factoring-difference-of-squares", "reteachFocus": "Recognizing a² - b² pattern, identifying a and b, writing (a + b)(a - b), distinguishing from sum of squares (not factorable)", "resources": ["polynomials_module.json - scaffold phases 7-8"] }
+    {
+      "skillId": "exponent-rules",
+      "reteachFocus": "Product rule (add exponents), quotient rule (subtract exponents), power rule (multiply exponents), zero and negative exponent rules",
+      "resources": [
+        "polynomials_module.json - scaffold phases 1-2"
+      ]
+    },
+    {
+      "skillId": "polynomial-addition-subtraction",
+      "reteachFocus": "Identifying like terms, combining coefficients, distributing the negative sign when subtracting polynomials",
+      "resources": [
+        "polynomials_module.json - scaffold phases 3-4"
+      ]
+    },
+    {
+      "skillId": "polynomial-multiplication",
+      "reteachFocus": "Distributing a monomial across a polynomial, FOIL for binomial multiplication, combining like terms in the product",
+      "resources": [
+        "polynomials_module.json - scaffold phases 4-5"
+      ]
+    },
+    {
+      "skillId": "factoring-gcf",
+      "reteachFocus": "Finding the GCF of coefficients and variables, dividing each term by the GCF, verifying by distributing back",
+      "resources": [
+        "polynomials_module.json - scaffold phases 6-8"
+      ]
+    },
+    {
+      "skillId": "factoring-trinomials",
+      "reteachFocus": "Finding two numbers that multiply to c and add to b, writing the factored form, checking by FOIL",
+      "resources": [
+        "polynomials_module.json - scaffold phases 7-8"
+      ]
+    },
+    {
+      "skillId": "factoring-difference-of-squares",
+      "reteachFocus": "Recognizing a² - b² pattern, identifying a and b, writing (a + b)(a - b), distinguishing from sum of squares (not factorable)",
+      "resources": [
+        "polynomials_module.json - scaffold phases 7-8"
+      ]
+    }
   ],
   "assessmentProblems": [
     {
       "id": "a1u5-1",
       "question": "Simplify: (3x⁴)(5x²)",
       "answer": "**Step 1: Multiply the coefficients.**\n3 × 5 = 15\n\n**Step 2: Apply the product rule (same base — add exponents).**\nx⁴ · x² = x⁴⁺² = x⁶\n\n**Answer: 15x⁶**\n\nVerification by expansion concept: 3x⁴ means 3 · (x·x·x·x) and 5x² means 5 · (x·x). Multiplying gives 15 · (x·x·x·x·x·x) = 15x⁶ ✓",
-      "skill": "exponent-rules-multiplication",
+      "skill": "exponent-rules",
       "difficulty": 2,
       "points": 8
     },
@@ -40,7 +74,7 @@
       "id": "a1u5-2",
       "question": "Simplify: (4x³)² / (2x)",
       "answer": "**Step 1: Simplify the numerator using the power rule.**\n(4x³)² = 4² · (x³)² = 16 · x⁶ = 16x⁶\n\n**Step 2: Divide by 2x using the quotient rule.**\n16x⁶ / (2x) = (16/2) · (x⁶/x¹) = 8 · x⁶⁻¹ = 8x⁵\n\n**Answer: 8x⁵**\n\nVerification: 8x⁵ · 2x = 16x⁶ = (4x³)² ✓",
-      "skill": "exponent-rules-division",
+      "skill": "exponent-rules",
       "difficulty": 4,
       "points": 10
     },
@@ -64,7 +98,7 @@
       "id": "a1u5-5",
       "question": "Multiply using FOIL: (x + 6)(x - 3)",
       "answer": "**Apply FOIL (First, Outer, Inner, Last):**\n\n**F**irst: x · x = x²\n**O**uter: x · (-3) = -3x\n**I**nner: 6 · x = 6x\n**L**ast: 6 · (-3) = -18\n\n**Combine all four terms:**\nx² - 3x + 6x - 18\n\n**Combine like terms:**\nx² + 3x - 18\n\n**Answer: x² + 3x - 18**\n\nVerification: Substitute x = 2. Original: (2 + 6)(2 - 3) = (8)(-1) = -8. Result: 4 + 6 - 18 = -8 ✓",
-      "skill": "polynomial-multiplication-monomial",
+      "skill": "polynomial-multiplication",
       "difficulty": 3,
       "points": 10
     },

--- a/public/modules/algebra-1/rational_expressions_module.json
+++ b/public/modules/algebra-1/rational_expressions_module.json
@@ -158,7 +158,7 @@
       "title": "Solving Rational Equations",
       "content": "A **rational equation** is an equation that contains one or more rational expressions (fractions with variables in the denominator).\n\nExamples: 3/x + 1/4 = 5/x, or x/(x − 3) = 3/(x − 3) + 2.\n\n**Strategy for solving rational equations:**\n1. **Identify the LCD** of all fractions in the equation.\n2. **Multiply every term** on both sides of the equation by the LCD. This clears all denominators.\n3. **Solve** the resulting equation (which should have no fractions).\n4. **Check for extraneous solutions.** A solution is **extraneous** if it makes any denominator in the original equation equal to zero. Extraneous solutions must be rejected.\n\n**Why extraneous solutions occur:**\nWhen we multiply both sides by the LCD, we may introduce values that were not in the domain of the original equation. The LCD contains the variable, so multiplying by it can create solutions that make the original denominators zero. These are not true solutions — they are artifacts of the solving process.\n\n**Critical step:** After solving, you MUST substitute every candidate solution back into the original equation's denominators. If any denominator becomes zero, that solution is extraneous and must be rejected.\n\n**Possible outcomes:**\n- All candidate solutions are valid → report them as the solution set.\n- Some candidate solutions are extraneous → reject the extraneous ones, keep the valid ones.\n- ALL candidate solutions are extraneous → the equation has **no solution**.",
       "initialPrompt": "Consider the equation 1/x = 1/(x − 2). If you multiply both sides by x(x − 2), what equation do you get? What values of x would be excluded from the start?",
-      "lessonId": "adding-subtracting-rationals"
+      "lessonId": "solving-rational-equations"
     },
     {
       "type": "model",
@@ -183,7 +183,7 @@
         }
       ],
       "initialPrompt": "In the second example, the algebra produced x = 3, but we had to reject it because x = 3 makes the denominator (x − 3) equal to zero. Why can't we just 'plug in' x = 3 and say the answer is infinity or some large number? What does 'undefined' really mean here?",
-      "lessonId": "adding-subtracting-rationals"
+      "lessonId": "solving-rational-equations"
     },
     {
       "type": "independent_practice",


### PR DESCRIPTION
U1: Replace equation-solving in a1u1-10(c) with evaluation
  (solving equations not taught until Unit 2)

U3: Fix 4 incorrect skill tags and rebuild skillsCovered:
  - a1u3-1: graphing-linear-equations-slope-intercept → understanding-functions
  - a1u3-5, a1u3-6: writing-linear-equations-slope-intercept → writing-linear-equations-point-slope
  - a1u3-7: writing-linear-equations-slope-intercept → standard-form-equations
  - Add understanding-functions, writing-linear-equations-point-slope, standard-form-equations to skillsCovered
  - Remove phantom skill writing-linear-equations-slope-intercept

U4: Fix skill tags and add systems-special-cases:
  - a1u4-6, a1u4-7, a1u4-10: systems-of-equations-elimination → systems-special-cases
  - Add systems-special-cases to skillsCovered with remediation entry

U5: Align checkpoint skill IDs with content module:
  - exponent-rules-multiplication/division → exponent-rules (matches content)
  - polynomial-multiplication-monomial → polynomial-multiplication (matches content)
  - a1u5-5 (FOIL) retagged from monomial to polynomial-multiplication

U9: Fix lessonId errors in rational_expressions_module.json:
  - solving-rational-equations scaffold phases had wrong lessonId (adding-subtracting-rationals → solving-rational-equations)

U10: Replace a1u10-8 (solving radical equations — no scaffold content
  exists for this skill) with radical multiplication problem testing
  operations-with-radicals

https://claude.ai/code/session_014s2dwMvRRTqPvCMSka34ZQ