### PR TITLE
Fix session destruction race condition and improve data handling

### DIFF
--- a/routes/email.js
+++ b/routes/email.js
@@ -126,6 +126,26 @@ router.post('/weekly-report', isAuthenticated, async (req, res) => {
       }
     }
 
+    // Calculate accuracy from conversation stats
+    const totalProblems = conversationStats.length > 0 ? conversationStats[0].totalProblems : 0;
+    const totalCorrect = conversationStats.length > 0 ? conversationStats[0].totalCorrect : 0;
+    const accuracy = totalProblems > 0 ? Math.round((totalCorrect / totalProblems) * 100) : 0;
+
+    // Calculate mastery breakdown from skillMastery
+    let masteredCount = 0;
+    let practicingCount = 0;
+    let learningCount = 0;
+    if (student.skillMastery && student.skillMastery.size > 0) {
+      for (const [, m] of student.skillMastery) {
+        if (m.status === 'mastered') masteredCount++;
+        else if (m.status === 'practicing' || m.status === 'fragile') practicingCount++;
+        else learningCount++;
+      }
+    }
+
+    // Current streak from daily quests
+    const currentStreak = student.dailyQuests?.currentStreak || 0;
+
     // Calculate weekly stats
     const studentData = {
       studentName: `${student.firstName} ${student.lastName}`,
@@ -133,7 +153,11 @@ router.post('/weekly-report', isAuthenticated, async (req, res) => {
       currentLevel: student.level || 1,
       xpEarned: student.xp || 0,
       activeMinutes: student.totalActiveTutoringMinutes || 0,
-      masteryGained: masteryGained,
+      accuracy: accuracy,
+      mastery: masteredCount + practicingCount + learningCount > 0
+        ? { mastered: masteredCount, practicing: practicingCount, learning: learningCount }
+        : null,
+      currentStreak: currentStreak,
       strugglingSkills: strugglingSkills,
       achievements: achievements
     };

--- a/routes/mastery.js
+++ b/routes/mastery.js
@@ -2308,8 +2308,12 @@ router.get('/user-stats', isAuthenticated, async (req, res) => {
     }
 
     // Calculate average theta
-    const skillMastery = user.skillMastery || {};
-    const thetas = Object.values(skillMastery)
+    // skillMastery is a Mongoose Map - use Array.from to extract values
+    const skillMastery = user.skillMastery || new Map();
+    const skillValues = skillMastery instanceof Map
+      ? Array.from(skillMastery.values())
+      : Object.values(skillMastery);
+    const thetas = skillValues
       .map(skill => skill.theta)
       .filter(theta => theta !== undefined && theta !== null);
 

--- a/routes/session.js
+++ b/routes/session.js
@@ -80,19 +80,27 @@ router.post('/end', async (req, res) => {
         // Clear the session cookie
         res.clearCookie('connect.sid');
 
-        // Destroy the session in MongoDB
-        await new Promise((resolve, reject) => {
-          req.session.destroy((err) => {
-            if (err) {
-              logger.error('Failed to destroy session on end', { error: err, userId });
-              reject(err);
-            } else {
-              resolve();
-            }
-          });
+        // Send response BEFORE destroying session to prevent connect-mongo
+        // "Unable to find the session to touch" error. When express-session
+        // finalizes the response, it tries to touch() the session TTL - but
+        // if we already destroyed it, connect-mongo throws. Sending the
+        // response first lets the touch happen while the session still exists,
+        // then we destroy it.
+        res.json({
+          success: true,
+          summary
         });
 
-        logger.info('Express session destroyed on session end', { userId, reason });
+        // Destroy the session in MongoDB after response is sent
+        req.session.destroy((err) => {
+          if (err) {
+            logger.error('Failed to destroy session on end', { error: err, userId });
+          } else {
+            logger.info('Express session destroyed on session end', { userId, reason });
+          }
+        });
+
+        return; // Already sent response
       } catch (destroyError) {
         logger.error('Error destroying express session', { error: destroyError, userId });
         // Still return success for the session summary even if destroy fails

--- a/services/sessionService.js
+++ b/services/sessionService.js
@@ -361,15 +361,17 @@ async function endSession(userId, sessionId, reason, sessionData = {}) {
  */
 async function recordHeartbeat(userId, sessionId, metrics = {}) {
   try {
-    // Update last activity time
-    const user = await User.findById(userId);
+    // Use atomic update to avoid VersionError race condition when concurrent
+    // requests (e.g. chat + heartbeat) modify the same user document
+    const result = await User.findByIdAndUpdate(
+      userId,
+      { $set: { lastActivityTime: new Date() } },
+      { new: true, projection: { _id: 1 } }
+    );
 
-    if (!user) {
+    if (!result) {
       return { error: 'User not found' };
     }
-
-    user.lastActivityTime = new Date();
-    await user.save();
 
     // Calculate time until timeout
     const timeUntilTimeout = SESSION_CONFIG.IDLE_TIMEOUT;


### PR DESCRIPTION
## Summary
This PR addresses a race condition in session destruction and improves data handling across multiple modules. The changes fix issues with concurrent request handling, session cleanup timing, and data structure compatibility.

## Key Changes

- **Session destruction race condition fix** (`routes/session.js`): Moved session destruction to occur after the response is sent to the client. This prevents a "Unable to find the session to touch" error from connect-mongo, which occurs when express-session tries to update the session TTL after it has already been destroyed.

- **Atomic user update in heartbeat** (`services/sessionService.js`): Replaced sequential read-modify-write pattern with atomic `findByIdAndUpdate` to prevent VersionError race conditions when concurrent requests (e.g., chat + heartbeat) modify the same user document.

- **Weekly report data calculation improvements** (`routes/email.js`): 
  - Added accuracy calculation from conversation statistics
  - Implemented mastery breakdown (mastered/practicing/learning counts) from skillMastery data
  - Added current streak tracking from daily quests
  - Replaced single `masteryGained` metric with more detailed mastery object

- **Mongoose Map compatibility fix** (`routes/mastery.js`): Updated skill mastery data extraction to properly handle Mongoose Map type by using `Array.from()` instead of assuming plain object structure.

## Implementation Details

The session destruction fix uses a callback-based approach to ensure cleanup happens asynchronously after the HTTP response is sent, preventing the session middleware from attempting to touch an already-destroyed session.

The atomic update in the heartbeat function eliminates the need for explicit save operations and reduces the window for concurrent modification conflicts.

The weekly report changes provide more granular insights into student progress by breaking down mastery levels and including accuracy metrics alongside existing engagement metrics.

https://claude.ai/code/session_01UetqxfRgKq91LsEgqGDn17