### PR TITLE
Use system Chromium for Puppeteer instead of bundled Chrome

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,14 @@
 # 1. Start with a lean Node.js image
 FROM node:20-slim
 
-# 2. Install Python3 and required dependencies for diagram generation
+# 2. Install Python3, Chromium (for Puppeteer PDF rendering), and required dependencies
 RUN apt-get update && apt-get install -y \
     python3 \
     python3-pip \
     python3-dev \
+    chromium \
+    chromium-common \
+    fonts-liberation \
     && rm -rf /var/lib/apt/lists/*
 
 # 3. Install Python dependencies for diagram generation
@@ -18,8 +21,9 @@ RUN pip3 install --no-cache-dir --break-system-packages \
 # 4. Set up the working directory
 WORKDIR /usr/src/app
 
-# 5. Skip Puppeteer's bundled Chrome download (use system Chrome at runtime)
+# 5. Skip Puppeteer's bundled Chrome download — use the system Chromium installed above
 ENV PUPPETEER_SKIP_DOWNLOAD=true
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 
 # 6. Copy package files and install npm dependencies deterministically
 COPY package*.json ./

--- a/render.yaml
+++ b/render.yaml
@@ -22,7 +22,7 @@ services:
       - key: PUPPETEER_SKIP_DOWNLOAD
         value: true
       - key: PUPPETEER_EXECUTABLE_PATH
-        value: /usr/bin/google-chrome-stable
+        value: /usr/bin/chromium
 
       # Your app's environment variables (set these in Render dashboard)
       - key: MONGO_URI

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -2182,6 +2182,7 @@ async function handleGreetingRequest(req, res, userId) {
         let systemPrompt;
         let greetingInstruction;
         let maxTokens = 150;
+        let openerResult = null;
 
         if (isCourseGreeting && courseContext) {
             // COURSE MODE: Use dedicated course prompt
@@ -2220,7 +2221,6 @@ async function handleGreetingRequest(req, res, userId) {
             systemPrompt = generateSystemPrompt(user.toObject(), currentTutor, null, 'student', null, null, greetingMasteryContext, [], null, null);
 
             // ── Intelligent session opener via TutorPlan ──
-            let openerResult = null;
             try {
                 const tutorPlan = await TutorPlan.findOne({ userId: user._id });
                 if (tutorPlan) {


### PR DESCRIPTION
## Summary
This PR updates the Docker configuration and deployment settings to use the system-installed Chromium browser for Puppeteer PDF rendering instead of relying on Puppeteer's bundled Chrome download. This reduces image size and improves build reliability.

## Key Changes
- **Dockerfile**: Added Chromium and related packages (`chromium`, `chromium-common`, `fonts-liberation`) to the system dependencies
- **Dockerfile**: Set `PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium` to explicitly point Puppeteer to the system Chromium installation
- **render.yaml**: Updated `PUPPETEER_EXECUTABLE_PATH` environment variable from `/usr/bin/google-chrome-stable` to `/usr/bin/chromium` for consistency with the Docker setup
- **routes/chat.js**: Moved `let openerResult = null;` declaration to the top of the variable initialization block for better code organization and to avoid potential hoisting issues

## Implementation Details
- The system Chromium installation eliminates the need for Puppeteer to download its own Chrome binary, reducing Docker image size and build time
- Font liberation package is included to ensure proper text rendering in generated PDFs
- Environment variable configuration is now consistent across both Docker and Render deployment platforms

https://claude.ai/code/session_018jF2S78ybVyYtxxaQGx95G