### PR TITLE
fix(voice): default Deepgram to nova-2 + graceful fallback on STT fai…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,8 +68,9 @@ CARTESIA_MODEL=sonic-2
 # at /api/voice-tutor/process still uses Whisper-1 if Deepgram is unset.
 # Get from: https://console.deepgram.com/
 DEEPGRAM_API_KEY=your_deepgram_key
-# Model: 'nova-3' (default), 'nova-2', or 'enhanced'
-DEEPGRAM_MODEL=nova-3
+# Model: 'nova-2' (default, GA on every tier) or 'nova-3' (newer, opt-in
+# per Deepgram project — using nova-3 without it being enabled returns 400)
+DEEPGRAM_MODEL=nova-2
 # LLM model used by the streaming voice pipeline (defaults to gpt-4o-mini)
 # VOICE_LLM_MODEL=gpt-4o-mini
 

--- a/public/js/voice-tutor-session.js
+++ b/public/js/voice-tutor-session.js
@@ -236,9 +236,25 @@
 
       case 'error':
         console.warn('[VoiceTutor] stream error:', ev.message);
-        if (ev.message === 'worklet_load_failed') {
+        // Any fatal-class error: disable streaming and let the legacy
+        // MediaRecorder path take over on the next user action.
+        if (
+          ev.message === 'worklet_load_failed' ||
+          (typeof ev.message === 'string' && ev.message.indexOf('Streaming STT unavailable') === 0)
+        ) {
+          console.warn('[VoiceTutor] disabling streaming pipeline, falling back to legacy path');
           state.useStreamingPipeline = false;
-          state.streamClient = null;
+          if (state.streamClient) {
+            try { state.streamClient.disconnect(); } catch (_) {}
+            state.streamClient = null;
+          }
+          // Reset the orb so the user isn't stuck in "listening"
+          if (state.mode === 'listening' || state.mode === 'thinking' || state.mode === 'speaking') {
+            setMode('idle');
+          }
+          if (typeof showToast === 'function') {
+            showToast('Voice mode falling back to standard quality. Try speaking again.', 4000);
+          }
         }
         break;
     }

--- a/utils/sttStream.js
+++ b/utils/sttStream.js
@@ -1,12 +1,15 @@
 // utils/sttStream.js
-// Deepgram Nova-3 streaming STT wrapper. Hides SDK details so a future
+// Deepgram streaming STT wrapper. Hides SDK details so a future
 // AssemblyAI swap is a single-file change.
 
 const { createClient, LiveTranscriptionEvents } = require('@deepgram/sdk');
 const logger = require('./logger').child({ module: 'sttStream' });
 
 const DEEPGRAM_API_KEY = process.env.DEEPGRAM_API_KEY;
-const MODEL = process.env.DEEPGRAM_MODEL || 'nova-3';
+// nova-2 is GA on every tier; nova-3 is opt-in and newer. Override with
+// DEEPGRAM_MODEL=nova-3 once you've confirmed the model is enabled on
+// your Deepgram project, otherwise the API returns HTTP 400 on connect.
+const MODEL = process.env.DEEPGRAM_MODEL || 'nova-2';
 
 let _client = null;
 function client() {
@@ -64,8 +67,6 @@ function createSession(opts = {}) {
         endpointing,
         utterance_end_ms: utteranceEndMs,
         vad_events: true,
-        // Don't fire UtteranceEnd from short partial fragments
-        no_delay: false,
     });
 
     let opened = false;
@@ -75,7 +76,7 @@ function createSession(opts = {}) {
 
     conn.on(LiveTranscriptionEvents.Open, () => {
         opened = true;
-        logger.debug('Deepgram open');
+        logger.info('Deepgram open', { model: MODEL, language, sampleRate });
     });
 
     conn.on(LiveTranscriptionEvents.Transcript, (data) => {
@@ -101,7 +102,8 @@ function createSession(opts = {}) {
     });
 
     conn.on(LiveTranscriptionEvents.Error, (err) => {
-        logger.warn('Deepgram error', { error: err?.message || String(err) });
+        const detail = err?.message || err?.reason || err?.statusCode || String(err);
+        logger.warn('Deepgram error', { error: detail, model: MODEL });
         onError(err);
     });
 

--- a/utils/voiceSession.js
+++ b/utils/voiceSession.js
@@ -166,7 +166,12 @@ class VoiceSession {
             onFinal: (text) => this._onFinal(text),
             onUtteranceEnd: () => this._onUtteranceEnd(),
             onError: (err) => {
-                this._send({ type: 'stt_error', message: err.message || 'stt error' });
+                const detail = err?.message || err?.reason || String(err);
+                logger.warn('stt error → telling client to fall back', { userId: this.userId, error: detail });
+                // Surface as fatal so the client switches off the streaming
+                // pipeline and re-enables the legacy MediaRecorder path.
+                this._send({ type: 'fatal', message: `Streaming STT unavailable: ${detail}` });
+                this.shutdown('stt_error');
             },
             onClose: () => {
                 logger.debug('stt closed', { userId: this.userId });


### PR DESCRIPTION
…lure

Production hit "Unexpected server response: 400" because nova-3 isn't GA on every Deepgram tier and our default landed on a model the project didn't have enabled. The orb sat in "listening" forever because nothing ever pushed it forward.

- utils/sttStream.js: default DEEPGRAM_MODEL to nova-2 (GA everywhere). Override with DEEPGRAM_MODEL=nova-3 once enabled on the project.
- utils/sttStream.js: log model name + statusCode on Deepgram errors so prod can diagnose without re-deploying.
- utils/voiceSession.js: when Deepgram fails to open, send a fatal event to the client and shut down the session — instead of swallowing the error and leaving the orb stuck.
- public/js/voice-tutor-session.js: on fatal STT failure, disable the streaming pipeline, disconnect the WS, reset the orb to idle, and surface a toast so the next user action falls back to the legacy MediaRecorder + Whisper path.
- .env.example: document the nova-2 default and the nova-3 caveat.

https://claude.ai/code/session_01YCUePSXta4Z7o8mZhj7QHM