### PR TITLE
Mobile-first PWA + UX overhaul for student engagement

### DIFF
--- a/config/middleware.js
+++ b/config/middleware.js
@@ -125,7 +125,9 @@ function configureMiddleware(app) {
   }, express.static(publicDir, {
     index: false, // Don't serve index.html — that goes through auth/CSP nonce pipeline
     setHeaders: (res, filePath) => {
-      if (/\.(woff2?|ttf|eot)$/i.test(filePath)) {
+      if (/sw\.js$/i.test(filePath)) {
+        res.setHeader('Cache-Control', 'no-cache'); // Service worker must always be fresh
+      } else if (/\.(woff2?|ttf|eot)$/i.test(filePath)) {
         res.setHeader('Cache-Control', 'public, max-age=2592000, immutable'); // 30 days — fonts never change
       } else if (/\.(css|js|png|jpg|jpeg|gif|svg|ico|webp)$/i.test(filePath)) {
         res.setHeader('Cache-Control', 'public, max-age=604800'); // 7 days
@@ -183,6 +185,31 @@ function configureMiddleware(app) {
         fs.readFile(filePath, 'utf8', (err, html) => {
           if (err) return callback ? callback(err) : next(err);
           html = html.replace(/<script(?![^>]*\bsrc\b)(?![^>]*\bnonce\b)/gi, `<script nonce="${nonce}"`);
+
+          // Inject PWA support (manifest, meta tags, service worker) into all HTML pages
+          if (!html.includes('rel="manifest"')) {
+            const pwaTags = [
+              '<link rel="manifest" href="/manifest.json" />',
+              '<meta name="theme-color" content="#12B3B3" />',
+              '<meta name="mobile-web-app-capable" content="yes" />',
+              '<meta name="apple-mobile-web-app-capable" content="yes" />',
+              '<meta name="apple-mobile-web-app-status-bar-style" content="default" />',
+              '<meta name="apple-mobile-web-app-title" content="MATHMATIX" />',
+              '<link rel="apple-touch-icon" href="/images/icon-192x192.png" />',
+              '<link rel="stylesheet" href="/css/pwa.css" />',
+              `<script src="/js/pwa-register.js" nonce="${nonce}" defer></script>`,
+            ].join('\n  ');
+            html = html.replace('</head>', `  ${pwaTags}\n</head>`);
+          } else if (!html.includes('pwa-register.js')) {
+            // Page already has manifest link (e.g. chat.html) — just add the missing pieces
+            const pwaExtras = [
+              '<link rel="apple-touch-icon" href="/images/icon-192x192.png" />',
+              '<link rel="stylesheet" href="/css/pwa.css" />',
+              `<script src="/js/pwa-register.js" nonce="${nonce}" defer></script>`,
+            ].join('\n  ');
+            html = html.replace('</head>', `  ${pwaExtras}\n</head>`);
+          }
+
           res.type('html').send(html);
         });
       } else {

--- a/public/chat.html
+++ b/public/chat.html
@@ -34,6 +34,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <link rel="stylesheet" href="/css/iep-accommodations.css" />
   <link rel="stylesheet" href="/css/age-adaptive.css" />
   <link rel="stylesheet" href="/css/floating-screener.css" />
+  <link rel="stylesheet" href="/css/resume-card.css" />
   <link rel="stylesheet" href="/css/floating-checkpoint.css" />
   <link rel="stylesheet" href="/css/show-your-work.css" />
   <link rel="stylesheet" href="/css/courseCatalog.css" />
@@ -1873,6 +1874,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <script src="/js/show-your-work.js"></script>
   <script src="/js/ghostTimer.js"></script>
   <script src="/js/badgeProgress.js"></script>
+  <script src="/js/resume-card.js"></script>
   <script src="/js/script.js" type="module"></script>
   <script src="/js/guidedPath.js" type="module"></script>
 <script src="/js/sessionManager.js"></script>

--- a/public/chat.html
+++ b/public/chat.html
@@ -35,6 +35,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <link rel="stylesheet" href="/css/age-adaptive.css" />
   <link rel="stylesheet" href="/css/floating-screener.css" />
   <link rel="stylesheet" href="/css/resume-card.css" />
+  <link rel="stylesheet" href="/css/mobile-ux-overhaul.css" />
   <link rel="stylesheet" href="/css/floating-checkpoint.css" />
   <link rel="stylesheet" href="/css/show-your-work.css" />
   <link rel="stylesheet" href="/css/courseCatalog.css" />
@@ -452,6 +453,26 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         </div>
       </div>
 
+      <!-- Persistent gamification bar — visible on mobile -->
+      <div id="mobile-stats-bar" class="mobile-stats-bar">
+        <div class="msb-item msb-streak">
+          <span class="msb-icon">🔥</span>
+          <span id="msb-streak" class="msb-value">0</span>
+        </div>
+        <div class="msb-item msb-level">
+          <span class="msb-label">Lv.</span>
+          <span id="msb-level" class="msb-value">1</span>
+          <div class="msb-xp-track">
+            <div id="msb-xp-fill" class="msb-xp-fill" style="width: 0%"></div>
+          </div>
+        </div>
+        <div class="msb-item msb-xp">
+          <span class="msb-icon">⭐</span>
+          <span id="msb-xp" class="msb-value">0</span>
+          <span class="msb-unit">XP</span>
+        </div>
+      </div>
+
       <div id="chat-messages-container"></div>
 
       <!-- Live XP Feed -->
@@ -533,6 +554,18 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <!-- Modern File Grid Container -->
     <div id="file-grid-container" class="file-grid-container"></div>
+
+    <!-- Hero action buttons — prominent on mobile -->
+    <div id="hero-actions" class="hero-actions">
+      <button id="hero-upload-btn" class="hero-action-btn" aria-label="Upload homework">
+        <i class="fas fa-file-upload"></i>
+        <span>Upload Homework</span>
+      </button>
+      <button id="hero-camera-btn" class="hero-action-btn" aria-label="Show your work">
+        <i class="fas fa-camera"></i>
+        <span>Show Your Work</span>
+      </button>
+    </div>
 
     <!-- Quick Reply Suggestions -->
     <div id="suggestion-chips-container" class="imessage-chips-row">
@@ -1874,6 +1907,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <script src="/js/show-your-work.js"></script>
   <script src="/js/ghostTimer.js"></script>
   <script src="/js/badgeProgress.js"></script>
+  <script src="/js/mobile-stats-bar.js"></script>
   <script src="/js/resume-card.js"></script>
   <script src="/js/script.js" type="module"></script>
   <script src="/js/guidedPath.js" type="module"></script>

--- a/public/chat.html
+++ b/public/chat.html
@@ -557,13 +557,9 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <!-- Hero action buttons — prominent on mobile -->
     <div id="hero-actions" class="hero-actions">
-      <button id="hero-upload-btn" class="hero-action-btn" aria-label="Upload homework">
-        <i class="fas fa-file-upload"></i>
-        <span>Upload Homework</span>
-      </button>
-      <button id="hero-camera-btn" class="hero-action-btn" aria-label="Show your work">
+      <button id="hero-upload-btn" class="hero-action-btn hero-action-primary" aria-label="Upload or photo">
         <i class="fas fa-camera"></i>
-        <span>Show Your Work</span>
+        <span>Upload / Photo</span>
       </button>
     </div>
 

--- a/public/css/mobile-redesign.css
+++ b/public/css/mobile-redesign.css
@@ -1026,13 +1026,13 @@
         box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.2);
     }
 
-    /* Rounded input with better focus state */
+    /* Rounded input — tall enough to see what you're typing */
     body.has-chat-nav #user-input {
         border-radius: 20px;
         padding: 10px 16px;
-        font-size: 15px;
+        font-size: 16px;
         line-height: 1.4;
-        min-height: 20px;
+        min-height: 44px;
         background: var(--clr-bg-subtle, #f5f7f9);
         border: 1.5px solid var(--clr-border-light, #e2e8f0);
         color: #1a1a2e;
@@ -1056,10 +1056,10 @@
         box-shadow: 0 0 0 3px rgba(18, 179, 179, 0.2);
     }
 
-    /* Send button pop */
+    /* Send button — 44px minimum for kids' fingers */
     body.has-chat-nav .imessage-send-btn {
-        width: 36px;
-        height: 36px;
+        width: 44px;
+        height: 44px;
         border-radius: 50%;
         background: var(--clr-primary-teal, #12B3B3);
         color: white;
@@ -1068,18 +1068,19 @@
         justify-content: center;
         border: none;
         flex-shrink: 0;
+        font-size: 1.05rem;
         transition: transform 150ms ease, background 150ms ease;
     }
 
     body.has-chat-nav .imessage-send-btn:active {
-        transform: scale(0.9);
+        transform: scale(0.92);
         background: #0E9494;
     }
 
-    /* Tool buttons styling — HIGH CONTRAST icons */
+    /* Tool buttons — 44px for proper touch targets */
     body.has-chat-nav .imessage-tool-btn {
-        width: 36px;
-        height: 36px;
+        width: 44px;
+        height: 44px;
         border-radius: 50%;
         display: flex;
         align-items: center;
@@ -1087,12 +1088,12 @@
         background: var(--clr-bg-subtle, #f0f2f5);
         border: 1px solid var(--clr-border-light, #d1d5db);
         color: #4a5568;
-        font-size: 0.95rem;
+        font-size: 1rem;
         transition: background 150ms ease, transform 150ms ease;
     }
 
     body.has-chat-nav .imessage-tool-btn:active {
-        transform: scale(0.9);
+        transform: scale(0.92);
         background: rgba(18, 179, 179, 0.12);
         color: var(--clr-primary-teal, #12B3B3);
         border-color: var(--clr-primary-teal, #12B3B3);
@@ -1108,6 +1109,18 @@
         background: rgba(18, 179, 179, 0.2);
         color: #2dd4bf;
         border-color: #2dd4bf;
+    }
+
+    /* Tool buttons row — horizontal scroll when they don't fit */
+    body.has-chat-nav .imessage-tool-btns {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: none;
+        gap: 8px;
+    }
+
+    body.has-chat-nav .imessage-tool-btns::-webkit-scrollbar {
+        display: none;
     }
 
     /* Better message bubble spacing */
@@ -1136,40 +1149,56 @@
         border-color: rgba(255, 255, 255, 0.08);
     }
 
-    /* Suggestion chips */
+    /* Suggestion chips — horizontally scrollable, teal brand */
     body.has-chat-nav .imessage-chips-row {
-        padding: 6px 12px;
-        gap: 6px;
+        padding: 8px 12px;
+        gap: 8px;
+        display: flex;
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: none;
+        /* Fade hint that more chips exist off-screen */
+        mask-image: linear-gradient(to right, #000 85%, transparent 100%);
+        -webkit-mask-image: linear-gradient(to right, #000 85%, transparent 100%);
+    }
+
+    body.has-chat-nav .imessage-chips-row::-webkit-scrollbar {
+        display: none;
     }
 
     body.has-chat-nav .suggestion-chip {
-        border-radius: 16px;
-        padding: 7px 14px;
-        font-size: 0.84rem;
+        border-radius: 20px;
+        padding: 10px 18px;
+        font-size: 0.9rem;
         font-weight: 600;
         background: var(--clr-bg-light, #fff);
-        border: 1px solid var(--clr-border-light, #d1d5db);
-        color: #2d3748;
+        border: 1.5px solid rgba(18, 179, 179, 0.3);
+        color: #0d8a8a;
         white-space: nowrap;
+        flex-shrink: 0;
+        cursor: pointer;
+        transition: all 0.15s ease;
     }
 
     body.has-chat-nav .suggestion-chip:active {
-        background: rgba(18, 179, 179, 0.1);
+        background: var(--clr-primary-teal, #12B3B3);
         border-color: var(--clr-primary-teal, #12B3B3);
-        color: #0d8a8a;
+        color: #fff;
+        transform: scale(0.95);
     }
 
     [data-theme="dark"] body.has-chat-nav .suggestion-chip {
-        background: rgba(255, 255, 255, 0.08);
-        border-color: rgba(255, 255, 255, 0.15);
-        color: #e8ecf2;
+        background: rgba(18, 179, 179, 0.08);
+        border-color: rgba(18, 179, 179, 0.3);
+        color: #2dd4bf;
         font-weight: 500;
     }
 
     [data-theme="dark"] body.has-chat-nav .suggestion-chip:active {
-        background: rgba(18, 179, 179, 0.15);
-        border-color: #2dd4bf;
-        color: #2dd4bf;
+        background: var(--clr-primary-teal, #12B3B3);
+        border-color: var(--clr-primary-teal, #12B3B3);
+        color: #fff;
     }
 }
 

--- a/public/css/mobile-ux-overhaul.css
+++ b/public/css/mobile-ux-overhaul.css
@@ -160,8 +160,10 @@
 /* Calculator: kids have their phone calculator. Break: not a primary action. */
 
 @media (max-width: 768px) {
+  /* Calculator: kids have their phone. Attach/camera: replaced by hero button above. */
   #calculator-toolbar-btn,
-  #break-toolbar-btn {
+  #attach-button,
+  #camera-button {
     display: none !important;
   }
 }

--- a/public/css/mobile-ux-overhaul.css
+++ b/public/css/mobile-ux-overhaul.css
@@ -1,0 +1,185 @@
+/* ============================================
+   MOBILE UX OVERHAUL — Stats bar, hero actions, polish
+   ============================================ */
+
+/* --- PERSISTENT STATS BAR (Level, Streak, XP) --- */
+
+.mobile-stats-bar {
+  display: none; /* Hidden on desktop */
+}
+
+@media (max-width: 768px) {
+  .mobile-stats-bar {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+    padding: 6px 16px;
+    background: var(--clr-bg-light, #fff);
+    border-bottom: 1px solid var(--clr-border-light, #edf0f3);
+    flex-shrink: 0;
+  }
+
+  [data-theme="dark"] .mobile-stats-bar {
+    background: var(--clr-bg-dark, #1a1d2e);
+    border-bottom-color: rgba(255, 255, 255, 0.06);
+  }
+
+  .msb-item {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--clr-text-dim, #6b7a8d);
+  }
+
+  .msb-icon {
+    font-size: 0.9rem;
+  }
+
+  .msb-value {
+    color: var(--clr-text-main, #1a1a2e);
+    font-weight: 700;
+    font-size: 0.85rem;
+  }
+
+  [data-theme="dark"] .msb-value {
+    color: #e2e8f0;
+  }
+
+  .msb-unit {
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+    color: var(--clr-text-dim, #8896a6);
+  }
+
+  .msb-label {
+    font-size: 0.7rem;
+    color: var(--clr-text-dim, #8896a6);
+  }
+
+  /* Inline XP progress track */
+  .msb-xp-track {
+    width: 48px;
+    height: 4px;
+    background: rgba(0, 0, 0, 0.08);
+    border-radius: 2px;
+    overflow: hidden;
+    margin-left: 2px;
+  }
+
+  [data-theme="dark"] .msb-xp-track {
+    background: rgba(255, 255, 255, 0.1);
+  }
+
+  .msb-xp-fill {
+    height: 100%;
+    background: var(--clr-primary-teal, #12B3B3);
+    border-radius: 2px;
+    transition: width 0.5s ease;
+  }
+
+  /* Streak highlight when active */
+  .msb-streak .msb-value {
+    color: #f59e0b;
+  }
+}
+
+/* --- HERO ACTION BUTTONS (Upload Homework, Show Your Work) --- */
+
+.hero-actions {
+  display: none; /* Hidden on desktop */
+}
+
+@media (max-width: 768px) {
+  .hero-actions {
+    display: flex;
+    gap: 8px;
+    padding: 8px 12px 4px;
+    flex-shrink: 0;
+  }
+
+  .hero-action-btn {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 12px 14px;
+    border-radius: 12px;
+    border: 1.5px solid rgba(18, 179, 179, 0.25);
+    background: linear-gradient(135deg, rgba(18, 179, 179, 0.06) 0%, rgba(18, 179, 179, 0.02) 100%);
+    color: #0d8a8a;
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .hero-action-btn i {
+    font-size: 1rem;
+    color: var(--clr-primary-teal, #12B3B3);
+  }
+
+  .hero-action-btn:active {
+    background: var(--clr-primary-teal, #12B3B3);
+    border-color: var(--clr-primary-teal, #12B3B3);
+    color: #fff;
+    transform: scale(0.97);
+  }
+
+  .hero-action-btn:active i {
+    color: #fff;
+  }
+
+  [data-theme="dark"] .hero-action-btn {
+    background: rgba(18, 179, 179, 0.08);
+    border-color: rgba(18, 179, 179, 0.2);
+    color: #2dd4bf;
+  }
+
+  [data-theme="dark"] .hero-action-btn i {
+    color: #2dd4bf;
+  }
+
+  [data-theme="dark"] .hero-action-btn:active {
+    background: var(--clr-primary-teal, #12B3B3);
+    color: #fff;
+  }
+
+  /* Hide hero actions once user has started chatting (first message sent) */
+  .hero-actions.hero-hidden {
+    display: none;
+  }
+}
+
+/* --- DECLUTTER TOOLBAR: Hide calculator & break on mobile --- */
+/* Calculator: kids have their phone calculator. Break: not a primary action. */
+
+@media (max-width: 768px) {
+  #calculator-toolbar-btn,
+  #break-toolbar-btn {
+    display: none !important;
+  }
+}
+
+/* --- AI MESSAGE BUBBLE CONTRAST FIX --- */
+
+@media (max-width: 768px) {
+  /* Slightly darker AI bubble so it doesn't vanish against light backgrounds */
+  body.has-chat-nav .message.ai,
+  body.has-chat-nav .message.ai-message {
+    background: #f0f1f3;
+    border: 1px solid #e2e5e9;
+    border-bottom-left-radius: 6px;
+  }
+
+  [data-theme="dark"] body.has-chat-nav .message.ai,
+  [data-theme="dark"] body.has-chat-nav .message.ai-message {
+    background: rgba(255, 255, 255, 0.08);
+    border-color: rgba(255, 255, 255, 0.1);
+  }
+}

--- a/public/css/pwa.css
+++ b/public/css/pwa.css
@@ -1,0 +1,112 @@
+/* PWA Install Banner */
+#pwa-install-banner {
+  position: fixed;
+  bottom: -100px;
+  left: 0;
+  right: 0;
+  z-index: 10000;
+  padding: 0 1rem 1rem;
+  transition: bottom 0.3s ease;
+  pointer-events: none;
+}
+
+#pwa-install-banner.pwa-install-visible {
+  bottom: 0;
+  pointer-events: auto;
+}
+
+/* iOS safe area padding */
+@supports (padding-bottom: env(safe-area-inset-bottom)) {
+  #pwa-install-banner {
+    padding-bottom: calc(1rem + env(safe-area-inset-bottom));
+  }
+}
+
+.pwa-install-content {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  max-width: 480px;
+  margin: 0 auto;
+  padding: 0.875rem 1rem;
+  background: #1a2a4a;
+  border: 1px solid rgba(18, 179, 179, 0.3);
+  border-radius: 14px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+}
+
+.pwa-install-icon {
+  border-radius: 10px;
+  flex-shrink: 0;
+}
+
+.pwa-install-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.pwa-install-text strong {
+  display: block;
+  font-size: 0.9rem;
+  color: #fff;
+  line-height: 1.3;
+}
+
+.pwa-install-text span {
+  display: block;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.6);
+  line-height: 1.3;
+}
+
+.pwa-install-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.pwa-install-btn {
+  padding: 0.5rem 1.1rem;
+  background: #12B3B3;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.2s;
+}
+
+.pwa-install-btn:hover {
+  background: #0e9494;
+}
+
+.pwa-dismiss-btn {
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 1.4rem;
+  cursor: pointer;
+  padding: 0.25rem;
+  line-height: 1;
+  transition: color 0.2s;
+}
+
+.pwa-dismiss-btn:hover {
+  color: #fff;
+}
+
+/* Standalone mode tweaks — hide browser-specific UI elements when running as PWA */
+@media (display-mode: standalone) {
+  /* Add top padding to account for mobile status bar */
+  body {
+    padding-top: env(safe-area-inset-top, 0);
+  }
+
+  /* Hide the install banner when already installed */
+  #pwa-install-banner {
+    display: none !important;
+  }
+}

--- a/public/css/resume-card.css
+++ b/public/css/resume-card.css
@@ -1,0 +1,357 @@
+/* Resume Card — Welcome back experience */
+
+.rc-card {
+  margin: 12px;
+  padding: 16px;
+  background: linear-gradient(135deg, #0f2027, #203a43, #2c5364);
+  border: 1px solid rgba(18, 179, 179, 0.2);
+  border-radius: 16px;
+  color: #fff;
+  animation: rc-slide-in 0.35s ease-out;
+  overflow: hidden;
+}
+
+@keyframes rc-slide-in {
+  from {
+    opacity: 0;
+    transform: translateY(-12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.rc-card.rc-dismissing {
+  animation: rc-slide-out 0.3s ease-in forwards;
+}
+
+@keyframes rc-slide-out {
+  to {
+    opacity: 0;
+    transform: translateY(-12px);
+    max-height: 0;
+    margin: 0;
+    padding: 0;
+    border: 0;
+  }
+}
+
+/* Header */
+.rc-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.rc-greeting {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+.rc-dismiss {
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.4);
+  font-size: 1.4rem;
+  cursor: pointer;
+  padding: 4px 8px;
+  line-height: 1;
+  border-radius: 6px;
+  transition: color 0.2s, background 0.2s;
+}
+
+.rc-dismiss:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+/* Top row: streak + XP */
+.rc-top-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+/* Streak */
+.rc-streak {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: rgba(255, 152, 0, 0.15);
+  border: 1px solid rgba(255, 152, 0, 0.3);
+  padding: 4px 10px;
+  border-radius: 20px;
+  flex-shrink: 0;
+}
+
+.rc-streak-flame {
+  font-size: 1rem;
+}
+
+.rc-streak-count {
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: #ffb74d;
+}
+
+.rc-streak-label {
+  font-size: 0.7rem;
+  color: rgba(255, 183, 77, 0.7);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+/* XP bar */
+.rc-xp {
+  flex: 1;
+  min-width: 0;
+}
+
+.rc-xp-label {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 4px;
+}
+
+.rc-level {
+  font-weight: 700;
+  font-size: 0.85rem;
+  color: #12B3B3;
+}
+
+.rc-xp-text {
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.rc-xp-track {
+  height: 6px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.rc-xp-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #12B3B3, #14d4d4);
+  border-radius: 3px;
+  transition: width 0.6s ease;
+}
+
+/* Weekly stats strip */
+.rc-stats-strip {
+  display: flex;
+  gap: 2px;
+  margin-bottom: 10px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.rc-stat {
+  flex: 1;
+  text-align: center;
+  padding: 8px 4px;
+}
+
+.rc-stat-val {
+  display: block;
+  font-weight: 700;
+  font-size: 1rem;
+  color: #fff;
+  line-height: 1.2;
+}
+
+.rc-stat-label {
+  display: block;
+  font-size: 0.6rem;
+  color: rgba(255, 255, 255, 0.45);
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  line-height: 1.3;
+}
+
+/* Learning progress */
+.rc-learning {
+  margin-bottom: 10px;
+}
+
+.rc-learning-item {
+  padding: 8px 10px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+  margin-bottom: 6px;
+}
+
+.rc-learning-item:last-child {
+  margin-bottom: 0;
+}
+
+.rc-learning-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2px;
+}
+
+.rc-learning-status {
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.5);
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.rc-learning-pct {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #12B3B3;
+}
+
+.rc-learning-name {
+  font-weight: 600;
+  font-size: 0.9rem;
+  margin-bottom: 6px;
+  color: #fff;
+}
+
+.rc-learning-track {
+  height: 4px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.rc-learning-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #12B3B3, #14d4d4);
+  border-radius: 2px;
+}
+
+.rc-mastery-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.rc-mastery-badge {
+  font-size: 1.1rem;
+}
+
+/* Sessions list */
+.rc-sessions {
+  margin-top: 2px;
+}
+
+.rc-sessions-label {
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.4);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+  padding-left: 2px;
+}
+
+.rc-session-btn {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 10px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  color: #fff;
+  cursor: pointer;
+  text-align: left;
+  margin-bottom: 6px;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.rc-session-btn:last-child {
+  margin-bottom: 0;
+}
+
+.rc-session-btn:hover,
+.rc-session-btn:active {
+  background: rgba(18, 179, 179, 0.12);
+  border-color: rgba(18, 179, 179, 0.3);
+}
+
+.rc-session-course {
+  border-color: rgba(102, 126, 234, 0.3);
+  background: rgba(102, 126, 234, 0.08);
+}
+
+.rc-session-course:hover,
+.rc-session-course:active {
+  background: rgba(102, 126, 234, 0.15);
+}
+
+.rc-session-emoji {
+  font-size: 1.3rem;
+  flex-shrink: 0;
+  width: 32px;
+  text-align: center;
+}
+
+.rc-session-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.rc-session-name {
+  display: block;
+  font-weight: 600;
+  font-size: 0.85rem;
+  line-height: 1.3;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.rc-session-meta {
+  display: block;
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.4);
+  line-height: 1.3;
+}
+
+.rc-session-arrow {
+  color: rgba(255, 255, 255, 0.3);
+  font-size: 1rem;
+  flex-shrink: 0;
+  transition: transform 0.15s;
+}
+
+.rc-session-btn:hover .rc-session-arrow {
+  transform: translateX(2px);
+  color: #12B3B3;
+}
+
+/* Dark mode adjustments (card is already dark, so just tweak borders) */
+[data-theme="dark"] .rc-card {
+  border-color: rgba(18, 179, 179, 0.15);
+}
+
+/* Make sure card scrolls with chat on smaller screens */
+@media (max-height: 600px) {
+  .rc-card {
+    margin: 8px;
+    padding: 12px;
+  }
+
+  .rc-greeting {
+    font-size: 1rem;
+  }
+
+  .rc-stat-val {
+    font-size: 0.85rem;
+  }
+}

--- a/public/css/resume-card.css
+++ b/public/css/resume-card.css
@@ -8,7 +8,9 @@
   border-radius: 16px;
   color: #fff;
   animation: rc-slide-in 0.35s ease-out;
-  overflow: hidden;
+  max-height: 55vh;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 @keyframes rc-slide-in {

--- a/public/js/mobile-stats-bar.js
+++ b/public/js/mobile-stats-bar.js
@@ -50,21 +50,12 @@
   // --- Hero Action Buttons ---
   function wireHeroButtons() {
     var uploadBtn = document.getElementById('hero-upload-btn');
-    var cameraBtn = document.getElementById('hero-camera-btn');
     var attachBtn = document.getElementById('attach-button');
-    var cameraTrigger = document.getElementById('camera-button');
 
-    // Upload Homework → trigger the existing attach button
+    // Upload / Photo → trigger the existing attach button (handles both files and camera)
     if (uploadBtn && attachBtn) {
       uploadBtn.addEventListener('click', function () {
         attachBtn.click();
-      });
-    }
-
-    // Show Your Work → trigger the existing camera button
-    if (cameraBtn && cameraTrigger) {
-      cameraBtn.addEventListener('click', function () {
-        cameraTrigger.click();
       });
     }
   }

--- a/public/js/mobile-stats-bar.js
+++ b/public/js/mobile-stats-bar.js
@@ -1,0 +1,98 @@
+// Mobile Stats Bar — syncs XP, level, and streak to the persistent bar
+// Also wires up hero action buttons (Upload Homework, Show Your Work)
+(function () {
+  'use strict';
+
+  // --- Stats Bar: Mirror data from drawer elements ---
+  function syncStatsBar() {
+    const msbLevel = document.getElementById('msb-level');
+    const msbStreak = document.getElementById('msb-streak');
+    const msbXp = document.getElementById('msb-xp');
+    const msbXpFill = document.getElementById('msb-xp-fill');
+
+    // Pull from drawer (already updated by sidebar.js)
+    const drawerLevel = document.getElementById('drawer-level');
+    const drawerStreak = document.getElementById('drawer-streak-count');
+    const drawerTotalXp = document.getElementById('drawer-total-xp');
+    const drawerProgressFill = document.getElementById('drawer-progress-fill');
+
+    if (msbLevel && drawerLevel) msbLevel.textContent = drawerLevel.textContent;
+    if (msbStreak && drawerStreak) msbStreak.textContent = drawerStreak.textContent;
+    if (msbXp && drawerTotalXp) msbXp.textContent = drawerTotalXp.textContent;
+    if (msbXpFill && drawerProgressFill) {
+      msbXpFill.style.width = drawerProgressFill.style.width;
+    }
+  }
+
+  // Observe drawer changes so stats bar stays in sync
+  function observeDrawerChanges() {
+    const targets = [
+      'drawer-level', 'drawer-streak-count',
+      'drawer-total-xp', 'drawer-progress-fill'
+    ];
+
+    const observer = new MutationObserver(syncStatsBar);
+
+    targets.forEach(function (id) {
+      var el = document.getElementById(id);
+      if (el) {
+        observer.observe(el, {
+          childList: true,
+          characterData: true,
+          subtree: true,
+          attributes: true,
+          attributeFilter: ['style']
+        });
+      }
+    });
+  }
+
+  // --- Hero Action Buttons ---
+  function wireHeroButtons() {
+    var uploadBtn = document.getElementById('hero-upload-btn');
+    var cameraBtn = document.getElementById('hero-camera-btn');
+    var attachBtn = document.getElementById('attach-button');
+    var cameraTrigger = document.getElementById('camera-button');
+
+    // Upload Homework → trigger the existing attach button
+    if (uploadBtn && attachBtn) {
+      uploadBtn.addEventListener('click', function () {
+        attachBtn.click();
+      });
+    }
+
+    // Show Your Work → trigger the existing camera button
+    if (cameraBtn && cameraTrigger) {
+      cameraBtn.addEventListener('click', function () {
+        cameraTrigger.click();
+      });
+    }
+  }
+
+  // --- Hide hero actions after first message sent ---
+  function watchForFirstMessage() {
+    var chatBox = document.getElementById('chat-messages-container');
+    var heroActions = document.getElementById('hero-actions');
+    if (!chatBox || !heroActions) return;
+
+    var observer = new MutationObserver(function () {
+      // If chat has messages beyond the resume card, hide hero buttons
+      var messages = chatBox.querySelectorAll('.message-container, .message');
+      if (messages.length > 0) {
+        heroActions.classList.add('hero-hidden');
+      }
+    });
+
+    observer.observe(chatBox, { childList: true });
+  }
+
+  // --- Init ---
+  document.addEventListener('DOMContentLoaded', function () {
+    // Initial sync after a small delay (sidebar loads data async)
+    setTimeout(syncStatsBar, 1500);
+    setTimeout(syncStatsBar, 4000);
+    observeDrawerChanges();
+    wireHeroButtons();
+    watchForFirstMessage();
+  });
+})();

--- a/public/js/pwa-register.js
+++ b/public/js/pwa-register.js
@@ -1,0 +1,101 @@
+// PWA Service Worker Registration & Install Prompt
+(function () {
+  'use strict';
+
+  // --- Service Worker Registration ---
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+      navigator.serviceWorker.register('/sw.js')
+        .then((reg) => {
+          // Auto-update check every 60 minutes
+          setInterval(() => reg.update(), 60 * 60 * 1000);
+        })
+        .catch(() => { /* SW registration failed — app works fine without it */ });
+    });
+  }
+
+  // --- Install Prompt ---
+  let deferredPrompt = null;
+  const DISMISS_KEY = 'mathmatix-pwa-dismiss';
+  const DISMISS_DURATION = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+  // Don't show if already installed (standalone mode) or recently dismissed
+  function isStandalone() {
+    return window.matchMedia('(display-mode: standalone)').matches
+      || window.navigator.standalone === true;
+  }
+
+  function wasDismissedRecently() {
+    const dismissed = localStorage.getItem(DISMISS_KEY);
+    if (!dismissed) return false;
+    return (Date.now() - parseInt(dismissed, 10)) < DISMISS_DURATION;
+  }
+
+  function createInstallBanner() {
+    if (document.getElementById('pwa-install-banner')) return;
+
+    const banner = document.createElement('div');
+    banner.id = 'pwa-install-banner';
+    banner.setAttribute('role', 'alert');
+    banner.innerHTML = `
+      <div class="pwa-install-content">
+        <img src="/images/icon-192x192.png" alt="MATHMATIX" class="pwa-install-icon" width="40" height="40" />
+        <div class="pwa-install-text">
+          <strong>Get the MATHMATIX app!</strong>
+          <span>Add to your home screen for quick access</span>
+        </div>
+        <div class="pwa-install-actions">
+          <button class="pwa-install-btn" id="pwa-install-accept">Install</button>
+          <button class="pwa-dismiss-btn" id="pwa-install-dismiss" aria-label="Dismiss">&times;</button>
+        </div>
+      </div>
+    `;
+    document.body.appendChild(banner);
+
+    // Animate in
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => { banner.classList.add('pwa-install-visible'); });
+    });
+
+    document.getElementById('pwa-install-accept').addEventListener('click', async () => {
+      if (!deferredPrompt) return;
+      deferredPrompt.prompt();
+      const { outcome } = await deferredPrompt.userChoice;
+      deferredPrompt = null;
+      removeBanner();
+      if (outcome === 'dismissed') {
+        localStorage.setItem(DISMISS_KEY, Date.now().toString());
+      }
+    });
+
+    document.getElementById('pwa-install-dismiss').addEventListener('click', () => {
+      localStorage.setItem(DISMISS_KEY, Date.now().toString());
+      removeBanner();
+    });
+  }
+
+  function removeBanner() {
+    const banner = document.getElementById('pwa-install-banner');
+    if (banner) {
+      banner.classList.remove('pwa-install-visible');
+      setTimeout(() => banner.remove(), 300);
+    }
+  }
+
+  // Listen for the browser's install prompt
+  window.addEventListener('beforeinstallprompt', (e) => {
+    e.preventDefault();
+    deferredPrompt = e;
+
+    if (!isStandalone() && !wasDismissedRecently()) {
+      // Delay showing the banner so it doesn't interrupt initial page load
+      setTimeout(createInstallBanner, 3000);
+    }
+  });
+
+  // If app is installed, clean up
+  window.addEventListener('appinstalled', () => {
+    deferredPrompt = null;
+    removeBanner();
+  });
+})();

--- a/public/js/resume-card.js
+++ b/public/js/resume-card.js
@@ -1,0 +1,268 @@
+// Resume Card — "Welcome back" experience for returning students
+// Shows streak, XP progress, last session context, and quick actions
+// Injected into #chat-messages-container before the welcome message
+
+(function () {
+  'use strict';
+
+  const CARD_ID = 'resume-card';
+
+  // Time-of-day greeting
+  function getTimeGreeting() {
+    const h = new Date().getHours();
+    if (h < 12) return 'Good morning';
+    if (h < 17) return 'Good afternoon';
+    return 'Good evening';
+  }
+
+  // Relative time formatting
+  function timeAgo(dateStr) {
+    if (!dateStr) return '';
+    const diff = Date.now() - new Date(dateStr).getTime();
+    const mins = Math.floor(diff / 60000);
+    if (mins < 1) return 'just now';
+    if (mins < 60) return `${mins}m ago`;
+    const hours = Math.floor(mins / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    if (days === 1) return 'yesterday';
+    if (days < 7) return `${days}d ago`;
+    return new Date(dateStr).toLocaleDateString();
+  }
+
+  // Fetch both endpoints in parallel
+  async function fetchResumeData() {
+    const [returningRes, summaryRes] = await Promise.all([
+      fetch('/api/conversations/returning-user-data', { credentials: 'include' }).catch(() => null),
+      fetch('/api/student/progress/summary', { credentials: 'include' }).catch(() => null),
+    ]);
+
+    const returning = returningRes?.ok ? await returningRes.json() : null;
+    const summary = summaryRes?.ok ? await summaryRes.json() : null;
+
+    return { returning, summary };
+  }
+
+  // Build the streak flame display
+  function streakHTML(count) {
+    if (!count || count < 1) return '';
+    const label = count === 1 ? 'day' : 'days';
+    return `<div class="rc-streak"><span class="rc-streak-flame">🔥</span><span class="rc-streak-count">${count}</span><span class="rc-streak-label">${label}</span></div>`;
+  }
+
+  // Build XP progress bar
+  function xpBarHTML(user) {
+    if (!user || !user.level) return '';
+    const level = user.level || 1;
+    const xpCurrent = user.xpForCurrentLevel || 0;
+    const xpNeeded = user.xpForNextLevel || 100;
+    const pct = Math.min(Math.round((xpCurrent / xpNeeded) * 100), 100);
+    return `
+      <div class="rc-xp">
+        <div class="rc-xp-label">
+          <span class="rc-level">Lv. ${level}</span>
+          <span class="rc-xp-text">${xpCurrent} / ${xpNeeded} XP</span>
+        </div>
+        <div class="rc-xp-track"><div class="rc-xp-fill" style="width: ${pct}%"></div></div>
+      </div>`;
+  }
+
+  // Build weekly stats strip
+  function weeklyStatsHTML(stats) {
+    if (!stats) return '';
+    const items = [];
+    if (stats.problemsSolved != null && stats.problemsSolved > 0) {
+      items.push(`<div class="rc-stat"><span class="rc-stat-val">${stats.problemsSolved}</span><span class="rc-stat-label">problems</span></div>`);
+    }
+    if (stats.accuracy != null) {
+      items.push(`<div class="rc-stat"><span class="rc-stat-val">${stats.accuracy}%</span><span class="rc-stat-label">accuracy</span></div>`);
+    }
+    if (stats.xpEarned != null && stats.xpEarned > 0) {
+      items.push(`<div class="rc-stat"><span class="rc-stat-val">+${stats.xpEarned}</span><span class="rc-stat-label">XP this week</span></div>`);
+    }
+    if (stats.skillsMastered != null && stats.skillsMastered > 0) {
+      items.push(`<div class="rc-stat"><span class="rc-stat-val">${stats.skillsMastered}</span><span class="rc-stat-label">mastered</span></div>`);
+    }
+    if (items.length === 0) return '';
+    return `<div class="rc-stats-strip">${items.join('')}</div>`;
+  }
+
+  // Build learning progress section
+  function learningHTML(summary) {
+    if (!summary) return '';
+    const parts = [];
+
+    if (summary.currentLearning) {
+      const pct = summary.currentLearning.progress || 0;
+      parts.push(`
+        <div class="rc-learning-item">
+          <div class="rc-learning-header">
+            <span class="rc-learning-status">📖 Currently learning</span>
+            <span class="rc-learning-pct">${pct}%</span>
+          </div>
+          <div class="rc-learning-name">${summary.currentLearning.displayName}</div>
+          <div class="rc-learning-track"><div class="rc-learning-fill" style="width: ${pct}%"></div></div>
+        </div>`);
+    }
+
+    if (summary.recentMastery) {
+      parts.push(`
+        <div class="rc-learning-item rc-mastery-item">
+          <span class="rc-mastery-badge">⭐</span>
+          <span>Recently mastered <strong>${summary.recentMastery.displayName}</strong></span>
+        </div>`);
+    }
+
+    return parts.length > 0 ? `<div class="rc-learning">${parts.join('')}</div>` : '';
+  }
+
+  // Build recent session buttons
+  function sessionsHTML(returning) {
+    if (!returning?.isReturningUser) return '';
+
+    const items = [];
+
+    // Course in progress
+    if (returning.courses?.length > 0) {
+      const c = returning.courses[0];
+      items.push(`
+        <button class="rc-session-btn rc-session-course" data-course-id="${c.courseSessionId}">
+          <span class="rc-session-emoji">📚</span>
+          <div class="rc-session-info">
+            <span class="rc-session-name">${c.courseName}</span>
+            <span class="rc-session-meta">${c.currentModuleLabel} · ${c.overallProgress}%</span>
+          </div>
+          <span class="rc-session-arrow">→</span>
+        </button>`);
+    }
+
+    // Recent sessions (top 3)
+    const sessions = (returning.recentSessions || []).slice(0, 3);
+    for (const s of sessions) {
+      items.push(`
+        <button class="rc-session-btn" data-session-id="${s._id}">
+          <span class="rc-session-emoji">${s.topicEmoji}</span>
+          <div class="rc-session-info">
+            <span class="rc-session-name">${s.name}</span>
+            <span class="rc-session-meta">${timeAgo(s.lastActivity)} · ${s.messageCount} messages</span>
+          </div>
+          <span class="rc-session-arrow">→</span>
+        </button>`);
+    }
+
+    if (items.length === 0) return '';
+
+    return `
+      <div class="rc-sessions">
+        <div class="rc-sessions-label">Pick up where you left off</div>
+        ${items.join('')}
+      </div>`;
+  }
+
+  // Build the full card
+  function buildCard(data, user) {
+    const { returning, summary } = data;
+    const firstName = user?.firstName || user?.name?.split(' ')[0] || '';
+    const greeting = `${getTimeGreeting()}${firstName ? ', ' + firstName : ''}!`;
+
+    // Only show card if there's meaningful content
+    const hasStreak = summary?.streak > 0;
+    const hasSessions = returning?.isReturningUser && (returning.courses?.length > 0 || returning.recentSessions?.length > 0);
+    const hasLearning = summary?.currentLearning || summary?.recentMastery;
+    const hasStats = summary?.weeklyStats && (summary.weeklyStats.problemsSolved > 0 || summary.weeklyStats.xpEarned > 0);
+
+    if (!hasSessions && !hasLearning && !hasStats && !hasStreak) return null;
+
+    const html = `
+      <div id="${CARD_ID}" class="rc-card" role="region" aria-label="Welcome back">
+        <div class="rc-header">
+          <div class="rc-greeting">${greeting}</div>
+          <button class="rc-dismiss" id="rc-dismiss-btn" aria-label="Dismiss">&times;</button>
+        </div>
+        <div class="rc-body">
+          <div class="rc-top-row">
+            ${streakHTML(summary?.streak)}
+            ${xpBarHTML(user)}
+          </div>
+          ${weeklyStatsHTML(summary?.weeklyStats)}
+          ${learningHTML(summary)}
+          ${sessionsHTML(returning)}
+        </div>
+      </div>`;
+
+    return html;
+  }
+
+  // Dismiss with animation
+  function dismissCard() {
+    const card = document.getElementById(CARD_ID);
+    if (!card) return;
+    card.classList.add('rc-dismissing');
+    setTimeout(() => card.remove(), 300);
+  }
+
+  // Wire up session resume clicks
+  function wireSessionClicks() {
+    const card = document.getElementById(CARD_ID);
+    if (!card) return;
+
+    card.querySelectorAll('.rc-session-btn[data-session-id]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const sessionId = btn.dataset.sessionId;
+        dismissCard();
+        // Use sidebar's switchSession to load conversation properly
+        if (window.sidebar?.switchSession) {
+          window.sidebar.switchSession(sessionId);
+        }
+      });
+    });
+
+    card.querySelectorAll('.rc-session-btn[data-course-id]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        dismissCard();
+        // Resume course via course manager
+        if (window.courseManager?.resumeCourse) {
+          window.courseManager.resumeCourse();
+        }
+      });
+    });
+  }
+
+  // Main: show resume card
+  async function showResumeCard() {
+    // Don't show if user isn't a student or data already loaded
+    const user = window.currentUser;
+    if (!user || user.role !== 'student') return;
+
+    // Don't show if chat already has messages (e.g., trial carryover)
+    const chatBox = document.getElementById('chat-messages-container');
+    if (!chatBox || chatBox.children.length > 0) return;
+
+    try {
+      const data = await fetchResumeData();
+      const cardHTML = buildCard(data, user);
+      if (!cardHTML) return;
+
+      // Insert at top of chat container
+      chatBox.insertAdjacentHTML('afterbegin', cardHTML);
+
+      // Wire up interactions
+      const dismissBtn = document.getElementById('rc-dismiss-btn');
+      if (dismissBtn) dismissBtn.addEventListener('click', dismissCard);
+      wireSessionClicks();
+
+      // Auto-dismiss after welcome message loads (card served its purpose)
+      // Give them 30 seconds to interact before auto-dismissing
+      setTimeout(() => {
+        const card = document.getElementById(CARD_ID);
+        if (card && !card.matches(':hover')) dismissCard();
+      }, 30000);
+    } catch (err) {
+      // Silent fail — welcome message will show normally
+      console.warn('[ResumeCard] Failed to load resume data:', err);
+    }
+  }
+
+  // Expose globally so initializeApp can call it
+  window.showResumeCard = showResumeCard;
+})();

--- a/public/js/resume-card.js
+++ b/public/js/resume-card.js
@@ -251,12 +251,8 @@
       if (dismissBtn) dismissBtn.addEventListener('click', dismissCard);
       wireSessionClicks();
 
-      // Auto-dismiss after welcome message loads (card served its purpose)
-      // Give them 30 seconds to interact before auto-dismissing
-      setTimeout(() => {
-        const card = document.getElementById(CARD_ID);
-        if (card && !card.matches(':hover')) dismissCard();
-      }, 30000);
+      // Card stays until the user dismisses it or taps a session.
+      // No auto-dismiss — let them read at their own pace.
     } catch (err) {
       // Silent fail — welcome message will show normally
       console.warn('[ResumeCard] Failed to load resume data:', err);

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1569,35 +1569,6 @@ document.addEventListener("DOMContentLoaded", () => {
             const chip = document.createElement('button');
             chip.className = 'suggestion-chip';
             chip.textContent = suggestion.text;
-            chip.style.cssText = `
-                background: linear-gradient(135deg, #f3f4f6 0%, #e5e7eb 100%);
-                border: 1px solid #d1d5db;
-                border-radius: 20px;
-                padding: 8px 16px;
-                font-size: 13px;
-                color: #374151;
-                cursor: pointer;
-                transition: all 0.2s ease;
-                white-space: nowrap;
-                font-weight: 500;
-            `;
-
-            // Hover effect
-            chip.addEventListener('mouseenter', () => {
-                chip.style.background = 'linear-gradient(135deg, #8b5cf6 0%, #7c3aed 100%)';
-                chip.style.color = 'white';
-                chip.style.borderColor = '#8b5cf6';
-                chip.style.transform = 'translateY(-2px)';
-                chip.style.boxShadow = '0 4px 8px rgba(139, 92, 246, 0.3)';
-            });
-
-            chip.addEventListener('mouseleave', () => {
-                chip.style.background = 'linear-gradient(135deg, #f3f4f6 0%, #e5e7eb 100%)';
-                chip.style.color = '#374151';
-                chip.style.borderColor = '#d1d5db';
-                chip.style.transform = 'translateY(0)';
-                chip.style.boxShadow = 'none';
-            });
 
             // Click handler - fills input but doesn't auto-send
             chip.addEventListener('click', () => {

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -334,6 +334,12 @@ document.addEventListener("DOMContentLoaded", () => {
                 return; // Skip the rest of initializeApp
             }
 
+            // Show resume card (streak, XP, last session) while welcome loads.
+            // Fires in parallel with getWelcomeMessage — non-blocking.
+            if (window.showResumeCard) {
+                window.showResumeCard();
+            }
+
             // Always start with a fresh AI welcome. Returning users get a
             // context-aware greeting that references their last session.
             // Past conversations are accessible via the sidebar.

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,10 +3,12 @@
   "short_name": "MATHMATIX",
   "description": "Unlock the Pattern. Learn for Life. - AI-powered math tutoring platform",
   "start_url": "/chat.html",
+  "scope": "/",
   "display": "standalone",
-  "background_color": "#ffffff",
+  "background_color": "#0a1628",
   "theme_color": "#12B3B3",
   "orientation": "portrait-primary",
+  "id": "/chat.html",
   "icons": [
     {
       "src": "/images/icon-192x192.png",
@@ -34,5 +36,9 @@
     }
   ],
   "categories": ["education", "productivity"],
-  "screenshots": []
+  "screenshots": [],
+  "prefer_related_applications": false,
+  "launch_handler": {
+    "client_mode": "navigate-existing"
+  }
 }

--- a/public/offline.html
+++ b/public/offline.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="theme-color" content="#12B3B3" />
+  <title>Offline | MATHMATIX AI</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: linear-gradient(135deg, #0a1628 0%, #1a2a4a 100%);
+      color: #fff;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      padding: 2rem;
+    }
+    .offline-container { max-width: 400px; }
+    .offline-icon {
+      font-size: 4rem;
+      margin-bottom: 1.5rem;
+      opacity: 0.8;
+    }
+    h1 {
+      font-size: 1.5rem;
+      margin-bottom: 0.75rem;
+      color: #12B3B3;
+    }
+    p {
+      font-size: 1rem;
+      line-height: 1.6;
+      opacity: 0.8;
+      margin-bottom: 1.5rem;
+    }
+    .retry-btn {
+      display: inline-block;
+      padding: 0.75rem 2rem;
+      background: #12B3B3;
+      color: #fff;
+      border: none;
+      border-radius: 8px;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+      text-decoration: none;
+      transition: background 0.2s;
+    }
+    .retry-btn:hover { background: #0e9494; }
+  </style>
+</head>
+<body>
+  <div class="offline-container">
+    <div class="offline-icon">📡</div>
+    <h1>You're Offline</h1>
+    <p>MATHMATIX needs an internet connection to work its math magic. Check your connection and try again.</p>
+    <button class="retry-btn" onclick="window.location.reload()">Try Again</button>
+  </div>
+</body>
+</html>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,84 @@
+// Service Worker for MATHMATIX AI PWA
+const CACHE_VERSION = 'mathmatix-v1';
+const STATIC_CACHE = `static-${CACHE_VERSION}`;
+const RUNTIME_CACHE = `runtime-${CACHE_VERSION}`;
+
+// Core assets to pre-cache on install
+const PRECACHE_URLS = [
+  '/offline.html',
+  '/style.css',
+  '/css/mobile-fixes.css',
+  '/css/dark-mode.css',
+  '/images/mathmatix-ai-logo.png',
+  '/images/icon-192x192.png',
+  '/images/icon-512x512.png',
+  '/favicon.ico',
+];
+
+// Install: pre-cache core assets
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(STATIC_CACHE)
+      .then((cache) => cache.addAll(PRECACHE_URLS))
+      .then(() => self.skipWaiting())
+  );
+});
+
+// Activate: clean up old caches
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((key) => key !== STATIC_CACHE && key !== RUNTIME_CACHE)
+          .map((key) => caches.delete(key))
+      )
+    ).then(() => self.clients.claim())
+  );
+});
+
+// Fetch: network-first for HTML/API, cache-first for static assets
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  // Skip non-GET requests and cross-origin requests
+  if (request.method !== 'GET' || url.origin !== self.location.origin) return;
+
+  // Skip API routes — always go to network
+  if (url.pathname.startsWith('/api/')) return;
+
+  // HTML pages: network-first with offline fallback
+  if (request.headers.get('accept')?.includes('text/html') || url.pathname.endsWith('.html')) {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          // Cache a copy of the response for offline use
+          const clone = response.clone();
+          caches.open(RUNTIME_CACHE).then((cache) => cache.put(request, clone));
+          return response;
+        })
+        .catch(() =>
+          caches.match(request).then((cached) => cached || caches.match('/offline.html'))
+        )
+    );
+    return;
+  }
+
+  // Static assets (CSS, JS, images, fonts): cache-first
+  if (/\.(css|js|png|jpg|jpeg|gif|svg|ico|webp|woff2?|ttf|eot|mp3|wav)$/i.test(url.pathname)) {
+    event.respondWith(
+      caches.match(request).then((cached) => {
+        if (cached) return cached;
+        return fetch(request).then((response) => {
+          if (response.ok) {
+            const clone = response.clone();
+            caches.open(STATIC_CACHE).then((cache) => cache.put(request, clone));
+          }
+          return response;
+        });
+      })
+    );
+    return;
+  }
+});


### PR DESCRIPTION
## Summary

Students asked for a mobile app. Instead of spending months on a native app, this turns Mathmatix into an installable PWA with a significantly improved mobile chat experience.

**PWA Foundation:**
- Service worker with cache-first assets, network-first pages, offline fallback
- Install prompt banner ("Get the MATHMATIX app!") — dismissible for 7 days
- PWA meta tags auto-injected into all HTML pages via middleware (no manual edits to 49 files)
- Service worker cache header set to no-cache for instant updates

**Welcome-Back Resume Card:**
- Returning students see streak, XP, level, weekly stats, and current skill progress
- "Pick up where you left off" with tappable recent sessions and courses
- Fetches from existing endpoints — no new backend work
- Stays until student dismisses or taps a session

**Mobile UX Overhaul:**
- Tap targets: 36px → 44px on send button and all tool buttons
- Input field: min-height 20px → 44px (can see what you're typing)
- "Upload / Photo" hero button — prominent, labeled, above the compose bar
- Persistent stats bar: level, streak, XP visible on chat screen (was hidden in drawer)
- Suggestion chips: removed hardcoded purple, now teal brand, bigger, horizontal scroll with fade hint
- Toolbar: 6 buttons → 3 (equation, mic, break). Calculator and redundant attach/camera hidden on mobile
- AI message bubble contrast improved

## Files changed (13 files, +1389 / -60)

| File | What |
|------|------|
| `public/sw.js` | Service worker |
| `public/offline.html` | Offline fallback |
| `public/js/pwa-register.js` | SW registration + install prompt |
| `public/css/pwa.css` | Install banner + standalone mode |
| `config/middleware.js` | Auto-inject PWA tags into all pages |
| `public/manifest.json` | Enhanced with scope, launch handler |
| `public/js/resume-card.js` | Welcome-back card logic |
| `public/css/resume-card.css` | Resume card styling |
| `public/js/mobile-stats-bar.js` | Persistent gamification bar + hero button wiring |
| `public/css/mobile-ux-overhaul.css` | Stats bar, hero actions, toolbar cleanup, AI bubble fix |
| `public/css/mobile-redesign.css` | Tap targets, input height, chip styling |
| `public/js/script.js` | Removed inline purple chip styles, added resume card hook |
| `public/chat.html` | Stats bar, hero button, resume card CSS/JS references |

## Test plan

- [ ] Install PWA on Android (Chrome → install prompt banner appears after 3s)
- [ ] Install PWA on iOS (Safari → Add to Home Screen → launches fullscreen)
- [ ] Open as returning student → resume card shows streak, XP, recent sessions
- [ ] Tap a session in resume card → loads conversation correctly
- [ ] Dismiss resume card → stays dismissed
- [ ] Stats bar shows correct level/streak/XP on mobile
- [ ] Hero "Upload / Photo" button triggers file attach modal
- [ ] Suggestion chips are teal, scroll horizontally with fade
- [ ] Send button and toolbar buttons are 44px (inspect or tap-test)
- [ ] Input field tall enough to see text (min-height 44px)
- [ ] Calculator button hidden on mobile, break button visible
- [ ] AI message bubbles have visible contrast against background
- [ ] Offline: kill network → navigate → see offline.html fallback
- [ ] Desktop: no visual regressions (stats bar, hero actions hidden on desktop)

https://claude.ai/code/session_015qwXEGMs3ymvadTCXusmyZ