### PR TITLE
Fix false misconception flag on correct derivative answers

### DIFF
--- a/tests/unit/mathSolverDerivative.test.js
+++ b/tests/unit/mathSolverDerivative.test.js
@@ -1,0 +1,171 @@
+/**
+ * MATH SOLVER — Derivative detection & solving tests
+ *
+ * Covers:
+ * - Pattern 1: "derivative of EXPR"
+ * - Pattern 1 with function definition: "derivative of f(x) = EXPR"
+ * - Pattern 2: "d/dx(EXPR)"
+ * - Pattern 3: "differentiate EXPR"
+ * - Pattern 4: Function definition + derivative mention in same message
+ * - Power rule solving
+ * - Answer verification for derivative answers
+ */
+
+const {
+  detectDerivative,
+  solveDerivative,
+  detectMathProblem,
+  processMathMessage,
+  verifyAnswer,
+} = require('../../utils/mathSolver');
+
+// ── Detection: Pattern 1 — "derivative of EXPR" ──
+
+describe('detectDerivative — Pattern 1: derivative of EXPR', () => {
+  test('"derivative of x^3 - 3x + 2"', () => {
+    const result = detectDerivative('derivative of x^3 - 3x + 2');
+    expect(result).not.toBeNull();
+    expect(result.type).toBe('derivative');
+  });
+
+  test('"what is the derivative of 5x^2 + 3x"', () => {
+    const result = detectDerivative('what is the derivative of 5x^2 + 3x');
+    expect(result).not.toBeNull();
+    expect(result.type).toBe('derivative');
+  });
+
+  test('"find the derivative of 2x^3 + 4x - 7"', () => {
+    const result = detectDerivative('find the derivative of 2x^3 + 4x - 7');
+    expect(result).not.toBeNull();
+    expect(result.type).toBe('derivative');
+  });
+
+  test('"derivative of f(x) = 5x^4 + 3x^2 - 7x + 1" strips function prefix', () => {
+    const result = detectDerivative('find the derivative of f(x) = 5x^4 + 3x^2 - 7x + 1');
+    expect(result).not.toBeNull();
+    expect(result.type).toBe('derivative');
+    // Verify the polynomial is parsed correctly (4 terms)
+    expect(result.terms).toHaveLength(4);
+  });
+
+  test('"derivative of g(x) = 2x^3 + 4x - 7" strips function prefix', () => {
+    const result = detectDerivative('the derivative of g(x) = 2x^3 + 4x - 7');
+    expect(result).not.toBeNull();
+    expect(result.type).toBe('derivative');
+    expect(result.terms).toHaveLength(3);
+  });
+});
+
+// ── Detection: Pattern 4 — Function definition + derivative mention ──
+
+describe('detectDerivative — Pattern 4: function definition + derivative mention', () => {
+  test('"g(x)=2x^3+4x-7. What do you get for the derivative g\'(x)?"', () => {
+    const result = detectDerivative('g(x)=2x^3+4x-7. What do you get for the derivative g\'(x)?');
+    expect(result).not.toBeNull();
+    expect(result.type).toBe('derivative');
+    expect(result.terms).toHaveLength(3);
+  });
+
+  test('tutor phrasing with surrounding text', () => {
+    const msg = 'Absolutely, go for it! Give this function a shot: g(x)=2x^3+4x-7. What do you get for the derivative g\'(x)? Take your time!';
+    const result = detectDerivative(msg);
+    expect(result).not.toBeNull();
+    expect(result.type).toBe('derivative');
+  });
+
+  test('"Let\'s try f(x) = 5x^2 - 3x + 8. Find the derivative."', () => {
+    const result = detectDerivative("Let's try f(x) = 5x^2 - 3x + 8. Find the derivative.");
+    expect(result).not.toBeNull();
+    expect(result.type).toBe('derivative');
+    expect(result.terms).toHaveLength(3);
+  });
+
+  test('"Consider h(x) = x^4 - 2x^3 + x. What\'s the derivative?"', () => {
+    const result = detectDerivative("Consider h(x) = x^4 - 2x^3 + x. What's the derivative?");
+    expect(result).not.toBeNull();
+    expect(result.type).toBe('derivative');
+  });
+
+  test('with Unicode superscripts', () => {
+    // After normalization by detectMathProblem, superscripts become ^n
+    // But detectDerivative itself doesn't normalize — the caller does.
+    // Test with already-normalized input:
+    const result = detectDerivative('g(x)=2x^3+4x-7. What do you get for the derivative?');
+    expect(result).not.toBeNull();
+    expect(result.type).toBe('derivative');
+  });
+
+  test('does NOT match function definition without derivative mention', () => {
+    const result = detectDerivative('Let\'s evaluate g(x) = 2x + 3 when x = 2');
+    expect(result).toBeNull();
+  });
+
+  test('does NOT match derivative keyword without function definition', () => {
+    // Just "derivative" alone without a parseable polynomial isn't enough
+    const result = detectDerivative('The derivative is a fundamental concept in calculus');
+    expect(result).toBeNull();
+  });
+});
+
+// ── Solving ──
+
+describe('solveDerivative — power rule', () => {
+  test('derivative of 2x^3 + 4x - 7 = 6x^2+4', () => {
+    const problem = { type: 'derivative', terms: [
+      { coeff: 2, exp: 3 },
+      { coeff: 4, exp: 1 },
+      { coeff: -7, exp: 0 },
+    ]};
+    const solution = solveDerivative(problem);
+    expect(solution.success).toBe(true);
+    expect(solution.answer).toBe('6x^2+4');
+  });
+
+  test('derivative of x^2 = 2x', () => {
+    const problem = { type: 'derivative', terms: [{ coeff: 1, exp: 2 }] };
+    const solution = solveDerivative(problem);
+    expect(solution.success).toBe(true);
+    expect(solution.answer).toBe('2x');
+  });
+
+  test('derivative of 5x^4 + 3x^2 - 7x + 1 = 20x^3+6x-7', () => {
+    const problem = { type: 'derivative', terms: [
+      { coeff: 5, exp: 4 },
+      { coeff: 3, exp: 2 },
+      { coeff: -7, exp: 1 },
+      { coeff: 1, exp: 0 },
+    ]};
+    const solution = solveDerivative(problem);
+    expect(solution.success).toBe(true);
+    expect(solution.answer).toBe('20x^3+6x-7');
+  });
+
+  test('derivative of constant = 0', () => {
+    const problem = { type: 'derivative', terms: [{ coeff: 7, exp: 0 }] };
+    const solution = solveDerivative(problem);
+    expect(solution.success).toBe(true);
+    expect(solution.answer).toBe('0');
+  });
+});
+
+// ── End-to-end: processMathMessage + verifyAnswer ──
+
+describe('End-to-end derivative detection and verification', () => {
+  test('function-def phrasing: "6x^2+4" verified against g(x)=2x^3+4x-7', () => {
+    const msg = 'Give this function a shot: g(x)=2x^3+4x-7. What do you get for the derivative g\'(x)?';
+    const result = processMathMessage(msg);
+    expect(result.hasMath).toBe(true);
+    expect(result.solution.success).toBe(true);
+    expect(result.solution.answer).toBe('6x^2+4');
+
+    const verification = verifyAnswer('6x^2+4', result.solution.answer);
+    expect(verification.isCorrect).toBe(true);
+  });
+
+  test('"derivative of f(x) = EXPR" phrasing detects and solves correctly', () => {
+    const msg = 'Find the derivative of f(x) = 5x^4 + 3x^2 - 7x + 1';
+    const result = processMathMessage(msg);
+    expect(result.hasMath).toBe(true);
+    expect(result.solution.answer).toBe('20x^3+6x-7');
+  });
+});

--- a/tests/unit/tutorValidation.test.js
+++ b/tests/unit/tutorValidation.test.js
@@ -693,3 +693,75 @@ describe('Tutor Validation: Answer Leak Prevention', () => {
   });
 });
 
+// ============================================================================
+// FUNCTION-DEFINITION DERIVATIVE DETECTION
+// ============================================================================
+
+describe('Tutor Validation: Function-Definition Derivative Detection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // BUG REPORT SCENARIO 5:
+  // Tutor asks: "g(x)=2x³+4x−7. What do you get for the derivative g'(x)?"
+  // Student answers: "6x^2+4"
+  // EXPECTED: Confirm correct (derivative of 2x³+4x-7 = 6x²+4)
+  // PREVIOUS BUG: System matched an older message ("derivative of x²"),
+  //   computed expected answer as "2x", and flagged "6x^2+4" as wrong.
+  // ────────────────────────────────────────────────────────────────────────
+
+  test('BUG 5: g(x)=2x^3+4x-7 derivative "6x^2+4" must be confirmed correct', async () => {
+    const { diagnosis, decision } = await runDeterministicStages(
+      '6x^2+4',
+      ['Absolutely, go for it! Give this function a shot: g(x)=2x^3+4x-7. What do you get for the derivative g\'(x)? Take your time, and let me know what you come up with!']
+    );
+
+    expect(diagnosis.isCorrect).toBe(true);
+    expect(diagnosis.correctAnswer).toBe('6x^2+4');
+    expect(decision.action).toBe(ACTIONS.CONFIRM_CORRECT);
+  });
+
+  test('function definition with Unicode superscripts and derivative mention', async () => {
+    const { diagnosis, decision } = await runDeterministicStages(
+      '6x^2+4',
+      ['Give this function a shot: g(x)=2x³+4x−7. What do you get for the derivative g′(x)?']
+    );
+
+    expect(diagnosis.isCorrect).toBe(true);
+    expect(decision.action).toBe(ACTIONS.CONFIRM_CORRECT);
+  });
+
+  test('"derivative of f(x) = EXPR" phrasing is detected correctly', async () => {
+    const { diagnosis, decision } = await runDeterministicStages(
+      '20x^3+6x-7',
+      ['Find the derivative of f(x) = 5x^4 + 3x^2 - 7x + 1']
+    );
+
+    expect(diagnosis.isCorrect).toBe(true);
+    expect(decision.action).toBe(ACTIONS.CONFIRM_CORRECT);
+  });
+
+  test('"Let\'s try f(x) = EXPR. Find the derivative." phrasing', async () => {
+    const { diagnosis, decision } = await runDeterministicStages(
+      '10x-3',
+      ['Let\'s try f(x) = 5x^2 - 3x + 8. Find the derivative.']
+    );
+
+    expect(diagnosis.isCorrect).toBe(true);
+    expect(decision.action).toBe(ACTIONS.CONFIRM_CORRECT);
+  });
+
+  test('does not match function definition without derivative mention', async () => {
+    // "g(x) = 2x + 3" without "derivative" should NOT be treated as a derivative problem
+    const { diagnosis } = await runDeterministicStages(
+      '7',
+      ['Let\'s evaluate g(x) = 2x + 3 when x = 2']
+    );
+
+    // Should not be detected as a derivative (answer would be 2 if derivative, 7 if evaluation)
+    // The key assertion: the system should NOT think the correct answer is "2"
+    expect(diagnosis.correctAnswer).not.toBe('2');
+  });
+});
+

--- a/utils/mathSolver.js
+++ b/utils/mathSolver.js
@@ -2977,10 +2977,13 @@ function detectDerivative(message) {
 
     // Pattern 1: "derivative of EXPR" or "the derivative of EXPR"
     // Also handles "can you tell me the derivative of...", "what is the derivative of..."
+    // Also handles "derivative of f(x) = EXPR" by stripping the function-definition prefix.
     const derivOfPattern = /(?:(?:can\s+you\s+(?:tell\s+me|find|compute)\s+)?(?:find|what(?:'s|\s+is)|compute|calculate|take)\s+)?(?:the\s+)?derivative\s+of\s+(.+)/i;
     const derivOfMatch = text.match(derivOfPattern);
     if (derivOfMatch) {
-        const cleaned = cleanTrailingText(derivOfMatch[1]);
+        let cleaned = cleanTrailingText(derivOfMatch[1]);
+        // Strip function-definition prefix: "f(x) = 2x^3+4x-7" → "2x^3+4x-7"
+        cleaned = cleaned.replace(/^[a-zA-Z]\w*\s*\(\s*x\s*\)\s*=\s*/, '');
         const terms = parsePolynomialTerms(cleaned);
         if (terms) {
             return { type: 'derivative', terms, raw: cleaned };
@@ -3006,6 +3009,22 @@ function detectDerivative(message) {
         const terms = parsePolynomialTerms(cleaned);
         if (terms) {
             return { type: 'derivative', terms, raw: cleaned };
+        }
+    }
+
+    // Pattern 4: Function definition + derivative mention in same message
+    // Handles tutor phrasings like:
+    //   "g(x) = 2x^3 + 4x - 7. What do you get for the derivative g'(x)?"
+    //   "Let's try f(x) = 5x^2 + 3x - 1. Find the derivative."
+    //   "Consider h(x) = x^4 - 2x^3 + x. What's the derivative?"
+    if (/\bderivative|differentiat/i.test(text)) {
+        const funcDefMatch = text.match(/[a-zA-Z]\w*\s*\(\s*x\s*\)\s*=\s*(.+)/i);
+        if (funcDefMatch) {
+            const cleaned = cleanTrailingText(funcDefMatch[1]);
+            const terms = parsePolynomialTerms(cleaned);
+            if (terms) {
+                return { type: 'derivative', terms, raw: cleaned };
+            }
         }
     }
 


### PR DESCRIPTION
When the tutor phrased derivative problems as "g(x)=2x³+4x−7. What do
you get for the derivative g'(x)?", detectDerivative() couldn't match
this pattern — it only handled "derivative of EXPR". The diagnose stage
then walked backwards through conversation history and matched an older
message ("the derivative of x²"), computing the expected answer as "2x"
instead of "6x²+4". This caused correct student answers to be flagged
as incorrect with a false "Misapplication of the power rule" warning.

Two fixes in detectDerivative():
- Pattern 1 now strips f(x)= prefixes so "derivative of g(x) = EXPR"
  parses the polynomial correctly
- New Pattern 4 detects function definitions (g(x) = EXPR) when
  "derivative" appears in the same message

https://claude.ai/code/session_01XasbLATyTYj9qeqdpTzVro