### PR TITLE
Fix algebra tiles taking over chat screen on load

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -1865,6 +1865,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <script src="/js/graphTool.js"></script>
   <script src="/js/diagram-display.js"></script>
   <script src="/js/inlineChatVisuals.js"></script>
+  <link rel="stylesheet" href="/css/algebra-tiles.css">
   <script src="/js/algebra-tiles.js"></script>
   <div id="algebraTilesContainer"></div>
   <script src="/js/dailyQuests.js"></script>

--- a/public/js/algebra-tiles.js
+++ b/public/js/algebra-tiles.js
@@ -2657,13 +2657,15 @@ function closeAlgebraTiles() {
   }
 }
 
-// Auto-initialize on DOM ready and hook up button
+// Expose functions to window but DON'T auto-create the workspace on load.
+// The workspace is heavy (full modal + canvas + SVG) — only build it when
+// actually needed (first open). This prevents unstyled content flash and
+// avoids the modal taking over the page if CSS hasn't loaded yet.
 document.addEventListener('DOMContentLoaded', () => {
-  // Initialize algebra tiles
-  initAlgebraTiles();
-
-  // Expose to window so AI visual teaching handler can access it
-  window.algebraTiles = algebraTiles;
+  // Expose lazy-init functions to window
+  window.openAlgebraTiles = openAlgebraTiles;
+  window.closeAlgebraTiles = closeAlgebraTiles;
+  window.initAlgebraTiles = initAlgebraTiles;
 
   // Hook up button in chat page
   const algebraTilesBtn = document.getElementById('algebra-tiles-btn');


### PR DESCRIPTION
Adding algebra-tiles.js to chat.html caused two issues:
1. The CSS (algebra-tiles.css) wasn't loaded, so the modal's display:none never applied — raw HTML rendered full-screen
2. The script auto-initialized on DOMContentLoaded, building a heavy modal+canvas workspace immediately on every page load

Fix: add the CSS link, and defer workspace creation until the user actually opens algebra tiles (lazy init on first open).

https://claude.ai/code/session_016pD8rPL3iQ8gmk1FqsqzEg