### PR TITLE
Add tool-based visual rendering (behind ENABLE_VISUAL_TOOLS flag)

### DIFF
--- a/public/js/inlineChatVisuals.js
+++ b/public/js/inlineChatVisuals.js
@@ -189,6 +189,124 @@ class InlineChatVisuals {
     }
 
     /**
+     * Render HTML directly from a structured tool call (new path).
+     *
+     * The backend may emit `tool_use` SSE events with a validated {name, input}
+     * payload. This method maps the tool name to the existing handler and
+     * returns rendered HTML — bypassing regex parsing entirely.
+     *
+     * @param {string} name - Tool name, e.g. "render_function_graph".
+     * @param {Object} input - Validated argument object from the LLM.
+     * @returns {string} HTML for the visual, or an error placeholder.
+     */
+    renderFromToolCall(name, input) {
+        const safeInput = input || {};
+        try {
+            const paramStr = this._toolInputToParamStr(name, safeInput);
+            switch (name) {
+                case 'render_function_graph': return this.createFunctionGraph(paramStr);
+                case 'render_number_line':    return this.createNumberLine(paramStr);
+                case 'render_fraction':       return this.createFraction(paramStr);
+                case 'render_algebra_tiles':  return this.createAlgebraTilesInline(paramStr);
+                case 'render_fraction_bars':  return this.createFraction(paramStr);
+                case 'render_base_ten_blocks': return this._renderBaseTenPlaceholder(safeInput);
+                case 'render_counters':       return this.createCounters(paramStr);
+                case 'render_unit_circle':    return this.createUnitCircle(paramStr);
+                case 'render_points_plot':    return this.createPointsPlot(paramStr);
+                case 'search_educational_image':
+                    return this._renderImageSearchPlaceholder(safeInput);
+                default:
+                    console.warn(`[InlineChatVisuals] Unknown tool: ${name}`);
+                    return '';
+            }
+        } catch (err) {
+            console.error(`[InlineChatVisuals] renderFromToolCall failed for ${name}:`, err);
+            return `<div class="icv-error">⚠️ Could not render visual</div>`;
+        }
+    }
+
+    /**
+     * Build a legacy "key=value,key=value" paramStr from a structured tool
+     * input, so existing regex-era handlers can consume it unchanged.
+     */
+    _toolInputToParamStr(name, input) {
+        const parts = [];
+        const push = (k, v) => {
+            if (v === undefined || v === null) return;
+            if (typeof v === 'string' && /[,\s]/.test(v)) {
+                parts.push(`${k}="${v}"`);
+            } else {
+                parts.push(`${k}=${v}`);
+            }
+        };
+
+        switch (name) {
+            case 'render_function_graph':
+                push('fn', input.function);
+                push('xMin', input.xMin);
+                push('xMax', input.xMax);
+                push('yMin', input.yMin);
+                push('yMax', input.yMax);
+                if (input.title) push('title', input.title);
+                break;
+            case 'render_number_line':
+                push('min', input.min);
+                push('max', input.max);
+                if (Array.isArray(input.points) && input.points.length > 0) {
+                    parts.push(`points=[${input.points.join(',')}]`);
+                }
+                if (input.label) push('label', input.label);
+                break;
+            case 'render_fraction':
+                push('numerator', input.numerator);
+                push('denominator', input.denominator);
+                push('type', input.shape || 'circle');
+                break;
+            case 'render_fraction_bars':
+                push('numerator', input.numerator);
+                push('denominator', input.denominator);
+                push('type', 'bar');
+                break;
+            case 'render_algebra_tiles':
+                return input.expression || '';
+            case 'render_counters':
+                push('positive', input.positive);
+                push('negative', input.negative);
+                break;
+            case 'render_unit_circle':
+                if (typeof input.angle === 'number') push('angle', input.angle);
+                break;
+            case 'render_points_plot': {
+                const rendered = (input.points || [])
+                    .map((p) => `(${p[0]},${p[1]})`).join(',');
+                return `points=${rendered}`;
+            }
+            default:
+                break;
+        }
+        return parts.join(',');
+    }
+
+    /**
+     * Base-ten blocks have no inline canvas renderer today — fall back to
+     * a caption so the student sees a cue while the manipulatives board
+     * (driven by the sidecar visualCommands) opens in parallel.
+     */
+    _renderBaseTenPlaceholder(input) {
+        const n = parseInt(input.number, 10) || 0;
+        return `<div class="icv-container icv-placeholder" role="region" aria-label="Base-10 blocks for ${n}">
+            <div class="icv-title">Base-10 blocks: ${n}</div>
+        </div>`;
+    }
+
+    _renderImageSearchPlaceholder(input) {
+        const q = this.escapeHtml(input.query || '');
+        return `<div class="icv-container icv-placeholder" role="region" aria-label="Image search: ${q}">
+            <div class="icv-title">Searching for: ${q}</div>
+        </div>`;
+    }
+
+    /**
      * Parse parameters from command string
      * Supports: key=value, key="value with spaces", arrays [1,2,3]
      * Special handling for 'params' key whose value contains commas (e.g., params=a:1:-3:3,b:0:-5:5)

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -2226,6 +2226,25 @@ document.addEventListener("DOMContentLoaded", () => {
                                 if (streamRef && streamRef.textNode) {
                                     streamRef.textNode.innerHTML = renderMarkdownMath(event.content);
                                 }
+                            } else if (event.type === 'tool_use' && event.name) {
+                                // Structured visual tool call — render inline immediately.
+                                if (!streamRef) {
+                                    showThinkingIndicator(false);
+                                    streamRef = startStreamingMessage();
+                                }
+                                if (window.inlineChatVisuals && typeof window.inlineChatVisuals.renderFromToolCall === 'function') {
+                                    try {
+                                        const toolHtml = window.inlineChatVisuals.renderFromToolCall(event.name, event.input || {});
+                                        if (toolHtml && streamRef && streamRef.textNode) {
+                                            const wrapper = document.createElement('div');
+                                            wrapper.className = 'icv-tool-output';
+                                            wrapper.innerHTML = toolHtml;
+                                            streamRef.textNode.appendChild(wrapper);
+                                        }
+                                    } catch (toolErr) {
+                                        console.error('[Stream] tool_use render failed:', toolErr);
+                                    }
+                                }
                             } else if (event.type === 'complete' && event.data) {
                                 completeData = event.data;
                             } else if (event.type === 'error') {

--- a/tests/unit/visualTools.test.js
+++ b/tests/unit/visualTools.test.js
@@ -1,0 +1,222 @@
+const {
+  VISUAL_TOOLS,
+  VISUAL_TOOL_NAMES,
+  SPECS,
+  resolveToolCall,
+  resolveToolCalls,
+  describeTools,
+} = require('../../utils/visualTools');
+
+describe('visualTools', () => {
+  describe('VISUAL_TOOLS schema export', () => {
+    it('is an array of OpenAI-shaped tool descriptors', () => {
+      expect(Array.isArray(VISUAL_TOOLS)).toBe(true);
+      expect(VISUAL_TOOLS.length).toBeGreaterThanOrEqual(10);
+      for (const tool of VISUAL_TOOLS) {
+        expect(tool.type).toBe('function');
+        expect(typeof tool.function.name).toBe('string');
+        expect(typeof tool.function.description).toBe('string');
+        expect(tool.function.parameters.type).toBe('object');
+      }
+    });
+
+    it('every spec has a unique name and at least one renderer', () => {
+      const names = new Set();
+      for (const [name, spec] of Object.entries(SPECS)) {
+        expect(names.has(name)).toBe(false);
+        names.add(name);
+        const hasRenderer = spec.toTag || spec.toVisualCommand;
+        expect(hasRenderer).toBeTruthy();
+      }
+    });
+
+    it('includes the canonical visuals from the refactor spec', () => {
+      const required = [
+        'render_function_graph',
+        'render_number_line',
+        'render_algebra_tiles',
+        'render_fraction_bars',
+        'render_base_ten_blocks',
+        'render_counters',
+        'search_educational_image',
+        'render_unit_circle',
+      ];
+      for (const name of required) {
+        expect(VISUAL_TOOL_NAMES.has(name)).toBe(true);
+      }
+    });
+
+    it('every function schema declares required params correctly', () => {
+      for (const tool of VISUAL_TOOLS) {
+        const { parameters } = tool.function;
+        if (parameters.required) {
+          for (const key of parameters.required) {
+            expect(parameters.properties[key]).toBeDefined();
+          }
+        }
+      }
+    });
+  });
+
+  describe('resolveToolCall', () => {
+    it('maps render_function_graph input to a legacy tag', () => {
+      const { tag, visualCommand } = resolveToolCall('render_function_graph', {
+        function: 'x^2',
+        xMin: -5,
+        xMax: 5,
+        title: 'Parabola',
+      });
+      expect(tag).toBe('[FUNCTION_GRAPH:fn=x^2,xMin=-5,xMax=5,title="Parabola"]');
+      expect(visualCommand).toBeNull();
+    });
+
+    it('omits optional params from render_function_graph tag when not given', () => {
+      const { tag } = resolveToolCall('render_function_graph', {
+        function: 'sin(x)',
+      });
+      expect(tag).toBe('[FUNCTION_GRAPH:fn=sin(x)]');
+    });
+
+    it('builds a NUMBER_LINE tag with optional points array', () => {
+      const { tag } = resolveToolCall('render_number_line', {
+        min: -5,
+        max: 5,
+        points: [0, 3],
+        label: 'Example',
+      });
+      expect(tag).toBe('[NUMBER_LINE:min=-5,max=5,points=[0,3],label="Example"]');
+    });
+
+    it('algebra tiles routes to both the inline tag AND a sidecar command', () => {
+      const { tag, visualCommand } = resolveToolCall('render_algebra_tiles', {
+        expression: 'x^2+5x+6',
+      });
+      expect(tag).toBe('[ALGEBRA_TILES:x^2+5x+6]');
+      expect(visualCommand).toEqual({
+        channel: 'algebraTiles',
+        command: { type: 'expression', expression: 'x^2+5x+6', autoOpen: true },
+      });
+    });
+
+    it('fraction bars produces a manipulatives sidecar entry', () => {
+      const { visualCommand } = resolveToolCall('render_fraction_bars', {
+        numerator: 3,
+        denominator: 4,
+      });
+      expect(visualCommand.channel).toBe('manipulatives');
+      expect(visualCommand.command.type).toBe('fractionBars');
+      expect(visualCommand.command.numerator).toBe(3);
+      expect(visualCommand.command.denominator).toBe(4);
+      expect(visualCommand.command.autoOpen).toBe(true);
+    });
+
+    it('base-10 blocks produces a manipulatives sidecar entry', () => {
+      const { tag, visualCommand } = resolveToolCall('render_base_ten_blocks', {
+        number: 345,
+      });
+      expect(tag).toBe('[BASE_TEN_BLOCKS:345]');
+      expect(visualCommand.channel).toBe('manipulatives');
+      expect(visualCommand.command.number).toBe(345);
+    });
+
+    it('unit circle tag omits angle when missing', () => {
+      expect(resolveToolCall('render_unit_circle', {}).tag).toBe('[UNIT_CIRCLE]');
+      expect(resolveToolCall('render_unit_circle', { angle: 45 }).tag).toBe(
+        '[UNIT_CIRCLE:angle=45]'
+      );
+    });
+
+    it('counters serializes positive and negative counts', () => {
+      const { tag } = resolveToolCall('render_counters', { positive: 5, negative: 3 });
+      expect(tag).toBe('[COUNTERS:positive=5,negative=3]');
+    });
+
+    it('search_educational_image stores a quoted query with optional category', () => {
+      const { tag, visualCommand } = resolveToolCall('search_educational_image', {
+        query: 'unit circle',
+        category: 'trigonometry',
+      });
+      expect(tag).toBe('[SEARCH_IMAGE:query="unit circle",category=trigonometry]');
+      expect(visualCommand.channel).toBe('images');
+      expect(visualCommand.command.query).toBe('unit circle');
+    });
+
+    it('unknown tool returns nulls (no crash)', () => {
+      const { tag, visualCommand } = resolveToolCall('does_not_exist', { x: 1 });
+      expect(tag).toBeNull();
+      expect(visualCommand).toBeNull();
+    });
+  });
+
+  describe('resolveToolCalls', () => {
+    const makeCall = (name, argsObj) => ({
+      id: `call_${Math.random().toString(36).slice(2, 8)}`,
+      type: 'function',
+      function: { name, arguments: JSON.stringify(argsObj) },
+    });
+
+    it('resolves multiple tool_calls into merged tags + sidecar visualCommands', () => {
+      const toolCalls = [
+        makeCall('render_function_graph', { function: 'x^2' }),
+        makeCall('render_algebra_tiles', { expression: '2x+3' }),
+        makeCall('render_fraction_bars', { numerator: 1, denominator: 4 }),
+      ];
+      const { tags, visualCommands, unknown } = resolveToolCalls(toolCalls);
+      expect(tags).toHaveLength(3);
+      expect(tags[0]).toContain('FUNCTION_GRAPH');
+      expect(tags[1]).toContain('ALGEBRA_TILES');
+      expect(tags[2]).toContain('FRACTION_BARS');
+      expect(visualCommands.algebraTiles).toHaveLength(1);
+      expect(visualCommands.manipulatives).toHaveLength(1);
+      expect(unknown).toHaveLength(0);
+    });
+
+    it('records unknown tool names without throwing', () => {
+      const toolCalls = [
+        { id: 'a', type: 'function', function: { name: 'render_wormhole', arguments: '{}' } },
+        { id: 'b', type: 'function', function: { name: 'render_function_graph', arguments: '{"function":"x"}' } },
+      ];
+      const { tags, unknown } = resolveToolCalls(toolCalls);
+      expect(unknown).toEqual(['render_wormhole']);
+      expect(tags).toHaveLength(1);
+    });
+
+    it('tolerates malformed JSON arguments', () => {
+      const toolCalls = [
+        { id: 'a', type: 'function', function: { name: 'render_function_graph', arguments: '{broken' } },
+        { id: 'b', type: 'function', function: { name: 'render_function_graph', arguments: '{"function":"sin(x)"}' } },
+      ];
+      const { tags } = resolveToolCalls(toolCalls);
+      // Malformed call is dropped; well-formed call still resolves
+      expect(tags).toHaveLength(1);
+      expect(tags[0]).toContain('sin(x)');
+    });
+
+    it('accepts already-parsed object arguments (some SDKs pre-parse)', () => {
+      const toolCalls = [
+        {
+          id: 'a',
+          type: 'function',
+          function: { name: 'render_number_line', arguments: { min: 0, max: 10 } },
+        },
+      ];
+      const { tags } = resolveToolCalls(toolCalls);
+      expect(tags[0]).toBe('[NUMBER_LINE:min=0,max=10]');
+    });
+
+    it('returns empty structures for non-array input', () => {
+      const r = resolveToolCalls(null);
+      expect(r.tags).toEqual([]);
+      expect(r.unknown).toEqual([]);
+    });
+  });
+
+  describe('describeTools', () => {
+    it('lists every tool with its required params and description', () => {
+      const text = describeTools();
+      for (const tool of VISUAL_TOOLS) {
+        expect(text).toContain(tool.function.name);
+      }
+    });
+  });
+});

--- a/utils/openaiClient.js
+++ b/utils/openaiClient.js
@@ -73,12 +73,22 @@ async function callLLM(model, messages, options = {}) {
             {} :
             { temperature: options.temperature || 0.7 };
 
+        const toolParams = {};
+        if (Array.isArray(options.tools) && options.tools.length > 0) {
+            toolParams.tools = options.tools;
+            if (options.tool_choice) toolParams.tool_choice = options.tool_choice;
+            if (typeof options.parallel_tool_calls === 'boolean') {
+                toolParams.parallel_tool_calls = options.parallel_tool_calls;
+            }
+        }
+
         const completion = await retryWithExponentialBackoff(() =>
             openai.chat.completions.create({
                 model: model,
                 messages: messages,
                 ...temperatureParam,
                 ...tokenParam,
+                ...toolParams,
                 stream: options.stream || false,
                 ...(options.response_format ? { response_format: options.response_format } : {}),
             })
@@ -113,11 +123,21 @@ async function callLLMStream(model, messages, options = {}) {
             {} :
             { temperature: options.temperature || 0.7 };
 
+        const toolParams = {};
+        if (Array.isArray(options.tools) && options.tools.length > 0) {
+            toolParams.tools = options.tools;
+            if (options.tool_choice) toolParams.tool_choice = options.tool_choice;
+            if (typeof options.parallel_tool_calls === 'boolean') {
+                toolParams.parallel_tool_calls = options.parallel_tool_calls;
+            }
+        }
+
         const stream = await openai.chat.completions.create({
             model: model,
             messages: messages,
             ...temperatureParam,
             ...tokenParam,
+            ...toolParams,
             stream: true,
         });
         return stream;

--- a/utils/pipeline/generate.js
+++ b/utils/pipeline/generate.js
@@ -14,8 +14,12 @@ const { callLLM, callLLMStream } = require('../llmGateway');
 const { ACTIONS } = require('./decide');
 const { STATIC_RULES, RULE_1_SOCRATIC, RULE_1_TEACHING } = require('../promptCompact');
 const { buildSlimRules } = require('./promptSlim');
+const { VISUAL_TOOLS, resolveToolCalls, describeTools } = require('../visualTools');
 
 const PRIMARY_CHAT_MODEL = 'gpt-4o-mini';
+
+/** Visual tool calling is opt-in until the frontend/backend are both deployed. */
+const VISUAL_TOOLS_ENABLED = process.env.ENABLE_VISUAL_TOOLS === 'true';
 
 /**
  * Build the action-specific instruction for the LLM.
@@ -356,10 +360,26 @@ function assemblePrompt(decision, promptContext) {
     }
   }
 
+  const options = { temperature: 0.55, max_tokens: 1200 };
+  if (VISUAL_TOOLS_ENABLED) {
+    options.tools = VISUAL_TOOLS;
+    options.tool_choice = 'auto';
+    options.parallel_tool_calls = true;
+    // Nudge the model to prefer structured tool calls over text tags when
+    // emitting visuals. The legacy VISUAL_TOOLS_SECTION still runs and is
+    // kept for the one-release backwards-compatibility window.
+    fullSystemPrompt +=
+      '\n\n--- STRUCTURED VISUAL TOOLS ---\n' +
+      describeTools() +
+      '\nPrefer these tool calls over emitting bracket tags for visuals. ' +
+      'The student-facing rendering is identical, but tool calls are ' +
+      'validated and reliable — tags can be malformed.';
+  }
+
   return {
     messages: [{ role: 'system', content: fullSystemPrompt }, ...messages],
     model: PRIMARY_CHAT_MODEL,
-    options: { temperature: 0.55, max_tokens: 1200 },
+    options,
   };
 }
 
@@ -380,7 +400,64 @@ async function generate(assembled, options = {}) {
   }
 
   const completion = await callLLM(model, messages, llmOptions);
-  return completion.choices[0]?.message?.content?.trim() || "I'm not sure how to respond.";
+  const message = completion.choices[0]?.message || {};
+
+  // Tool-calling path: append dummy tool results and re-prompt for narration.
+  if (Array.isArray(message.tool_calls) && message.tool_calls.length > 0) {
+    const resolved = resolveToolCalls(message.tool_calls);
+    const narrationText = await generateToolNarration(
+      model,
+      messages,
+      message,
+      llmOptions
+    );
+    return {
+      text: narrationText || '',
+      toolCalls: message.tool_calls,
+      resolvedTools: resolved,
+    };
+  }
+
+  const text = message.content?.trim() || "I'm not sure how to respond.";
+  return { text, toolCalls: [], resolvedTools: null };
+}
+
+/**
+ * After the model emits tool_calls (and OpenAI halts generation), append
+ * stub tool results and re-prompt for the narrative text that goes with
+ * the visuals. This is the canonical OpenAI tool loop.
+ */
+async function generateToolNarration(model, priorMessages, assistantMessage, llmOptions) {
+  const toolResults = assistantMessage.tool_calls.map((call) => ({
+    role: 'tool',
+    tool_call_id: call.id,
+    content: JSON.stringify({ status: 'rendered' }),
+  }));
+
+  const nextMessages = [
+    ...priorMessages,
+    {
+      role: 'assistant',
+      content: assistantMessage.content || null,
+      tool_calls: assistantMessage.tool_calls,
+    },
+    ...toolResults,
+  ];
+
+  // Re-prompt WITHOUT tools to force text output (no tool-calling recursion).
+  const narrationOptions = { ...llmOptions };
+  delete narrationOptions.tools;
+  delete narrationOptions.tool_choice;
+  delete narrationOptions.parallel_tool_calls;
+
+  try {
+    const completion = await callLLM(model, nextMessages, narrationOptions);
+    const content = completion.choices[0]?.message?.content?.trim();
+    return content || "";
+  } catch (err) {
+    console.error('[Generate] Tool narration call failed:', err.message);
+    return "";
+  }
 }
 
 /**
@@ -390,6 +467,10 @@ async function generateStreaming(model, messages, llmOptions, res) {
   const { callLLMStream } = require('../llmGateway');
 
   let fullResponse = '';
+  // Index → { id, name, arguments: string } — accumulated from delta.tool_calls
+  const toolCallAccumulator = new Map();
+  let finishReason = null;
+
   try {
     const stream = await callLLMStream(model, messages, llmOptions);
     let clientDisconnected = false;
@@ -399,15 +480,74 @@ async function generateStreaming(model, messages, llmOptions, res) {
     for await (const chunk of stream) {
       if (clientDisconnected) break;
 
-      const content = chunk.choices[0]?.delta?.content || '';
+      const delta = chunk.choices[0]?.delta || {};
+      const reason = chunk.choices[0]?.finish_reason;
+      if (reason) finishReason = reason;
 
-      if (content) {
-        fullResponse += content;
-        res.write(`data: ${JSON.stringify({ type: 'chunk', content })}\n\n`);
+      if (delta.content) {
+        fullResponse += delta.content;
+        res.write(`data: ${JSON.stringify({ type: 'chunk', content: delta.content })}\n\n`);
+      }
+
+      if (Array.isArray(delta.tool_calls)) {
+        for (const tc of delta.tool_calls) {
+          const idx = tc.index;
+          if (idx == null) continue;
+          const existing = toolCallAccumulator.get(idx) || {
+            id: null,
+            type: 'function',
+            function: { name: '', arguments: '' },
+          };
+          if (tc.id) existing.id = tc.id;
+          if (tc.function?.name) existing.function.name = tc.function.name;
+          if (tc.function?.arguments) {
+            existing.function.arguments += tc.function.arguments;
+          }
+          toolCallAccumulator.set(idx, existing);
+        }
       }
     }
 
-    return fullResponse.trim() || "I'm not sure how to respond.";
+    // If the model emitted tool_calls, resolve them and emit SSE events,
+    // then re-prompt for the narrative text.
+    if (finishReason === 'tool_calls' && toolCallAccumulator.size > 0) {
+      const toolCalls = Array.from(toolCallAccumulator.values());
+      const resolved = resolveToolCalls(toolCalls);
+
+      for (const call of toolCalls) {
+        let parsedInput = {};
+        try {
+          parsedInput = call.function.arguments ? JSON.parse(call.function.arguments) : {};
+        } catch {}
+        if (!clientDisconnected) {
+          res.write(`data: ${JSON.stringify({
+            type: 'tool_use',
+            name: call.function.name,
+            input: parsedInput,
+          })}\n\n`);
+        }
+      }
+
+      const narration = await generateToolNarration(
+        model,
+        messages,
+        { content: fullResponse || null, tool_calls: toolCalls },
+        llmOptions
+      );
+
+      if (narration && !clientDisconnected) {
+        res.write(`data: ${JSON.stringify({ type: 'chunk', content: narration })}\n\n`);
+      }
+
+      return {
+        text: (fullResponse + (narration ? (fullResponse ? '\n\n' : '') + narration : '')).trim() || '',
+        toolCalls,
+        resolvedTools: resolved,
+      };
+    }
+
+    const finalText = fullResponse.trim() || "I'm not sure how to respond.";
+    return { text: finalText, toolCalls: [], resolvedTools: null };
   } catch (streamError) {
     console.error('[Generate] Streaming failed, falling back:', streamError.message);
 
@@ -423,7 +563,7 @@ async function generateStreaming(model, messages, llmOptions, res) {
     } else {
       res.write(`data: ${JSON.stringify({ type: 'chunk', content: text })}\n\n`);
     }
-    return text;
+    return { text, toolCalls: [], resolvedTools: null };
   }
 }
 

--- a/utils/pipeline/index.js
+++ b/utils/pipeline/index.js
@@ -289,15 +289,19 @@ async function runPipeline(message, ctx) {
     suppressSocratic,
   });
 
-  let rawResponseText;
+  let generatedResult;
   if (ctx.stream && ctx.res) {
-    rawResponseText = await generate(assembled, { stream: true, res: ctx.res });
+    generatedResult = await generate(assembled, { stream: true, res: ctx.res });
   } else {
-    rawResponseText = await generate(assembled);
+    generatedResult = await generate(assembled);
   }
+
+  const rawResponseText = generatedResult.text;
+  const resolvedTools = generatedResult.resolvedTools || null;
 
   // ── Stage 5: VERIFY ──
   const verified = await verify(rawResponseText, {
+    resolvedTools,
     userId: ctx.user._id?.toString(),
     userMessage: message,
     iepReadingLevel: ctx.user.iepPlan?.readingLevel || null,

--- a/utils/pipeline/verify.js
+++ b/utils/pipeline/verify.js
@@ -483,6 +483,37 @@ async function verify(responseText, context = {}) {
     }
   }
 
+  // ── 3b. Merge LLM tool_calls (structured visual tools) ──
+  // When ENABLE_VISUAL_TOOLS is on, the LLM may emit tool_calls alongside
+  // text. Resolve each into (a) a legacy bracket tag we append to the text
+  // so the frontend's inline regex renderer picks it up, and (b) a sidecar
+  // visualCommand for the whiteboard/manipulatives channels.
+  const toolVisualCommands = {
+    whiteboard: [],
+    algebraTiles: [],
+    images: [],
+    manipulatives: [],
+  };
+  if (context.resolvedTools) {
+    if (Array.isArray(context.resolvedTools.tags) && context.resolvedTools.tags.length > 0) {
+      const tagBlock = context.resolvedTools.tags.join('\n');
+      text = text ? `${text}\n\n${tagBlock}` : tagBlock;
+    }
+    if (context.resolvedTools.visualCommands) {
+      for (const channel of Object.keys(toolVisualCommands)) {
+        if (Array.isArray(context.resolvedTools.visualCommands[channel])) {
+          toolVisualCommands[channel].push(
+            ...context.resolvedTools.visualCommands[channel]
+          );
+        }
+      }
+    }
+    if (context.resolvedTools.unknown && context.resolvedTools.unknown.length > 0) {
+      console.warn(`[Verify] Unknown visual tool calls: ${context.resolvedTools.unknown.join(', ')}`);
+      flags.push('unknown_visual_tool');
+    }
+  }
+
   // ── 4. Visual teaching enforcement ──
   if (context.userMessage) {
     // Always run: handles explicit student requests ("show me", "graph this")
@@ -500,6 +531,15 @@ async function verify(responseText, context = {}) {
   // ── 5. Parse visual commands ──
   const visualResult = parseVisualTeaching(text);
   text = visualResult.cleanedText;
+
+  // Merge tool-derived sidecar visualCommands into the parsed result.
+  // Tool calls take precedence (already structured and validated); legacy
+  // tags still contribute for backwards compatibility.
+  for (const channel of Object.keys(toolVisualCommands)) {
+    if (toolVisualCommands[channel].length > 0 && visualResult.visualCommands?.[channel]) {
+      visualResult.visualCommands[channel].push(...toolVisualCommands[channel]);
+    }
+  }
 
   // ── 6. Parse board references ──
   const boardParsed = processAIResponse(text);

--- a/utils/visualTools.js
+++ b/utils/visualTools.js
@@ -1,0 +1,419 @@
+/**
+ * VISUAL TOOLS — Structured tool definitions for LLM-driven visual rendering.
+ *
+ * Replaces text-tag parsing (e.g. "[FUNCTION_GRAPH:fn=x^2]") with OpenAI
+ * function-calling. The model emits structured tool_calls with validated JSON
+ * arguments, which we deterministically map to either:
+ *   (a) the legacy inline bracket-tag the frontend already parses
+ *   (b) a visualCommands sidecar entry (whiteboard / algebraTiles / etc.)
+ *
+ * Rolled out behind the ENABLE_VISUAL_TOOLS flag. When disabled, the
+ * existing tag-parsing pipeline runs unchanged.
+ *
+ * @module visualTools
+ */
+
+// ---------------------------------------------------------------------------
+// Tool specs: one entry per visual. Each spec includes:
+//   - `function`:  OpenAI tool schema (name, description, parameters)
+//   - `toTag(input)` → string | null  : legacy bracket tag for inline rendering
+//   - `toVisualCommand(input)` → { channel, command } | null : sidecar entry
+// At least one of `toTag` / `toVisualCommand` must be non-null.
+// ---------------------------------------------------------------------------
+
+const SPECS = {
+  render_function_graph: {
+    function: {
+      name: 'render_function_graph',
+      description:
+        'Plot a mathematical function on a coordinate plane. Use when explaining function behavior, transformations, or comparing functions (e.g. student asks "show me x^2" or you are teaching parabolas).',
+      parameters: {
+        type: 'object',
+        properties: {
+          function: {
+            type: 'string',
+            description:
+              'Function in standard math notation using x as the variable. Examples: "x^2", "sin(x)", "2*x+3", "(x^2-4)/(x-2)".',
+          },
+          xMin: { type: 'number', description: 'Minimum x value (default -10).' },
+          xMax: { type: 'number', description: 'Maximum x value (default 10).' },
+          yMin: { type: 'number', description: 'Optional minimum y value.' },
+          yMax: { type: 'number', description: 'Optional maximum y value.' },
+          title: { type: 'string', description: 'Optional caption, e.g. "y = x^2".' },
+        },
+        required: ['function'],
+      },
+    },
+    toTag(input) {
+      const parts = [`fn=${input.function}`];
+      if (typeof input.xMin === 'number') parts.push(`xMin=${input.xMin}`);
+      if (typeof input.xMax === 'number') parts.push(`xMax=${input.xMax}`);
+      if (typeof input.yMin === 'number') parts.push(`yMin=${input.yMin}`);
+      if (typeof input.yMax === 'number') parts.push(`yMax=${input.yMax}`);
+      if (input.title) parts.push(`title="${input.title}"`);
+      return `[FUNCTION_GRAPH:${parts.join(',')}]`;
+    },
+    toVisualCommand: null,
+  },
+
+  render_number_line: {
+    function: {
+      name: 'render_number_line',
+      description:
+        'Render a number line. Use for integer arithmetic, inequalities, fraction placement, absolute value, or when the student says "show me a number line".',
+      parameters: {
+        type: 'object',
+        properties: {
+          min: { type: 'number', description: 'Leftmost value.' },
+          max: { type: 'number', description: 'Rightmost value.' },
+          points: {
+            type: 'array',
+            items: { type: 'number' },
+            description: 'Optional list of values to mark on the line.',
+          },
+          label: { type: 'string', description: 'Optional caption.' },
+        },
+        required: ['min', 'max'],
+      },
+    },
+    toTag(input) {
+      const parts = [`min=${input.min}`, `max=${input.max}`];
+      if (Array.isArray(input.points) && input.points.length > 0) {
+        parts.push(`points=[${input.points.join(',')}]`);
+      }
+      if (input.label) parts.push(`label="${input.label}"`);
+      return `[NUMBER_LINE:${parts.join(',')}]`;
+    },
+    toVisualCommand: null,
+  },
+
+  render_fraction: {
+    function: {
+      name: 'render_fraction',
+      description:
+        'Visualize a fraction as a circle or bar. Use when teaching fraction meaning, comparison, or equivalent fractions.',
+      parameters: {
+        type: 'object',
+        properties: {
+          numerator: { type: 'integer' },
+          denominator: { type: 'integer' },
+          shape: {
+            type: 'string',
+            enum: ['circle', 'bar'],
+            description: 'Rendering shape (default "circle").',
+          },
+        },
+        required: ['numerator', 'denominator'],
+      },
+    },
+    toTag(input) {
+      const parts = [
+        `numerator=${input.numerator}`,
+        `denominator=${input.denominator}`,
+        `type=${input.shape || 'circle'}`,
+      ];
+      return `[FRACTION:${parts.join(',')}]`;
+    },
+    toVisualCommand: null,
+  },
+
+  render_algebra_tiles: {
+    function: {
+      name: 'render_algebra_tiles',
+      description:
+        'Show algebra tiles for an expression like "2x+3" or "x^2-x-6". Use when teaching factoring, combining like terms, or representing polynomials visually.',
+      parameters: {
+        type: 'object',
+        properties: {
+          expression: {
+            type: 'string',
+            description: 'Polynomial expression, e.g. "x^2+5x+6" or "2x+3".',
+          },
+        },
+        required: ['expression'],
+      },
+    },
+    toTag(input) {
+      return `[ALGEBRA_TILES:${input.expression}]`;
+    },
+    toVisualCommand(input) {
+      return {
+        channel: 'algebraTiles',
+        command: { type: 'expression', expression: input.expression, autoOpen: true },
+      };
+    },
+  },
+
+  render_fraction_bars: {
+    function: {
+      name: 'render_fraction_bars',
+      description:
+        'Show fraction bars on the manipulatives board. Use when teaching fractions, equivalent fractions, or comparing fractions.',
+      parameters: {
+        type: 'object',
+        properties: {
+          numerator: { type: 'integer' },
+          denominator: { type: 'integer' },
+        },
+        required: ['numerator', 'denominator'],
+      },
+    },
+    toTag(input) {
+      return `[FRACTION_BARS:${input.numerator},${input.denominator}]`;
+    },
+    toVisualCommand(input) {
+      return {
+        channel: 'manipulatives',
+        command: {
+          type: 'fractionBars',
+          numerator: input.numerator,
+          denominator: input.denominator,
+          autoOpen: true,
+        },
+      };
+    },
+  },
+
+  render_base_ten_blocks: {
+    function: {
+      name: 'render_base_ten_blocks',
+      description:
+        'Show base-10 blocks for a number. Use for place value, addition with regrouping, multi-digit operations.',
+      parameters: {
+        type: 'object',
+        properties: {
+          number: { type: 'integer', description: 'Whole number to decompose.' },
+        },
+        required: ['number'],
+      },
+    },
+    toTag(input) {
+      return `[BASE_TEN_BLOCKS:${input.number}]`;
+    },
+    toVisualCommand(input) {
+      return {
+        channel: 'manipulatives',
+        command: { type: 'baseTenBlocks', number: input.number, autoOpen: true },
+      };
+    },
+  },
+
+  render_counters: {
+    function: {
+      name: 'render_counters',
+      description:
+        'Show positive and negative counters with zero-pair cancellation. Use for integer operations and opposites.',
+      parameters: {
+        type: 'object',
+        properties: {
+          positive: { type: 'integer', minimum: 0 },
+          negative: { type: 'integer', minimum: 0 },
+        },
+        required: ['positive', 'negative'],
+      },
+    },
+    toTag(input) {
+      return `[COUNTERS:positive=${input.positive},negative=${input.negative}]`;
+    },
+    toVisualCommand: null,
+  },
+
+  render_unit_circle: {
+    function: {
+      name: 'render_unit_circle',
+      description:
+        'Render the unit circle. Use for trig angle/coordinate mapping, sine/cosine definitions, reference angles.',
+      parameters: {
+        type: 'object',
+        properties: {
+          angle: {
+            type: 'number',
+            description: 'Optional angle in degrees to highlight.',
+          },
+        },
+      },
+    },
+    toTag(input) {
+      if (typeof input.angle === 'number') {
+        return `[UNIT_CIRCLE:angle=${input.angle}]`;
+      }
+      return `[UNIT_CIRCLE]`;
+    },
+    toVisualCommand: null,
+  },
+
+  render_points_plot: {
+    function: {
+      name: 'render_points_plot',
+      description:
+        'Plot points on a coordinate plane. Use when teaching coordinates, ordered pairs, or plotting data.',
+      parameters: {
+        type: 'object',
+        properties: {
+          points: {
+            type: 'array',
+            description: 'Array of [x, y] pairs.',
+            items: {
+              type: 'array',
+              items: { type: 'number' },
+              minItems: 2,
+              maxItems: 2,
+            },
+          },
+        },
+        required: ['points'],
+      },
+    },
+    toTag(input) {
+      const rendered = input.points
+        .map((p) => `(${p[0]},${p[1]})`)
+        .join(',');
+      return `[POINTS:points=${rendered}]`;
+    },
+    toVisualCommand: null,
+  },
+
+  search_educational_image: {
+    function: {
+      name: 'search_educational_image',
+      description:
+        'Find a canonical educational image (diagram, real-world picture) from whitelisted edu sources. Use for concepts that benefit from a diagram the student would see in a textbook (geometric shapes, scientific visualizations).',
+      parameters: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: 'Concise search query.' },
+          category: {
+            type: 'string',
+            description: 'Optional domain hint (e.g. "geometry", "chemistry").',
+          },
+        },
+        required: ['query'],
+      },
+    },
+    toTag(input) {
+      const parts = [`query="${input.query}"`];
+      if (input.category) parts.push(`category=${input.category}`);
+      return `[SEARCH_IMAGE:${parts.join(',')}]`;
+    },
+    toVisualCommand(input) {
+      return {
+        channel: 'images',
+        command: {
+          type: 'search',
+          query: input.query,
+          category: input.category || null,
+          inline: true,
+        },
+      };
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/** OpenAI tool definitions (pass directly as `tools` parameter). */
+const VISUAL_TOOLS = Object.values(SPECS).map((spec) => ({
+  type: 'function',
+  function: spec.function,
+}));
+
+/** Set of canonical tool names. */
+const VISUAL_TOOL_NAMES = new Set(Object.keys(SPECS));
+
+/**
+ * Resolve a single tool call into {tag, visualCommand}.
+ * @param {string} name - Tool name from the LLM.
+ * @param {Object} input - Validated argument object.
+ * @returns {{ tag: string | null, visualCommand: { channel: string, command: Object } | null }}
+ */
+function resolveToolCall(name, input) {
+  const spec = SPECS[name];
+  if (!spec) {
+    return { tag: null, visualCommand: null };
+  }
+  const safeInput = input || {};
+  const tag = spec.toTag ? spec.toTag(safeInput) : null;
+  const visualCommand = spec.toVisualCommand ? spec.toVisualCommand(safeInput) : null;
+  return { tag, visualCommand };
+}
+
+/**
+ * Resolve an array of tool_calls (as returned by OpenAI) into merged outputs.
+ * Each tool_call is `{ id, type: 'function', function: { name, arguments } }`
+ * where `arguments` is a JSON string. Malformed JSON is skipped with a warning.
+ *
+ * @param {Array} toolCalls
+ * @returns {{ tags: string[], visualCommands: { whiteboard:[], algebraTiles:[], images:[], manipulatives:[] }, unknown: string[] }}
+ */
+function resolveToolCalls(toolCalls) {
+  const tags = [];
+  const visualCommands = {
+    whiteboard: [],
+    algebraTiles: [],
+    images: [],
+    manipulatives: [],
+  };
+  const unknown = [];
+
+  if (!Array.isArray(toolCalls)) {
+    return { tags, visualCommands, unknown };
+  }
+
+  for (const call of toolCalls) {
+    const fnName = call?.function?.name;
+    if (!fnName) continue;
+
+    if (!VISUAL_TOOL_NAMES.has(fnName)) {
+      unknown.push(fnName);
+      continue;
+    }
+
+    let parsed = {};
+    try {
+      const raw = call.function.arguments;
+      if (typeof raw === 'string' && raw.trim().length > 0) {
+        parsed = JSON.parse(raw);
+      } else if (raw && typeof raw === 'object') {
+        parsed = raw;
+      }
+    } catch (err) {
+      console.warn(`[visualTools] Malformed arguments for ${fnName}: ${err.message}`);
+      continue;
+    }
+
+    const { tag, visualCommand } = resolveToolCall(fnName, parsed);
+    if (tag) tags.push(tag);
+    if (visualCommand && visualCommands[visualCommand.channel]) {
+      visualCommands[visualCommand.channel].push(visualCommand.command);
+    }
+  }
+
+  return { tags, visualCommands, unknown };
+}
+
+/**
+ * Short human-readable description of available tools, for injection into
+ * a system prompt. Keeps the model aware that tools exist even before the
+ * provider surfaces the tool schema.
+ */
+function describeTools() {
+  const lines = VISUAL_TOOLS.map((t) => {
+    const required = t.function.parameters.required || [];
+    return `- ${t.function.name}(${required.join(', ')}): ${t.function.description}`;
+  });
+  return [
+    'VISUAL TOOLS AVAILABLE (structured function calls — prefer these over text tags when emitting visuals):',
+    ...lines,
+  ].join('\n');
+}
+
+module.exports = {
+  VISUAL_TOOLS,
+  VISUAL_TOOL_NAMES,
+  SPECS,
+  resolveToolCall,
+  resolveToolCalls,
+  describeTools,
+};


### PR DESCRIPTION
Foundation for migrating visual rendering from text-tag parsing (e.g. [FUNCTION_GRAPH:fn=x^2]) to structured LLM function calls. Text tags kept in parallel for backwards compatibility.

- utils/visualTools.js: 10 OpenAI tool schemas (graph, number line, algebra tiles, fraction, fraction bars, base-ten, counters, unit circle, points plot, image search). Each resolves to a validated legacy tag + optional sidecar visualCommand.
- utils/openaiClient.js: thread tools / tool_choice / parallel_tool_calls through callLLM and callLLMStream.
- utils/pipeline/generate.js: when ENABLE_VISUAL_TOOLS=true, attach tool schemas + directive to the prompt. Handle tool_calls in both streaming (accumulate deltas, emit tool_use SSE events) and non-streaming paths. Append tool-result stubs and re-prompt for narration when the model halts on tool_calls.
- utils/pipeline/verify.js: merge resolved tool tags back into the response text and sidecar visualCommands so existing renderers work.
- utils/pipeline/index.js: thread resolvedTools from generate → verify.
- public/js/inlineChatVisuals.js: renderFromToolCall(name, input) entry point maps structured inputs to existing handlers.
- public/js/script.js: stream consumer handles tool_use events inline.
- tests/unit/visualTools.test.js: 20 tests covering schemas, mappers, and resolver edge cases (malformed JSON, unknown tools, pre-parsed arguments).

Flag off by default — live behavior unchanged. 1272/1272 tests pass.

https://claude.ai/code/session_01H3ZnqZ4a4PjJqCBPjoqcvu