### PR TITLE
Fix math board scrollability on mobile and desktop

### DIFF
--- a/public/css/voice-tutor.css
+++ b/public/css/voice-tutor.css
@@ -138,6 +138,7 @@ html, body {
   flex-direction: column;
   position: relative;
   min-width: 0;
+  min-height: 0; /* critical: allow flex child to shrink so overflow-y works */
   overflow: hidden;
 }
 
@@ -196,6 +197,8 @@ html, body {
   flex-direction: column;
   gap: 16px;
   counter-reset: mathstep;
+  flex-shrink: 0; /* don't collapse — let parent scroll instead */
+  padding-bottom: 24px; /* breathing room below last step */
 }
 
 .vt-math-step {
@@ -1081,7 +1084,15 @@ html, body {
   .vt-mic-btn { width: 60px; height: 60px; font-size: 22px; }
   .vt-end-btn, .vt-mute-btn { width: 48px; height: 48px; font-size: 20px; }
 
-  .vt-canvas-area { padding: 16px; }
+  .vt-visual-panel {
+    min-height: 0;
+    max-height: calc(100vh - 64px - 80px); /* header + controls */
+  }
+
+  .vt-canvas-area {
+    padding: 16px;
+    -webkit-overflow-scrolling: touch; /* smooth momentum scroll on iOS */
+  }
 
   .vt-math-step .vt-step-content { font-size: 20px; line-height: 1.5; }
 


### PR DESCRIPTION
- Add min-height: 0 to vt-visual-panel so flex children can shrink and overflow-y: auto on vt-canvas-area actually triggers scrolling
- Add flex-shrink: 0 to vt-math-display so steps don't collapse — they grow the container and let the parent scroll
- Add padding-bottom for breathing room below the last step
- Mobile: constrain visual panel max-height and enable iOS momentum scrolling (-webkit-overflow-scrolling: touch)

https://claude.ai/code/session_01JDwWaagKaPGAT1PoCRrvhN