### PR TITLE
fix(visuals): drop empty [POINTS] commands instead of rendering ghost…

### DIFF
--- a/public/js/inlineChatVisuals.js
+++ b/public/js/inlineChatVisuals.js
@@ -1278,6 +1278,13 @@ class InlineChatVisuals {
             });
         }
 
+        // Don't render an empty default-axis grid when the LLM emitted [POINTS:...]
+        // without actual coordinate data. Returning empty string drops the placeholder
+        // entirely so the user doesn't see ghost widgets.
+        if (points.length === 0) {
+            return '';
+        }
+
         const xMin = params.xMin ?? params.xmin ?? -10;
         const xMax = params.xMax ?? params.xmax ?? 10;
         const yMin = params.yMin ?? params.ymin ?? -10;

--- a/utils/visualCapabilities.js
+++ b/utils/visualCapabilities.js
@@ -80,7 +80,7 @@ INTERACTIVE GRAPHS (live, explorable graphs):
   Example: [SLIDER_GRAPH:fn=m*x+b,params="m:1:-5:5,b:0:-5:5",title="Explore slope"]
   Multiple sliders: [SLIDER_GRAPH:fn=a*x^2+b*x+c,params="a:1:-3:3,b:0:-5:5,c:0:-5:5",title="Explore quadratics"]
   IMPORTANT: Always QUOTE the params value with double quotes when using multiple sliders.
-[POINTS:points=(x1,y1),(x2,y2),connect=bool,title="T"]
+[POINTS:points=(x1,y1),(x2,y2),connect=bool,title="T"] — REQUIRED: include at least one (x,y) pair. Emitting [POINTS] without real coordinates renders nothing.
 
 CALCULUS & ADVANCED GRAPHS (interactive, auto-detect key features):
 [DERIVATIVE_GRAPH:fn=EXPR,xMin=V,xMax=V,title="T"] — overlays f(x) and f′(x) on the same graph with interactive tangent line. Student can hover to see slope at any point. Use when teaching derivatives, power rule, rates of change.


### PR DESCRIPTION
… grids

When the LLM emits [POINTS:...] with no parseable (x,y) coordinates, createPointsPlot was returning a styled empty axis grid (default xMin/xMax of -10..10 with x/y labels). Users saw stacked "Coordinate Points" widgets with no plotted data — visible in a recent transcript where Maya emitted 4 of these as a fallback for a circle-geometry question she couldn't draw.

Now the renderer returns an empty string when no points parse, so the placeholder is silently dropped. System-prompt doc is also tightened to make the (x,y) requirement explicit.