### PR TITLE
Add meta.json for Facebook crawler

### DIFF
--- a/public/meta.json
+++ b/public/meta.json
@@ -1,0 +1,13 @@
+{
+  "name": "Mathmatix AI",
+  "short_name": "MATHMATIX",
+  "description": "Personalized, AI-powered math tutoring that adapts to your child's learning style. Get one-on-one help anytime, anywhere.",
+  "url": "https://mathmatix.ai",
+  "logo": "https://mathmatix.ai/images/mathmatix-ai-logo.png",
+  "theme_color": "#12B3B3",
+  "background_color": "#ffffff",
+  "version": "1.0.0",
+  "author": "Mathmatix AI",
+  "contact": "support@mathmatix.ai",
+  "categories": ["education", "productivity"]
+}


### PR DESCRIPTION
## Summary
- Adds `public/meta.json` with app metadata (name, description, logo, theme color, contact info)
- Fixes 404s from Facebook's crawler which was requesting `/meta.json` for link preview metadata
- Identified from Render log analysis showing repeated 404s from `facebookexternalhit` user agent

## Test plan
- [ ] Verify `/meta.json` returns 200 with correct JSON after deploy
- [ ] Share a Mathmatix AI link on Facebook/Messenger and confirm link preview renders correctly

https://claude.ai/code/session_01RGik4KqmkzNLosD8NDRsmB