### PR TITLE
Fix false answer classification and stale derivative graphs

### DIFF
--- a/tests/unit/autoVisualize.test.js
+++ b/tests/unit/autoVisualize.test.js
@@ -196,4 +196,23 @@ describe('autoVisualizeByTopic', () => {
         // Should NOT also have FUNCTION_GRAPH from trig topic
         expect(result).not.toContain('[FUNCTION_GRAPH:');
     });
+
+    // ── Unicode superscript handling ──
+    it('should extract function with Unicode superscripts for derivative graph', () => {
+        const result = autoVisualizeByTopic(
+            '2x',
+            'The derivative of x² is indeed 2x.'
+        );
+        expect(result).toContain('[DERIVATIVE_GRAPH:');
+        expect(result).toContain('fn=x^2');
+    });
+
+    it('should extract polynomial with Unicode superscripts for derivative graph', () => {
+        const result = autoVisualizeByTopic(
+            'what is the derivative?',
+            'Let\'s find the derivative of f(x) = 3x³−5x²+2x−7.'
+        );
+        expect(result).toContain('[DERIVATIVE_GRAPH:');
+        expect(result).toContain('fn=3x^3-5x^2+2x-7');
+    });
 });

--- a/tests/unit/pipeline.test.js
+++ b/tests/unit/pipeline.test.js
@@ -108,6 +108,16 @@ describe('Pipeline: Observe Stage', () => {
     test('classifies skip requests', () => {
       expect(observe('skip').messageType).toBe(MESSAGE_TYPES.SKIP_REQUEST);
       expect(observe('next one').messageType).toBe(MESSAGE_TYPES.SKIP_REQUEST);
+      expect(observe('harder problem').messageType).toBe(MESSAGE_TYPES.SKIP_REQUEST);
+      expect(observe('another question').messageType).toBe(MESSAGE_TYPES.SKIP_REQUEST);
+      expect(observe('harder one').messageType).toBe(MESSAGE_TYPES.SKIP_REQUEST);
+    });
+
+    test('does not classify "give me" requests as answer attempts', () => {
+      // "Can you give me a harder problem?" was falsely matched as answer "m"
+      const result = observe('Can you give me a harder problem?');
+      expect(result.messageType).not.toBe(MESSAGE_TYPES.ANSWER_ATTEMPT);
+      expect(result.answer).toBeNull();
     });
 
     test('give-up takes priority over IDK', () => {

--- a/utils/pipeline/observe.js
+++ b/utils/pipeline/observe.js
@@ -56,7 +56,7 @@ const PATTERNS = {
 
   // "Intermediate" patterns (lower priority): "you get x+2", "gives 3x"
   // These may be intermediate steps, not the final answer.
-  embeddedAnswerIntermediate: /(?:(?:you\s+)?(?:get|gives?)\s+)(-?\d*[a-z](?:\^[\d{}]+)?(?:\s*[+\-]\s*\d*[a-z]?(?:\^[\d{}]+)?)*|-?\d+\.?\d*(?:\s*\/\s*\d+)?)/gi,
+  embeddedAnswerIntermediate: /(?:(?:you\s+)?(?:get|gives)\s+)(-?\d*[a-z](?:\^[\d{}]+)?(?:\s*[+\-]\s*\d*[a-z]?(?:\^[\d{}]+)?)*|-?\d+\.?\d*(?:\s*\/\s*\d+)?)/gi,
 
   // Reasoning phrases that indicate the student is showing their work
   reasoningIndicators: /\b(because|since|after\s+(?:i\s+)?(?:factor|simplif|cancel|distribut|combin|reduc)|(?:i\s+)?(?:factor|simplif|cancel)(?:ed|ing)?|if\s+(?:you|i)\s+(?:factor|simplif|cancel)|by\s+(?:factoring|simplifying|canceling)|using\s+the\s+(?:power|chain|quotient|product)\s+rule|(?:which|that|so)\s+(?:means|gives|leaves|simplifies?\s+to))\b/i,
@@ -65,7 +65,7 @@ const PATTERNS = {
   idk: /\b(idk|i\s*don'?t\s*know|no\s*idea|no\s*clue|dunno|i\s*have\s*no\s*idea|beats\s*me)\b/i,
   giveUp: /\b(just\s*tell\s*me|give\s*me\s*the\s*answer|tell\s*me\s*the\s*answer|what'?s\s*the\s*answer|i\s*give\s*up|show\s*me\s*the\s*answer|can\s*you\s*just\s*solve\s*it)\b/i,
   helpRequest: /\b(help|hint|stuck|confused|don'?t\s*(understand|get\s*it)|what\s*do\s*i\s*do|how\s*do\s*i|can\s*you\s*(explain|show|help))\b/i,
-  skipRequest: /\b(skip|next\s*one|move\s*on|different\s*problem|new\s*problem|next\s*question|what'?s\s*next|whats\s*next|now\s*what|what\s*now|ready\s*for\s*(the\s*)?next|let'?s\s*(keep|move)\s*(going|on)|what\s*do\s*we\s*do\s*next)\b/i,
+  skipRequest: /\b(skip|next\s*one|move\s*on|different\s*problem|new\s*problem|harder\s*(problem|question|one)|another\s*(problem|question|one)|next\s*question|what'?s\s*next|whats\s*next|now\s*what|what\s*now|ready\s*for\s*(the\s*)?next|let'?s\s*(keep|move)\s*(going|on)|what\s*do\s*we\s*do\s*next)\b/i,
 
   // Check my work
   checkMyWork: /\b(check|verify|grade|review|is\s*this\s*right|is\s*this\s*correct|did\s*i\s*(get|do)\s*(it|this)\s*right|am\s*i\s*right|how'?d\s*i\s*do)\b/i,

--- a/utils/visualCommandEnforcer.js
+++ b/utils/visualCommandEnforcer.js
@@ -1044,8 +1044,16 @@ const TOPIC_VISUALS = [
         detect: /\b(derivative|differentiat\w*|power\s+rule|tangent\s+line|instantaneous\s+rate|d\s*\/\s*dx|f\s*'\s*\()/i,
         build(studentMsg, aiResponse) {
             const combined = studentMsg + ' ' + aiResponse;
+            // Normalize Unicode superscripts and minus signs before extraction
+            const normalized = combined
+                .replace(/⁰/g, '^0').replace(/¹/g, '^1').replace(/²/g, '^2')
+                .replace(/³/g, '^3').replace(/⁴/g, '^4').replace(/⁵/g, '^5')
+                .replace(/⁶/g, '^6').replace(/⁷/g, '^7').replace(/⁸/g, '^8')
+                .replace(/⁹/g, '^9')
+                .replace(/−/g, '-').replace(/×/g, '*');
             // Try to extract the function from context
-            const fnMatch = combined.match(/(?:f\s*\(\s*x\s*\)\s*=\s*|derivative\s+of\s+|differentiat\w+\s+)([\w\^*+\-/().]+(?:\s*[\w\^*+\-/().]+)*)/i);
+            // After "derivative of" or "differentiate", optionally skip "f(x) =" prefix
+            const fnMatch = normalized.match(/(?:f\s*\(\s*x\s*\)\s*=\s*|(?:derivative\s+of|differentiat\w+)\s+(?:f\s*\(\s*x\s*\)\s*=\s*)?)([\w\^*+\-/().]+(?:\s*[\w\^*+\-/().]+)*)/i);
             let fn = fnMatch ? fnMatch[1].trim().replace(/\s+/g, '') : 'x^3-3*x^2+2*x';
             // Clean up common artifacts
             fn = fn.replace(/[,.:;!?]+$/, '').replace(/\bthe\b/g, '');
@@ -1058,8 +1066,15 @@ const TOPIC_VISUALS = [
         detect: /\b(velocity\s+and\s+acceleration|position\s+function|s\s*\(\s*t\s*\)\s*=|v\s*\(\s*t\s*\)|acceleration\s+function|kinematics|motion\s+along)/i,
         build(studentMsg, aiResponse) {
             const combined = studentMsg + ' ' + aiResponse;
+            // Normalize Unicode superscripts and minus signs before extraction
+            const normalized = combined
+                .replace(/⁰/g, '^0').replace(/¹/g, '^1').replace(/²/g, '^2')
+                .replace(/³/g, '^3').replace(/⁴/g, '^4').replace(/⁵/g, '^5')
+                .replace(/⁶/g, '^6').replace(/⁷/g, '^7').replace(/⁸/g, '^8')
+                .replace(/⁹/g, '^9')
+                .replace(/−/g, '-').replace(/×/g, '*');
             // Try to extract position function
-            const fnMatch = combined.match(/s\s*\(\s*t\s*\)\s*=\s*([\w\^*+\-/().]+(?:\s*[\w\^*+\-/().]+)*)/i);
+            const fnMatch = normalized.match(/s\s*\(\s*t\s*\)\s*=\s*([\w\^*+\-/().]+(?:\s*[\w\^*+\-/().]+)*)/i);
             let fn = fnMatch ? fnMatch[1].trim().replace(/\s+/g, '').replace(/t/g, 'x') : '4*x^3-6*x^2+2*x';
             fn = fn.replace(/[,.:;!?]+$/, '');
             if (fn.length < 2) fn = '4*x^3-6*x^2+2*x';


### PR DESCRIPTION
Three bugs fixed:

1. "Can you give me a harder problem?" was falsely classified as answer
   attempt "m" because the embeddedAnswerIntermediate regex matched
   "you give m" via `gives?`. Changed to `gives` (requires third-person
   form) since bare "give" is always a request, never an answer statement.

2. Added "harder problem/question/one" and "another problem/question/one"
   to the skipRequest pattern so these natural requests are properly
   classified.

3. Derivative graph always showed default function (x³-3x²+2x) because
   the function extraction regex couldn't handle Unicode superscripts
   (², ³) or minus signs (−). Added normalization step to convert Unicode
   to ASCII before extraction. Also fixed "derivative of f(x) = ..."
   pattern to skip past the f(x)= prefix.

https://claude.ai/code/session_014eZxizDkAwVo82ngG3ZuXu