### PR TITLE
Fix voice tutor: mobile support, latency, and math display

### DIFF
--- a/public/css/voice-tutor.css
+++ b/public/css/voice-tutor.css
@@ -299,6 +299,27 @@ html, body {
   to { opacity: 1; transform: translateY(0); }
 }
 
+/* Problem divider — separates multiple problems on the board */
+.vt-step-divider {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 20px 0 16px;
+  padding: 0 8px;
+}
+.vt-divider-line {
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(18, 179, 179, 0.25), transparent);
+}
+.vt-divider-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: rgba(18, 179, 179, 0.4);
+  box-shadow: 0 0 6px rgba(18, 179, 179, 0.3);
+}
+
 /* Graph canvas */
 .vt-graph-canvas {
   width: 100%;

--- a/public/js/voice-controller.js
+++ b/public/js/voice-controller.js
@@ -339,6 +339,27 @@ class VoiceController {
     }
 
     /**
+     * Detect the best supported audio MIME type for MediaRecorder.
+     * Safari/iOS does not support audio/webm — falls back to mp4 or default.
+     */
+    getSupportedMimeType() {
+        const types = [
+            'audio/webm;codecs=opus',
+            'audio/webm',
+            'audio/mp4;codecs=opus',
+            'audio/mp4',
+            'audio/ogg;codecs=opus',
+            'audio/ogg',
+        ];
+        for (const type of types) {
+            if (typeof MediaRecorder !== 'undefined' && MediaRecorder.isTypeSupported(type)) {
+                return type;
+            }
+        }
+        return ''; // Let browser choose default
+    }
+
+    /**
      * Check if user is currently typing in an input field
      * Prevents spacebar from activating voice when typing
      * @param {HTMLElement} target - The event target element
@@ -417,10 +438,9 @@ class VoiceController {
             this.isListening = true;
             this.updateUI('listening');
 
-            // Setup MediaRecorder
-            this.mediaRecorder = new MediaRecorder(stream, {
-                mimeType: 'audio/webm;codecs=opus'
-            });
+            // Setup MediaRecorder with best supported MIME type
+            const mimeType = this.getSupportedMimeType();
+            this.mediaRecorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined);
 
             const audioChunks = [];
 
@@ -432,8 +452,9 @@ class VoiceController {
 
             this.mediaRecorder.onstop = async () => {
                 console.log('🛑 [Voice] Recording stopped, audio chunks:', audioChunks.length);
-                const audioBlob = new Blob(audioChunks, { type: 'audio/webm' });
-                console.log('📦 [Voice] Audio blob size:', audioBlob.size, 'bytes');
+                const recordedType = this.mediaRecorder.mimeType || 'audio/webm';
+                const audioBlob = new Blob(audioChunks, { type: recordedType });
+                console.log('📦 [Voice] Audio blob size:', audioBlob.size, 'bytes, type:', recordedType);
                 await this.sendAudioToBackend(audioBlob);
 
                 // Stop all tracks
@@ -575,6 +596,7 @@ class VoiceController {
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
                         audio: base64Audio,
+                        mimeType: audioBlob.type || 'audio/webm',
                         boardContext: this.getBoardContext()
                     })
                 });
@@ -582,9 +604,8 @@ class VoiceController {
                 console.log('📥 [Voice] Response received, status:', response.status);
 
                 if (!response.ok) {
-                    const errorData = await response.json();
+                    const errorData = await response.json().catch(() => ({}));
                     // COMPLIANCE: Under-13 users blocked from third-party voice chat.
-                    // Show a clear message and stop the voice session.
                     if (response.status === 403 && errorData.useWebSpeech) {
                         console.warn('🔇 [Voice] Under-13 user blocked from voice chat. Stopping.');
                         this.updateUI('idle');
@@ -594,53 +615,18 @@ class VoiceController {
                         }
                         return;
                     }
-                    console.error('❌ [Voice] Server error:', errorData);
-                    console.error('❌ [Voice] Error message:', errorData.message);
-                    console.error('❌ [Voice] Error details:', errorData.details);
                     throw new Error(errorData.message || errorData.error || 'Server error');
                 }
 
-                const data = await response.json();
-                console.log('📝 [Voice] Response data:', data);
-
-                if (data.transcription) {
-                    console.log('📝 Transcription:', data.transcription);
-
-                    // Display user's message in chat
-                    if (window.appendMessage) {
-                        window.appendMessage(data.transcription, 'user');
-                    }
+                // Handle NDJSON streaming response
+                const contentType = response.headers.get('content-type') || '';
+                if (contentType.includes('application/x-ndjson')) {
+                    await this.processStreamedResponse(response);
+                } else {
+                    // Legacy JSON fallback
+                    const data = await response.json();
+                    await this.handleLegacyResponse(data);
                 }
-
-                if (data.response) {
-                    // Process voice commands if present
-                    if (data.boardActions && this.config.enableBoardCommands) {
-                        await this.executeBoardActions(data.boardActions);
-                    }
-
-                    // Display AI response in chat
-                    if (window.appendMessage) {
-                        window.appendMessage(data.response, 'ai', null, data.isMasteryQuiz);
-                    }
-
-                    // Speak AI response (TTS audio with tutor voice)
-                    if (data.audioUrl) {
-                        await this.playAIResponse(data.audioUrl);
-                    }
-                }
-
-                // Apply board context for spatial anchoring
-                if (data.boardContext && window.chatBoardController) {
-                    const messageElements = document.querySelectorAll('.message.ai');
-                    const latestMessage = messageElements[messageElements.length - 1];
-                    if (latestMessage) {
-                        window.chatBoardController.enhanceChatMessage(
-                            latestMessage, 'ai', data.boardContext
-                        );
-                    }
-                }
-
-                this.updateUI('idle');
 
             };
 
@@ -723,6 +709,106 @@ class VoiceController {
             this.currentAudio = null;
             this.updateUI('error');
         }
+    }
+
+    /**
+     * Process NDJSON streamed response — shows transcription and text immediately,
+     * plays audio only when ready. Much lower perceived latency.
+     */
+    async processStreamedResponse(response) {
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+        let responseText = '';
+        let boardContextData = null;
+        let gotAudio = false;
+
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+
+            buffer += decoder.decode(value, { stream: true });
+
+            let newlineIdx;
+            while ((newlineIdx = buffer.indexOf('\n')) !== -1) {
+                const line = buffer.slice(0, newlineIdx).trim();
+                buffer = buffer.slice(newlineIdx + 1);
+                if (!line) continue;
+
+                let phase;
+                try { phase = JSON.parse(line); } catch (e) { continue; }
+
+                if (phase.phase === 'transcription' && phase.transcription) {
+                    if (window.appendMessage) {
+                        window.appendMessage(phase.transcription, 'user');
+                    }
+
+                } else if (phase.phase === 'response') {
+                    responseText = phase.response || '';
+                    boardContextData = phase.boardContext || null;
+
+                    if (phase.boardActions && this.config.enableBoardCommands) {
+                        this.executeBoardActions(phase.boardActions);
+                    }
+
+                    if (responseText && window.appendMessage) {
+                        window.appendMessage(responseText, 'ai');
+                    }
+
+                    // Apply board context
+                    if (boardContextData && window.chatBoardController) {
+                        const messageElements = document.querySelectorAll('.message.ai');
+                        const latestMessage = messageElements[messageElements.length - 1];
+                        if (latestMessage) {
+                            window.chatBoardController.enhanceChatMessage(latestMessage, 'ai', boardContextData);
+                        }
+                    }
+
+                } else if (phase.phase === 'audio') {
+                    gotAudio = true;
+                    if (phase.audioUrl) {
+                        await this.playAIResponse(phase.audioUrl);
+                    } else {
+                        this.updateUI('idle');
+                    }
+
+                } else if (phase.phase === 'error') {
+                    throw new Error(phase.message || 'Voice processing failed');
+                }
+            }
+        }
+
+        if (!gotAudio) {
+            this.updateUI('idle');
+        }
+    }
+
+    /**
+     * Handle legacy (non-streaming) JSON response — backwards compatibility
+     */
+    async handleLegacyResponse(data) {
+        if (data.transcription && window.appendMessage) {
+            window.appendMessage(data.transcription, 'user');
+        }
+        if (data.response) {
+            if (data.boardActions && this.config.enableBoardCommands) {
+                await this.executeBoardActions(data.boardActions);
+            }
+            if (window.appendMessage) {
+                window.appendMessage(data.response, 'ai', null, data.isMasteryQuiz);
+            }
+            if (data.audioUrl) {
+                await this.playAIResponse(data.audioUrl);
+            }
+        }
+        if (data.boardContext && window.chatBoardController) {
+            const messageElements = document.querySelectorAll('.message.ai');
+            const latestMessage = messageElements[messageElements.length - 1];
+            if (latestMessage) {
+                window.chatBoardController.enhanceChatMessage(latestMessage, 'ai', data.boardContext);
+            }
+        }
+        this.updateUI('idle');
     }
 
     // Stop AI speaking (for interruption)

--- a/public/js/voice-tutor-session.js
+++ b/public/js/voice-tutor-session.js
@@ -819,63 +819,78 @@
   /**
    * Merge incoming math steps into the cumulative board.
    *
-   * The LLM is instructed to return ALL steps each turn (full board state),
-   * but sometimes it forgets earlier steps. This function protects against
-   * that by keeping a client-side accumulator:
+   * The board is a PERSISTENT WHITEBOARD — it NEVER erases previous work.
+   * When a new problem arrives, a visual divider is inserted and the new
+   * steps are appended. All equations, slopes, steps from the entire
+   * session remain visible so the student can scroll back.
    *
-   * - If the LLM sent a superset of our board (starts with the same steps),
-   *   trust it as the new canonical board state.
-   * - If the LLM sent fewer steps than we have but they overlap at the start,
-   *   keep our extras and append any truly new steps from the LLM.
-   * - If the LLM sent completely new steps (no overlap), append them —
-   *   they're probably a new problem or a continuation.
-   *
-   * Deduplication is by normalized LaTeX content.
+   * The LLM sends the full step list for the CURRENT problem each turn.
+   * This function finds what's new and appends it to the cumulative board.
    */
   function mergeBoardSteps(incomingSteps) {
     if (!incomingSteps || incomingSteps.length === 0) return state.boardSteps;
 
     const normalize = (latex) => (latex || '').replace(/\s+/g, '').trim();
-    const boardLatex = state.boardSteps.map(s => normalize(s.latex));
+
+    // Get only the real (non-divider) steps on the board
+    const realBoardSteps = state.boardSteps.filter(s => !s._divider);
+    const boardLatex = realBoardSteps.map(s => normalize(s.latex));
     const incomingLatex = incomingSteps.map(s => normalize(s.latex));
 
-    // Check: does incoming start with the same sequence as our board?
-    let overlapLen = 0;
-    for (let i = 0; i < Math.min(boardLatex.length, incomingLatex.length); i++) {
-      if (boardLatex[i] === incomingLatex[i]) {
-        overlapLen = i + 1;
-      } else {
-        break;
+    // Find how many incoming steps match the TAIL of our board (current problem overlap)
+    // The LLM sends the full current problem each turn, so overlapping steps
+    // will appear at the end of our board.
+    let tailOverlap = 0;
+    if (realBoardSteps.length > 0 && incomingSteps.length > 0) {
+      // Walk backwards from the end of the board to find where the incoming
+      // sequence starts matching
+      for (let startIdx = Math.max(0, realBoardSteps.length - incomingSteps.length);
+           startIdx < realBoardSteps.length; startIdx++) {
+        let match = true;
+        const remaining = realBoardSteps.length - startIdx;
+        const toCheck = Math.min(remaining, incomingSteps.length);
+        for (let j = 0; j < toCheck; j++) {
+          if (boardLatex[startIdx + j] !== incomingLatex[j]) {
+            match = false;
+            break;
+          }
+        }
+        if (match && toCheck > 0) {
+          tailOverlap = toCheck;
+          break;
+        }
       }
     }
 
-    if (overlapLen > 0 && incomingSteps.length >= state.boardSteps.length) {
-      // LLM sent a superset or equal set — trust it as canonical
-      state.boardSteps = incomingSteps.slice();
-    } else if (overlapLen > 0) {
-      // LLM sent fewer steps but they overlap — keep our extras, append new
-      const newSteps = incomingSteps.slice(overlapLen).filter(
+    if (tailOverlap > 0) {
+      // The LLM resent existing steps plus potentially new ones.
+      // Append only the genuinely new steps after the overlap.
+      const newSteps = incomingSteps.slice(tailOverlap).filter(
         s => !boardLatex.includes(normalize(s.latex))
       );
-      state.boardSteps = state.boardSteps.concat(newSteps);
+      if (newSteps.length > 0) {
+        state.boardSteps = state.boardSteps.concat(newSteps);
+      }
     } else {
-      // No overlap at start — check if incoming steps are already on our board
+      // No tail overlap — these steps don't continue the current board tail.
+      // Filter out any steps already on the board (dedup).
       const genuinelyNew = incomingSteps.filter(
         s => !boardLatex.includes(normalize(s.latex))
       );
-      if (genuinelyNew.length === incomingSteps.length && incomingSteps.length >= 1) {
-        // Completely different steps — likely a new problem. Check if LLM
-        // sent a "Given" or first step, signaling a fresh board.
-        const firstLabel = (incomingSteps[0].label || '').toLowerCase();
-        if (firstLabel === 'given' || firstLabel === 'start' || firstLabel === 'problem') {
-          // New problem — replace the board
-          state.boardSteps = incomingSteps.slice();
-        } else {
-          // Continuation — append
-          state.boardSteps = state.boardSteps.concat(genuinelyNew);
+
+      if (genuinelyNew.length > 0) {
+        // If the board already has content and this looks like a new problem,
+        // insert a visual divider so the student sees a clear separation.
+        if (realBoardSteps.length > 0) {
+          const firstLabel = (genuinelyNew[0].label || '').toLowerCase();
+          const isNewProblem = firstLabel === 'given' || firstLabel === 'start'
+            || firstLabel === 'problem' || firstLabel.startsWith('problem');
+          // Also treat it as new work if there's zero overlap at all
+          const noOverlapAtAll = genuinelyNew.length === incomingSteps.length;
+          if (isNewProblem || noOverlapAtAll) {
+            state.boardSteps.push({ _divider: true, label: genuinelyNew[0].label || 'New Problem' });
+          }
         }
-      } else {
-        // Partial overlap in the middle — append only new ones
         state.boardSteps = state.boardSteps.concat(genuinelyNew);
       }
     }
@@ -902,13 +917,30 @@
     // Render full board with minimal delay
     const renderDelay = existing.length > 0 ? 160 : 0;
     setTimeout(() => {
+      // Count real (non-divider) steps for "new" animation detection
+      const realSteps = board.filter(s => !s._divider);
+      const realIncoming = steps.filter(s => !s._divider);
+      const newStartIdx = realSteps.length - realIncoming.length;
+      let realIdx = 0;
+
       board.forEach((step, i) => {
+        // Render dividers as visual separators between problems
+        if (step._divider) {
+          const divEl = document.createElement('div');
+          divEl.className = 'vt-step-divider';
+          divEl.innerHTML = `<span class="vt-divider-line"></span><span class="vt-divider-dot"></span><span class="vt-divider-line"></span>`;
+          dom.mathDisplay.appendChild(divEl);
+          return;
+        }
+
         const el = document.createElement('div');
         el.className = 'vt-math-step';
-        if (i === board.length - 1) el.classList.add('highlighted');
-        // Only animate new steps (skip stagger for already-seen ones)
-        const isNew = i >= board.length - steps.length;
-        el.style.animationDelay = isNew ? `${(i - (board.length - steps.length)) * 80}ms` : '0ms';
+        // Highlight the most recent real step
+        if (realIdx === realSteps.length - 1) el.classList.add('highlighted');
+        // Only animate new steps
+        const isNew = realIdx >= newStartIdx;
+        el.style.animationDelay = isNew ? `${(realIdx - newStartIdx) * 80}ms` : '0ms';
+        realIdx++;
 
         let html = '';
         if (step.label) {

--- a/public/js/voice-tutor-session.js
+++ b/public/js/voice-tutor-session.js
@@ -298,11 +298,8 @@
       clearTimeout(startingTimeout);
       if (dom.micBtn) dom.micBtn.style.opacity = '';
 
-      state.mediaRecorder = new MediaRecorder(stream, {
-        mimeType: MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
-          ? 'audio/webm;codecs=opus'
-          : 'audio/webm'
-      });
+      const mimeType = getSupportedMimeType();
+      state.mediaRecorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined);
 
       const chunks = [];
       state.mediaRecorder.ondataavailable = (e) => {
@@ -310,7 +307,8 @@
       };
 
       state.mediaRecorder.onstop = async () => {
-        const blob = new Blob(chunks, { type: 'audio/webm' });
+        const recordedType = state.mediaRecorder.mimeType || 'audio/webm';
+        const blob = new Blob(chunks, { type: recordedType });
         // DON'T kill the stream — keep it alive for the next turn
         if (blob.size > 1000) { // Minimum size to avoid empty recordings
           await processVoiceInput(blob);
@@ -512,7 +510,7 @@
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ audio: base64 })
+        body: JSON.stringify({ audio: base64, mimeType: audioBlob.type || 'audio/webm' })
       });
 
       if (!res.ok) {
@@ -577,10 +575,18 @@
 
           // Render math immediately — don't wait for audio
           if (state.showVisuals) {
-            const steps = (phase.mathSteps && phase.mathSteps.length > 0)
-              ? phase.mathSteps
-              : extractEquationsFromText(responseText);
-            if (steps.length > 0) renderMathSteps(steps);
+            if (phase.mathSteps && phase.mathSteps.length > 0) {
+              // Server sent explicit math steps — always render
+              renderMathSteps(phase.mathSteps);
+            } else {
+              // Try client-side extraction as fallback
+              const extracted = extractEquationsFromText(responseText);
+              if (extracted.length > 0) {
+                renderMathSteps(extracted);
+              }
+              // If no steps found and board already has content, keep it
+              // (don't blank the board on encouragement-only responses)
+            }
           }
 
         } else if (phase.phase === 'audio') {
@@ -621,10 +627,12 @@
     if (data.response) addMessage(data.response, 'ai');
 
     if (state.showVisuals) {
-      const steps = (data.mathSteps && data.mathSteps.length > 0)
-        ? data.mathSteps
-        : extractEquationsFromText(data.response || '');
-      if (steps.length > 0) renderMathSteps(steps);
+      if (data.mathSteps && data.mathSteps.length > 0) {
+        renderMathSteps(data.mathSteps);
+      } else {
+        const extracted = extractEquationsFromText(data.response || '');
+        if (extracted.length > 0) renderMathSteps(extracted);
+      }
     }
 
     if (data.audioUrl && !state.muted) {
@@ -661,10 +669,12 @@
 
       if (data.response) addMessage(data.response, 'ai');
       if (state.showVisuals) {
-        const steps = (data.mathSteps && data.mathSteps.length > 0)
-          ? data.mathSteps
-          : extractEquationsFromText(data.response || '');
-        if (steps.length > 0) renderMathSteps(steps);
+        if (data.mathSteps && data.mathSteps.length > 0) {
+          renderMathSteps(data.mathSteps);
+        } else {
+          const extracted = extractEquationsFromText(data.response || '');
+          if (extracted.length > 0) renderMathSteps(extracted);
+        }
       }
 
       if (data.audioUrl && !state.muted) {
@@ -1505,6 +1515,27 @@
   // ═══════════════════════════════════════
   // UTILITIES
   // ═══════════════════════════════════════
+
+  /**
+   * Detect the best supported audio MIME type for MediaRecorder.
+   * Safari/iOS doesn't support audio/webm — falls back to mp4 or default.
+   */
+  function getSupportedMimeType() {
+    const types = [
+      'audio/webm;codecs=opus',
+      'audio/webm',
+      'audio/mp4;codecs=opus',
+      'audio/mp4',
+      'audio/ogg;codecs=opus',
+      'audio/ogg',
+    ];
+    for (const type of types) {
+      if (typeof MediaRecorder !== 'undefined' && MediaRecorder.isTypeSupported(type)) {
+        return type;
+      }
+    }
+    return ''; // Let browser choose default
+  }
 
   function blobToBase64(blob) {
     return new Promise((resolve, reject) => {

--- a/routes/voice.js
+++ b/routes/voice.js
@@ -13,6 +13,19 @@ const { processAIResponse } = require('../utils/chatBoardParser');
 const { cleanTextForTTS } = require('../utils/mathTTS');
 
 const PRIMARY_CHAT_MODEL = "gpt-4o-mini"; // Fast, cost-effective model for voice responses
+
+// Map client MIME types to file extensions for Whisper API
+const MIME_TO_EXT = {
+    'audio/webm;codecs=opus': '.webm',
+    'audio/webm': '.webm',
+    'audio/mp4;codecs=opus': '.mp4',
+    'audio/mp4': '.mp4',
+    'audio/ogg;codecs=opus': '.ogg',
+    'audio/ogg': '.ogg',
+    'audio/wav': '.wav',
+    'audio/mpeg': '.mp3',
+    'audio/x-m4a': '.m4a',
+};
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
@@ -43,7 +56,7 @@ function isUnder13(user) {
  * 4. Returns transcription, response, audio URL, and board actions
  */
 router.post('/process', isAuthenticated, async (req, res) => {
-    const { audio, boardContext } = req.body;
+    const { audio, mimeType, boardContext } = req.body;
     const userId = req.user._id;
 
     logger.info('[Voice] Received request from user:', userId);
@@ -82,106 +95,98 @@ router.post('/process', isAuthenticated, async (req, res) => {
         });
     }
 
+    // ── Switch to NDJSON streaming for lower perceived latency ──
+    res.setHeader('Content-Type', 'application/x-ndjson');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('X-Accel-Buffering', 'no'); // Disable nginx buffering
+
+    function sendPhase(data) {
+        res.write(JSON.stringify(data) + '\n');
+        if (res.flush) res.flush();
+    }
+
     try {
         const startTime = Date.now();
 
         // ============================================
-        // STEP 1: SPEECH-TO-TEXT (Whisper)
+        // STEP 1: SPEECH-TO-TEXT (Whisper) — parallelized with user data
         // ============================================
 
         logger.info('[Voice] Processing audio from user:', userId);
-        const step1Start = Date.now();
 
         // Decode base64 audio
         let audioBuffer;
         try {
             audioBuffer = Buffer.from(audio, 'base64');
-            logger.info('[Voice] Audio decoded, size:', audioBuffer.length, 'bytes');
         } catch (error) {
-            logger.error('[Voice] Failed to decode base64 audio:', error.message);
-            throw new Error('Invalid audio format');
+            sendPhase({ phase: 'error', message: 'Invalid audio format' });
+            return res.end();
         }
 
         // Create temporary file for Whisper API
         const tempDir = path.join(__dirname, '../temp');
         if (!fs.existsSync(tempDir)) {
-            logger.info('[Voice] Creating temp directory:', tempDir);
             fs.mkdirSync(tempDir, { recursive: true });
         }
 
-        const tempAudioPath = path.join(tempDir, `voice_${userId}_${Date.now()}.webm`);
+        const audioExt = MIME_TO_EXT[mimeType] || '.webm';
+        const tempAudioPath = path.join(tempDir, `voice_${userId}_${Date.now()}${audioExt}`);
         fs.writeFileSync(tempAudioPath, audioBuffer);
-        logger.info('[Voice] Saved temp audio file:', tempAudioPath);
 
-        logger.info('[Voice] Calling Whisper API for transcription...');
-
-        // Map preferredLanguage to Whisper ISO-639-1 codes for non-English transcription
-        const userLangPref = await User.findById(userId).select('preferredLanguage').lean();
         const langMap = {
             'English': 'en', 'Spanish': 'es', 'Russian': 'ru', 'Chinese': 'zh',
             'Vietnamese': 'vi', 'Arabic': 'ar', 'Somali': 'so', 'French': 'fr', 'German': 'de'
         };
-        const whisperLang = langMap[userLangPref?.preferredLanguage] || 'en';
 
-        let transcription;
-        try {
-            transcription = await openai.audio.transcriptions.create({
+        // ── Run Whisper + full user data + conversation history in parallel ──
+        const [transcription, user, conversation] = await Promise.all([
+            openai.audio.transcriptions.create({
                 file: fs.createReadStream(tempAudioPath),
                 model: 'whisper-1',
-                language: whisperLang,
-            });
-        } catch (error) {
-            logger.error('[Voice] Whisper API error:', error.message);
-            logger.error('Error details:', error.response?.data || error);
-            // Clean up temp file before throwing
-            if (fs.existsSync(tempAudioPath)) {
-                fs.unlinkSync(tempAudioPath);
-            }
-            throw new Error(`Whisper transcription failed: ${error.message}`);
-        }
+                language: langMap[req.user.preferredLanguage] || 'en',
+            }).finally(() => {
+                if (fs.existsSync(tempAudioPath)) fs.unlinkSync(tempAudioPath);
+            }),
+            User.findById(userId).lean(),
+            Conversation.findOne({ userId })
+                .sort({ updatedAt: -1 })
+                .select({ messages: { $slice: -10 } })
+                .lean()
+        ]);
 
+        const step1Time = Date.now() - startTime;
         const userMessage = transcription.text;
-        const step1Time = Date.now() - step1Start;
         logger.info(`[Voice] Transcription (${step1Time}ms):`, userMessage);
 
-        // Clean up temp file
-        if (fs.existsSync(tempAudioPath)) {
-            fs.unlinkSync(tempAudioPath);
-            logger.info('[Voice] Cleaned up temp audio file');
+        if (!userMessage || userMessage.trim().length === 0) {
+            sendPhase({ phase: 'transcription', transcription: '' });
+            sendPhase({ phase: 'response', response: "I didn't catch that. Could you try again?", boardActions: [] });
+            return res.end();
         }
 
-        if (!userMessage || userMessage.trim().length === 0) {
-            return res.json({
-                transcription: '',
-                response: "I didn't catch that. Could you try again?",
-                audioUrl: null,
-                boardActions: []
-            });
+        if (!user) {
+            sendPhase({ phase: 'error', message: 'User not found' });
+            return res.end();
         }
+
+        // ── Send transcription immediately ──
+        sendPhase({ phase: 'transcription', transcription: userMessage });
 
         // ============================================
         // STEP 2: AI RESPONSE GENERATION
         // ============================================
-
-        // Fetch user data and conversation history
-        const user = await User.findById(userId)
-            .lean();
-
-        if (!user) {
-            return res.status(404).json({ error: 'User not found' });
-        }
 
         // Load tutor configuration
         const TUTOR_CONFIG = require('../utils/tutorConfig');
         const selectedTutorId = user.selectedTutorId || 'default';
         const tutorProfile = TUTOR_CONFIG[selectedTutorId] || TUTOR_CONFIG['default'];
 
-        // Fetch conversation history
-        const conversation = await Conversation.findOne({ userId })
-            .sort({ updatedAt: -1 })
-            .lean();
-
-        const conversationHistory = conversation?.messages || [];
+        const conversationHistory = (conversation?.messages || [])
+            .filter(msg => msg.content && msg.content.trim().length > 0)
+            .map(msg => ({
+                role: msg.role === 'user' ? 'user' : 'assistant',
+                content: msg.content
+            }));
 
         // Add board context to system prompt if available
         let boardContextPrompt = '';
@@ -197,11 +202,8 @@ router.post('/process', isAuthenticated, async (req, res) => {
             boardContextPrompt = `\n\n**WHITEBOARD CONTEXT:** Board is currently empty. You can write equations and draw on the board using voice commands.\n`;
         }
 
-        // Generate system prompt with correct parameters
         const systemPrompt = await generateSystemPrompt(user, tutorProfile);
-        const enhancedSystemPrompt = systemPrompt + boardContextPrompt;
 
-        // Add voice-specific instructions
         const voiceInstructions = `\n\n**VOICE MODE ACTIVE:**
 - Keep responses conversational and brief (1-3 sentences for chat)
 - Use the whiteboard for complex explanations
@@ -215,46 +217,29 @@ router.post('/process', isAuthenticated, async (req, res) => {
 - Reference board objects using [BOARD_REF:objectId]
 `;
 
-        // Build messages array for AI
         const messages = [
-            { role: 'system', content: enhancedSystemPrompt + voiceInstructions },
-            ...conversationHistory.slice(-10)
-                .filter(msg => msg.content && msg.content.trim().length > 0) // Filter out null/empty messages
-                .map(msg => ({
-                    role: msg.role === 'user' ? 'user' : 'assistant',
-                    content: msg.content
-                })),
+            { role: 'system', content: systemPrompt + boardContextPrompt + voiceInstructions },
+            ...conversationHistory,
             { role: 'user', content: userMessage }
         ];
 
         const step2Start = Date.now();
-        logger.info('[Voice] Generating AI response...');
-        logger.info(`[Voice] Message count: ${messages.length} (system + ${messages.length - 2} history + user)`);
-
-        // Validate all messages have content
-        const invalidMessages = messages.filter(m => !m.content || m.content.trim().length === 0);
-        if (invalidMessages.length > 0) {
-            logger.error('[Voice] Found messages with null/empty content:', invalidMessages);
-            throw new Error('Invalid message format: some messages have null or empty content');
-        }
 
         const completion = await callLLM(PRIMARY_CHAT_MODEL, messages, {
-            temperature: 0.7,
-            max_tokens: 1000 // Shorter for voice responses
+            temperature: 0.5,
+            max_tokens: 500
         });
 
         let aiResponseText = completion.choices[0].message.content.trim();
         const step2Time = Date.now() - step2Start;
-
-        logger.info(`[Voice] AI response (${step2Time}ms):`, aiResponseText);
+        logger.info(`[Voice] AI response (${step2Time}ms)`);
 
         // ============================================
-        // STEP 3: PARSE BOARD ACTIONS
+        // STEP 3: PARSE BOARD ACTIONS + SEND RESPONSE
         // ============================================
 
         const boardActions = parseBoardActionsFromResponse(aiResponseText);
 
-        // Remove board action syntax from spoken response
         aiResponseText = aiResponseText
             .replace(/\[WRITE:[^\]]+\]/g, '')
             .replace(/\[CIRCLE:[^\]]+\]/g, '')
@@ -263,132 +248,82 @@ router.post('/process', isAuthenticated, async (req, res) => {
             .replace(/\[CLEAR\]/g, '')
             .trim();
 
-        // Process board-first chat philosophy
         const boardParsed = processAIResponse(aiResponseText);
         aiResponseText = boardParsed.text;
         const boardContextData = boardParsed.boardContext;
 
-        // Clean text for TTS (remove markdown and LaTeX)
-        const ttsText = cleanTextForTTS(aiResponseText);
-
-        // ============================================
-        // STEP 4: TEXT-TO-SPEECH (via ttsProvider — Cartesia)
-        // ============================================
-
-        const step3Start = Date.now();
-        logger.info(`[Voice] Generating speech with ${ttsProvider.getProviderName()}...`);
-
-        // Get tutor's voice ID for the active provider
-        const tutorVoiceId = ttsProvider.getVoiceId(tutorProfile);
-        logger.info(`[Voice] Using tutor: ${tutorProfile.name} (${selectedTutorId})`);
-        logger.info(`[Voice] Using ${ttsProvider.getProviderName()} voice ID: ${tutorVoiceId}`);
-        logger.info(`[Voice] TTS text length: ${ttsText.length} chars`);
-
-        if (!tutorVoiceId) {
-            throw new Error(`No ${ttsProvider.getProviderName()} voice ID configured for tutor: ${selectedTutorId}`);
-        }
-
-        // Generate TTS audio via the active provider
-        let audioData;
-        try {
-            audioData = await ttsProvider.generateAudio(ttsText, tutorVoiceId);
-        } catch (error) {
-            logger.error(`[Voice] ${ttsProvider.getProviderName()} TTS error:`, error.message);
-            logger.error('Error response:', error.response?.data);
-            logger.error('Error status:', error.response?.status);
-            throw new Error(`TTS generation failed: ${error.message}`);
-        }
-
-        const step3Time = Date.now() - step3Start;
-        logger.info(`[Voice] TTS audio received (${step3Time}ms), size:`, audioData.length, 'bytes');
-
-        // Save audio file
-        const audioDir = path.join(__dirname, '../public/audio/voice');
-        if (!fs.existsSync(audioDir)) {
-            logger.info('[Voice] Creating audio directory:', audioDir);
-            fs.mkdirSync(audioDir, { recursive: true });
-        }
-
-        const ext = ttsProvider.getFileExtension();
-        const audioFilename = `voice_${userId}_${Date.now()}_${crypto.randomBytes(4).toString('hex')}${ext}`;
-        const audioPath = path.join(audioDir, audioFilename);
-        fs.writeFileSync(audioPath, audioData);
-
-        const audioUrl = `/audio/voice/${audioFilename}`;
-
-        logger.info('[Voice] Speech generated and saved:', audioUrl);
-
-        // ============================================
-        // STEP 5: SAVE TO CONVERSATION HISTORY
-        // ============================================
-
-        // Save messages to conversation history
-        // Note: findOneAndUpdate bypasses Mongoose middleware, so validate content here
-        const messagesToPush = [];
-        if (userMessage && typeof userMessage === 'string' && userMessage.trim() !== '') {
-            messagesToPush.push({
-                role: 'user',
-                content: userMessage.trim(),
-                timestamp: new Date()
-            });
-        }
-        if (aiResponseText && typeof aiResponseText === 'string' && aiResponseText.trim() !== '') {
-            messagesToPush.push({
-                role: 'assistant',
-                content: aiResponseText.trim(),
-                timestamp: new Date()
-            });
-        }
-
-        if (messagesToPush.length > 0) {
-            await Conversation.findOneAndUpdate(
-                { userId },
-                {
-                    $push: { messages: { $each: messagesToPush } },
-                    $set: { updatedAt: new Date() }
-                },
-                { upsert: true }
-            );
-        }
-
-        // ============================================
-        // STEP 6: RETURN RESPONSE
-        // ============================================
-
-        const totalTime = Date.now() - startTime;
-        logger.info(`[Voice] Total processing time: ${totalTime}ms (Whisper: ${step1Time}ms, AI: ${step2Time}ms, TTS: ${step3Time}ms, Other: ${totalTime - step1Time - step2Time - step3Time}ms)`);
-
-        res.json({
-            transcription: userMessage,
+        // ── Send text + board immediately — don't wait for TTS ──
+        sendPhase({
+            phase: 'response',
             response: aiResponseText,
-            audioUrl: audioUrl,
             boardActions: boardActions,
             boardContext: boardContextData
         });
 
-        // Clean up old audio files (keep last 100)
-        cleanupOldAudioFiles(audioDir, 100);
+        // ============================================
+        // STEP 4: TTS + history save in parallel
+        // ============================================
+
+        const ttsText = cleanTextForTTS(aiResponseText);
+        const tutorVoiceId = ttsProvider.getVoiceId(tutorProfile);
+
+        const [audioUrl] = await Promise.all([
+            // TTS generation
+            (async () => {
+                if (!tutorVoiceId || !ttsText) return null;
+                try {
+                    const audioData = await ttsProvider.generateAudio(ttsText, tutorVoiceId);
+                    const audioDir = path.join(__dirname, '../public/audio/voice');
+                    if (!fs.existsSync(audioDir)) fs.mkdirSync(audioDir, { recursive: true });
+                    const ext = ttsProvider.getFileExtension();
+                    const audioFilename = `voice_${userId}_${Date.now()}_${crypto.randomBytes(4).toString('hex')}${ext}`;
+                    const audioPath = path.join(audioDir, audioFilename);
+                    fs.writeFileSync(audioPath, audioData);
+                    // Cleanup old files (fire and forget)
+                    cleanupOldAudioFiles(audioDir, 100);
+                    return `/audio/voice/${audioFilename}`;
+                } catch (err) {
+                    logger.warn('[Voice] TTS failed:', err.message);
+                    return null;
+                }
+            })(),
+            // Save to conversation history
+            (async () => {
+                const messagesToPush = [];
+                if (userMessage) messagesToPush.push({ role: 'user', content: userMessage.trim(), timestamp: new Date() });
+                if (aiResponseText) messagesToPush.push({ role: 'assistant', content: aiResponseText.trim(), timestamp: new Date() });
+                if (messagesToPush.length > 0) {
+                    await Conversation.findOneAndUpdate(
+                        { userId },
+                        { $push: { messages: { $each: messagesToPush } }, $set: { updatedAt: new Date() } },
+                        { upsert: true }
+                    );
+                }
+            })()
+        ]);
+
+        const totalTime = Date.now() - startTime;
+        logger.info(`[Voice] Total: ${totalTime}ms (Whisper: ${step1Time}ms, AI: ${step2Time}ms, TTS+Save: ${totalTime - step1Time - step2Time}ms)`);
+
+        // ── Send audio URL ──
+        sendPhase({ phase: 'audio', audioUrl });
+        res.end();
 
     } catch (error) {
         logger.error('[Voice] FATAL ERROR processing voice:', error);
         logger.error('Error stack:', error.stack);
 
-        // Provide specific error message
-        let userMessage = 'Failed to process voice input';
+        let message = 'Failed to process voice input';
         if (error.message.includes('Whisper')) {
-            userMessage = 'Speech recognition failed. Please try speaking again.';
+            message = 'Speech recognition failed. Please try speaking again.';
         } else if (error.message.includes('TTS') || error.message.includes('Cartesia')) {
-            userMessage = 'Voice synthesis failed. Please try again.';
+            message = 'Voice synthesis failed. Please try again.';
         } else if (error.message.includes('API key')) {
-            userMessage = 'Voice feature is not configured. Please contact support.';
+            message = 'Voice feature is not configured. Please contact support.';
         }
 
-        res.status(500).json({
-            error: 'Failed to process voice input',
-            message: userMessage,
-            details: error.message,
-            timestamp: new Date().toISOString()
-        });
+        sendPhase({ phase: 'error', message });
+        res.end();
     }
 });
 

--- a/routes/voiceTutor.js
+++ b/routes/voiceTutor.js
@@ -75,7 +75,9 @@ Always guide, never give away. If the student is truly stuck after multiple atte
 FORMAT: JSON array wrapped in <mathsteps>...</mathsteps> tags.
 Each step: { "label": string (optional), "latex": LaTeX string, "explanation": string (optional) }
 
-Show the FULL progression of completed steps — not just the latest one. Include all steps from the beginning of the current problem so the student sees their complete work.
+IMPORTANT — THE BOARD ACCUMULATES: The student's board keeps ALL work from the entire session — every equation, every step, every problem. Previous work is never erased. You only need to send steps for the CURRENT problem. The board will append them below any earlier work. If the student switches to a new problem, start fresh with a new "Given" step — it will appear below the previous problem on their board.
+
+Include ALL steps for the current problem from its beginning — not just the latest step. This way the board always shows the full progression for the active problem.
 
 Example conversation:
 Student says: "solve 2x minus 4 equals 0"
@@ -110,6 +112,29 @@ That's it! x equals 2. Great job working through that!
   {"label": "Given", "latex": "2x - 4 = 0"},
   {"label": "Add 4", "latex": "2x = 4"},
   {"label": "Divide by 2", "latex": "x = 2", "explanation": "Divide both sides by 2"}
+]</mathsteps>
+
+Student says: "now let's try 3x plus 6 equals 15"
+Your response:
+Great, new problem! What's the first thing we should do?
+<mathsteps>[
+  {"label": "Given", "latex": "3x + 6 = 15", "explanation": "New equation"}
+]</mathsteps>
+
+Note: the board now shows BOTH problems — the previous one stays visible above. The student can scroll up to review their earlier work.
+
+ALSO INCLUDE <mathsteps> FOR NON-EQUATION MATH:
+If the student is working with slopes, derivatives, graphs, or any visual math concept, include those as steps too. Examples:
+<mathsteps>[
+  {"label": "Slope formula", "latex": "m = \\frac{y_2 - y_1}{x_2 - x_1}"},
+  {"label": "Substitute", "latex": "m = \\frac{5 - 1}{3 - 1} = \\frac{4}{2}"},
+  {"label": "Simplify", "latex": "m = 2"}
+]</mathsteps>
+
+<mathsteps>[
+  {"label": "Function", "latex": "f(x) = x^3 - 3x"},
+  {"label": "Derivative", "latex": "f'(x) = 3x^2 - 3"},
+  {"label": "At x=1", "latex": "f'(1) = 3(1)^2 - 3 = 0", "explanation": "Tangent slope at x=1"}
 ]</mathsteps>
 
 FINAL REMINDER — READ THIS CAREFULLY:

--- a/routes/voiceTutor.js
+++ b/routes/voiceTutor.js
@@ -18,6 +18,19 @@ const crypto = require('crypto');
 
 const VOICE_MODEL = 'gpt-4o-mini';
 
+// Map client MIME types to file extensions for Whisper API
+const MIME_TO_EXT = {
+  'audio/webm;codecs=opus': '.webm',
+  'audio/webm': '.webm',
+  'audio/mp4;codecs=opus': '.mp4',
+  'audio/mp4': '.mp4',
+  'audio/ogg;codecs=opus': '.ogg',
+  'audio/ogg': '.ogg',
+  'audio/wav': '.wav',
+  'audio/mpeg': '.mp3',
+  'audio/x-m4a': '.m4a',
+};
+
 // Voice-specific system instructions appended to the base tutor prompt
 const VOICE_TUTOR_INSTRUCTIONS = `
 
@@ -256,7 +269,7 @@ function isUnder13(user) {
 // Phase 3: { phase: "audio", audioUrl }                  — audio plays when ready
 // ═══════════════════════════════════════
 router.post('/process', isAuthenticated, async (req, res) => {
-  const { audio } = req.body;
+  const { audio, mimeType } = req.body;
   const userId = req.user._id;
 
   if (!audio) {
@@ -302,7 +315,8 @@ router.post('/process', isAuthenticated, async (req, res) => {
     // ── Step 1: Transcribe with Whisper (parallel: fetch user data) ──
     const tempDir = path.join(__dirname, '../temp');
     if (!fs.existsSync(tempDir)) fs.mkdirSync(tempDir, { recursive: true });
-    const tempPath = path.join(tempDir, `vt_${userId}_${Date.now()}.webm`);
+    const audioExt = MIME_TO_EXT[mimeType] || '.webm';
+    const tempPath = path.join(tempDir, `vt_${userId}_${Date.now()}${audioExt}`);
     fs.writeFileSync(tempPath, audioBuffer);
 
     const langMap = {
@@ -335,8 +349,19 @@ router.post('/process', isAuthenticated, async (req, res) => {
     // ── Step 2: Generate AI response ──
     const aiResponse = await generateResponse(userId, userMessage, user);
 
-    const mathSteps = extractMathSteps(aiResponse);
+    let mathSteps = extractMathSteps(aiResponse);
     const cleanResponse = stripMathSteps(aiResponse);
+
+    // If LLM didn't include <mathsteps> but math was previously discussed,
+    // recover the last known steps from conversation history so the board
+    // doesn't go blank. The LLM is instructed to always include them but
+    // sometimes forgets on encouragement-only responses.
+    if (mathSteps.length === 0) {
+      const lastSteps = await getLastMathSteps(userId);
+      if (lastSteps.length > 0) {
+        mathSteps = lastSteps;
+      }
+    }
 
     // ── Send text + math immediately ──
     sendPhase({ phase: 'response', response: cleanResponse, mathSteps });
@@ -385,8 +410,14 @@ router.post('/process-text', isAuthenticated, async (req, res) => {
 
   try {
     const aiResponse = await generateResponse(userId, text.trim());
-    const mathSteps = extractMathSteps(aiResponse);
+    let mathSteps = extractMathSteps(aiResponse);
     const cleanResponse = stripMathSteps(aiResponse);
+
+    // Recover last math steps if LLM omitted them
+    if (mathSteps.length === 0) {
+      const lastSteps = await getLastMathSteps(userId);
+      if (lastSteps.length > 0) mathSteps = lastSteps;
+    }
 
     let audioUrl = null;
     if (ttsProvider.isConfigured()) {
@@ -515,6 +546,33 @@ async function generateTTS(userId, responseText, preloadedUser) {
   } catch (e) { /* cleanup is best-effort */ }
 
   return `/audio/voice/${filename}`;
+}
+
+/**
+ * Recover the last math steps from conversation history.
+ * Scans recent assistant messages for <mathsteps> blocks.
+ */
+async function getLastMathSteps(userId) {
+  try {
+    const conversation = await Conversation.findOne({ userId })
+      .sort({ updatedAt: -1 })
+      .select({ messages: { $slice: -12 } })
+      .lean();
+    if (!conversation?.messages) return [];
+
+    // Walk backwards through assistant messages to find the most recent mathsteps
+    const assistantMsgs = conversation.messages
+      .filter(m => m.role === 'assistant' && m.content)
+      .reverse();
+
+    for (const msg of assistantMsgs) {
+      const steps = extractMathSteps(msg.content);
+      if (steps.length > 0) return steps;
+    }
+  } catch (e) {
+    console.warn('[VoiceTutor] Failed to recover last math steps:', e.message);
+  }
+  return [];
 }
 
 async function saveToHistory(userId, userMessage, aiResponse) {


### PR DESCRIPTION
Mobile: Add MIME type detection with Safari/iOS fallback (audio/mp4)
in both voice-controller.js and voice-tutor-session.js. Pass MIME type
to server so Whisper gets correct file extension instead of always .webm.

Latency: Convert voice.js to NDJSON streaming (matching voiceTutor.js)
so transcription shows immediately, text+board render before TTS finishes.
Parallelize Whisper + user data + history fetch. Run TTS and history save
concurrently. Reduce max_tokens 1000→500 and temperature 0.7→0.5 for
faster voice responses. Add streaming client support in voice-controller.js.

Math display: Add server-side getLastMathSteps() that recovers the most
recent <mathsteps> from conversation history when the LLM omits them,
preventing the board from going blank on encouragement-only responses.
Client-side: protect existing board state when no new steps arrive.

All 1252 tests pass (56/56 suites).

https://claude.ai/code/session_01Vy1AgALvJi66Zd1qYWpZS3