### PR TITLE
Fix dark mode panels showing white backgrounds with unreadable text

### DIFF
--- a/public/css/dark-mode.css
+++ b/public/css/dark-mode.css
@@ -639,59 +639,6 @@
 
 /* Math Keyboard Panel dark mode */
 [data-theme="dark"] .math-keyboard-panel {
-    background: #141E29;
-    border-top-color: #243040;
-}
-[data-theme="dark"] .mk-tabs {
-    border-bottom-color: #243040;
-}
-[data-theme="dark"] .mk-tab-icon,
-[data-theme="dark"] .mk-tab-label {
-    color: #8899aa;
-}
-[data-theme="dark"] .mk-tab-active .mk-tab-icon,
-[data-theme="dark"] .mk-tab-active .mk-tab-label {
-    color: #5ac8fa;
-}
-[data-theme="dark"] .mk-tab-active {
-    border-bottom-color: #5ac8fa;
-}
-[data-theme="dark"] .mk-section-label {
-    color: #667788;
-}
-[data-theme="dark"] .mk-key {
-    background: #1A2633;
-    border-color: #243040;
-    color: var(--text-primary, #e0e0e0);
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
-}
-[data-theme="dark"] .mk-key:active {
-    background: #243040;
-}
-[data-theme="dark"] .mk-key-action {
-    background: #243040;
-}
-[data-theme="dark"] .mk-key-hint {
-    color: #667788;
-}
-[data-theme="dark"] .math-keyboard-field {
-    background: #1A2633;
-    border-color: rgba(90, 200, 250, 0.5);
-    color: var(--text-primary, #e0e0e0);
-}
-[data-theme="dark"] .mk-done-btn {
-    background: #5ac8fa;
-    color: #0a1520;
-}
-[data-theme="dark"] .mk-helper-text {
-    color: #667788;
-}
-[data-theme="dark"] .mk-helper-text strong {
-    color: #5ac8fa;
-}
-
-/* Math Keyboard Panel dark mode */
-[data-theme="dark"] .math-keyboard-panel {
     background: #1c1c1e;
     border-top-color: #38383a;
 }

--- a/public/css/mobile-fixes.css
+++ b/public/css/mobile-fixes.css
@@ -847,7 +847,7 @@ a {
 
 /* Dark mode menu sheet */
 [data-theme="dark"] .mobile-menu-sheet {
-    background: var(--clr-bg-dark, #1a1d2e);
+    background: #141E29;
     box-shadow: 0 -8px 32px rgba(0, 0, 0, 0.4);
 }
 

--- a/public/css/mobile-redesign.css
+++ b/public/css/mobile-redesign.css
@@ -72,7 +72,7 @@
 
 /* Dark mode panels */
 [data-theme="dark"] .mobile-panel {
-    background: var(--clr-bg-dark, #0f1219);
+    background: #0F1A24;
 }
 
 /* --- PANEL HEADER --- */
@@ -89,7 +89,7 @@
 }
 
 [data-theme="dark"] .mp-header {
-    background: var(--clr-bg-dark, #1a1d2e);
+    background: #0D151D;
     border-bottom-color: rgba(255, 255, 255, 0.06);
 }
 
@@ -1031,7 +1031,7 @@
     }
 
     [data-theme="dark"] body.has-chat-nav .imessage-compose-bar {
-        background: var(--clr-bg-dark, #1a1d2e);
+        background: #0D151D;
         border-top-color: rgba(255, 255, 255, 0.06);
         box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.2);
     }
@@ -1228,7 +1228,7 @@
     }
 
     [data-theme="dark"] body.has-chat-nav .math-keyboard-panel {
-        background: var(--clr-bg-dark, #1a1d2e);
+        background: #1c1c1e;
         border-top-color: rgba(255, 255, 255, 0.08);
         box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.3);
     }
@@ -1444,7 +1444,7 @@
     }
 
     [data-theme="dark"] body.has-chat-nav .inline-equation-palette {
-        background: var(--clr-bg-dark, #1a1d2e);
+        background: #141E29;
     }
 
     /* Header with drag handle */
@@ -1546,7 +1546,7 @@
     }
 
     [data-theme="dark"] body.has-chat-nav .inline-equation-palette .inline-math-field-container {
-        background: var(--clr-bg-dark, #1a1d2e);
+        background: #141E29;
         border-top-color: rgba(255, 255, 255, 0.08);
     }
 
@@ -1601,7 +1601,7 @@
     }
 
     [data-theme="dark"] body.has-chat-nav .file-grid-container {
-        background: var(--clr-bg-dark, #1a1d2e);
+        background: #141E29;
         border-top-color: rgba(255, 255, 255, 0.06);
     }
 

--- a/public/css/mobile-ux-overhaul.css
+++ b/public/css/mobile-ux-overhaul.css
@@ -21,7 +21,7 @@
   }
 
   [data-theme="dark"] .mobile-stats-bar {
-    background: var(--clr-bg-dark, #1a1d2e);
+    background: #0D151D;
     border-bottom-color: rgba(255, 255, 255, 0.06);
   }
 

--- a/public/js/mobile-chat-nav.js
+++ b/public/js/mobile-chat-nav.js
@@ -719,9 +719,12 @@
         }
     }
 
-    // Keep theme in sync
+    // Keep theme in sync across all panels
     document.addEventListener('themechange', function () {
         if (panelsBuilt['profile']) refreshProfilePanel();
+        // Update Learn panel theme button icon
+        var learnIcon = document.querySelector('#mp-learn-theme-btn i');
+        if (learnIcon) learnIcon.className = 'fas ' + (isDark() ? 'fa-sun' : 'fa-moon');
     });
 
     // ESC closes panels and goes back to chat


### PR DESCRIPTION
The CSS variable --clr-bg-dark is overridden to #FFFFFF in dark mode
(intentional inversion), but all dark-mode panel selectors referenced
var(--clr-bg-dark) for their backgrounds. This caused Learn, Quests,
Profile panels, math keyboard, compose bar, and other surfaces to
render with white backgrounds while text colors flipped to near-white,
making text invisible.

Replace var(--clr-bg-dark) with hardcoded dark colors in all 9
affected dark-mode selectors across 4 CSS files. Also remove duplicate
math keyboard dark rules in dark-mode.css and sync the Learn panel
theme icon on theme change.

https://claude.ai/code/session_01VFrybXrB7bRPwZop6hSaWM