### PR TITLE
Add self-contradiction guard to catch rejection-then-confirmation replies

### DIFF
--- a/tests/unit/tutorValidation.test.js
+++ b/tests/unit/tutorValidation.test.js
@@ -488,6 +488,87 @@ describe('Tutor Validation: False Rejection Guard (Full Pipeline)', () => {
 });
 
 // ============================================================================
+// FULL PIPELINE: SELF-CONTRADICTION GUARD
+// ============================================================================
+
+describe('Tutor Validation: Self-Contradiction Guard (Full Pipeline)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __mainTextQueue.length = 0;
+    __installMockRouter();
+  });
+
+  // Reproduces the probability-quiz transcript: the deterministic solver
+  // can't verify combinatorics, the LLM verifier returns low confidence
+  // (so action stays unverifiable and llmVerdict.isCorrect is null), and
+  // the LLM's reply opens with "Close, but not quite!" yet ends with
+  // "So you were right!". The self-contradiction guard must catch this on
+  // the response text alone.
+  test('rejection-then-confirmation in same reply triggers regeneration', async () => {
+    const user = mockUser();
+    const conversation = mockConversation([
+      { role: 'assistant', content: 'If you roll two six-sided dice, what is the probability of rolling a total of 7?' },
+      { role: 'user', content: '1/6' },
+    ]);
+
+    // Original buggy reply: opens with rejection, computes the math,
+    // then admits the student was right.
+    mockLLMResponse(
+      "Close, but not quite! The probability of rolling a total of 7 with two six-sided dice is actually a bit different. " +
+      "To get a total of 7, the possible combinations are (1,6), (2,5), (3,4), (4,3), (5,2), (6,1) — 6 favorable outcomes. " +
+      "Since there are 6x6 = 36 possible outcomes, the probability is 6/36 = 1/6. " +
+      "So you were right! You just caught yourself in a little trap there!"
+    );
+    // Regeneration call returns a clean confirmation.
+    mockLLMResponse("That's it — 1/6. Six combinations land on a sum of 7 out of 36 total rolls, so 6/36 = 1/6. Nice.");
+
+    const result = await runPipeline('1/6', buildCtx(user, conversation));
+
+    expect(result._pipeline.flags).toContain('self_contradiction_detected');
+    expect(result._pipeline.flags).toContain('self_contradiction_regenerated');
+    expect(result.text).not.toMatch(/close,?\s*but/i);
+    expect(result.text).not.toMatch(/not quite/i);
+    expect(result.text).not.toMatch(/caught yourself/i);
+  });
+
+  // A reply that opens with rejection but never confirms must NOT regenerate
+  // — the rejection might be legitimate.
+  test('rejection without later confirmation does NOT trigger guard', async () => {
+    const user = mockUser();
+    const conversation = mockConversation([
+      { role: 'assistant', content: 'If you roll two six-sided dice, what is the probability of rolling a total of 7?' },
+      { role: 'user', content: '1/12' },
+    ]);
+
+    mockLLMResponse(
+      "Not quite. Think about how many ways two dice can land — and how many of those add to 7. " +
+      "Want to list out the pairs?"
+    );
+
+    const result = await runPipeline('1/12', buildCtx(user, conversation));
+
+    expect(result._pipeline.flags).not.toContain('self_contradiction_detected');
+  });
+
+  // A clean confirmation (no rejection at the start) must pass through
+  // untouched — the rejection regex is anchored to the opening, so this
+  // is the existing-behavior baseline.
+  test('clean confirmation passes through untouched', async () => {
+    const user = mockUser();
+    const conversation = mockConversation([
+      { role: 'assistant', content: 'If you roll two six-sided dice, what is the probability of rolling a total of 7?' },
+      { role: 'user', content: '1/6' },
+    ]);
+
+    mockLLMResponse("That's it — 1/6. Six pairs sum to 7 out of 36 rolls.");
+
+    const result = await runPipeline('1/6', buildCtx(user, conversation));
+
+    expect(result._pipeline.flags).not.toContain('self_contradiction_detected');
+  });
+});
+
+// ============================================================================
 // ANSWER EXTRACTION EDGE CASES
 // ============================================================================
 

--- a/utils/pipeline/verify.js
+++ b/utils/pipeline/verify.js
@@ -517,6 +517,56 @@ async function verify(responseText, context = {}) {
     }
   }
 
+  // ── 2d-self. Self-contradiction guard ──
+  // Defense-in-depth for the case where neither the deterministic solver
+  // nor the LLM verifier returns a high-confidence verdict (so upstream
+  // guards 2c/2d and their llm variants never fire). The LLM still
+  // sometimes opens with rejection language ("Close, but not quite!"),
+  // walks through the arithmetic, discovers the student was right, and
+  // ends with "So you were right!" — leaving a self-contradicting reply.
+  // This guard inspects the response text alone and asks the LLM to
+  // rewrite with a single, consistent verdict.
+  //
+  // To minimize false positives ("you were right that we should factor,
+  // but..."), the confirmation half requires either explicit verdict
+  // language with terminal punctuation or strong "I changed my mind"
+  // markers ("caught yourself", "actually, you're right").
+  if (!regeneratedThisPass && falseRejectionOpener.test(text.trim())) {
+    const selfContradictionConfirm = /(?:\bso\s+you(?:'?re|\s+(?:are|were))\s+(?:right|correct)\s*[!.]|\byou\s+(?:were|are)\s+(?:right|correct)\s*[!.]|\byou(?:'?re|\s+are)\s+(?:absolutely|actually)\s+(?:right|correct)\b|\byou\s+(?:got|nailed)\s+it\s*[!.]|\bactually[,!]?\s+you(?:'?re|\s+(?:are|were))\s+(?:right|correct)\b|\bcaught\s+yourself\b)/i;
+    // Strip the opening rejection sentence so the rejection itself can't
+    // satisfy the confirmation pattern.
+    const afterFirstSentence = text.trim().replace(/^[^.!?\n]*[.!?\n]\s*/, '');
+    if (selfContradictionConfirm.test(afterFirstSentence)) {
+      flags.push('self_contradiction_detected');
+      console.log('[Verify] SELF-CONTRADICTION: response opens with rejection but later confirms — regenerating');
+
+      try {
+        const correctionPrompt = 'CRITICAL: Your previous response opened by telling the student they were wrong ("close, but not quite", "almost", "let\'s check", etc.) and then later said they were right. That is contradictory and confusing. Re-examine the math in your own response, decide whether the student\'s answer is actually correct, and rewrite with a single, consistent verdict. If the student is correct, confirm immediately and naturally — do NOT use any "let\'s check / not quite / close but / almost" language. If the student is wrong, guide them with a Socratic question without revealing the answer. Keep your tutor personality.';
+        const regenerated = await callLLM(PRIMARY_CHAT_MODEL,
+          [{ role: 'system', content: correctionPrompt },
+           { role: 'assistant', content: text },
+           { role: 'user', content: 'Rewrite this with one consistent verdict. No contradiction.' }],
+          { temperature: 0.4, max_tokens: 1500 }
+        );
+        const regeneratedText = regenerated.choices[0]?.message?.content?.trim();
+        if (regeneratedText && regeneratedText.length > 10) {
+          text = regeneratedText;
+          flags.push('self_contradiction_regenerated');
+          regeneratedThisPass = true;
+
+          if (context.isStreaming && context.res) {
+            try {
+              context.res.write(`data: ${JSON.stringify({ type: 'replacement', content: text })}\n\n`);
+            } catch (e) { /* client disconnected */ }
+          }
+        }
+      } catch (err) {
+        console.error('[Verify] Self-contradiction regeneration failed:', err.message);
+        flags.push('self_contradiction_regeneration_failed');
+      }
+    }
+  }
+
   // ── 2e. Math contradiction cross-check ──
   // Catches a subtle but damaging pattern: the AI shows the correct computation
   // (e.g., "24(2) - 12 = 36") but affirms the student's different answer


### PR DESCRIPTION
## Summary
Adds a new defense-in-depth guard to the verification pipeline that detects and regenerates LLM responses that contradict themselves by opening with rejection language ("Close, but not quite!") but later confirming the student was correct ("So you were right!"). This addresses a specific failure mode where neither the deterministic solver nor the LLM verifier returns a high-confidence verdict, leaving the student confused by mixed signals.

## Key Changes
- **New self-contradiction guard in `verify.js`**: Inspects response text for the pattern of opening rejection followed by later confirmation. Uses anchored regex patterns to minimize false positives (e.g., "you were right that we should factor, but...").
  - Detects rejection openers via existing `falseRejectionOpener` regex
  - Confirms contradiction via new `selfContradictionConfirm` regex requiring explicit verdict language with terminal punctuation or strong "I changed my mind" markers ("caught yourself", "actually, you're right")
  - Strips the opening rejection sentence before checking for confirmation to avoid self-matching
  - Triggers LLM regeneration with a `CRITICAL` prompt instructing the model to decide on a single consistent verdict
  - Sets `regeneratedThisPass` flag to prevent cascading regenerations

- **Comprehensive test suite in `tutorValidation.test.js`**: Three test cases covering:
  - Rejection-then-confirmation in same reply triggers regeneration and removes contradictory language
  - Rejection without later confirmation does NOT trigger guard (legitimate rejection is preserved)
  - Clean confirmation (no opening rejection) passes through untouched

## Implementation Details
- Guard runs after false-rejection and LLM verdict checks but before math contradiction cross-check
- Confirmation pattern requires either explicit verdict language (`you were right/correct` with `!` or `.`) or strong markers like `caught yourself` or `actually, you're right`
- Regeneration uses lower temperature (0.4) to encourage consistency
- Flags added: `self_contradiction_detected`, `self_contradiction_regenerated`, `self_contradiction_regeneration_failed`
- Supports streaming responses by writing replacement content to response stream

https://claude.ai/code/session_014WUnx4VkUqD3GdCNaxHPVo