### PR TITLE
Fix send button click handling with event delegation

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -2937,7 +2937,14 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     // --- Event Listeners ---
-    if (sendBtn) sendBtn.addEventListener("click", sendMessage);
+    // Delegated so the click survives iOS focus-swallowing and any stale sendBtn cache.
+    document.addEventListener("mousedown", (e) => {
+        if (e.target.closest("#send-button")) e.preventDefault();
+    });
+    document.addEventListener("click", (e) => {
+        const btn = e.target.closest("#send-button");
+        if (btn && !btn.disabled) sendMessage();
+    });
     if (userInput) {
         userInput.addEventListener("keydown", (e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendMessage(); } });
         // Hide suggestions when user starts typing


### PR DESCRIPTION
## Summary
Replaced direct event listener attachment to the send button with delegated event listeners on the document to improve reliability and handle edge cases on iOS devices.

## Key Changes
- Removed direct `sendBtn.addEventListener("click", sendMessage)` attachment
- Implemented delegated event handling using `document.addEventListener()` with two listeners:
  - `mousedown` listener that prevents default behavior on the send button
  - `click` listener that checks for the send button and executes `sendMessage()` only if the button is not disabled
- Event delegation uses `e.target.closest("#send-button")` to identify the target button

## Implementation Details
- The delegated approach survives iOS focus-swallowing behavior that can interfere with direct element listeners
- Eliminates issues with stale `sendBtn` cache references
- Maintains the disabled state check to prevent sending messages when the button is disabled
- The `mousedown` preventDefault call helps ensure consistent behavior across browsers and devices

https://claude.ai/code/session_01VEhuu7jGJmCLmrqiceA2Qb