### PR TITLE
Fix 4 mobile bugs: calculator touch dismiss, clipping, dashboard layout, progress values

### DIFF
--- a/public/badge-map.html
+++ b/public/badge-map.html
@@ -983,6 +983,56 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       font-size: 14px;
       font-style: italic;
     }
+
+    /* Mobile responsive: stack columns vertically */
+    @media (max-width: 968px) {
+      body {
+        overflow: auto;
+        height: auto;
+      }
+
+      .page-layout {
+        height: auto;
+        overflow: visible;
+      }
+
+      .main-content {
+        display: flex;
+        flex-direction: column;
+        overflow: visible;
+      }
+
+      .left-sidebar {
+        display: none;
+      }
+
+      .right-sidebar {
+        order: -1;
+        border-left: none;
+        border-bottom: 1px solid #e0e0e0;
+        overflow: visible;
+        padding: 16px;
+      }
+
+      .center-content {
+        overflow: visible;
+        padding: 16px;
+      }
+
+      .main-header {
+        padding: 12px 16px;
+      }
+    }
+
+    @media (max-width: 768px) {
+      .right-sidebar {
+        padding: 12px;
+      }
+
+      .center-content {
+        padding: 12px;
+      }
+    }
   </style>
 </head>
 <body>
@@ -1528,9 +1578,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             </div>
             <div style="font-size: 11px; color: #666; margin-bottom: 8px;">${challenge.description}</div>
             <div style="height: 4px; background: #e0e0e0; border-radius: 2px; overflow: hidden;">
-              <div style="height: 100%; background: linear-gradient(90deg, #FFD93D 0%, #FFA500 100%); width: ${challenge.progress}%; transition: width 0.3s;"></div>
+              <div style="height: 100%; background: linear-gradient(90deg, #FFD93D 0%, #FFA500 100%); width: ${challenge.targetCount > 0 ? Math.min((challenge.progress / challenge.targetCount) * 100, 100) : 0}%; transition: width 0.3s;"></div>
             </div>
-            <div style="font-size: 10px; color: #999; margin-top: 4px; font-weight: 600;">${challenge.current}/${challenge.target}</div>
+            <div style="font-size: 10px; color: #999; margin-top: 4px; font-weight: 600;">${challenge.progress || 0}/${challenge.targetCount || 0}</div>
           </div>
         `).join('');
 

--- a/public/css/calculator.css
+++ b/public/css/calculator.css
@@ -69,6 +69,8 @@ body.standalone-calculator-page {
 
 .calculator {
     width: 380px;
+    max-width: 100%;
+    box-sizing: border-box;
     background: linear-gradient(145deg, #2c3e50, #34495e);
     border-radius: 20px;
     padding: 25px;
@@ -774,6 +776,7 @@ body.standalone-calculator-page {
         0 0 0 1px rgba(0, 0, 0, 0.5);
     width: 320px;
     max-width: 95vw;
+    box-sizing: border-box;
     border: 2px solid #2c4b73;
 }
 

--- a/public/js/floating-calculator.js
+++ b/public/js/floating-calculator.js
@@ -193,7 +193,11 @@ class FloatingCalculator {
         if (this._backdrop) return;
         this._backdrop = document.createElement('div');
         this._backdrop.className = 'calculator-backdrop';
-        this._backdrop.addEventListener('click', () => this.hideCalculator());
+        this._backdrop.addEventListener('click', (e) => {
+            // Only dismiss if the click target is the backdrop itself,
+            // not a touch event that was re-targeted from the calculator
+            if (e.target === this._backdrop) this.hideCalculator();
+        });
         document.body.appendChild(this._backdrop);
     }
 
@@ -374,6 +378,10 @@ class FloatingCalculator {
 
         // Mobile: swipe down on header to dismiss
         this._initMobileSwipe();
+
+        // Prevent clicks inside the calculator from reaching document-level handlers
+        this.floatingCalc.addEventListener('click', (e) => e.stopPropagation());
+        this.floatingCalc.addEventListener('touchend', (e) => e.stopPropagation());
 
         // Calculator buttons
         this.floatingCalc.querySelectorAll('[data-num]').forEach(btn => {


### PR DESCRIPTION
Bug 1 — Calculator disappears on touch: The backdrop click handler was
firing on mobile when tapping calculator buttons. Added e.target guard
on the backdrop handler and stopPropagation on the calculator container
to prevent touch events from being re-targeted or bubbling to
document-level handlers.

Bug 2 — Calculator right side clipped: The .calculator element had
width: 380px with padding: 25px but no box-sizing: border-box, making
the actual rendered width 430px and overflowing mobile viewports. Added
box-sizing: border-box and max-width: 100% to both the standalone and
floating calculator.

Bug 3 — Dashboard horizontal scroll blocked: badge-map.html used a
3-column grid (280px 1fr 300px) with overflow: hidden and had zero
mobile breakpoints. Added responsive CSS to stack the layout vertically
on screens <= 968px, hiding the left sidebar and placing stats above
the main content.

Bug 4 — Undefined progress values: The weekly challenge mini-cards in
badge-map.html used challenge.current/challenge.target, but the API
returns challenge.progress/challenge.targetCount. Also fixed the
progress bar width calculation to use a proper percentage instead of
the raw count.

https://claude.ai/code/session_013GZCbqJimv1BvCTRdmbA9j