### PR TITLE
feat(voice): Phase 2 — chat-page orb on the streaming pipeline

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -2157,6 +2157,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <script src="/js/auto-logout.js"></script>
   <script src="/js/tutor-config-data.js"></script>
   <script src="/js/avatar-config-data.js"></script>
+  <script src="/js/voice-stream-client.js?v=1"></script>
   <script src="/js/voice-controller.js"></script>
   <!-- Intelligent Whiteboard stack (Phase 0 wire-up — order matters: core → enhancements → integration) -->
   <script src="/js/whiteboard.js"></script>

--- a/public/js/voice-controller.js
+++ b/public/js/voice-controller.js
@@ -81,7 +81,134 @@ class VoiceController {
         // Setup event listeners
         this.setupEventListeners();
 
+        // Try the streaming pipeline. Falls back to legacy MediaRecorder
+        // path if browser lacks AudioWorklet/WebSocket or upgrade fails.
+        this.setupStreamingPipeline().catch(err => {
+            console.warn('[Voice] streaming pipeline unavailable, using legacy path:', err?.message);
+        });
+
         console.log('✅ Voice Controller ready');
+    }
+
+    // ============================================
+    // STREAMING PIPELINE (Phase 2 — chat-page orb)
+    // ============================================
+
+    async setupStreamingPipeline() {
+        if (typeof window.VoiceStreamClient !== 'function') return;
+        if (typeof window.AudioWorklet === 'undefined' &&
+            !(window.AudioContext && AudioContext.prototype.audioWorklet)) {
+            return;
+        }
+
+        const client = new window.VoiceStreamClient({
+            wsPath: '/api/voice/stream',
+            on: (ev) => this.handleStreamEvent(ev),
+        });
+
+        try {
+            await client.connect();
+        } catch (err) {
+            console.warn('[Voice] WebSocket connect failed:', err?.message);
+            return;
+        }
+
+        this.streamClient = client;
+        this.useStreamingPipeline = true;
+        console.log('[Voice] streaming pipeline active (chat-page orb)');
+    }
+
+    handleStreamEvent(ev) {
+        switch (ev.type) {
+            case 'ready':
+                break;
+
+            case 'listening_started':
+                this.isListening = true;
+                this.updateUI('listening');
+                break;
+
+            case 'listening_stopped':
+                this.isListening = false;
+                if (!this.isAISpeaking) this.updateUI('idle');
+                break;
+
+            case 'transcript_final':
+                if (ev.text && window.appendMessage) {
+                    window.appendMessage(ev.text, 'user');
+                }
+                break;
+
+            case 'turn_start':
+                this.updateUI('thinking');
+                this._pendingResponseText = '';
+                break;
+
+            case 'response_delta':
+                this._pendingResponseText = (this._pendingResponseText || '') + (ev.text || '');
+                break;
+
+            case 'board_actions':
+                if (this.config.enableBoardCommands && Array.isArray(ev.boardActions)) {
+                    this.executeBoardActions(ev.boardActions);
+                }
+                break;
+
+            case 'response_final':
+                if (ev.text && window.appendMessage) {
+                    window.appendMessage(ev.text, 'ai');
+                }
+                if (this.config.enableBoardCommands && Array.isArray(ev.boardActions) && ev.boardActions.length) {
+                    this.executeBoardActions(ev.boardActions);
+                }
+                this._pendingResponseText = '';
+                break;
+
+            case 'ai_speaking_started':
+                this.isAISpeaking = true;
+                this.updateUI('speaking');
+                break;
+
+            case 'ai_speaking_ended':
+                this.isAISpeaking = false;
+                this.updateUI('idle');
+                break;
+
+            case 'barge_in':
+                // local UI ack — server does the heavy lifting
+                break;
+
+            case 'interrupted':
+                this.isAISpeaking = false;
+                this.updateUI('idle');
+                break;
+
+            case 'turn_end':
+                break;
+
+            case 'disconnected':
+                console.warn('[Voice] stream disconnected — falling back to legacy path');
+                this.useStreamingPipeline = false;
+                this.streamClient = null;
+                this.updateUI('idle');
+                break;
+
+            case 'error':
+                console.warn('[Voice] stream error:', ev.message);
+                if (
+                    ev.message === 'worklet_load_failed' ||
+                    (typeof ev.message === 'string' && ev.message.indexOf('Streaming STT unavailable') === 0)
+                ) {
+                    console.warn('[Voice] disabling streaming pipeline, falling back');
+                    this.useStreamingPipeline = false;
+                    if (this.streamClient) {
+                        try { this.streamClient.disconnect(); } catch (_) {}
+                        this.streamClient = null;
+                    }
+                    if (this.isListening || this.isAISpeaking) this.updateUI('idle');
+                }
+                break;
+        }
     }
 
     // ============================================
@@ -433,6 +560,23 @@ class VoiceController {
 
     async startListening() {
         console.log('🎙️ [Voice] startListening() called');
+
+        // ── Streaming pipeline path (Phase 2) ──
+        if (this.useStreamingPipeline && this.streamClient) {
+            try {
+                // Push current board state so the AI can reference existing objects
+                if (this.whiteboard) {
+                    this.streamClient.setBoardContext(this.getBoardContext());
+                }
+                await this.streamClient.startListening();
+                return;
+            } catch (err) {
+                console.warn('[Voice] stream startListening failed, falling back:', err);
+                this.useStreamingPipeline = false;
+                // fall through to legacy path
+            }
+        }
+
         console.log('🎙️ [Voice] handsFreeMode:', this.handsFreeMode);
         console.log('🎙️ [Voice] silenceThreshold:', this.silenceThreshold, 'ms');
         console.log('🎙️ [Voice] minSpeechDuration:', this.minSpeechDuration, 'ms');
@@ -514,6 +658,12 @@ class VoiceController {
 
     stopListening() {
         if (!this.isListening) return;
+
+        // ── Streaming pipeline path ──
+        if (this.useStreamingPipeline && this.streamClient) {
+            this.streamClient.stopListening();
+            return;
+        }
 
         console.log('🎙️ [Voice] stopListening() called');
         this.isListening = false;
@@ -849,6 +999,14 @@ class VoiceController {
 
     // Stop AI speaking (for interruption)
     stopSpeaking() {
+        // ── Streaming pipeline: barge-in via local VAD or explicit user action ──
+        if (this.useStreamingPipeline && this.streamClient) {
+            this.streamClient._fireBargeIn();
+            this.isAISpeaking = false;
+            this.updateUI('idle');
+            return;
+        }
+
         if (this.currentAudio) {
             console.log('🛑 [Voice] Stopping AI speech (interrupted by user)');
             this.currentAudio.pause();

--- a/public/js/voice-stream-client.js
+++ b/public/js/voice-stream-client.js
@@ -16,7 +16,7 @@
 (function (global) {
     'use strict';
 
-    const WS_PATH = '/api/voice-tutor/stream';
+    const DEFAULT_WS_PATH = '/api/voice-tutor/stream';
     const WORKLET_PATH = '/js/audio/pcm16-worklet.js';
 
     // Local VAD tuning
@@ -28,6 +28,7 @@
     class VoiceStreamClient {
         constructor(opts = {}) {
             this.on = opts.on || (() => {});
+            this.wsPath = opts.wsPath || DEFAULT_WS_PATH;
             this.ws = null;
             this.connected = false;
 
@@ -55,7 +56,7 @@
             if (this.ws && this.ws.readyState <= 1) return;
             // ws scheme matches page scheme
             const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
-            this.ws = new WebSocket(`${proto}//${location.host}${WS_PATH}`);
+            this.ws = new WebSocket(`${proto}//${location.host}${this.wsPath}`);
             this.ws.binaryType = 'arraybuffer';
 
             await new Promise((resolve, reject) => {
@@ -192,6 +193,16 @@
             this._sendJson({ type: 'text_input', text: text.trim() });
         }
 
+        /**
+         * Push current whiteboard state to the server (board-actions mode).
+         * Call before each user turn so the AI can reference existing
+         * objects by id.
+         */
+        setBoardContext(boardContext) {
+            if (!boardContext) return;
+            this._sendJson({ type: 'set_board_context', boardContext });
+        }
+
         _sendJson(obj) {
             if (!this.ws || this.ws.readyState !== 1) return;
             try { this.ws.send(JSON.stringify(obj)); } catch (_) { /* socket dead */ }
@@ -268,11 +279,15 @@
                 case 'math_steps_partial':
                     this.on({ type: 'math_steps', mathSteps: msg.mathSteps });
                     break;
+                case 'board_actions_partial':
+                    this.on({ type: 'board_actions', boardActions: msg.boardActions });
+                    break;
                 case 'response_final':
                     this.on({
                         type: 'response_final',
                         text: msg.text,
                         mathSteps: msg.mathSteps,
+                        boardActions: msg.boardActions,
                     });
                     break;
                 case 'tts_flush':

--- a/routes/voice.js
+++ b/routes/voice.js
@@ -30,7 +30,10 @@ const MIME_TO_EXT = {
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
+const { WebSocketServer } = require('ws');
 const ttsProvider = require('../utils/ttsProvider');
+const sttStream = require('../utils/sttStream');
+const { createVoiceSession } = require('../utils/voiceSession');
 const logger = require('../utils/logger').child({ route: 'voice' });
 
 /**
@@ -441,4 +444,79 @@ function cleanupOldAudioFiles(directory, keepCount = 100) {
 
 // cleanTextForTTS and convertLatexToSpeech are now in utils/mathTTS.js
 
+// ═══════════════════════════════════════
+// WebSocket: /api/voice/stream  (Phase 2 — chat-page orb)
+// Streaming voice pipeline for the chat-page orb. Same orchestrator as
+// /api/voice-tutor/stream but in 'board-actions' mode so the AI emits
+// inline [WRITE:x,y,text] etc. tags that update the whiteboard.
+// Falls back to the legacy /process endpoint above if upgrade fails.
+// ═══════════════════════════════════════
+function attachStreamWebSocket(server, app) {
+    const wss = new WebSocketServer({ noServer: true });
+    const STREAM_PATH = '/api/voice/stream';
+
+    server.on('upgrade', (request, socket, head) => {
+        let pathname;
+        try { pathname = new URL(request.url, 'http://x').pathname; }
+        catch (_) { socket.destroy(); return; }
+        if (pathname !== STREAM_PATH) return;
+
+        if (!sttStream.isConfigured() || !ttsProvider.isConfigured()) {
+            socket.write('HTTP/1.1 503 Service Unavailable\r\n\r\n');
+            socket.destroy();
+            return;
+        }
+
+        const sessionMw = app.locals.sessionMiddleware;
+        const passportInit = app.locals.passportInit;
+        const passportSession = app.locals.passportSession;
+        if (!sessionMw || !passportInit || !passportSession) {
+            logger.error('voice ws upgrade: middleware not registered on app.locals');
+            socket.write('HTTP/1.1 500 Internal Server Error\r\n\r\n');
+            socket.destroy();
+            return;
+        }
+
+        const fakeRes = {
+            writeHead: () => {}, setHeader: () => {}, getHeader: () => undefined,
+            end: () => {}, on: () => {}, once: () => {}, emit: () => {},
+        };
+
+        sessionMw(request, fakeRes, () => {
+            passportInit(request, fakeRes, () => {
+                passportSession(request, fakeRes, () => {
+                    if (!request.user) {
+                        socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+                        socket.destroy();
+                        return;
+                    }
+                    if (isUnder13(request.user)) {
+                        socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
+                        socket.destroy();
+                        return;
+                    }
+                    wss.handleUpgrade(request, socket, head, (ws) => {
+                        wss.emit('connection', ws, request);
+                    });
+                });
+            });
+        });
+    });
+
+    wss.on('connection', async (ws, request) => {
+        const userDoc = await User.findById(request.user._id).lean();
+        if (!userDoc) { ws.close(1008, 'user not found'); return; }
+        try {
+            await createVoiceSession({ ws, user: userDoc, mode: 'board-actions' });
+            logger.info('voice ws session opened (board-actions mode)', { userId: String(userDoc._id) });
+        } catch (err) {
+            logger.error('voice ws session init failed', { error: err.message });
+            try { ws.close(1011, 'init failed'); } catch (_) {}
+        }
+    });
+
+    logger.info('voice ws upgrade handler attached', { path: STREAM_PATH, mode: 'board-actions' });
+}
+
 module.exports = router;
+module.exports.attachStreamWebSocket = attachStreamWebSocket;

--- a/server.js
+++ b/server.js
@@ -42,7 +42,7 @@ const server = app.listen(PORT, () => {
   });
 });
 
-// --- WebSocket: streaming voice tutor ---
+// --- WebSocket: streaming voice (immersive tutor + chat-page orb) ---
 // Attached after listen so the HTTP server is ready to receive upgrades.
 try {
   const voiceTutorRoutes = require('./routes/voiceTutor');
@@ -51,6 +51,14 @@ try {
   }
 } catch (err) {
   logger.error('Failed to attach voice-tutor WebSocket', { error: err.message });
+}
+try {
+  const voiceRoutes = require('./routes/voice');
+  if (typeof voiceRoutes.attachStreamWebSocket === 'function') {
+    voiceRoutes.attachStreamWebSocket(server, app);
+  }
+} catch (err) {
+  logger.error('Failed to attach voice (chat orb) WebSocket', { error: err.message });
 }
 
 // --- Graceful Shutdown ---

--- a/utils/voiceSession.js
+++ b/utils/voiceSession.js
@@ -63,12 +63,51 @@ REMEMBER: never speak math notation. The LaTeX goes in the math tag only.
 Never put system tags or JSON inside the spoken portion.
 `;
 
+// Board-actions voice prompt — used by the chat-page orb. Actions are
+// inline, scattered through the response (a [WRITE:x,y,text] can sit
+// mid-sentence). The orchestrator strips action tags from the TTS stream
+// in real time and forwards them to the client as discrete board events.
+const BOARD_ACTIONS_VOICE_INSTRUCTIONS = `
+
+**STREAMING VOICE MODE — ACTIVE**
+
+You are in a real-time spoken math tutoring session with a shared
+whiteboard. Speak conversationally (1-3 sentences) and use the
+whiteboard for any visual math. Whatever you SAY is heard by the
+student; whatever you WRITE inline as a tag updates the board.
+
+CRITICAL RULES FOR SPOKEN TEXT:
+- Plain English only. No LaTeX delimiters ($, $$, \\(, \\[).
+- "x squared plus 3x" not "$x^2 + 3x$".
+- Warm, conversational, like a tutor sitting next to the student.
+- ONE follow-up question per turn.
+
+BOARD ACTIONS (inline, anywhere in your response):
+- [WRITE:x,y,text]              write text at canvas position (x,y)
+- [CIRCLE:objectId,message]     circle an existing board object
+- [ARROW:fromId,toX,toY,message] draw arrow from a board object
+- [HIGHLIGHT:objectId,color]    highlight an object (color = hex)
+- [CLEAR]                       clear the board
+
+The student does NOT hear these tags — they're stripped before TTS.
+Use [BOARD_REF:objectId] inline to reference an existing object by id
+(this is also stripped from spoken text but kept in the chat transcript).
+
+PEDAGOGY (CRITICAL):
+- Don't show steps the student hasn't worked through yet.
+- Wrong answer: don't add it to the board. Gently guide.
+- Never just give the answer — scaffold with hints and parallel problems.
+
+REMEMBER: speak naturally; let the board do the visual work.
+`;
+
 class VoiceSession {
-    constructor({ ws, user, sessionId }) {
+    constructor({ ws, user, sessionId, mode }) {
         this.ws = ws;
         this.user = user;                       // populated user doc (lean)
         this.userId = String(user._id);
         this.sessionId = sessionId || `${this.userId}-${Date.now()}`;
+        this.mode = mode === 'board-actions' ? 'board-actions' : 'math-steps';
         this.tutorProfile = TUTOR_CONFIG[user.selectedTutorId || 'default'] || TUTOR_CONFIG['default'];
         this.voiceId = ttsProvider.getVoiceId(this.tutorProfile);
         this.langCode = ({
@@ -77,7 +116,8 @@ class VoiceSession {
         })[user.preferredLanguage] || 'en';
 
         this.history = [];        // {role, content} from Mongo + this session
-        this.lastBoardSteps = []; // most recent <math> array, used as fallback
+        this.lastBoardSteps = []; // most recent <math> array (math-steps mode)
+        this.boardContext = null; // current whiteboard state (board-actions mode)
         this.systemPrompt = '';
 
         this.stt = null;
@@ -136,6 +176,13 @@ class VoiceSession {
             case 'text_input':
                 if (typeof msg.text === 'string' && msg.text.trim()) {
                     this._startTurn(msg.text.trim(), { source: 'text' });
+                }
+                break;
+            case 'set_board_context':
+                // board-actions mode: the chat orb sends current whiteboard
+                // state so the AI can reference existing objects by id.
+                if (msg.boardContext && typeof msg.boardContext === 'object') {
+                    this.boardContext = msg.boardContext;
                 }
                 break;
             case 'ping':
@@ -233,9 +280,10 @@ class VoiceSession {
             startedAt: Date.now(),
             status: 'thinking',
             spokenAcc: '',           // accumulating spoken portion forwarded to TTS
-            mathBuffer: '',          // buffered <math>...</math> contents
+            mathBuffer: '',          // buffered <math>...</math> contents (math-steps mode)
             inMathTag: false,
             tagBuffer: '',           // straddle buffer for tag boundaries
+            boardActions: [],        // accumulated [WRITE:...] etc. (board-actions mode)
             tts: null,
             spokenSent: '',          // already-sent-to-TTS spoken text
             tokensEmitted: 0,
@@ -270,8 +318,29 @@ class VoiceSession {
 
     async _driveTurn(turn) {
         // ── Build messages for LLM ──
+        const modeInstructions = this.mode === 'board-actions'
+            ? BOARD_ACTIONS_VOICE_INSTRUCTIONS
+            : STREAMING_VOICE_INSTRUCTIONS;
+
+        let systemContent = this.systemPrompt + modeInstructions;
+
+        // board-actions mode: enrich prompt with current whiteboard state
+        if (this.mode === 'board-actions' && this.boardContext) {
+            const ctx = this.boardContext;
+            let boardPrompt = '\n\n**WHITEBOARD STATE:**\n';
+            if (ctx.semanticObjects && ctx.semanticObjects.length > 0) {
+                boardPrompt += `Mode: ${ctx.mode || 'default'}\nCurrent objects:\n`;
+                for (const obj of ctx.semanticObjects) {
+                    boardPrompt += `- [${obj.id}] ${obj.type}: ${obj.content} (${obj.region || 'main'})\n`;
+                }
+            } else {
+                boardPrompt += 'Board is empty.\n';
+            }
+            systemContent += boardPrompt;
+        }
+
         const messages = [
-            { role: 'system', content: this.systemPrompt + STREAMING_VOICE_INSTRUCTIONS },
+            { role: 'system', content: systemContent },
             ...this.history,
             { role: 'user', content: turn.userMessage },
         ];
@@ -332,7 +401,10 @@ class VoiceSession {
 
         // ── Pipeline verify on assembled spoken text in parallel with TTS draining ──
         let verifiedText = turn.spokenAcc;
-        let mathStepsForBoard = this._parseMathBuffer(turn.mathBuffer);
+        let mathStepsForBoard = this.mode === 'math-steps'
+            ? this._parseMathBuffer(turn.mathBuffer)
+            : [];
+        let boardActionsForFinal = turn.boardActions || [];
 
         try {
             const verified = await pipelineVerify(turn.spokenAcc, {
@@ -354,6 +426,7 @@ class VoiceSession {
                 this._send({ type: 'tts_flush', turnId: turn.metric.turnId });
                 verifiedText = verified.text;
                 mathStepsForBoard = []; // drop board content alongside redirect
+                boardActionsForFinal = []; // drop board actions alongside redirect
                 await this._synthesizeOneShot(turn, verifiedText);
                 turn.metric.abortReason = 'verify_redirect';
             } else if (verified.text) {
@@ -378,15 +451,16 @@ class VoiceSession {
             } catch (_) { /* non-fatal */ }
         }
 
-        // ── Send final response + math ──
+        // ── Send final response + math/board ──
         this._send({
             type: 'response_final',
             turnId: turn.metric.turnId,
             text: verifiedText,
             mathSteps: mathStepsForBoard,
+            boardActions: boardActionsForFinal,
         });
 
-        // Update local state for next turn's pedagogy
+        // Update local state for next turn's pedagogy (math-steps mode only)
         if (mathStepsForBoard.length > 0) this.lastBoardSteps = mathStepsForBoard;
 
         // ── Persist to history (do not block turn_end) ──
@@ -409,13 +483,23 @@ class VoiceSession {
     }
 
     /**
-     * Token processor — splits incoming text on the <math>...</math> boundary.
-     * Spoken portion streams to TTS; math portion buffers for the board.
+     * Token processor — dispatches to the active mode's tag scanner.
+     * Spoken portion streams to TTS; meta portion (math JSON or action
+     * tags) is held back and parsed.
      */
     _processToken(turn, delta) {
-        // Walk char-by-char through delta and route into spoken or math buckets.
-        // We use a small straddle buffer so a tag opener split across deltas
-        // ("<ma" + "th>") doesn't get mistakenly spoken.
+        if (this.mode === 'board-actions') {
+            this._processTokenBoardActions(turn, delta);
+        } else {
+            this._processTokenMathSteps(turn, delta);
+        }
+    }
+
+    /**
+     * Math-steps parser: <math>...</math> at the END of the response.
+     * Forwards everything before <math> directly to TTS.
+     */
+    _processTokenMathSteps(turn, delta) {
         let working = turn.tagBuffer + delta;
         turn.tagBuffer = '';
 
@@ -429,7 +513,6 @@ class VoiceSession {
                 turn.mathBuffer += working.slice(0, closeIdx);
                 working = working.slice(closeIdx + '</math>'.length);
                 turn.inMathTag = false;
-                // Emit math snapshot now (live board update)
                 const steps = this._parseMathBuffer(turn.mathBuffer);
                 if (steps.length) {
                     this._send({
@@ -458,6 +541,115 @@ class VoiceSession {
                 working = working.slice(openIdx + '<math>'.length);
                 turn.inMathTag = true;
             }
+        }
+    }
+
+    /**
+     * Board-actions parser: inline tags like [WRITE:...] [CIRCLE:...] can
+     * appear ANYWHERE in the response. We hold back text from TTS until
+     * we're sure it doesn't start a tag, then flush.
+     */
+    _processTokenBoardActions(turn, delta) {
+        // Accumulate into a sliding buffer. Forward characters to TTS
+        // greedily, but stop at any '[' until we know whether it's a
+        // known action tag (closed by ']').
+        let buf = turn.tagBuffer + delta;
+        turn.tagBuffer = '';
+
+        while (buf.length > 0) {
+            const openIdx = buf.indexOf('[');
+            if (openIdx === -1) {
+                this._forwardSpoken(turn, buf);
+                return;
+            }
+            // Speak everything before the '['
+            if (openIdx > 0) {
+                this._forwardSpoken(turn, buf.slice(0, openIdx));
+                buf = buf.slice(openIdx);
+            }
+            // buf now starts with '['. Look for ']'.
+            const closeIdx = buf.indexOf(']');
+            if (closeIdx === -1) {
+                // Tag still open — defer the rest. Cap at 200 chars to
+                // protect against runaway buffers (an unmatched '[' in
+                // free-form text). If too long, treat as plain text.
+                if (buf.length > 200) {
+                    this._forwardSpoken(turn, buf);
+                    return;
+                }
+                turn.tagBuffer = buf;
+                return;
+            }
+            const candidate = buf.slice(0, closeIdx + 1);
+            buf = buf.slice(closeIdx + 1);
+
+            if (this._isKnownActionTag(candidate)) {
+                const action = this._parseActionTag(candidate);
+                if (action) {
+                    turn.boardActions = turn.boardActions || [];
+                    turn.boardActions.push(action);
+                    this._send({
+                        type: 'board_actions_partial',
+                        turnId: turn.metric.turnId,
+                        boardActions: [action],
+                    });
+                }
+                // Strip the tag from spoken stream (don't speak the bracket text)
+            } else {
+                // Not an action tag — speak it verbatim
+                this._forwardSpoken(turn, candidate);
+            }
+        }
+    }
+
+    _isKnownActionTag(s) {
+        return /^\[(?:WRITE|CIRCLE|ARROW|HIGHLIGHT|CLEAR|BOARD_REF)(?::[^\]]*)?\]$/.test(s);
+    }
+
+    _parseActionTag(s) {
+        // s looks like "[WRITE:100,200,2x+5=10]" — strip brackets, split on first ':'.
+        const inner = s.slice(1, -1);
+        const colonIdx = inner.indexOf(':');
+        const name = colonIdx === -1 ? inner : inner.slice(0, colonIdx);
+        const args = colonIdx === -1 ? '' : inner.slice(colonIdx + 1);
+
+        switch (name) {
+            case 'WRITE': {
+                const m = args.match(/^(\d+),(\d+),(.+)$/s);
+                if (!m) return null;
+                return { type: 'write', x: parseInt(m[1]), y: parseInt(m[2]), text: m[3].trim(), pause: true };
+            }
+            case 'CIRCLE': {
+                const [objectId, ...msg] = args.split(',');
+                if (!objectId) return null;
+                return { type: 'circle', objectId: objectId.trim(), message: msg.join(',').trim() || null };
+            }
+            case 'ARROW': {
+                const m = args.match(/^([^,]+),(\d+),(\d+)(?:,(.+))?$/s);
+                if (!m) return null;
+                return {
+                    type: 'arrow', fromId: m[1].trim(),
+                    toX: parseInt(m[2]), toY: parseInt(m[3]),
+                    message: m[4] ? m[4].trim() : null,
+                };
+            }
+            case 'HIGHLIGHT': {
+                const [objectId, color] = args.split(',');
+                if (!objectId) return null;
+                return {
+                    type: 'highlight', objectId: objectId.trim(),
+                    color: color ? color.trim() : '#fbbf24',
+                    duration: 3000,
+                };
+            }
+            case 'CLEAR':
+                return { type: 'clear' };
+            case 'BOARD_REF':
+                // Inline reference — keep the chat transcript reference but
+                // don't trigger a board action. Return null so we strip it.
+                return null;
+            default:
+                return null;
         }
     }
 
@@ -613,9 +805,19 @@ function hash32(str) {
 /**
  * Factory used by the upgrade handler. Returns a session that's already
  * begun loading user/history. Caller binds ws lifecycle.
+ *
+ * @param {Object} opts
+ * @param {WebSocket} opts.ws
+ * @param {Object} opts.user           - lean user doc
+ * @param {string} [opts.sessionId]
+ * @param {'math-steps'|'board-actions'} [opts.mode='math-steps']
+ *        - 'math-steps' (default): immersive /voice-tutor.html flow.
+ *          AI emits <math>JSON</math> at the end; client renders math board.
+ *        - 'board-actions': chat-page orb. AI emits inline tags like
+ *          [WRITE:x,y,text], [CIRCLE:id], etc. Client executes against whiteboard.
  */
-async function createVoiceSession({ ws, user, sessionId }) {
-    const session = new VoiceSession({ ws, user, sessionId });
+async function createVoiceSession({ ws, user, sessionId, mode }) {
+    const session = new VoiceSession({ ws, user, sessionId, mode });
     await session.init();
     return session;
 }


### PR DESCRIPTION
Migrates the chat-page voice orb (routes/voice.js + public/js/voice-controller.js) onto the same VoiceSession orchestrator that powers /voice-tutor.html. Same sub-300ms TTFA + mid-utterance interrupt, now everywhere a student talks to the tutor.

Server:
- utils/voiceSession.js: parameterized with mode 'math-steps' (default, /voice-tutor) or 'board-actions' (new, chat-page orb).
  - Adds BOARD_ACTIONS_VOICE_INSTRUCTIONS prompt — inline tags like [WRITE:x,y,text], [CIRCLE:id,msg], [ARROW:fromId,toX,toY,msg], [HIGHLIGHT:id,color], [CLEAR], [BOARD_REF:id].
  - Adds streaming inline-tag scanner (_processTokenBoardActions) that strips action tags from the TTS stream as tokens arrive — the student NEVER hears bracket text, but the board updates in real time.
  - Adds set_board_context client message so the orb can push current whiteboard state before each turn (lets AI reference existing objects by id).
- routes/voice.js: attachStreamWebSocket(server, app) at /api/voice/stream. Same auth + 503-fallback pattern as /api/voice-tutor/stream.
- server.js: wires the new upgrade handler after listen.

Client:
- voice-stream-client.js: wsPath option + setBoardContext(). Emits a new 'board_actions' event for partial action streams.
- voice-controller.js: setupStreamingPipeline() at init pointing at /api/voice/stream. handleStreamEvent dispatches transcripts, deltas, board actions, and lifecycle events into the existing orb UI + executeBoardActions(). startListening / stopListening / stopSpeaking delegate to the stream client when active. Legacy MediaRecorder + POST path stays as automatic fallback.
- chat.html: loads voice-stream-client.js before voice-controller.js.

Behavior preserved on the chat orb: spacebar push-to-talk, ESC interrupt, hands-free auto-listen, board-action execution, board context (whiteboard objects by id), under-13 compliance gate, graceful degradation when Deepgram or Cartesia is unconfigured.

https://claude.ai/code/session_01YCUePSXta4Z7o8mZhj7QHM