### PR TITLE
Optimize static asset performance: caching, preconnect, defer

### DIFF
--- a/config/middleware.js
+++ b/config/middleware.js
@@ -93,6 +93,8 @@ function configureMiddleware(app) {
   app.use('/api/billing/webhook', express.raw({ type: 'application/json' }));
 
   app.use(compression({
+    level: 6, // Good balance of speed vs compression ratio (default is 6, but explicit)
+    threshold: 1024, // Skip tiny responses under 1 KB
     filter: (req, res) => {
       if (req.headers.accept === 'text/event-stream') return false;
       return compression.filter(req, res);
@@ -104,6 +106,15 @@ function configureMiddleware(app) {
   // temporarily unreachable, and avoids unnecessary middleware overhead for assets.
   // HTML files are excluded — they need CSP nonce injection from the later pipeline.
   const publicDir = path.join(__dirname, '..', 'public');
+
+  // Vendor assets (versioned/pinned libs) — 30-day immutable cache
+  app.use('/vendor', express.static(path.join(publicDir, 'vendor'), {
+    index: false,
+    setHeaders: (res) => {
+      res.setHeader('Cache-Control', 'public, max-age=2592000, immutable'); // 30 days
+    },
+  }));
+
   app.use((req, res, next) => {
     // Skip HTML files — they need CSP nonce injection via the full middleware pipeline
     if (req.method === 'GET' && /\.html?$/i.test(req.path)) return next();
@@ -113,7 +124,9 @@ function configureMiddleware(app) {
   }, express.static(publicDir, {
     index: false, // Don't serve index.html — that goes through auth/CSP nonce pipeline
     setHeaders: (res, filePath) => {
-      if (/\.(css|js|png|jpg|jpeg|gif|svg|ico|woff2?|ttf|eot)$/i.test(filePath)) {
+      if (/\.(woff2?|ttf|eot)$/i.test(filePath)) {
+        res.setHeader('Cache-Control', 'public, max-age=2592000, immutable'); // 30 days — fonts never change
+      } else if (/\.(css|js|png|jpg|jpeg|gif|svg|ico|webp)$/i.test(filePath)) {
         res.setHeader('Cache-Control', 'public, max-age=604800'); // 7 days
       } else {
         res.setHeader('Cache-Control', 'public, max-age=86400'); // 1 day default
@@ -219,7 +232,7 @@ function configureMiddleware(app) {
     frameguard: { action: 'deny' },
     hsts: { maxAge: 31536000, includeSubDomains: true, preload: true },
     referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
-    dnsPrefetchControl: { allow: false },
+    dnsPrefetchControl: { allow: true }, // Allow DNS prefetch for CDN domains (jsdelivr, cloudflare, google fonts)
   }));
 
   // Permissions-Policy header

--- a/config/routes.js
+++ b/config/routes.js
@@ -602,27 +602,8 @@ function registerHtmlRoutes(app) {
 function registerStaticRoutes(app) {
   const publicDir = path.join(__dirname, '..', 'public');
 
-  // Long cache for fingerprinted/immutable assets (CSS, JS, images, fonts)
-  const immutableCacheOptions = { maxAge: '7d', etag: true, lastModified: true };
-  // Short cache for HTML (needs fresh CSP nonces + deploys)
-  const htmlCacheOptions = { maxAge: 0, etag: true, lastModified: true };
-
-  // Set cache-control by file type
-  const staticCacheOptions = {
-    etag: true,
-    lastModified: true,
-    setHeaders: (res, filePath) => {
-      if (/\.(css|js|png|jpg|jpeg|gif|svg|ico|woff2?|ttf|eot)$/i.test(filePath)) {
-        res.setHeader('Cache-Control', 'public, max-age=604800'); // 7 days
-      } else if (/\.html$/i.test(filePath)) {
-        res.setHeader('Cache-Control', 'no-cache'); // Always revalidate HTML
-      } else {
-        res.setHeader('Cache-Control', 'public, max-age=86400'); // 1 day default
-      }
-    },
-  };
-
   // Serve HTML via sendFile for CSP nonce injection
+  // (Static assets are already served by middleware.js before session/CSRF pipeline)
   app.use((req, res, next) => {
     if (req.method === 'GET' && req.path.endsWith('.html')) {
       const filePath = path.resolve(publicDir, req.path.replace(/^\/+/, ''));
@@ -635,9 +616,6 @@ function registerStaticRoutes(app) {
       next();
     }
   });
-
-  app.use(express.static(publicDir, staticCacheOptions));
-  app.use('/images', express.static(path.join(publicDir, 'images'), immutableCacheOptions));
 }
 
 module.exports = { registerRoutes };

--- a/public/chat.html
+++ b/public/chat.html
@@ -41,6 +41,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <!-- returning-user-modal removed — returning users now get an AI welcome directly -->
   <link rel="stylesheet" href="/css/textbook-mode.css" />
   <link rel="stylesheet" href="/css/mobile-redesign.css" />
+  <!-- DNS prefetch & preconnect for CDN domains -->
+  <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin />
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="/vendor/mathlive/mathlive-static.css">
   <link rel="stylesheet" href="/vendor/mathlive/mathlive-fonts.css">
@@ -49,7 +52,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <!-- Core libs (needed before first render) -->
   <script defer src="/vendor/katex/katex.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/marked@11.1.1/marked.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
   <script defer src="/vendor/mathlive/mathlive.min.js"></script>
 
   <!-- MathGraph: self-contained canvas graphing engine (replaces function-plot CDN) -->
@@ -93,8 +96,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     });
   </script>
   <link rel="stylesheet" href="/css/demo-mode.css" />
-  <script src="/js/i18n-translations.js"></script>
-  <script src="/js/i18n.js"></script>
+  <script defer src="/js/i18n-translations.js"></script>
+  <script defer src="/js/i18n.js"></script>
 </head>
 <body class="landing-page-body">
 <!-- Google Tag Manager (noscript) -->

--- a/public/index.html
+++ b/public/index.html
@@ -74,6 +74,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin />
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="/style.css" />
   <link rel="stylesheet" href="/css/dark-mode.css" />
@@ -82,7 +84,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <link rel="stylesheet" href="/vendor/katex/katex.min.css" />
   <script defer src="/vendor/katex/katex.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/marked@11.1.1/marked.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
   <script src="/js/csrf.js"></script>
   <script src="/js/landing.js" defer></script>
   <script src="/js/analytics.js" data-ga="G-EMX730XF5H" data-fbp=""></script>


### PR DESCRIPTION
- Add 30-day immutable cache for vendor/ libs and font files
- Add preconnect hints for CDN domains (jsdelivr, cloudflare)
- Enable DNS prefetching for faster CDN resolution
- Defer render-blocking DOMPurify and i18n scripts in <head>
- Remove duplicate express.static in routes.js (already in middleware.js)
- Add webp to cache-control regex, compression threshold tuning

https://claude.ai/code/session_01RGik4KqmkzNLosD8NDRsmB