### PR TITLE
Fix 429 rate-limit flood and 404 on /api/user/profile

### DIFF
--- a/config/middleware.js
+++ b/config/middleware.js
@@ -274,7 +274,23 @@ function configureMiddleware(app) {
     next();
   });
 
-  app.use('/api/', apiLimiter);
+  // Exempt lightweight polling/heartbeat endpoints from the global rate limiter.
+  // These are all authenticated and called on fixed intervals by the client;
+  // counting them against the general budget starves real user requests.
+  const rateLimitExemptPaths = new Set([
+    '/session/heartbeat',
+    '/browser-lock/check',
+    '/browser-lock/heartbeat',
+    '/impersonation/status',
+    '/announcements/student/unread-count',
+    '/chat/track-time',
+  ]);
+  app.use('/api/', (req, res, next) => {
+    if (rateLimitExemptPaths.has(req.path)) {
+      return next();
+    }
+    return apiLimiter(req, res, next);
+  });
 
   // CSRF Protection
   app.use(csrfProtection);

--- a/config/routes.js
+++ b/config/routes.js
@@ -447,7 +447,7 @@ function registerUserRoutes(app) {
       const allowedUpdates = [
         'firstName', 'lastName', 'gradeLevel', 'mathCourse',
         'tonePreference', 'learningStyle', 'interests', 'needsProfileCompletion',
-        'selectedTutorId', 'selectedAvatarId', 'reportFrequency', 'goalViewPreference',
+        'selectedTutorId', 'selectedAvatarId', 'reportFrequency', 'goalViewPreference', 'textbookMode',
         'parentTone', 'parentLanguage', 'preferredLanguage', 'preferences',
       ];
 

--- a/public/js/browser-lock.js
+++ b/public/js/browser-lock.js
@@ -6,14 +6,20 @@
 (function () {
   'use strict';
 
+  const BASE_POLL_INTERVAL = 30000; // Check lock status every 30 seconds
+  const MAX_POLL_INTERVAL = 300000; // Cap backoff at 5 minutes
+  const HEARTBEAT_INTERVAL = 15000; // Heartbeat every 15 seconds when locked
+
   let lockState = {
     locked: false,
     sessionId: null,
     settings: {},
     heartbeatTimer: null,
+    pollTimer: null,
     overlay: null,
     violationCount: 0,
-    tabSwitchStart: null
+    tabSwitchStart: null,
+    consecutivePollFailures: 0
   };
 
   // ─── INITIALIZATION ─────────────────────────────────────────────────────────
@@ -21,8 +27,12 @@
   async function checkLockStatus() {
     try {
       const res = await fetch('/api/browser-lock/check', { credentials: 'include' });
-      if (!res.ok) return;
+      if (!res.ok) {
+        if (res.status === 429) lockState.consecutivePollFailures++;
+        return;
+      }
 
+      lockState.consecutivePollFailures = 0;
       const data = await res.json();
       if (data.locked) {
         activateLock(data);
@@ -30,6 +40,7 @@
         deactivateLock();
       }
     } catch (e) {
+      lockState.consecutivePollFailures++;
       console.warn('[BrowserLock] Failed to check status:', e.message);
     }
   }
@@ -220,11 +231,11 @@
     // Send immediately
     sendHeartbeat('active');
 
-    // Then every 5 seconds
+    // Then on interval
     lockState.heartbeatTimer = setInterval(() => {
       const status = document.hidden ? 'tab-away' : 'active';
       sendHeartbeat(status);
-    }, 5000);
+    }, HEARTBEAT_INTERVAL);
   }
 
   async function sendHeartbeat(status) {
@@ -393,14 +404,27 @@
 
   // ─── POLL FOR LOCK STATUS CHANGES ──────────────────────────────────────────
 
-  // Check every 10 seconds if lock status has changed
-  setInterval(checkLockStatus, 10000);
+  function schedulePoll() {
+    if (lockState.pollTimer) clearTimeout(lockState.pollTimer);
+    const interval = Math.min(
+      BASE_POLL_INTERVAL * Math.pow(2, lockState.consecutivePollFailures),
+      MAX_POLL_INTERVAL
+    );
+    lockState.pollTimer = setTimeout(async () => {
+      await checkLockStatus();
+      schedulePoll();
+    }, interval);
+  }
 
-  // Initial check on page load
+  // Initial check on page load, then start polling
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', checkLockStatus);
+    document.addEventListener('DOMContentLoaded', () => {
+      checkLockStatus();
+      schedulePoll();
+    });
   } else {
     checkLockStatus();
+    schedulePoll();
   }
 
   // Expose for debugging

--- a/public/js/textbook-mode.js
+++ b/public/js/textbook-mode.js
@@ -19,11 +19,11 @@
   // ── Initialize state from user profile ──
   async function initTextbookMode() {
     try {
-      const res = await fetch('/api/user/profile', { credentials: 'same-origin' });
+      const res = await fetch('/user', { credentials: 'same-origin' });
       if (!res.ok) return;
       const data = await res.json();
 
-      textbookModeEnabled = data.textbookMode || false;
+      textbookModeEnabled = (data.user && data.user.textbookMode) || false;
       toggle.checked = textbookModeEnabled;
       updateUI();
 
@@ -41,10 +41,10 @@
 
     // Check if student is enrolled in a course (has a teacher)
     try {
-      const profileRes = await fetch('/api/user/profile', { credentials: 'same-origin' });
+      const profileRes = await fetch('/user', { credentials: 'same-origin' });
       const profileData = await profileRes.json();
 
-      if (newState && !profileData.teacherId) {
+      if (newState && !(profileData.user && profileData.user.teacherId)) {
         // Not enrolled — revert toggle and show prompt
         toggle.checked = false;
         showEnrollPrompt();
@@ -52,7 +52,7 @@
       }
 
       // Persist the setting
-      const res = await fetch('/api/settings/user', {
+      const res = await fetch('/api/user/settings', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'same-origin',


### PR DESCRIPTION
Root cause: client-side polling endpoints consumed the entire 300-req/15-min rate-limit budget, starving real user requests and eventually causing 502s.

Changes:
- browser-lock.js: reduce poll interval 10s→30s, heartbeat 5s→15s, add exponential backoff on 429/network errors
- textbook-mode.js: fix 404 by calling /user instead of /api/user/profile, fix settings endpoint /api/settings/user→/api/user/settings
- config/routes.js: add textbookMode to allowedUpdates in PATCH /api/user/settings
- config/middleware.js: exempt lightweight polling/heartbeat endpoints from the global API rate limiter so they don't crowd out user interactions

https://claude.ai/code/session_01DMokyvbK1z3ixrw1siMNNJ