### PR TITLE
Enforce IEP reading level compliance on voice tutor, guided lessons, …

### DIFF
--- a/routes/chat.js
+++ b/routes/chat.js
@@ -1846,10 +1846,36 @@ Keep it casual and low-pressure. Don't make it sound like a test they need to ta
                     $inc: { weeklyAISeconds: greetingAiSeconds, totalAISeconds: greetingAiSeconds }
                 }).catch(err => console.error('[Greeting] AI time tracking error:', err));
 
+                // IEP reading level enforcement (post-stream)
+                let greetingText = fullResponse.trim();
+                const greetingIepLevel = user.iepPlan?.readingLevel || null;
+                if (greetingIepLevel) {
+                    const readCheck = checkReadingLevel(greetingText, greetingIepLevel);
+                    if (!readCheck.passes) {
+                        console.log(
+                            `[Greeting] Reading level violation: response at Grade ${readCheck.responseGrade}, target Grade ${readCheck.targetGrade}`
+                        );
+                        try {
+                            const simplifyPrompt = buildSimplificationPrompt(greetingText, readCheck.targetGrade, user.firstName || 'the student');
+                            const simplified = await callLLM(PRIMARY_CHAT_MODEL, [{ role: 'system', content: simplifyPrompt }], {
+                                temperature: 0.3, max_tokens: maxTokens
+                            });
+                            const simplifiedText = simplified.choices[0]?.message?.content?.trim();
+                            if (simplifiedText && simplifiedText.length > 20) {
+                                greetingText = simplifiedText;
+                                res.write(`data: ${JSON.stringify({ type: 'replacement', content: greetingText })}\n\n`);
+                                console.log(`[Greeting] Response simplified to target Grade ${readCheck.targetGrade}`);
+                            }
+                        } catch (err) {
+                            console.error('[Greeting] Simplification failed:', err.message);
+                        }
+                    }
+                }
+
                 // Save greeting to conversation (AI message only, no user message)
                 activeConversation.messages.push({
                     role: 'assistant',
-                    content: fullResponse.trim(),
+                    content: greetingText,
                     timestamp: new Date()
                 });
                 activeConversation.lastActivity = new Date();
@@ -1881,7 +1907,31 @@ Keep it casual and low-pressure. Don't make it sound like a test they need to ta
         } else {
             // NON-STREAMING MODE
             const completion = await callLLM(PRIMARY_CHAT_MODEL, messagesForAI, { temperature: 0.8, max_tokens: maxTokens });
-            const greetingText = completion.choices[0].message.content.trim();
+            let greetingText = completion.choices[0].message.content.trim();
+
+            // IEP reading level enforcement
+            const nsGreetingIepLevel = user.iepPlan?.readingLevel || null;
+            if (nsGreetingIepLevel) {
+                const readCheck = checkReadingLevel(greetingText, nsGreetingIepLevel);
+                if (!readCheck.passes) {
+                    console.log(
+                        `[Greeting] Reading level violation: response at Grade ${readCheck.responseGrade}, target Grade ${readCheck.targetGrade}`
+                    );
+                    try {
+                        const simplifyPrompt = buildSimplificationPrompt(greetingText, readCheck.targetGrade, user.firstName || 'the student');
+                        const simplified = await callLLM(PRIMARY_CHAT_MODEL, [{ role: 'system', content: simplifyPrompt }], {
+                            temperature: 0.3, max_tokens: maxTokens
+                        });
+                        const simplifiedText = simplified.choices[0]?.message?.content?.trim();
+                        if (simplifiedText && simplifiedText.length > 20) {
+                            greetingText = simplifiedText;
+                            console.log(`[Greeting] Response simplified to target Grade ${readCheck.targetGrade}`);
+                        }
+                    } catch (err) {
+                        console.error('[Greeting] Simplification failed:', err.message);
+                    }
+                }
+            }
 
             // Track AI processing time
             const greetingAiSeconds = Math.ceil((Date.now() - greetingAiStart) / 1000);

--- a/routes/guidedLesson.js
+++ b/routes/guidedLesson.js
@@ -7,6 +7,7 @@ const { isAuthenticated } = require('../middleware/auth');
 const { generateSystemPrompt } = require('../utils/prompt');
 const User = require('../models/user');
 const { callLLM, retryWithExponentialBackoff } = require("../utils/llmGateway"); // CTO REVIEW FIX: Use unified LLMGateway
+const { checkReadingLevel, buildSimplificationPrompt } = require('../utils/readability');
 const { selectWarmupSkill, checkPrerequisiteReadiness } = require('../utils/prerequisiteMapper');
 const logger = require('../utils/logger').child({ route: 'guidedLesson' });
 const {
@@ -144,7 +145,31 @@ ${phasePrompt}
             }).catch(err => logger.error('[GuidedLesson] AI time tracking error:', err));
         }
 
-        const aiResponseText = completion.choices[0].message.content.trim();
+        let aiResponseText = completion.choices[0].message.content.trim();
+
+        // IEP reading level enforcement
+        const iepReadingLevel = userProfile.iepPlan?.readingLevel || null;
+        if (iepReadingLevel) {
+            const readCheck = checkReadingLevel(aiResponseText, iepReadingLevel);
+            if (!readCheck.passes) {
+                logger.info(
+                    `[GuidedLesson] Reading level violation: response at Grade ${readCheck.responseGrade}, target Grade ${readCheck.targetGrade}`
+                );
+                try {
+                    const simplifyPrompt = buildSimplificationPrompt(aiResponseText, readCheck.targetGrade, userProfile.firstName || 'the student');
+                    const simplified = await callLLM("gpt-4o-mini", [{ role: 'system', content: simplifyPrompt }], {
+                        temperature: 0.3, max_tokens: 500
+                    });
+                    const simplifiedText = simplified.choices[0]?.message?.content?.trim();
+                    if (simplifiedText && simplifiedText.length > 20) {
+                        aiResponseText = simplifiedText;
+                        logger.info(`[GuidedLesson] Response simplified to target Grade ${readCheck.targetGrade}`);
+                    }
+                } catch (err) {
+                    logger.error('[GuidedLesson] Simplification failed:', err.message);
+                }
+            }
+        }
 
         let lessonState = 'continue';
         let cleanMessage = aiResponseText;
@@ -248,7 +273,33 @@ A student needs help with a problem. Use your adaptive teaching strategies to pr
             }).catch(err => logger.error('[GuidedLesson/Hint] AI time tracking error:', err));
         }
 
-        res.json({ hint: aiHint.choices[0].message.content.trim() });
+        let hintText = aiHint.choices[0].message.content.trim();
+
+        // IEP reading level enforcement
+        const hintReadingLevel = userProfile.iepPlan?.readingLevel || null;
+        if (hintReadingLevel) {
+            const readCheck = checkReadingLevel(hintText, hintReadingLevel);
+            if (!readCheck.passes) {
+                logger.info(
+                    `[GuidedLesson/Hint] Reading level violation: response at Grade ${readCheck.responseGrade}, target Grade ${readCheck.targetGrade}`
+                );
+                try {
+                    const simplifyPrompt = buildSimplificationPrompt(hintText, readCheck.targetGrade, userProfile.firstName || 'the student');
+                    const simplified = await callLLM("gpt-4o-mini", [{ role: 'system', content: simplifyPrompt }], {
+                        temperature: 0.3, max_tokens: 150
+                    });
+                    const simplifiedText = simplified.choices[0]?.message?.content?.trim();
+                    if (simplifiedText && simplifiedText.length > 20) {
+                        hintText = simplifiedText;
+                        logger.info(`[GuidedLesson/Hint] Hint simplified to target Grade ${readCheck.targetGrade}`);
+                    }
+                } catch (err) {
+                    logger.error('[GuidedLesson/Hint] Simplification failed:', err.message);
+                }
+            }
+        }
+
+        res.json({ hint: hintText });
     } catch (error) {
         logger.error('Error in /get-scaffolded-hint:', error?.response?.data || error.message || error);
         res.status(500).json({ error: 'Failed to generate hint. Please try again.' });

--- a/routes/voiceTutor.js
+++ b/routes/voiceTutor.js
@@ -9,6 +9,7 @@ const User = require('../models/user');
 const Conversation = require('../models/conversation');
 const { generateSystemPrompt } = require('../utils/prompt');
 const { callLLM } = require('../utils/llmGateway');
+const { checkReadingLevel, buildSimplificationPrompt } = require('../utils/readability');
 const { openai } = require('../utils/openaiClient');
 const ttsProvider = require('../utils/ttsProvider');
 const fs = require('fs');
@@ -414,7 +415,35 @@ async function generateResponse(userId, userMessage, preloadedUser) {
     max_tokens: 600
   });
 
-  return completion.choices[0].message.content.trim();
+  let responseText = completion.choices[0].message.content.trim();
+
+  // IEP reading level enforcement
+  const iepReadingLevel = user.iepPlan?.readingLevel || null;
+  if (iepReadingLevel) {
+    const readCheck = checkReadingLevel(responseText, iepReadingLevel);
+    if (!readCheck.passes) {
+      console.log(
+        `[VoiceTutor] Reading level violation for ${user.firstName}: ` +
+        `response at Grade ${readCheck.responseGrade}, target Grade ${readCheck.targetGrade}`
+      );
+      try {
+        const simplifyPrompt = buildSimplificationPrompt(responseText, readCheck.targetGrade, user.firstName || 'the student');
+        const simplified = await callLLM(VOICE_MODEL, [{ role: 'system', content: simplifyPrompt }], {
+          temperature: 0.3,
+          max_tokens: 600
+        });
+        const simplifiedText = simplified.choices[0]?.message?.content?.trim();
+        if (simplifiedText && simplifiedText.length > 20) {
+          responseText = simplifiedText;
+          console.log(`[VoiceTutor] Response simplified to target Grade ${readCheck.targetGrade}`);
+        }
+      } catch (err) {
+        console.error('[VoiceTutor] Simplification failed:', err.message);
+      }
+    }
+  }
+
+  return responseText;
 }
 
 async function generateTTS(userId, responseText, preloadedUser) {


### PR DESCRIPTION
…and greetings

Routes that called the LLM directly were bypassing the reading level verification pipeline, meaning a 3rd grader with a 500L IEP could receive 12th-grade vocabulary and sentence structures. Added checkReadingLevel + auto-simplification to voiceTutor.js, guidedLesson.js (both lesson and hint endpoints), and chat.js greeting (streaming and non-streaming paths).

https://claude.ai/code/session_0167hyD7qgyjpGazegKLE1TK