### PR TITLE
Fix voice tutor mic, mobile equation input, and dark mode visibility

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -594,7 +594,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <div id="user-input" contenteditable="true" data-placeholder="Ask a math question..." data-i18n-placeholder="chat.askQuestion" role="textbox" aria-multiline="true"></div>
         <!-- Math-field input (hidden until math mode activated) -->
         <div id="math-input-wrapper" class="math-input-wrapper" style="display:none;">
-          <math-field id="math-keyboard-field" class="math-keyboard-field" virtual-keyboard-mode="off"></math-field>
+          <math-field id="math-keyboard-field" class="math-keyboard-field" virtual-keyboard-mode="off" math-virtual-keyboard-policy="manual"></math-field>
           <button id="mk-done-btn" class="mk-done-btn" title="Insert equation and return to text">Done</button>
         </div>
         <button id="send-button" class="imessage-send-btn" title="Send" aria-label="Send message">

--- a/public/css/dark-mode.css
+++ b/public/css/dark-mode.css
@@ -690,6 +690,103 @@
     color: #5ac8fa;
 }
 
+/* Math Keyboard Panel dark mode */
+[data-theme="dark"] .math-keyboard-panel {
+    background: #1c1c1e;
+    border-top-color: #38383a;
+}
+
+[data-theme="dark"] .mk-tabs {
+    border-bottom-color: #38383a;
+}
+
+[data-theme="dark"] .mk-tab-icon,
+[data-theme="dark"] .mk-tab-label {
+    color: #8e8e93;
+}
+
+[data-theme="dark"] .mk-tab-active .mk-tab-icon,
+[data-theme="dark"] .mk-tab-active .mk-tab-label {
+    color: #0a84ff;
+}
+
+[data-theme="dark"] .mk-tab-active {
+    border-bottom-color: #0a84ff;
+}
+
+[data-theme="dark"] .mk-key {
+    background: #2c2c2e;
+    border-color: #3a3a3c;
+    color: #f0f0f0;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+
+[data-theme="dark"] .mk-key:active {
+    background: #3a3a3c;
+}
+
+[data-theme="dark"] .mk-key-action {
+    background: #48484a;
+}
+
+[data-theme="dark"] .mk-key-hint {
+    color: #8e8e93;
+}
+
+[data-theme="dark"] .mk-section-label {
+    color: #8e8e93;
+}
+
+[data-theme="dark"] .math-keyboard-field {
+    background: #1c1c1e;
+    border-color: #14C8C8;
+    color: #f0f0f0;
+}
+
+[data-theme="dark"] .mk-done-btn {
+    background: #14C8C8;
+    color: #000;
+}
+
+[data-theme="dark"] .mk-helper-text {
+    color: #8e8e93;
+}
+
+[data-theme="dark"] .mk-helper-text strong {
+    color: #0a84ff;
+}
+
+[data-theme="dark"] .mk-tooltip {
+    background: #0a84ff;
+}
+
+/* User messages in dark mode — ensure text is always white and visible */
+[data-theme="dark"] .message.user {
+    background: #0b84fe;
+    color: #fff;
+}
+
+[data-theme="dark"] .message.user * {
+    color: inherit;
+}
+
+/* User message KaTeX math — keep white in dark mode */
+[data-theme="dark"] .message.user .katex {
+    color: #fff;
+}
+
+/* User message links — lighter shade for contrast on blue */
+[data-theme="dark"] .message.user a {
+    color: #d4e9ff;
+    text-decoration: underline;
+}
+
+/* User message code snippets */
+[data-theme="dark"] .message.user code {
+    background: rgba(255, 255, 255, 0.15);
+    color: #fff;
+}
+
 /* Transition for smooth theme switching */
 html.theme-transitioning,
 html.theme-transitioning *,

--- a/public/css/mobile-fixes.css
+++ b/public/css/mobile-fixes.css
@@ -1917,18 +1917,74 @@ a {
         display: none !important;
     }
 
+    /* Also suppress MathLive popover and alternate keys panel */
+    .ML__popover,
+    .ML__keyboard-toggle {
+        display: none !important;
+    }
+
     /* --- Math Keyboard Panel: mobile tuning --- */
     .math-keyboard-panel {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        z-index: 200;
+        background: #f2f2f7;
+        border-top: 1px solid rgba(0, 0, 0, 0.12);
         padding-bottom: env(safe-area-inset-bottom, 0);
+        box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.08);
+        max-height: 55vh;
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    /* Numbers page: use 4-column grid on mobile for bigger keys */
+    .math-keyboard-panel .mk-page[data-page="123"] .mk-grid-5 {
+        grid-template-columns: repeat(4, 1fr);
     }
 
     .mk-key {
-        min-height: 44px;
-        font-size: 1.05rem;
+        min-height: 46px;
+        font-size: 1.1rem;
+        border-radius: 6px;
     }
 
+    .mk-key-main {
+        font-size: 1.15rem;
+    }
+
+    .mk-key-hint {
+        font-size: 0.6rem;
+    }
+
+    /* Math field stays in compose bar, styled clearly */
     .math-keyboard-field {
-        min-height: 38px;
-        font-size: 1.05rem;
+        min-height: 40px;
+        font-size: 16px; /* 16px prevents iOS auto-zoom */
+        border: 2px solid #12B3B3;
+        border-radius: 20px;
+        background: #fff;
+    }
+
+    .mk-done-btn {
+        min-height: 40px;
+        padding: 8px 16px;
+        font-size: 0.9rem;
+        border-radius: 20px;
+        background: #12B3B3;
+    }
+
+    /* Helper text: more visible */
+    .mk-helper-text {
+        font-size: 0.75rem;
+        padding: 6px 12px 2px;
+    }
+
+    /* When math keyboard is open, push input area above it */
+    .math-keyboard-panel ~ #input-container,
+    body:has(.math-keyboard-panel[style*="display: block"]) #input-container,
+    body:has(.math-keyboard-panel:not([style*="display: none"]):not([style*="display:none"])) #input-container {
+        padding-bottom: 0;
     }
 }

--- a/public/css/voice-tutor.css
+++ b/public/css/voice-tutor.css
@@ -1140,6 +1140,32 @@ html, body {
   }
 }
 
+/* --- Toast messages (visible on mobile even when chat panel is hidden) --- */
+.vt-toast {
+  position: fixed;
+  top: 80px;
+  left: 50%;
+  transform: translateX(-50%) translateY(-10px);
+  background: rgba(30, 30, 50, 0.95);
+  color: #f0f0f0;
+  font-size: 14px;
+  line-height: 1.4;
+  padding: 12px 20px;
+  border-radius: 12px;
+  max-width: 90vw;
+  text-align: center;
+  z-index: 1000;
+  opacity: 0;
+  transition: opacity 0.3s, transform 0.3s;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  pointer-events: none;
+}
+
+.vt-toast-visible {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
 /* --- Reduced motion --- */
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -3140,6 +3140,8 @@ document.addEventListener("DOMContentLoaded", () => {
         if (!mkPanel || !mkField || !mkWrapper || !userInput) return;
         mathModeOn = true;
 
+        const isMobile = window.innerWidth <= 768;
+
         // Swap input: hide text input, show math field + wrapper
         userInput.style.display = 'none';
         mkWrapper.style.display = '';
@@ -3149,10 +3151,16 @@ document.addEventListener("DOMContentLoaded", () => {
         // Close old overlay palette if open
         if (typeof closeEquationPalette === 'function') closeEquationPalette();
 
-        // Blur native keyboard on mobile, then focus math field
-        if (window.innerWidth <= 768) {
+        // On mobile: suppress native keyboard by setting inputmode="none"
+        // before focusing, so only our custom math keyboard shows
+        if (isMobile) {
             document.activeElement?.blur();
-            setTimeout(() => mkField.focus(), 50);
+            mkField.setAttribute('inputmode', 'none');
+            // Prevent MathLive from showing its own virtual keyboard
+            mkField.mathVirtualKeyboardPolicy = 'manual';
+            setTimeout(() => {
+                mkField.focus({ preventScroll: true });
+            }, 80);
         } else {
             mkField.focus();
         }

--- a/public/js/voice-tutor-session.js
+++ b/public/js/voice-tutor-session.js
@@ -90,8 +90,9 @@
     startSessionTimer();
     addSystemMessage('Voice session started. Tap the mic or just say something.');
 
-    // Auto-start listening if hands-free
-    if (state.handsFree) {
+    // Auto-start listening if hands-free (skip on mobile — requires user gesture)
+    const isMobile = /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent) || window.innerWidth <= 768;
+    if (state.handsFree && !isMobile) {
       setTimeout(() => startListening(), 800);
     }
   }
@@ -150,8 +151,9 @@
   // ═══════════════════════════════════════
 
   function setupEventListeners() {
-    // Main mic button
-    dom.micBtn.addEventListener('click', () => {
+    // Main mic button — handle both click and touchend for mobile responsiveness
+    function handleMicTap(e) {
+      if (e) e.preventDefault();
       if (state.mode === 'starting' || state.mode === 'thinking') return;
       if (state.mode === 'speaking') {
         interruptAndListen();
@@ -160,6 +162,17 @@
       } else {
         startListening();
       }
+    }
+
+    // Use touchend on mobile to bypass 300ms click delay; fall back to click
+    let touchHandled = false;
+    dom.micBtn.addEventListener('touchend', (e) => {
+      touchHandled = true;
+      handleMicTap(e);
+    }, { passive: false });
+    dom.micBtn.addEventListener('click', (e) => {
+      if (touchHandled) { touchHandled = false; return; }
+      handleMicTap(e);
     });
 
     // End session
@@ -222,6 +235,19 @@
     // Guard: set mode immediately to prevent double-click races
     state.mode = 'starting';
 
+    // Show immediate visual feedback so user knows the tap registered
+    if (dom.statusText) dom.statusText.textContent = 'Starting mic...';
+    if (dom.micBtn) dom.micBtn.style.opacity = '0.6';
+
+    // Safety: if 'starting' hangs for >5s (e.g. permission dialog dismissed), reset
+    const startingTimeout = setTimeout(() => {
+      if (state.mode === 'starting') {
+        console.warn('[VoiceTutor] startListening timed out in starting state');
+        setMode('idle');
+        showToast('Mic timed out. Tap to try again.');
+      }
+    }, 5000);
+
     try {
       // Resume AudioContext
       if (!state.audioContext || state.audioContext.state === 'closed') {
@@ -240,6 +266,9 @@
           sampleRate: 16000
         }
       });
+
+      clearTimeout(startingTimeout);
+      if (dom.micBtn) dom.micBtn.style.opacity = '';
 
       state.mediaRecorder = new MediaRecorder(state.mediaStream, {
         mimeType: MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
@@ -275,6 +304,9 @@
       }, MAX_RECORDING_DURATION);
 
     } catch (err) {
+      clearTimeout(startingTimeout);
+      if (dom.micBtn) dom.micBtn.style.opacity = '';
+
       console.error('[VoiceTutor] Mic error:', err);
       let msg = 'Could not access microphone.';
       if (err.name === 'NotAllowedError' || err.name === 'PermissionDeniedError') {
@@ -293,6 +325,8 @@
         msg += ' Make sure no other app is using your microphone and try again.';
       }
       addSystemMessage(msg);
+      // Also show a toast so mobile users see the error (chat panel may be hidden)
+      showToast(msg);
       setMode('idle');
     }
   }
@@ -1244,6 +1278,27 @@
     el.textContent = text;
     dom.chatMessages.appendChild(el);
     dom.chatMessages.scrollTo({ top: dom.chatMessages.scrollHeight, behavior: 'smooth' });
+  }
+
+  /** Show a floating toast message visible on mobile even when chat panel is hidden */
+  function showToast(text, duration) {
+    duration = duration || 4000;
+    const existing = document.querySelector('.vt-toast');
+    if (existing) existing.remove();
+
+    const toast = document.createElement('div');
+    toast.className = 'vt-toast';
+    toast.textContent = text;
+    toast.setAttribute('role', 'alert');
+    document.body.appendChild(toast);
+
+    // Trigger enter animation
+    requestAnimationFrame(() => toast.classList.add('vt-toast-visible'));
+
+    setTimeout(() => {
+      toast.classList.remove('vt-toast-visible');
+      setTimeout(() => toast.remove(), 300);
+    }, duration);
   }
 
   function renderMathInText(text) {


### PR DESCRIPTION
Voice tutor:
- Skip auto-start getUserMedia on mobile (requires user gesture)
- Add touchend handler for responsive mic button on mobile
- Add safety timeout for 'starting' mode to prevent stuck state
- Show visible toast errors (chat panel hidden on mobile)
- Add immediate visual feedback when mic button is tapped

Equation input (mobile):
- Suppress native keyboard with inputmode="none" on math-field
- Set mathVirtualKeyboardPolicy="manual" to prevent MathLive keyboard
- Fixed-position math keyboard panel as native keyboard replacement
- Larger touch targets (46px min-height) for math keys
- 4-column number grid on mobile for bigger digits
- Dark mode support for all math keyboard elements

Dark mode:
- Explicit white text on user message bubbles
- Ensure child elements inherit white color in user messages
- KaTeX math in user bubbles renders white
- Visible links and code snippets in user messages
- Full dark mode theme for math keyboard panel

https://claude.ai/code/session_01JDwWaagKaPGAT1PoCRrvhN