### PR TITLE
feat(orchestrator): real-time segment orchestration layer (v1.1 plan)

### DIFF
--- a/public/js/segmentPlayer.js
+++ b/public/js/segmentPlayer.js
@@ -1,0 +1,317 @@
+// public/js/segmentPlayer.js
+// Client-side player for the segment orchestrator. Consumes NDJSON
+// frames produced by utils/orchestrator/dispatcher.js and drives
+// playback of:
+//   - segment audio (HTMLAudioElement or WebAudio queue)
+//   - board ops (delegated to window.whiteboard / visualTeachingHandler)
+//   - wait state + hint-ladder rungs
+//
+// Speech-leads-pen: board ops for a segment are scheduled to begin
+// SPEECH_LEADS_PEN_MS after audio onset. If audio is no-op'd (whiteboard
+// closed or TTS off), board ops fire immediately on segment-start.
+//
+// On VAD onset (mic energy detected), call .interrupt() — that pauses
+// audio, clears draw timers, and notifies the server. The interrupt
+// path does NOT wait for the server; client is the source of truth for
+// "I started talking just now."
+
+(function () {
+  'use strict';
+
+  const SPEECH_LEADS_PEN_MS = 300;
+
+  /**
+   * @typedef {Object} SegmentPlayerOpts
+   * @property {(frame:Object) => void} sendInterrupt - called with {type, segmentId, atMs, ...}
+   * @property {(latex:Array) => void} [renderMathSteps] - legacy mirror callback (voice tutor)
+   * @property {Object} [whiteboard] - window.whiteboard equivalent (for board-op execution)
+   * @property {(text:string) => void} [onTranscript] - student transcript stream
+   * @property {(payload:{turnId,reason}) => void} [onTurnEnd]
+   * @property {(payload:{message}) => void} [onError]
+   */
+
+  class SegmentPlayer {
+    /** @param {SegmentPlayerOpts} opts */
+    constructor(opts = {}) {
+      this.opts = opts;
+      this.activeSegment = null;     // {id, audio, drawTimers:[], spoken, mode, startedAt}
+      this.pendingBoardOps = [];     // queued during the leads-pen window
+      this.boardOpsByseg = new Map();// segmentId -> [boardOp, ...]
+      this.audioByseg = new Map();   // segmentId -> audioUrl (when sent separately)
+      this.cumulativeMathSteps = []; // legacy mirror (renderMathSteps consumer)
+      this.envelope = null;
+      this.mode = 'idle';            // 'idle' | 'playing' | 'waiting' | 'interrupted' | 'ended'
+    }
+
+    /**
+     * Feed a single NDJSON frame from the server.
+     */
+    handleFrame(frame) {
+      if (!frame || typeof frame !== 'object') return;
+      switch (frame.phase) {
+        // ── Legacy voice-tutor frames (HTTP /process) ──
+        case 'transcription':
+          if (this.opts.onTranscript) this.opts.onTranscript(frame.transcription || '');
+          break;
+        case 'response':
+          // Legacy single-segment response — also paints the math board
+          // immediately like the existing voice-tutor flow.
+          if (Array.isArray(frame.mathSteps) && this.opts.renderMathSteps) {
+            this.opts.renderMathSteps(frame.mathSteps);
+          }
+          break;
+        case 'audio':
+          this._playAudioUrl(frame.audioUrl, null);
+          break;
+
+        // ── Orchestrator frames ──
+        case 'envelope':
+          this.envelope = frame.envelope;
+          // Paint legacy math board IMMEDIATELY using the auto-derived
+          // mirror so the student sees the math while audio loads.
+          if (Array.isArray(frame.envelope?.mathSteps) && this.opts.renderMathSteps) {
+            this.opts.renderMathSteps(frame.envelope.mathSteps);
+            this.cumulativeMathSteps = frame.envelope.mathSteps.slice();
+          }
+          break;
+        case 'segment-start':
+          this._startSegment(frame);
+          break;
+        case 'board-op':
+          this._enqueueBoardOp(frame.segmentId, frame.op);
+          break;
+        case 'segment-audio':
+          this._playAudioUrl(frame.audioUrl, frame.segmentId);
+          break;
+        case 'segment-end':
+          this._endSegment(frame.segmentId);
+          break;
+        case 'wait':
+          this.mode = 'waiting';
+          if (this.opts.onWait) this.opts.onWait(frame);
+          break;
+        case 'wait-rung':
+          if (this.opts.onWaitRung) this.opts.onWaitRung(frame);
+          break;
+        case 'prefetch-hint':
+          // Optional — clients with a TTS warm-pool can use this to start
+          // synthesis early. Default no-op.
+          if (this.opts.onPrefetchHint) this.opts.onPrefetchHint(frame);
+          break;
+        case 'interrupt-ack':
+          // Server confirmed our interrupt. Already paused locally.
+          if (this.opts.onInterruptAck) this.opts.onInterruptAck(frame);
+          break;
+        case 'flushed':
+          if (this.opts.onFlushed) this.opts.onFlushed(frame.segmentIds || []);
+          break;
+        case 'turn-end':
+          this.mode = 'ended';
+          if (this.opts.onTurnEnd) this.opts.onTurnEnd({ turnId: frame.turnId, reason: frame.reason });
+          break;
+        case 'error':
+          if (this.opts.onError) this.opts.onError(frame);
+          break;
+        default:
+          // Unknown — ignore but don't fail
+          break;
+      }
+    }
+
+    _startSegment(frame) {
+      // Tear down any prior segment cleanly
+      if (this.activeSegment) this._teardownActive('superseded');
+      const seg = {
+        id: frame.segmentId,
+        spoken: frame.spoken || '',
+        mode: frame.mode || 'teacher',
+        leadsPenMs: typeof frame.leadsPenMs === 'number' ? frame.leadsPenMs : SPEECH_LEADS_PEN_MS,
+        startedAt: Date.now(),
+        audio: null,
+        drawTimers: [],
+        boardOpsApplied: false,
+      };
+      this.activeSegment = seg;
+      this.boardOpsByseg.set(seg.id, []);
+      this.mode = 'playing';
+      // Apply any board ops already queued for this segment
+      this._maybeApplyBoardOps(seg.id);
+    }
+
+    _enqueueBoardOp(segmentId, op) {
+      if (!segmentId || !op) return;
+      const list = this.boardOpsByseg.get(segmentId) || [];
+      list.push(op);
+      this.boardOpsByseg.set(segmentId, list);
+      this._maybeApplyBoardOps(segmentId);
+    }
+
+    _maybeApplyBoardOps(segmentId) {
+      const seg = this.activeSegment;
+      if (!seg || seg.id !== segmentId) return;
+      const ops = this.boardOpsByseg.get(segmentId) || [];
+      if (!ops.length) return;
+      // Schedule via leads-pen — but if no audio is available for this
+      // segment, fire immediately (e.g. whiteboard-closed mode that still
+      // gets text). The existence of a queued audio URL is what gates it.
+      const delay = seg.audio ? seg.leadsPenMs : 0;
+      const timer = setTimeout(() => {
+        if (!this.activeSegment || this.activeSegment.id !== segmentId) return;
+        this._applyBoardOps(segmentId, ops.slice());
+        // Mark as applied so subsequent ops on this segment fire immediately
+        this.activeSegment.boardOpsApplied = true;
+        // Drain the queue we already snapshotted
+        this.boardOpsByseg.set(segmentId, []);
+      }, delay);
+      seg.drawTimers.push(timer);
+    }
+
+    _applyBoardOps(segmentId, ops) {
+      if (!this.opts.whiteboard && !this.opts.onBoardOp) return;
+      for (const op of ops) {
+        try {
+          if (this.opts.onBoardOp) {
+            this.opts.onBoardOp(segmentId, op);
+            continue;
+          }
+          this._dispatchToWhiteboard(op);
+        } catch (e) {
+          // Single op failure shouldn't abort the segment
+          // eslint-disable-next-line no-console
+          console.warn('[SegmentPlayer] boardOp failed', op, e);
+        }
+      }
+    }
+
+    _dispatchToWhiteboard(op) {
+      const wb = this.opts.whiteboard;
+      if (!wb) return;
+      switch (op.op) {
+        case 'writeStep':
+          // Append to the legacy mirror so the math board updates in step
+          // with audio. Only writeStep ops feed renderMathSteps; other op
+          // types render directly on the whiteboard canvas.
+          if (this.opts.renderMathSteps) {
+            this.cumulativeMathSteps.push({
+              label: op.label, latex: op.latex, explanation: op.explanation,
+            });
+            this.opts.renderMathSteps(this.cumulativeMathSteps.slice());
+          }
+          break;
+        case 'writeText':
+          if (typeof wb.aiWritePartialStep === 'function') {
+            wb.aiWritePartialStep(op.text || '', op.x || 100, op.y || 100, false);
+          }
+          break;
+        case 'highlight':
+          if (typeof wb.highlightObject === 'function') {
+            wb.highlightObject(op.objectId, op.color || '#fbbf24', op.durationMs || 3000);
+          }
+          break;
+        case 'circleWithQuestion':
+          if (typeof wb.aiCircleWithQuestion === 'function') {
+            wb.aiCircleWithQuestion(op.objectId, op.message || '');
+          }
+          break;
+        case 'drawArrowToBlank':
+          if (typeof wb.aiDrawArrowToBlank === 'function') {
+            wb.aiDrawArrowToBlank(op.fromId, op.message || '');
+          }
+          break;
+        case 'moveToRegion':
+          if (typeof wb.moveToRegion === 'function') {
+            wb.moveToRegion(op.objectId, op.region);
+          }
+          break;
+        case 'clear':
+          if (typeof wb.clearBoard === 'function') wb.clearBoard();
+          this.cumulativeMathSteps = [];
+          if (this.opts.renderMathSteps) this.opts.renderMathSteps([]);
+          break;
+        case 'inlineTag':
+          // Defer to existing visualTeachingHandler if available
+          if (window.visualTeachingHandler && typeof window.visualTeachingHandler.handleInlineTag === 'function') {
+            window.visualTeachingHandler.handleInlineTag(op.raw);
+          }
+          break;
+        // graph / algebraTiles / unitCircle / etc. — best handled by the
+        // existing visualTeachingHandler via inlineTag bridge for now.
+        default:
+          break;
+      }
+    }
+
+    _playAudioUrl(url, segmentId) {
+      if (!url) return;
+      const audio = new Audio(url);
+      audio.addEventListener('ended', () => {
+        // If this segment had no segment-end frame (legacy /process path),
+        // synthesize one so cumulative state advances.
+        if (!segmentId) return;
+        this._endSegment(segmentId);
+      });
+      audio.addEventListener('error', () => {
+        if (this.opts.onError) this.opts.onError({ message: 'audio playback error' });
+      });
+      const playPromise = audio.play();
+      if (playPromise && typeof playPromise.catch === 'function') {
+        playPromise.catch(() => { /* autoplay blocked; client handles */ });
+      }
+      if (segmentId && this.activeSegment && this.activeSegment.id === segmentId) {
+        this.activeSegment.audio = audio;
+      } else if (!segmentId) {
+        // Legacy single-segment audio
+        this.activeSegment = this.activeSegment || { id: null, spoken: '', drawTimers: [] };
+        this.activeSegment.audio = audio;
+      }
+    }
+
+    _endSegment(segmentId) {
+      if (!this.activeSegment || this.activeSegment.id !== segmentId) return;
+      this._teardownActive('ended');
+    }
+
+    _teardownActive(reason) {
+      const seg = this.activeSegment;
+      if (!seg) return;
+      try { seg.audio?.pause(); } catch (_) {}
+      for (const t of seg.drawTimers) {
+        try { clearTimeout(t); } catch (_) {}
+      }
+      this.activeSegment = null;
+    }
+
+    /**
+     * Student spoke. Stop audio + draw timers immediately, then notify
+     * the server. Returns the {segmentId, atMs} pair we sent.
+     */
+    interrupt() {
+      const seg = this.activeSegment;
+      const atMs = seg?.audio?.currentTime != null
+        ? Math.round(seg.audio.currentTime * 1000)
+        : (seg ? Date.now() - seg.startedAt : 0);
+      const segmentId = seg?.id || null;
+      this._teardownActive('interrupted');
+      this.mode = 'interrupted';
+      if (typeof this.opts.sendInterrupt === 'function') {
+        try {
+          this.opts.sendInterrupt({
+            type: 'interruptStart',
+            segmentId,
+            atMs,
+            ts: Date.now(),
+          });
+        } catch (_) { /* swallow */ }
+      }
+      return { segmentId, atMs };
+    }
+
+    /** External shutdown — used on page unload / manual stop. */
+    shutdown(reason = 'shutdown') {
+      this._teardownActive(reason);
+      this.mode = 'ended';
+    }
+  }
+
+  window.MMXSegmentPlayer = SegmentPlayer;
+})();

--- a/public/js/voice-tutor-session.js
+++ b/public/js/voice-tutor-session.js
@@ -267,7 +267,16 @@
       return; // Old browser — keep legacy path
     }
 
+    // When the orchestrator flag is on, request the orchestrated server
+    // mode at WS connect time. The server's _driveTurnOrchestrated path
+    // emits the same legacy events (response_final, math_steps,
+    // ai_speaking_started/ended) plus type:'orch' frames; the existing
+    // handleStreamEvent handler covers the legacy ones.
+    const wsPath = state.useOrchestrator
+      ? '/api/voice-tutor/stream?mode=orchestrated'
+      : '/api/voice-tutor/stream';
     const client = new window.VoiceStreamClient({
+      wsPath,
       on: (ev) => handleStreamEvent(ev),
     });
 

--- a/public/js/voice-tutor-session.js
+++ b/public/js/voice-tutor-session.js
@@ -41,6 +41,13 @@
     streamClient: null,
     useStreamingPipeline: false,
     pendingResponseText: '',     // accumulator for response_delta tokens within current turn
+    // Segment orchestrator (opt-in feature flag — ?orchestrator=1 or
+    // localStorage.mmx_orchestrator='1'). Engages only when the WS
+    // streaming pipeline is NOT active; the WS path gets the orchestrator
+    // separately in voiceSession.js.
+    useOrchestrator: false,
+    orchestratorSessionId: null,
+    segmentPlayer: null,
   };
 
   // --- DOM refs ---
@@ -95,6 +102,11 @@
     startSessionTimer();
     addSystemMessage('Voice session started. Tap the mic or just say something.');
 
+    // Orchestrator opt-in (independent of streaming pipeline). Engages
+    // only when WS streaming isn't active — see processVoiceInput for
+    // the precedence rules.
+    setupOrchestratorPlayer();
+
     // Try to set up the streaming pipeline. Falls back to legacy MediaRecorder
     // path if the browser lacks AudioWorklet/WebSocket or if the connection
     // fails. The fallback is the entire pre-existing flow below.
@@ -107,6 +119,140 @@
     const isMobile = /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent) || window.innerWidth <= 768;
     if (state.handsFree && !isMobile) {
       setTimeout(() => startListening(), 1500);
+    }
+  }
+
+  // ═══════════════════════════════════════
+  // SEGMENT ORCHESTRATOR (opt-in)
+  // Drives /process-orchestrated and renders the resulting NDJSON
+  // segment frames via MMXSegmentPlayer. Falls through to legacy if
+  // disabled or if MMXSegmentPlayer didn't load.
+  // ═══════════════════════════════════════
+  function setupOrchestratorPlayer() {
+    if (typeof window.MMXSegmentPlayer !== 'function') return;
+    const flag = (() => {
+      try {
+        const url = new URL(window.location.href);
+        if (url.searchParams.get('orchestrator') === '1') return true;
+        if (window.localStorage?.getItem('mmx_orchestrator') === '1') return true;
+      } catch (_) { /* private mode etc. */ }
+      return false;
+    })();
+    if (!flag) return;
+
+    state.useOrchestrator = true;
+    state.orchestratorSessionId = `vt-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+    state.segmentPlayer = new window.MMXSegmentPlayer({
+      sendInterrupt: postInterrupt,
+      renderMathSteps: state.showVisuals ? renderMathSteps : null,
+      whiteboard: window.whiteboard || null,
+      onTranscript: (t) => { if (t) addMessage(t, 'user'); },
+      onTurnEnd: () => {
+        if (state.handsFree && state.autoListen) startListening();
+        else setMode('idle');
+      },
+      onError: (e) => {
+        console.warn('[VoiceTutor] orchestrator error:', e?.message);
+        setMode('idle');
+      },
+      onWait: (frame) => {
+        // WAIT entered — keep mode='speaking' through hint rungs but
+        // mark the orb so the user knows it's their turn.
+        if (dom.statusText) dom.statusText.textContent = 'Your turn — take your time.';
+      },
+      onWaitRung: (rung) => {
+        // Hint-ladder rung played from the server. Spoken text is
+        // delivered as a fresh segment-start, not here — this handler
+        // is informational for UI-side cues if needed.
+      },
+    });
+    console.log('[VoiceTutor] orchestrator player active', { sessionId: state.orchestratorSessionId });
+  }
+
+  function postInterrupt(payload) {
+    // Wired in the WS commit. For now: HTTP /interrupt with the
+    // sessionId; client doesn't transcribe, so this only fires on
+    // explicit text-mode interrupts. VAD-triggered interrupts during
+    // 'speaking' mode are deferred to the WS path.
+    if (!state.orchestratorSessionId) return;
+    const fetchFn = window.csrfFetch || fetch;
+    fetchFn('/api/voice-tutor/interrupt', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sessionId: state.orchestratorSessionId,
+        studentText: payload.studentText || '',
+        atMs: payload.atMs || 0,
+      }),
+    }).catch(() => { /* best-effort */ });
+  }
+
+  /**
+   * Run a turn through /process-orchestrated. Accepts either an audio
+   * blob (base64 + mimeType) or text. Streams NDJSON frames into the
+   * segment player.
+   */
+  async function processOrchestrated({ audioBase64, mimeType, text }) {
+    if (!state.segmentPlayer) return false;
+    setMode('thinking');
+
+    const fetchFn = window.csrfFetch || fetch;
+    const body = { sessionId: state.orchestratorSessionId };
+    if (audioBase64) { body.audio = audioBase64; body.mimeType = mimeType || 'audio/webm'; }
+    else if (text) { body.text = text; }
+    else return false;
+
+    const res = await fetchFn('/api/voice-tutor/process-orchestrated', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.message || 'Orchestrated processing failed');
+    }
+
+    setMode('speaking');
+    await consumeNDJSON(res, (frame) => state.segmentPlayer.handleFrame(frame));
+    return true;
+  }
+
+  /**
+   * Read an NDJSON streamed response, parsing one JSON object per line.
+   * Tolerates trailing partials between chunks.
+   */
+  async function consumeNDJSON(res, onFrame) {
+    const contentType = res.headers.get('content-type') || '';
+    if (!contentType.includes('application/x-ndjson') || !res.body || typeof res.body.getReader !== 'function') {
+      const txt = await res.text();
+      for (const line of txt.split('\n')) {
+        const t = line.trim();
+        if (!t) continue;
+        try { onFrame(JSON.parse(t)); } catch (_) { /* skip bad line */ }
+      }
+      return;
+    }
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buf = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      let nl;
+      while ((nl = buf.indexOf('\n')) >= 0) {
+        const line = buf.slice(0, nl).trim();
+        buf = buf.slice(nl + 1);
+        if (!line) continue;
+        try { onFrame(JSON.parse(line)); } catch (_) { /* skip */ }
+      }
+    }
+    const tail = buf.trim();
+    if (tail) {
+      try { onFrame(JSON.parse(tail)); } catch (_) { /* skip */ }
     }
   }
 
@@ -685,6 +831,19 @@
     try {
       const base64 = await blobToBase64(audioBlob);
 
+      // Orchestrator path takes precedence over the legacy /process
+      // endpoint when the feature flag is on AND the WS pipeline isn't
+      // active. (WS path will gain its own orchestrator wiring later.)
+      if (state.useOrchestrator && !state.useStreamingPipeline) {
+        try {
+          await processOrchestrated({ audioBase64: base64, mimeType: audioBlob.type || 'audio/webm' });
+          return;
+        } catch (err) {
+          console.warn('[VoiceTutor] orchestrator path failed, falling back:', err?.message);
+          // fall through to legacy /process path
+        }
+      }
+
       const fetchFn = window.csrfFetch || fetch;
       const res = await fetchFn('/api/voice-tutor/process', {
         method: 'POST',
@@ -882,6 +1041,17 @@
 
     addMessage(text, 'user');
     setMode('thinking');
+
+    // Orchestrator path (text input) — same precedence rules as voice.
+    if (state.useOrchestrator) {
+      try {
+        await processOrchestrated({ text });
+        return;
+      } catch (err) {
+        console.warn('[VoiceTutor] orchestrator text path failed, falling back:', err?.message);
+        // fall through to legacy /process-text
+      }
+    }
 
     try {
       const fetchFn = window.csrfFetch || fetch;

--- a/public/voice-tutor.html
+++ b/public/voice-tutor.html
@@ -172,6 +172,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <script src="/js/csrf.js"></script>
   <script src="/js/age-tier-standalone.js"></script>
   <script src="/js/voice-stream-client.js?v=1"></script>
-  <script src="/js/voice-tutor-session.js?v=5"></script>
+  <script src="/js/segmentPlayer.js?v=1"></script>
+  <script src="/js/voice-tutor-session.js?v=6"></script>
 </body>
 </html>

--- a/routes/voiceTutor.js
+++ b/routes/voiceTutor.js
@@ -1007,9 +1007,17 @@ function attachStreamWebSocket(server, app) {
       ws.close(1008, 'user not found');
       return;
     }
+    // Mode is opt-in via ?mode=orchestrated. Defaults preserve the
+    // existing immersive math-steps experience.
+    let requestedMode = 'math-steps';
     try {
-      await createVoiceSession({ ws, user: userDoc, mode: 'math-steps' });
-      logger.info('voice ws session opened', { userId: String(userDoc._id), mode: 'math-steps' });
+      const url = new URL(request.url, `http://${request.headers.host || 'localhost'}`);
+      const m = url.searchParams.get('mode');
+      if (m === 'orchestrated' || m === 'board-actions') requestedMode = m;
+    } catch (_) { /* fall through to default */ }
+    try {
+      await createVoiceSession({ ws, user: userDoc, mode: requestedMode });
+      logger.info('voice ws session opened', { userId: String(userDoc._id), mode: requestedMode });
     } catch (err) {
       logger.error('voice ws session init failed', { error: err.message });
       try { ws.close(1011, 'init failed'); } catch (_) {}

--- a/routes/voiceTutor.js
+++ b/routes/voiceTutor.js
@@ -16,6 +16,8 @@ const { openai } = require('../utils/openaiClient');
 const ttsProvider = require('../utils/ttsProvider');
 const { createVoiceSession } = require('../utils/voiceSession');
 const voiceMetrics = require('../utils/voiceMetrics');
+const orchestrator = require('../utils/orchestrator');
+const { loadOrCreatePlan, resolveCurrentTarget } = require('../utils/tutorPlanManager');
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
@@ -443,6 +445,228 @@ router.post('/process-text', isAuthenticated, async (req, res) => {
   } catch (err) {
     logger.error('Text session error', { userId, error: err.message });
     res.status(500).json({ error: 'Processing failed', message: 'Could not get a response. Please try again.' });
+  }
+});
+
+// ═══════════════════════════════════════
+// POST /api/voice-tutor/process-orchestrated
+// Opt-in orchestrator path. Same input shape as /process — accepts an
+// audio blob (base64) or text, runs the same generateResponse() flow
+// (which already routes through pipelineVerify), then streams the result
+// as orchestrator NDJSON frames instead of the legacy 3-phase ones.
+//
+// Compatible with the legacy /process — clients pick at request time
+// based on a feature flag. The client uses public/js/segmentPlayer.js
+// to consume these frames; renderMathSteps still works because the
+// orchestrator emits the legacy mathSteps mirror in the 'envelope' frame.
+// ═══════════════════════════════════════
+router.post('/process-orchestrated', isAuthenticated, async (req, res) => {
+  const { audio, mimeType, text, sessionId: providedSessionId } = req.body;
+  const userId = req.user._id;
+  const sessionId = providedSessionId || `vt-${userId}-${Date.now()}`;
+
+  if (!audio && !text) {
+    return res.status(400).json({ error: 'audio or text is required' });
+  }
+  if (!ttsProvider.isConfigured()) {
+    return res.status(503).json({ error: 'Voice not configured' });
+  }
+  if (!process.env.OPENAI_API_KEY) {
+    return res.status(503).json({ error: 'Voice not configured' });
+  }
+  if (isUnder13(req.user)) {
+    return res.status(403).json({ error: 'Voice unavailable for your account', useWebSpeech: true });
+  }
+
+  res.setHeader('Content-Type', 'application/x-ndjson');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('X-Accel-Buffering', 'no');
+
+  function send(frame) {
+    res.write(JSON.stringify(frame) + '\n');
+    if (res.flush) res.flush();
+  }
+  const transport = { send, end: () => res.end() };
+
+  try {
+    let userMessage = text ? String(text).trim() : '';
+
+    if (audio) {
+      let audioBuffer;
+      try { audioBuffer = Buffer.from(audio, 'base64'); }
+      catch (e) {
+        send({ phase: 'error', message: 'Invalid audio format' });
+        return res.end();
+      }
+      const tempDir = path.join(__dirname, '../temp');
+      if (!fs.existsSync(tempDir)) fs.mkdirSync(tempDir, { recursive: true });
+      const audioExt = resolveAudioExt(mimeType);
+      const tempPath = path.join(tempDir, `vto_${userId}_${Date.now()}${audioExt}`);
+      fs.writeFileSync(tempPath, audioBuffer);
+      const langMap = {
+        'English': 'en', 'Spanish': 'es', 'Russian': 'ru', 'Chinese': 'zh',
+        'Vietnamese': 'vi', 'Arabic': 'ar', 'Somali': 'so', 'French': 'fr', 'German': 'de'
+      };
+      const transcription = await openai.audio.transcriptions.create({
+        file: fs.createReadStream(tempPath),
+        model: 'whisper-1',
+        language: langMap[req.user.preferredLanguage] || 'en',
+      }).finally(() => {
+        if (fs.existsSync(tempPath)) fs.unlinkSync(tempPath);
+      });
+      userMessage = transcription.text || '';
+      send({ phase: 'transcription', transcription: userMessage });
+    }
+
+    if (!userMessage) {
+      send({ phase: 'error', message: 'empty input' });
+      return res.end();
+    }
+
+    // Resolve current phase + target so phaseEnforcer can apply rules.
+    let expectedPhase = null;
+    let activeTarget = null;
+    try {
+      const plan = await loadOrCreatePlan(userId, { user: req.user });
+      const resolved = await resolveCurrentTarget(plan, { user: req.user });
+      expectedPhase = resolved?.plan?.currentTarget?.instructionPhase || null;
+      activeTarget = resolved?.plan?.currentTarget || null;
+    } catch (e) {
+      logger.warn('orchestrated: tutorplan load failed (non-fatal)', { error: e.message });
+    }
+
+    // Run the existing voice-tutor response generation. This already
+    // routes through pipelineVerify — see generateResponse() above.
+    const { spoken, mathSteps, raw: aiRaw } = await generateResponse(userId, userMessage, req.user);
+
+    // Hand off to orchestrator
+    const dispatcher = new (require('../utils/orchestrator/dispatcher').Dispatcher)({
+      transport,
+      session: orchestrator.sessionStore.getOrCreate(sessionId, userId),
+      user: req.user,
+    });
+
+    const result = await orchestrator.handleTurn(
+      { kind: 'voice', voiceJson: { spoken, mathSteps } },
+      { sessionId, userId: String(userId), expectedPhase, activeTarget },
+      dispatcher,
+    );
+
+    // Persist the assistant turn to history (same shape as /process)
+    saveToHistory(userId, userMessage, aiRaw).catch(err => {
+      logger.warn('orchestrated: persist failed', { error: err.message });
+    });
+
+    // Synthesize TTS for the spoken portion alongside streaming. We send
+    // the audio URL once it's ready; segmentPlayer ties it to the active
+    // segment (single segment in this path, so id matching is automatic).
+    if (!result.paused) {
+      generateTTS(userId, spoken, req.user).then(audioUrl => {
+        if (audioUrl) send({ phase: 'segment-audio', segmentId: null, audioUrl });
+        send({ phase: 'turn-end', turnId: result.turnId });
+        res.end();
+      }).catch(err => {
+        logger.warn('orchestrated: TTS failed', { error: err.message });
+        send({ phase: 'turn-end', turnId: result.turnId });
+        res.end();
+      });
+    } else {
+      // Paused on a WAIT — keep the connection open via the dispatcher's
+      // own frames. (Not implemented for HTTP-NDJSON in this build —
+      // the hint-ladder rungs require a long-lived connection. WS path
+      // is the production target for full WAIT support.)
+      generateTTS(userId, spoken, req.user).then(audioUrl => {
+        if (audioUrl) send({ phase: 'segment-audio', segmentId: null, audioUrl });
+        res.end();
+      }).catch(() => res.end());
+    }
+
+  } catch (err) {
+    logger.error('orchestrated voice session error', { userId, error: err.message, stack: err.stack });
+    send({ phase: 'error', message: 'Something went wrong. Please try again.' });
+    res.end();
+  }
+});
+
+// ═══════════════════════════════════════
+// POST /api/voice-tutor/interrupt
+// Student spoke mid-turn. Body: {sessionId, studentText, atMs?}.
+// The classifier + evaluator decide a tier action; the response streams
+// orchestrator frames for the resolution (fast-path clarification,
+// disambiguator, or {needsPipelinePass:true} hint). Caller (the page's
+// client JS) issues a follow-up /process-orchestrated when needed.
+// ═══════════════════════════════════════
+router.post('/interrupt', isAuthenticated, async (req, res) => {
+  const { sessionId, studentText, atMs } = req.body || {};
+  const userId = req.user._id;
+  if (!sessionId || !studentText) {
+    return res.status(400).json({ error: 'sessionId and studentText required' });
+  }
+
+  res.setHeader('Content-Type', 'application/x-ndjson');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('X-Accel-Buffering', 'no');
+
+  function send(frame) {
+    res.write(JSON.stringify(frame) + '\n');
+    if (res.flush) res.flush();
+  }
+  const transport = { send, end: () => res.end() };
+
+  try {
+    const dispatcher = new (require('../utils/orchestrator/dispatcher').Dispatcher)({
+      transport,
+      session: orchestrator.sessionStore.getOrCreate(sessionId, userId),
+      user: req.user,
+    });
+
+    let expectedPhase = null;
+    try {
+      const plan = await loadOrCreatePlan(userId, { user: req.user });
+      const resolved = await resolveCurrentTarget(plan, { user: req.user });
+      expectedPhase = resolved?.plan?.currentTarget?.instructionPhase || null;
+    } catch (_) { /* non-fatal */ }
+
+    const result = await orchestrator.handleInterrupt(
+      String(studentText),
+      { sessionId, userId: String(userId), expectedPhase, atMs: Number(atMs) || 0 },
+      dispatcher,
+    );
+
+    // Stream the resolution envelope (fast-path or disambiguator) if any
+    if (result.envelope) {
+      const session = orchestrator.sessionStore.getOrCreate(sessionId, userId);
+      // Reuse the dispatcher to stream the new envelope as if it were a
+      // fresh turn. Segment ids are unique so client can distinguish.
+      session.startTurn(result.envelope.turnId);
+      await dispatcher.stream(result.envelope, {});
+      // For fast-path clarification, also synthesize TTS for the spoken
+      // portion. Single segment so segmentId match is implicit.
+      const seg = result.envelope.segments?.[0];
+      if (seg?.spoken) {
+        try {
+          const audioUrl = await generateTTS(userId, seg.spoken, req.user);
+          if (audioUrl) send({ phase: 'segment-audio', segmentId: seg.id, audioUrl });
+        } catch (e) {
+          logger.warn('interrupt: TTS failed', { error: e.message });
+        }
+      }
+    }
+
+    // Tell the caller whether they need to issue a pipeline pass next
+    send({
+      phase: 'interrupt-resolution',
+      resolution: result.resolution,
+      needsPipelinePass: !!result.needsPipelinePass,
+      previousInterruption: result.previousInterruption,
+      nextPhaseHint: result.nextPhaseHint || null,
+    });
+    send({ phase: 'turn-end', turnId: result.previousInterruption?.turnId || null });
+    res.end();
+  } catch (err) {
+    logger.error('interrupt error', { userId, error: err.message, stack: err.stack });
+    send({ phase: 'error', message: 'interrupt processing failed' });
+    res.end();
   }
 });
 

--- a/utils/openaiClient.js
+++ b/utils/openaiClient.js
@@ -91,7 +91,7 @@ async function callLLM(model, messages, options = {}) {
                 ...toolParams,
                 stream: options.stream || false,
                 ...(options.response_format ? { response_format: options.response_format } : {}),
-            })
+            }, options.signal ? { signal: options.signal } : undefined)
         );
         return completion;
     } catch (openAiError) {

--- a/utils/orchestrator/answerEvaluator.js
+++ b/utils/orchestrator/answerEvaluator.js
@@ -1,0 +1,167 @@
+// utils/orchestrator/answerEvaluator.js
+// Quick math-equivalence evaluator for the answer-attempt path. Used in
+// parallel with the interrupt classifier on every STT-final — when the
+// classifier says "answer_attempt" the verdict here decides routing, and
+// when the evaluator has no `expect` it returns 'cannot-evaluate' so the
+// classifier wins.
+//
+// No mathjs in this build — we normalize both sides and compare. That
+// covers the vast majority of K-12 cases (linear equations, simple
+// fractions, integers, decimals). Extend with a CAS later if needed;
+// the API stays the same.
+
+'use strict';
+
+/**
+ * @param {string} studentText            What the student said/typed.
+ * @param {import('./types').ExpectSpec|null} expect
+ * @returns {{verdict:'correct'|'incorrect'|'cannot-evaluate', confidence:number, normalizedStudent?:string, normalizedTarget?:string, reason?:string}}
+ */
+function evaluate(studentText, expect) {
+  if (!expect || !expect.kind) {
+    return { verdict: 'cannot-evaluate', confidence: 0, reason: 'no_expect' };
+  }
+  const text = (studentText || '').trim();
+  if (!text) return { verdict: 'cannot-evaluate', confidence: 0, reason: 'empty_student' };
+
+  switch (expect.kind) {
+    case 'choice':         return evaluateChoice(text, expect);
+    case 'free-text':      return evaluateFreeText(text, expect);
+    case 'math-equiv':     return evaluateMath(text, expect);
+    case 'any':            return { verdict: 'cannot-evaluate', confidence: 0, reason: 'kind_any' };
+    default:               return { verdict: 'cannot-evaluate', confidence: 0, reason: 'unknown_kind' };
+  }
+}
+
+function evaluateChoice(text, expect) {
+  const candidates = [expect.target, ...(expect.acceptable || [])].filter(Boolean);
+  if (!candidates.length) return { verdict: 'cannot-evaluate', confidence: 0, reason: 'no_target' };
+  const norm = text.toLowerCase().replace(/[^a-z0-9]/g, '');
+  for (const c of candidates) {
+    const cnorm = String(c).toLowerCase().replace(/[^a-z0-9]/g, '');
+    if (cnorm && norm === cnorm) {
+      return { verdict: 'correct', confidence: 0.95, normalizedStudent: norm, normalizedTarget: cnorm };
+    }
+  }
+  return { verdict: 'incorrect', confidence: 0.85, normalizedStudent: norm };
+}
+
+function evaluateFreeText(text, expect) {
+  const candidates = [expect.target, ...(expect.acceptable || [])].filter(Boolean);
+  if (!candidates.length) return { verdict: 'cannot-evaluate', confidence: 0, reason: 'no_target' };
+  const norm = text.toLowerCase().replace(/[^a-z0-9 ]/g, ' ').replace(/\s+/g, ' ').trim();
+  for (const c of candidates) {
+    const cnorm = String(c).toLowerCase().replace(/[^a-z0-9 ]/g, ' ').replace(/\s+/g, ' ').trim();
+    if (cnorm && norm === cnorm) {
+      return { verdict: 'correct', confidence: 0.85, normalizedStudent: norm, normalizedTarget: cnorm };
+    }
+    // Substring containment with a length floor — guards against "yes" matching "yes I think 4 is the answer"
+    if (cnorm && cnorm.length >= 3 && norm.includes(cnorm)) {
+      return { verdict: 'correct', confidence: 0.7, normalizedStudent: norm, normalizedTarget: cnorm };
+    }
+  }
+  return { verdict: 'incorrect', confidence: 0.65, normalizedStudent: norm };
+}
+
+function evaluateMath(text, expect) {
+  const candidates = [expect.target, ...(expect.acceptable || [])].filter(Boolean);
+  if (!candidates.length) return { verdict: 'cannot-evaluate', confidence: 0, reason: 'no_target' };
+  const studentNum = extractNumeric(text);
+  for (const c of candidates) {
+    const targetNum = extractNumeric(c);
+    if (studentNum != null && targetNum != null) {
+      const tol = (expect.domain && expect.domain.tolerance) || 1e-6;
+      if (Math.abs(studentNum - targetNum) <= tol) {
+        return {
+          verdict: 'correct', confidence: 0.92,
+          normalizedStudent: String(studentNum),
+          normalizedTarget: String(targetNum),
+        };
+      }
+    }
+    // Symbolic string compare as fallback
+    const sNorm = normalizeMathString(text);
+    const tNorm = normalizeMathString(c);
+    if (sNorm && tNorm && sNorm === tNorm) {
+      return {
+        verdict: 'correct', confidence: 0.85,
+        normalizedStudent: sNorm, normalizedTarget: tNorm,
+      };
+    }
+  }
+  // Could not match — but only call it incorrect if we successfully
+  // extracted SOMETHING from the student. If we got nothing, it's
+  // cannot-evaluate (e.g. student said "I think so").
+  if (studentNum != null || normalizeMathString(text)) {
+    return { verdict: 'incorrect', confidence: 0.75 };
+  }
+  return { verdict: 'cannot-evaluate', confidence: 0, reason: 'no_extraction' };
+}
+
+/**
+ * Extract a single numeric value from natural-language student input.
+ * Handles "x equals 6", "the answer is 6", "6", "six", "negative 3", "1/2",
+ * "0.5". Returns null if nothing parseable found.
+ */
+function extractNumeric(input) {
+  if (input == null) return null;
+  let s = String(input).trim().toLowerCase();
+
+  // Strip equation prefix: "x = 6" → "6", "y equals 12" → "12"
+  s = s.replace(/^.*?(=|equals|is)\s+/i, '');
+
+  // Words → digits for small numbers (covers most K-8 spoken answers)
+  const WORD_TO_NUM = {
+    zero: 0, one: 1, two: 2, three: 3, four: 4, five: 5, six: 6, seven: 7,
+    eight: 8, nine: 9, ten: 10, eleven: 11, twelve: 12, thirteen: 13,
+    fourteen: 14, fifteen: 15, sixteen: 16, seventeen: 17, eighteen: 18,
+    nineteen: 19, twenty: 20, thirty: 30, forty: 40, fifty: 50, sixty: 60,
+    seventy: 70, eighty: 80, ninety: 90, hundred: 100,
+    half: 0.5, third: 1 / 3, quarter: 0.25,
+  };
+  // "negative six" → "-6", "minus six" → "-6"
+  let sign = 1;
+  s = s.replace(/^\s*(negative|minus)\s+/i, () => { sign = -1; return ''; });
+
+  // Direct numeric: "6", "-3.14", "1/2"
+  const fracMatch = s.match(/^\s*(-?\d+)\s*\/\s*(-?\d+)\s*$/);
+  if (fracMatch) {
+    const num = parseFloat(fracMatch[1]);
+    const den = parseFloat(fracMatch[2]);
+    if (den !== 0) return sign * (num / den);
+  }
+  const numMatch = s.match(/-?\d+(?:\.\d+)?/);
+  if (numMatch) return sign * parseFloat(numMatch[0]);
+
+  // Word match
+  const word = s.match(/[a-z]+/);
+  if (word && WORD_TO_NUM[word[0]] != null) return sign * WORD_TO_NUM[word[0]];
+
+  return null;
+}
+
+/**
+ * Loose symbolic normalizer — strips whitespace, LaTeX delimiters, and
+ * common cosmetic differences. NOT a real CAS; equivalent expressions
+ * with different forms (e.g. "2(x+1)" vs "2x+2") will not match.
+ */
+function normalizeMathString(input) {
+  if (input == null) return '';
+  let s = String(input).toLowerCase();
+  // Strip LaTeX delimiters
+  s = s.replace(/\\\(|\\\)|\\\[|\\\]|\$\$|\$/g, '');
+  // Strip LaTeX backslash commands (\\frac → frac, etc.) — keep the word
+  s = s.replace(/\\([a-z]+)/g, '$1');
+  // Strip braces
+  s = s.replace(/[{}]/g, '');
+  // "x equals 6" → "x=6"
+  s = s.replace(/\bequals\b/g, '=');
+  // Spoken operators
+  s = s.replace(/\bplus\b/g, '+').replace(/\bminus\b/g, '-')
+       .replace(/\btimes\b/g, '*').replace(/\bdivided by\b/g, '/');
+  // Whitespace
+  s = s.replace(/\s+/g, '').trim();
+  return s;
+}
+
+module.exports = { evaluate, extractNumeric, normalizeMathString };

--- a/utils/orchestrator/disambiguator.js
+++ b/utils/orchestrator/disambiguator.js
@@ -1,0 +1,76 @@
+// utils/orchestrator/disambiguator.js
+// Context-keyed disambiguator lookup. Used when the interrupt classifier's
+// confidence falls in the 0.55–0.80 band — the soft-pause prompt should
+// reflect WHERE in the lesson the student interrupted, not a flat
+// "what were you thinking there?".
+//
+// Lookup is keyed by (phase, mode, lastBoardOpType). Falls back to a
+// generic phrase if no specific row applies.
+
+'use strict';
+
+const FALLBACK = 'What were you thinking there?';
+
+// Order matters: more specific rows first. Each row's `match` is checked
+// in order; first hit wins.
+const TABLE = [
+  // ── i-do (teacher demonstration) ──
+  { match: { phase: 'i-do', lastOp: 'writeStep' },
+    spoken: "What's catching your eye on this step?" },
+  { match: { phase: 'i-do', lastOp: 'graph' },
+    spoken: 'Something about the picture standing out?' },
+  { match: { phase: 'i-do', lastOp: 'unitCircle' },
+    spoken: 'What part of the circle are you looking at?' },
+  { match: { phase: 'i-do' },
+    spoken: 'Want to pause here, or did something land funny?' },
+
+  // ── concept-intro / vocabulary ──
+  { match: { phase: 'concept-intro' },
+    spoken: 'Is the idea making sense, or is something off?' },
+  { match: { phase: 'vocabulary' },
+    spoken: 'Want me to use that word a different way?' },
+
+  // ── we-do (collaborative) ──
+  { match: { phase: 'we-do', lastOp: 'writeStep' },
+    spoken: 'Working it out, or want me to take that step?' },
+  { match: { phase: 'we-do' },
+    spoken: 'Are you with me, or want to back up a step?' },
+
+  // ── you-do (student turn) ──
+  { match: { phase: 'you-do' },
+    spoken: 'Want a hint, or are you close?' },
+
+  // ── mastery-check ──
+  { match: { phase: 'mastery-check' },
+    spoken: 'Is that your answer, or are you still thinking?' },
+
+  // ── prerequisite-review ──
+  { match: { phase: 'prerequisite-review' },
+    spoken: 'Does this look familiar from before?' },
+];
+
+/**
+ * Pick a disambiguator phrase given orchestrator state.
+ *
+ * @param {Object} ctx
+ * @param {string} [ctx.phase]
+ * @param {string} [ctx.mode]
+ * @param {string} [ctx.lastBoardOpType] - 'writeStep' | 'graph' | 'unitCircle' | etc.
+ * @returns {string}
+ */
+function pickDisambiguator(ctx = {}) {
+  const phase = ctx.phase || null;
+  const mode = ctx.mode || null;
+  const lastOp = ctx.lastBoardOpType || null;
+
+  for (const row of TABLE) {
+    const m = row.match;
+    if (m.phase && m.phase !== phase) continue;
+    if (m.mode && m.mode !== mode) continue;
+    if (m.lastOp && m.lastOp !== lastOp) continue;
+    return row.spoken;
+  }
+  return FALLBACK;
+}
+
+module.exports = { pickDisambiguator, FALLBACK };

--- a/utils/orchestrator/dispatcher.js
+++ b/utils/orchestrator/dispatcher.js
@@ -1,0 +1,206 @@
+// utils/orchestrator/dispatcher.js
+// Streams an OrchestratorEnvelope's segments to the client over NDJSON
+// (HTTP) or a WebSocket. Owns:
+//   - per-segment lifecycle frames
+//   - segment-N+1 TTS prefetch while segment-N plays
+//   - WAIT timer scheduling on segments that carry one
+//   - speech-leads-pen 300ms client offset (advisory metadata only;
+//     actual offset is enforced client-side in segmentPlayer.js)
+//
+// Transport-agnostic: caller passes `{ send(frame), end() }` so this
+// module works behind both /api/voice-tutor/process (NDJSON) and the
+// existing WebSocket path in voiceSession.js.
+//
+// Note on TTS: prefetch is currently ADVISORY in this build — we send a
+// "prefetch" frame to the client, but actual audio synthesis happens via
+// the persistent Cartesia pool that voiceSession already manages. When
+// the orchestrator runs alongside voiceSession (the streaming voice
+// path), it shares that pool. When it runs behind the HTTP /process
+// path (legacy), TTS happens synchronously in the route handler. Both
+// paths emit the same frame shape, so segmentPlayer doesn't care.
+
+'use strict';
+
+const ttsProvider = require('../ttsProvider');
+const waitTimer = require('./waitTimer');
+const logger = require('../logger').child({ module: 'orchestratorDispatcher' });
+
+const SPEECH_LEADS_PEN_MS = 300;
+
+/**
+ * Frame protocol — extends voiceTutor's existing 3-phase NDJSON:
+ *   {phase:'transcription', transcription}
+ *   {phase:'response', response, mathSteps}
+ *   {phase:'audio', audioUrl}
+ * Adds:
+ *   {phase:'envelope', envelope}                  initial envelope (for legacy mathSteps render)
+ *   {phase:'segment-start', segmentId, spoken, mode, expectedDurationMs, leadsPenMs}
+ *   {phase:'board-op', segmentId, op}             one boardOp at a time
+ *   {phase:'segment-audio', segmentId, audioUrl}  audio ready for this segment
+ *   {phase:'wait', segmentId, expect, timeoutMs}
+ *   {phase:'wait-rung', segmentId, kind, spoken}  hint ladder rung firing
+ *   {phase:'segment-end', segmentId}
+ *   {phase:'interrupt-ack', segmentId}
+ *   {phase:'flushed', segmentIds}
+ *   {phase:'turn-end', turnId}
+ *   {phase:'error', message}
+ */
+
+class Dispatcher {
+  /**
+   * @param {Object} args
+   * @param {{send:(frame:Object)=>void, end:()=>void}} args.transport
+   * @param {import('./sessionStore').OrchestratorSession} args.session
+   * @param {Object} [args.user]                  For TTS voice resolution
+   */
+  constructor({ transport, session, user }) {
+    this.transport = transport;
+    this.session = session;
+    this.user = user || null;
+    this._closed = false;
+  }
+
+  send(frame) {
+    if (this._closed) return;
+    try { this.transport.send(frame); }
+    catch (err) { logger.warn('dispatch send failed', { error: err.message }); }
+  }
+
+  end() {
+    if (this._closed) return;
+    this._closed = true;
+    try { this.transport.end(); }
+    catch (_) { /* swallow */ }
+  }
+
+  /**
+   * Stream an envelope. Returns when the queue is drained OR a WAIT was
+   * entered (in which case the caller's interrupt handler will resume).
+   *
+   * @param {import('./types').OrchestratorEnvelope} envelope
+   * @param {Object} [opts]
+   * @param {Function} [opts.onWait] - (segment) => void — fires when a WAIT segment is reached
+   */
+  async stream(envelope, opts = {}) {
+    if (!envelope || !Array.isArray(envelope.segments)) {
+      this.send({ phase: 'error', message: 'invalid envelope' });
+      return;
+    }
+
+    // Initial envelope frame — gives the client the legacy mathSteps mirror
+    // immediately so renderMathSteps() can paint the math board before audio.
+    this.send({
+      phase: 'envelope',
+      envelope: {
+        schemaVersion: envelope.schemaVersion,
+        turnId: envelope.turnId,
+        segments: envelope.segments.map(s => ({
+          id: s.id,
+          mode: s.mode,
+          hasWait: !!s.wait,
+          spokenLength: (s.spoken || '').length,
+        })),
+        mathSteps: envelope.mathSteps || [],
+        spoken: envelope.spoken || '',
+      },
+    });
+
+    this.session.queue = envelope.segments;
+    this.session.queueIndex = -1;
+
+    for (let i = 0; i < envelope.segments.length; i++) {
+      if (this._closed) break;
+      if (this.session.turnAbort?.signal.aborted) break;
+
+      const seg = envelope.segments[i];
+      this.session.queueIndex = i;
+      this.session.activeSegmentId = seg.id;
+
+      // Register a per-segment AbortController scoped to the turn
+      this.session.registerSegmentAbort(seg.id);
+
+      // Pre-fetch hint for the NEXT segment so the client (or the audio
+      // pool) can start synthesis early. Advisory only — see header note.
+      const nextSeg = envelope.segments[i + 1];
+      if (nextSeg) {
+        this.send({ phase: 'prefetch-hint', segmentId: nextSeg.id, spoken: nextSeg.spoken || '' });
+      }
+
+      this.send({
+        phase: 'segment-start',
+        segmentId: seg.id,
+        spoken: seg.spoken || '',
+        mode: seg.mode,
+        leadsPenMs: SPEECH_LEADS_PEN_MS,
+        expectedDurationMs: seg.expectedDurationMs || estimateSpokenDurationMs(seg.spoken),
+      });
+
+      // Stream board ops one at a time so the client can interleave them
+      // with TTS pacing. Order is preserved; the client decides timing
+      // relative to audio onset (300ms speech-leads-pen).
+      for (const op of (seg.boardOps || [])) {
+        if (this._closed) break;
+        this.send({ phase: 'board-op', segmentId: seg.id, op });
+      }
+
+      // If the segment carries a WAIT, schedule the ladder and PAUSE the
+      // outer loop. The orchestrator's interrupt handler will either
+      // resume (next segment) or replan (new envelope).
+      if (seg.wait) {
+        const ladder = waitTimer.resolveLadder(seg, seg.emittedUnderPhase || null);
+        const ctrl = waitTimer.schedule({
+          ladder,
+          onRung: (rung) => this.send({
+            phase: 'wait-rung',
+            segmentId: seg.id,
+            kind: rung.kind,
+            spoken: rung.spoken,
+            boardOps: rung.boardOps || [],
+          }),
+        });
+        this.session.setWaitTimer(ctrl, seg.id);
+
+        this.send({
+          phase: 'wait',
+          segmentId: seg.id,
+          expect: seg.wait.expect || null,
+          timeoutMs: ladder[ladder.length - 1]?.delayMs || 30000,
+        });
+        if (typeof opts.onWait === 'function') {
+          try { opts.onWait(seg); } catch (_) { /* swallow */ }
+        }
+        // Do not advance — caller resumes when student responds.
+        return;
+      }
+
+      this.send({ phase: 'segment-end', segmentId: seg.id });
+    }
+
+    if (!this._closed) {
+      this.send({ phase: 'turn-end', turnId: envelope.turnId });
+    }
+  }
+
+  /** Acknowledge an interrupt to the client. Caller decides what comes after. */
+  ackInterrupt(segmentId) {
+    this.send({ phase: 'interrupt-ack', segmentId });
+  }
+
+  /** Notify the client that segments were flushed (won't be played). */
+  notifyFlushed(segmentIds) {
+    if (!segmentIds?.length) return;
+    this.send({ phase: 'flushed', segmentIds });
+  }
+}
+
+/**
+ * Rough TTS duration estimate. ~150 wpm spoken cadence ≈ 400ms per word.
+ * Used only to schedule prefetch hints; doesn't gate playback.
+ */
+function estimateSpokenDurationMs(spoken) {
+  if (!spoken) return 0;
+  const words = String(spoken).trim().split(/\s+/).length;
+  return words * 400;
+}
+
+module.exports = { Dispatcher, SPEECH_LEADS_PEN_MS, estimateSpokenDurationMs };

--- a/utils/orchestrator/dispatcher.js
+++ b/utils/orchestrator/dispatcher.js
@@ -80,6 +80,10 @@ class Dispatcher {
    * @param {import('./types').OrchestratorEnvelope} envelope
    * @param {Object} [opts]
    * @param {Function} [opts.onWait] - (segment) => void — fires when a WAIT segment is reached
+   * @param {Function} [opts.onSegmentTTS] - async (segment, abortSignal) => void
+   *        Called between board-op dispatch and segment-end. Awaited.
+   *        Used by the WS path to drive per-segment Cartesia synthesis
+   *        through voiceSession's persistent pool.
    */
   async stream(envelope, opts = {}) {
     if (!envelope || !Array.isArray(envelope.segments)) {
@@ -141,6 +145,23 @@ class Dispatcher {
       for (const op of (seg.boardOps || [])) {
         if (this._closed) break;
         this.send({ phase: 'board-op', segmentId: seg.id, op });
+      }
+
+      // Per-segment TTS hook (WS path uses this to drive Cartesia). The
+      // hook owns segment audio lifecycle; dispatcher just awaits it.
+      // Aborts via the segment's AbortController if the turn is killed.
+      if (typeof opts.onSegmentTTS === 'function') {
+        const segAc = this.session.segmentAbort.get(seg.id);
+        try {
+          await opts.onSegmentTTS(seg, segAc?.signal || null);
+        } catch (err) {
+          if (segAc?.signal?.aborted) {
+            // Aborted mid-TTS — emit segment-end so client can clean up
+            this.send({ phase: 'segment-end', segmentId: seg.id, aborted: true });
+            return;
+          }
+          logger.warn('onSegmentTTS error', { error: err.message, segmentId: seg.id });
+        }
       }
 
       // If the segment carries a WAIT, schedule the ladder and PAUSE the

--- a/utils/orchestrator/index.js
+++ b/utils/orchestrator/index.js
@@ -120,9 +120,14 @@ function decidePauseResolution(c, e, phase) {
  * @param {string} [ctx.expectedPhase]         tutorPlan.currentTarget.instructionPhase
  * @param {Object} [ctx.activeTarget]          {prompt, expect, masteryPrompt} for phaseEnforcer rewrites
  * @param {Object} dispatcher                  Built by route handler
+ * @param {Object} [opts]
+ * @param {Function} [opts.onSegmentTTS]       async (segment, abortSignal) => void
+ *        Forwarded to dispatcher.stream(); used by the WS path to drive
+ *        per-segment Cartesia synthesis. HTTP path leaves this null and
+ *        synthesizes audio out-of-band via generateTTS.
  * @returns {Promise<{turnId:string, segmentsPlayed:number, paused:boolean}>}
  */
-async function handleTurn(input, ctx, dispatcher) {
+async function handleTurn(input, ctx, dispatcher, opts = {}) {
   const session = sessionStore.getOrCreate(ctx.sessionId, ctx.userId);
   const turnSignal = session.startTurn(/* turnId set below */);
 
@@ -157,6 +162,7 @@ async function handleTurn(input, ctx, dispatcher) {
   let paused = false;
   await dispatcher.stream(rewritten, {
     onWait: () => { paused = true; },
+    onSegmentTTS: opts.onSegmentTTS,
   });
 
   return {

--- a/utils/orchestrator/index.js
+++ b/utils/orchestrator/index.js
@@ -1,0 +1,398 @@
+// utils/orchestrator/index.js
+// Segment orchestrator entry point.
+//
+// Two public operations:
+//   handleTurn(input, ctx, dispatcher, opts)
+//     - wraps a verified pipeline output (or voice-tutor JSON envelope),
+//       runs segmentation + phase enforcement, streams via dispatcher.
+//
+//   handleInterrupt(studentText, ctx, dispatcher)
+//     - aborts current segment, classifies + evaluates in parallel,
+//       resolves a tier action, returns a descriptor for what the
+//       caller should do next (fast-path response, flush+replan,
+//       or abort-turn).
+//
+// This module never calls runPipeline itself — it consumes verified
+// output and returns "next action" descriptors. That keeps it free of
+// chat.js / voiceTutor.js concerns and lets both surfaces share it.
+
+'use strict';
+
+const segmentationLayer = require('./segmentationLayer');
+const phaseEnforcer = require('./phaseEnforcer');
+const sessionStore = require('./sessionStore');
+const { classify } = require('./interruptClassifier');
+const { evaluate } = require('./answerEvaluator');
+const { pickDisambiguator } = require('./disambiguator');
+const voiceMetrics = require('../voiceMetrics');
+const logger = require('../logger').child({ module: 'orchestrator' });
+
+sessionStore.startSweep();
+
+// ── Tier resolution ─────────────────────────────────────────────────
+// The 3-tier action ladder (pause / flush-queue / abort-turn) keyed by
+// (label, confidence, phase). Mastery-check is a special case — even
+// the "always soft except for control" hard rule has to bend there.
+
+/**
+ * @param {{label:string, confidence:number}} c        Classifier result
+ * @param {{verdict:string, confidence:number}} e      Evaluator result
+ * @param {string|null} phase
+ * @returns {'pause'|'flush-queue'|'abort-turn'}
+ */
+function decideTier(c, e, phase) {
+  if (c.label === 'control') return 'abort-turn';
+
+  if (phase === 'mastery-check' && c.label === 'answer_attempt') {
+    // Mastery items are definitive — answer ends the WAIT, item is
+    // recorded, and we move on regardless of correct/incorrect.
+    return 'flush-queue';
+  }
+
+  if (c.label === 'confusion' && c.confidence >= 0.9) {
+    // High-confidence confusion mid-lesson means the queue is wrong
+    // for this student. Replan instead of pushing more confusing content.
+    return 'flush-queue';
+  }
+
+  return 'pause';
+}
+
+/**
+ * Decide what to do once we're paused. The "soft override" matrix from
+ * v1.1: classifier + evaluator both fire, evaluator wins routing in
+ * the 0.55–0.80 confidence band when expect was present.
+ *
+ * @returns {{action:'fast-path-clarification'|'paused-advance'|'paused-retry'|'paused-disambiguator', spoken?:string}}
+ */
+function decidePauseResolution(c, e, phase) {
+  // Answer attempts during instruction phases: skip-ahead if correct
+  if (c.label === 'answer_attempt') {
+    if (e.verdict === 'correct') {
+      // High classifier conf OR mid-band: evaluator agrees — skip i-do
+      return { action: 'paused-advance' };
+    }
+    if (e.verdict === 'incorrect') {
+      return { action: 'paused-retry' };
+    }
+    // cannot-evaluate
+    if (c.confidence < 0.55) {
+      return {
+        action: 'paused-disambiguator',
+        spoken: pickDisambiguator({ phase }),
+      };
+    }
+    return { action: 'paused-retry' };
+  }
+
+  if (c.label === 'clarification') {
+    return { action: 'fast-path-clarification' };
+  }
+
+  if (c.label === 'confusion') {
+    return { action: 'paused-retry' };
+  }
+
+  if (c.label === 'off_track') {
+    return { action: 'paused-disambiguator',
+      spoken: 'I hear you — want to come back to this in a sec, or pivot now?' };
+  }
+
+  // Below thresholds, fall back to disambiguator
+  return {
+    action: 'paused-disambiguator',
+    spoken: pickDisambiguator({ phase }),
+  };
+}
+
+// ── handleTurn ──────────────────────────────────────────────────────
+
+/**
+ * Stream an already-verified pipeline output to the client.
+ *
+ * @param {Object} input
+ * @param {'voice'|'pipeline'} input.kind
+ * @param {Object} input.verified              When kind='pipeline': verify() return.
+ * @param {Object} input.voiceJson             When kind='voice': {spoken, mathSteps[]}.
+ * @param {Object} ctx
+ * @param {string} ctx.sessionId
+ * @param {string} ctx.userId
+ * @param {string} [ctx.expectedPhase]         tutorPlan.currentTarget.instructionPhase
+ * @param {Object} [ctx.activeTarget]          {prompt, expect, masteryPrompt} for phaseEnforcer rewrites
+ * @param {Object} dispatcher                  Built by route handler
+ * @returns {Promise<{turnId:string, segmentsPlayed:number, paused:boolean}>}
+ */
+async function handleTurn(input, ctx, dispatcher) {
+  const session = sessionStore.getOrCreate(ctx.sessionId, ctx.userId);
+  const turnSignal = session.startTurn(/* turnId set below */);
+
+  let envelope;
+  if (input.kind === 'voice') {
+    envelope = segmentationLayer.fromVoiceTutorJSON(input.voiceJson, {
+      expectedPhase: ctx.expectedPhase,
+      generator: 'voice',
+    });
+  } else if (input.kind === 'pipeline') {
+    envelope = segmentationLayer.fromPipelineVerified(input.verified, {
+      expectedPhase: ctx.expectedPhase,
+      generator: 'chat',
+    });
+  } else {
+    dispatcher.send({ phase: 'error', message: `unknown input kind: ${input.kind}` });
+    return { turnId: null, segmentsPlayed: 0, paused: false };
+  }
+
+  session.currentTurnId = envelope.turnId;
+
+  // Phase enforcement — strip silently, log strip rate.
+  const { envelope: rewritten, strips } = phaseEnforcer.rewrite(envelope, {
+    expectedPhase: ctx.expectedPhase || null,
+    activeTarget: ctx.activeTarget || null,
+  });
+  for (const s of strips) {
+    logger.info('phase_strip', { ...s, sessionId: ctx.sessionId, expectedPhase: ctx.expectedPhase });
+    voiceMetrics.recordPhaseStrip?.(ctx.expectedPhase, s.from, s.to);
+  }
+
+  let paused = false;
+  await dispatcher.stream(rewritten, {
+    onWait: () => { paused = true; },
+  });
+
+  return {
+    turnId: envelope.turnId,
+    segmentsPlayed: paused ? session.queueIndex + 1 : rewritten.segments.length,
+    paused,
+  };
+}
+
+// ── handleInterrupt ─────────────────────────────────────────────────
+
+/**
+ * Process a student utterance that arrived mid-turn. Aborts current
+ * segment audio, classifies, evaluates against any pending expect,
+ * decides a tier action, returns a descriptor.
+ *
+ * The CALLER is responsible for:
+ *   - actually issuing audio.pause() on the client (the client did this
+ *     locally on VAD onset; this method just acknowledges)
+ *   - running a new pipeline pass when result.needsPipelinePass=true,
+ *     passing result.previousInterruption into ctx.previousInterruptions
+ *
+ * @param {string} studentText
+ * @param {Object} ctx
+ * @param {string} ctx.sessionId
+ * @param {string} [ctx.expectedPhase]
+ * @param {string} [ctx.expectedMode]
+ * @param {number} [ctx.atMs]                  playback offset where stopped
+ * @param {Object} dispatcher
+ * @returns {Promise<{
+ *   resolution: 'fast-path'|'paused-advance'|'paused-retry'|'paused-disambiguator'|'flush-queue'|'abort-turn',
+ *   envelope?: import('./types').OrchestratorEnvelope,
+ *   needsPipelinePass?: boolean,
+ *   previousInterruption: import('./types').InterruptionEvent,
+ *   nextPhaseHint?: string
+ * }>}
+ */
+async function handleInterrupt(studentText, ctx, dispatcher) {
+  const session = sessionStore.get(ctx.sessionId);
+  if (!session) {
+    return {
+      resolution: 'abort-turn',
+      previousInterruption: buildEvent({ ctx, studentText, label: 'control', conf: 1, tier: 'abort-turn' }),
+    };
+  }
+
+  // Abort the active segment + clear any wait timer immediately
+  if (session.activeSegmentId) {
+    session.abortSegment(session.activeSegmentId, 'student_interrupt');
+  }
+  session.clearWaitTimer();
+
+  // Tell the client we got it. (Client likely already paused locally.)
+  dispatcher.ackInterrupt(session.activeSegmentId);
+
+  // Pull context for classifier + evaluator
+  const activeSeg = session.queue[session.queueIndex] || null;
+  const lastBoardOpType = pickLastBoardOpType(activeSeg);
+  const pendingExpect = activeSeg?.wait?.expect || null;
+
+  // Run classifier + evaluator in parallel
+  const [c, e] = await Promise.all([
+    classify(studentText, {
+      currentPhase: ctx.expectedPhase,
+      currentMode: ctx.expectedMode,
+      lastSegmentSpoken: activeSeg?.spoken,
+      lastBoardOpType,
+    }).catch(err => {
+      logger.warn('classify failed', { error: err.message });
+      return { label: 'clarification', confidence: 0.4, source: 'fallback', consensus: 'split' };
+    }),
+    Promise.resolve(evaluate(studentText, pendingExpect)),
+  ]);
+
+  voiceMetrics.recordClassifierConsensus?.(c.consensus || 'unanimous');
+
+  const tier = decideTier(c, e, ctx.expectedPhase);
+  const referent = pickReferent(activeSeg, lastBoardOpType);
+
+  const event = buildEvent({
+    ctx, studentText, label: c.label, conf: c.confidence,
+    consensus: c.consensus, tier, referent,
+    pendingExpect, evaluatorVerdict: e.verdict,
+  });
+  session.appendInterruption(event);
+
+  if (tier === 'abort-turn') {
+    session.flushQueue('control');
+    dispatcher.send({ phase: 'turn-end', turnId: session.currentTurnId, reason: 'control' });
+    return {
+      resolution: 'abort-turn',
+      previousInterruption: event,
+    };
+  }
+
+  if (tier === 'flush-queue') {
+    const flushed = session.flushQueue('replan');
+    event.flushedSegmentIds = flushed;
+    dispatcher.notifyFlushed(flushed);
+    return {
+      resolution: 'flush-queue',
+      needsPipelinePass: true,
+      previousInterruption: event,
+    };
+  }
+
+  // tier === 'pause'
+  const resolution = decidePauseResolution(c, e, ctx.expectedPhase);
+
+  if (resolution.action === 'fast-path-clarification') {
+    // Fast path: if the active segment carries an `explanation`, we can
+    // answer locally with a one-segment envelope. Hits the 600ms ack
+    // budget without a pipeline pass.
+    const explanation = pickExplanationFromSegment(activeSeg, lastBoardOpType);
+    if (explanation) {
+      const env = segmentationLayer.buildClarificationSegment({
+        explanation,
+        referentObjectId: referent?.boardObjectId,
+        turnId: session.currentTurnId,
+      });
+      return {
+        resolution: 'fast-path',
+        envelope: env,
+        needsPipelinePass: false,
+        previousInterruption: event,
+      };
+    }
+    // No explanation available — emit a thinking-ack now and signal
+    // caller to run the pipeline for a substantive response.
+    return {
+      resolution: 'paused-disambiguator',
+      envelope: segmentationLayer.buildThinkingAck({ turnId: session.currentTurnId }),
+      needsPipelinePass: true,
+      previousInterruption: event,
+    };
+  }
+
+  if (resolution.action === 'paused-advance') {
+    // Student answered correctly mid-instruction — skip ahead.
+    // Caller will read previousInterruption.evaluatorVerdict='correct'
+    // and pass it to advanceInstructionPhase.
+    return {
+      resolution: 'paused-advance',
+      needsPipelinePass: true,
+      previousInterruption: event,
+      nextPhaseHint: 'advance',
+    };
+  }
+
+  if (resolution.action === 'paused-retry') {
+    return {
+      resolution: 'paused-retry',
+      needsPipelinePass: true,
+      previousInterruption: event,
+    };
+  }
+
+  // paused-disambiguator
+  const env = {
+    schemaVersion: '1.0',
+    turnId: session.currentTurnId,
+    segments: [{
+      id: `seg_disambig_${Date.now().toString(36)}`,
+      spoken: resolution.spoken || pickDisambiguator({ phase: ctx.expectedPhase }),
+      mode: 'teacher',
+      boardOps: [],
+      emittedUnderPhase: ctx.expectedPhase || null,
+      wait: { expect: { kind: 'free-text' }, timeoutMs: 30000 },
+    }],
+    mathSteps: [],
+    spoken: resolution.spoken,
+    meta: { generator: 'voice', pipelineRunId: 'disambiguator' },
+  };
+  return {
+    resolution: 'paused-disambiguator',
+    envelope: env,
+    needsPipelinePass: false,
+    previousInterruption: event,
+  };
+}
+
+// ── helpers ─────────────────────────────────────────────────────────
+
+function buildEvent({ ctx, studentText, label, conf, consensus, tier, referent, pendingExpect, evaluatorVerdict }) {
+  const session = sessionStore.get(ctx.sessionId);
+  const seq = session?.interruptionChain?.length || 0;
+  return {
+    seq,
+    turnId: session?.currentTurnId || null,
+    segmentId: session?.activeSegmentId || null,
+    atMs: ctx.atMs || 0,
+    label,
+    classifierConfidence: conf,
+    classifierConsensus: consensus,
+    studentText,
+    referent: referent || undefined,
+    pendingExpect: pendingExpect || undefined,
+    resolutionTier: tier,
+    flushedSegmentIds: [],
+    evaluatorVerdict: evaluatorVerdict || undefined,
+  };
+}
+
+function pickLastBoardOpType(seg) {
+  if (!seg?.boardOps?.length) return null;
+  const ops = seg.boardOps;
+  return ops[ops.length - 1].op || null;
+}
+
+function pickExplanationFromSegment(seg, lastBoardOpType) {
+  if (!seg?.boardOps?.length) return null;
+  // Prefer the most recent writeStep with explanation
+  for (let i = seg.boardOps.length - 1; i >= 0; i--) {
+    const op = seg.boardOps[i];
+    if (op.op === 'writeStep' && op.explanation) return op.explanation;
+  }
+  return null;
+}
+
+function pickReferent(seg, lastBoardOpType) {
+  if (!seg?.boardOps?.length) return null;
+  for (let i = seg.boardOps.length - 1; i >= 0; i--) {
+    const op = seg.boardOps[i];
+    if (op.id) return { boardObjectId: op.id, latex: op.latex };
+    if (op.op === 'writeStep' && op.latex) return { boardObjectId: null, latex: op.latex };
+  }
+  return null;
+}
+
+module.exports = {
+  handleTurn,
+  handleInterrupt,
+  decideTier,
+  decidePauseResolution,
+  // Re-exports for testing / advanced wiring
+  segmentationLayer,
+  phaseEnforcer,
+  sessionStore,
+};

--- a/utils/orchestrator/interruptClassifier.js
+++ b/utils/orchestrator/interruptClassifier.js
@@ -1,0 +1,230 @@
+// utils/orchestrator/interruptClassifier.js
+// Two-stage interrupt classifier: regex fast-path → gpt-4o-mini majority.
+//
+// The 0.80 / 0.55 thresholds in the brief are policy numbers, not real
+// probabilities. gpt-4o-mini's self-reported confidence in a JSON field
+// is poorly calibrated and reliably overconfident on short student
+// utterances. So: when the LLM's self-confidence falls below 0.95, we
+// run the call three times in parallel and take the majority. Ties
+// resolve toward the lower-action label (LABEL_PRIORITY in types.js).
+//
+// All three votes share one prompt and one model — they're cheap (input
+// is ~150 tokens, output is one JSON object). Three votes ≈ one round-
+// trip when batched.
+
+'use strict';
+
+const { callLLM } = require('../openaiClient');
+const { LABEL_PRIORITY, INTERRUPT_LABELS } = require('./types');
+const logger = require('../logger').child({ module: 'interruptClassifier' });
+
+const MODEL = process.env.INTERRUPT_CLASSIFIER_MODEL || 'gpt-4o-mini';
+const HIGH_CONF_BYPASS = 0.95;
+const NUM_VOTES = 3;
+
+// ── Regex fast-path ─────────────────────────────────────────────────
+// Order matters — first match wins. Patterns are tuned for short student
+// utterances; longer ambiguous text falls through to the LLM.
+
+const REGEX_RULES = [
+  // control — explicit stop/cancel/restart
+  { label: 'control', conf: 0.95,
+    pattern: /^\s*(stop|wait stop|cancel|never\s*mind|nevermind|skip this|let'?s? move on|forget it|hold on stop)\s*[.!?]?\s*$/i },
+
+  // clarification — "wait why", "but why", "what do you mean", "i don't get"
+  { label: 'clarification', conf: 0.92,
+    pattern: /\b(wait\s+why|why\s+(did|do|are|does|is)|but\s+why|what\s+do\s+you\s+mean|how\s+come|what'?s?\s+that|how\s+did\s+you|where\s+did\s+(that|the))\b/i },
+
+  // confusion — "i don't get it", "i'm lost", "i don't understand"
+  { label: 'confusion', conf: 0.9,
+    pattern: /\b(i\s+(don'?t|do not)\s+(get|understand|follow)|i'?m\s+(lost|confused|stuck)|this\s+is\s+confusing|i\s+don'?t\s+know\s+what)\b/i },
+
+  // answer_attempt — "is it X", "the answer is", "x equals/is N", bare number
+  { label: 'answer_attempt', conf: 0.85,
+    pattern: /^\s*(is\s+it|the\s+answer\s+is|i\s+think\s+(it'?s|its)|so\s+it'?s|its?\s+|x\s*(=|equals|is)\s|y\s*(=|equals|is)\s)/i },
+  { label: 'answer_attempt', conf: 0.7,
+    // Bare number with optional sign — only fires when student utterance
+    // is short (<= 6 words) to avoid matching "we add 5 to both sides"
+    pattern: /^[\s\-]*(?:negative\s+|minus\s+)?\d+(?:\s*\/\s*\d+|\.\d+)?\s*[.!?]?\s*$/i },
+
+  // off_track — "can we talk about", "what about my homework", topic switch markers
+  { label: 'off_track', conf: 0.85,
+    pattern: /\b(can\s+we\s+talk\s+about|what\s+about\s+(my|the)\s+(homework|test|quiz)|change\s+(the\s+)?subject|different\s+problem)\b/i },
+];
+
+function classifyRegex(text) {
+  if (!text || typeof text !== 'string') return null;
+  const t = text.trim();
+  if (!t) return null;
+  // Word-count gate for the bare-number rule: refuse to match if the
+  // utterance has more than 6 words (prevents "now we add 5 to both sides"
+  // → answer_attempt).
+  const wordCount = t.split(/\s+/).length;
+  for (const rule of REGEX_RULES) {
+    if (rule.pattern.test(t)) {
+      if (rule.label === 'answer_attempt' && rule.conf === 0.7 && wordCount > 6) continue;
+      return {
+        label: rule.label,
+        confidence: rule.conf,
+        source: 'regex',
+        reasoning: `regex rule: ${rule.pattern.source}`,
+      };
+    }
+  }
+  return null;
+}
+
+// ── LLM path ────────────────────────────────────────────────────────
+
+const SYSTEM_PROMPT = `You are an interrupt classifier for a tutoring system. The student
+interrupted the AI tutor mid-explanation. Classify the student's utterance
+into exactly one label:
+
+- clarification: asking why/how the tutor did something
+- answer_attempt: trying to give an answer to the current problem
+- confusion: signaling they're lost / don't understand
+- off_track: changing the subject / asking about something else
+- control: stop / cancel / move on / restart
+
+Respond with ONLY a JSON object:
+{"label": "<label>", "confidence": <0.0-1.0>, "ambiguity": "<low|medium|high>", "reasoning": "<one short sentence>"}
+
+Confidence reflects how unambiguous the label is. Use ambiguity=high if the
+utterance could plausibly be two of the labels.`;
+
+async function classifyLLMOnce(studentText, ctx, signal) {
+  const userMsg = buildUserMessage(studentText, ctx);
+  const completion = await callLLM(MODEL, [
+    { role: 'system', content: SYSTEM_PROMPT },
+    { role: 'user', content: userMsg },
+  ], {
+    temperature: 0.1,
+    max_tokens: 120,
+    response_format: { type: 'json_object' },
+    signal,
+  });
+  const raw = completion?.choices?.[0]?.message?.content || '{}';
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (_) {
+    return null;
+  }
+  if (!parsed.label || !INTERRUPT_LABELS.includes(parsed.label)) return null;
+  return {
+    label: parsed.label,
+    confidence: typeof parsed.confidence === 'number'
+      ? Math.max(0, Math.min(1, parsed.confidence))
+      : 0.5,
+    ambiguity: parsed.ambiguity || 'medium',
+    reasoning: parsed.reasoning || '',
+    source: 'llm',
+  };
+}
+
+function buildUserMessage(studentText, ctx) {
+  const parts = [];
+  if (ctx?.currentPhase) parts.push(`Phase: ${ctx.currentPhase}`);
+  if (ctx?.currentMode) parts.push(`Mode: ${ctx.currentMode}`);
+  if (ctx?.lastSegmentSpoken) {
+    const t = String(ctx.lastSegmentSpoken).slice(0, 200);
+    parts.push(`AI was just saying: "${t}"`);
+  }
+  if (ctx?.lastBoardOpType) parts.push(`Last board action: ${ctx.lastBoardOpType}`);
+  parts.push(`Student said: "${studentText}"`);
+  return parts.join('\n');
+}
+
+/**
+ * Three-vote majority. Takes ties toward the lower-action label per
+ * LABEL_PRIORITY (clarification < answer_attempt < confusion < off_track
+ * < control). This keeps an ambiguous interrupt from auto-escalating
+ * into a turn-aborting `control`.
+ *
+ * @param {Array<{label:string, confidence:number}>} votes
+ * @returns {{label:string, confidence:number, consensus:'unanimous'|'majority'|'split'}}
+ */
+function resolveVotes(votes) {
+  const counts = {};
+  for (const v of votes) {
+    if (!v) continue;
+    counts[v.label] = (counts[v.label] || 0) + 1;
+  }
+  const labels = Object.keys(counts);
+  if (labels.length === 0) {
+    return { label: 'clarification', confidence: 0.4, consensus: 'split' };
+  }
+  // Highest-count wins. Tiebreak by LABEL_PRIORITY index (lower = preferred).
+  labels.sort((a, b) => {
+    if (counts[b] !== counts[a]) return counts[b] - counts[a];
+    return LABEL_PRIORITY.indexOf(a) - LABEL_PRIORITY.indexOf(b);
+  });
+  const winner = labels[0];
+  const winnerCount = counts[winner];
+  const totalVotes = votes.filter(Boolean).length;
+  const consensus = winnerCount === totalVotes ? 'unanimous'
+    : winnerCount > totalVotes / 2 ? 'majority' : 'split';
+  // Confidence = average self-confidence among the winning votes
+  const winnerConfs = votes.filter(v => v && v.label === winner).map(v => v.confidence);
+  const avgConf = winnerConfs.reduce((a, b) => a + b, 0) / Math.max(winnerConfs.length, 1);
+  return {
+    label: winner,
+    confidence: avgConf,
+    consensus,
+  };
+}
+
+/**
+ * Classify a student interrupt. Tries regex first, then LLM.
+ *
+ * @param {string} studentText
+ * @param {Object} ctx                          Orchestrator context.
+ * @param {string} [ctx.currentPhase]
+ * @param {string} [ctx.currentMode]
+ * @param {string} [ctx.lastSegmentSpoken]
+ * @param {string} [ctx.lastBoardOpType]
+ * @param {AbortSignal} [ctx.signal]
+ * @returns {Promise<{label:string, confidence:number, source:'regex'|'llm', consensus?:string, reasoning?:string}>}
+ */
+async function classify(studentText, ctx = {}) {
+  const fast = classifyRegex(studentText);
+  if (fast) return fast;
+
+  // First LLM call — single shot
+  let primary;
+  try {
+    primary = await classifyLLMOnce(studentText, ctx, ctx.signal);
+  } catch (err) {
+    if (ctx.signal?.aborted) throw err;
+    logger.warn('interrupt classify llm error', { error: err.message });
+    return { label: 'clarification', confidence: 0.4, source: 'llm_fallback', consensus: 'split' };
+  }
+  if (!primary) {
+    return { label: 'clarification', confidence: 0.4, source: 'llm_fallback', consensus: 'split' };
+  }
+  if (primary.confidence >= HIGH_CONF_BYPASS) {
+    return { ...primary, consensus: 'unanimous' };
+  }
+
+  // Sub-confident — kick off two more votes in parallel and resolve
+  const [v2, v3] = await Promise.all([
+    classifyLLMOnce(studentText, ctx, ctx.signal).catch(() => null),
+    classifyLLMOnce(studentText, ctx, ctx.signal).catch(() => null),
+  ]);
+  const resolved = resolveVotes([primary, v2, v3]);
+  return {
+    label: resolved.label,
+    confidence: resolved.confidence,
+    consensus: resolved.consensus,
+    source: 'llm',
+    reasoning: primary.reasoning,
+    voteBreakdown: { primary: primary.label, v2: v2?.label || null, v3: v3?.label || null },
+  };
+}
+
+module.exports = {
+  classify,
+  classifyRegex,
+  resolveVotes,
+  HIGH_CONF_BYPASS,
+};

--- a/utils/orchestrator/phaseEnforcer.js
+++ b/utils/orchestrator/phaseEnforcer.js
@@ -1,0 +1,155 @@
+// utils/orchestrator/phaseEnforcer.js
+// Deterministic struct rewriter that enforces phase semantics on the
+// segmented pipeline output. NO re-prompt loop — if the model emits an
+// "i-do" segment during "we-do", we strip silently rather than blow the
+// latency budget retrying. The strip rate is exposed as a metric; if
+// any phase exceeds 5%, the fix lives in promptPlanLayer.js, not here.
+
+'use strict';
+
+const PRODUCTIVE_OPS = new Set([
+  'writeStep', 'graph', 'algebraTiles', 'unitCircle', 'writeText',
+]);
+
+/**
+ * Classify a segment's "style" by looking at its boardOps + wait shape.
+ */
+function classifySegmentStyle(seg) {
+  const productiveOpCount = (seg.boardOps || [])
+    .filter(op => PRODUCTIVE_OPS.has(op.op)).length;
+  const hasWait = !!seg.wait;
+  const hasExpect = hasWait && !!seg.wait.expect;
+
+  return {
+    productiveOpCount,
+    hasWait,
+    hasExpect,
+    isIDoStyle: productiveOpCount >= 2 && !hasWait && seg.mode === 'teacher',
+    isWeDoStyle: productiveOpCount >= 1 && hasWait,
+    isYouDoStyle: productiveOpCount === 0 && hasWait && hasExpect,
+  };
+}
+
+/**
+ * Strip the segment back to a "what comes next" prompt. Keeps the first
+ * productive op so the student still has visual anchor.
+ */
+function rewriteToWeDoPrompt(seg) {
+  const ops = seg.boardOps || [];
+  const firstProductiveIdx = ops.findIndex(op => PRODUCTIVE_OPS.has(op.op));
+  const kept = firstProductiveIdx >= 0 ? ops.slice(0, firstProductiveIdx + 1) : [];
+  const trimmedSpoken = trimAfterFirstSentence(seg.spoken);
+  return {
+    ...seg,
+    boardOps: kept,
+    spoken: trimmedSpoken
+      ? `${trimmedSpoken} What should we do next?`
+      : 'What should we do next?',
+    wait: { expect: { kind: 'free-text' }, timeoutMs: 30000 },
+  };
+}
+
+function rewriteToYouDoPrompt(seg, target) {
+  const prompt = target?.prompt || 'Your turn — try the next step.';
+  return {
+    ...seg,
+    boardOps: [],
+    spoken: prompt,
+    wait: {
+      expect: target?.expect || { kind: 'any' },
+      timeoutMs: 30000,
+    },
+  };
+}
+
+function rewriteToMasteryItem(seg, target) {
+  const prompt = target?.masteryPrompt || target?.prompt || 'Show me the answer.';
+  return {
+    ...seg,
+    boardOps: [],
+    spoken: prompt,
+    wait: {
+      expect: target?.expect || { kind: 'any' },
+      timeoutMs: 30000,
+      // Mastery-check has no hint ladder — hints defeat the assessment.
+      // Caller-side wait timer applies the mastery override.
+    },
+  };
+}
+
+function trimAfterFirstSentence(spoken) {
+  if (!spoken) return '';
+  const m = String(spoken).match(/^([^.!?]*[.!?])/);
+  return m ? m[1].trim() : String(spoken).trim();
+}
+
+/**
+ * Apply phase rules to every segment in an envelope. Mutates a shallow
+ * copy and returns it; original envelope is preserved. Records strip
+ * events in `_phaseStrips` for telemetry.
+ *
+ * @param {import('./types').OrchestratorEnvelope} envelope
+ * @param {Object} ctx
+ * @param {string} ctx.expectedPhase            From tutorPlan.currentTarget.instructionPhase
+ * @param {Object} [ctx.activeTarget]           {prompt, expect, masteryPrompt}
+ * @returns {{envelope: import('./types').OrchestratorEnvelope, strips: Array<{segmentId:string, from:string, to:string}>}}
+ */
+function rewrite(envelope, ctx = {}) {
+  const expectedPhase = ctx.expectedPhase || null;
+  const target = ctx.activeTarget || null;
+  const strips = [];
+
+  if (!expectedPhase) {
+    // No active phase — pass through. This also covers GUIDE/STRENGTHEN/
+    // LEVERAGE modes where instructionPhase is null.
+    return { envelope, strips };
+  }
+
+  const segments = (envelope.segments || []).map((seg) => {
+    seg.emittedUnderPhase = expectedPhase;
+    const style = classifySegmentStyle(seg);
+
+    switch (expectedPhase) {
+      case 'prerequisite-review':
+      case 'vocabulary':
+      case 'concept-intro':
+      case 'i-do':
+        return seg;
+
+      case 'we-do':
+        if (style.isIDoStyle) {
+          strips.push({ segmentId: seg.id, from: 'i-do', to: 'we-do' });
+          return rewriteToWeDoPrompt(seg);
+        }
+        return seg;
+
+      case 'you-do':
+        if (style.isIDoStyle || style.isWeDoStyle) {
+          strips.push({
+            segmentId: seg.id,
+            from: style.isIDoStyle ? 'i-do' : 'we-do',
+            to: 'you-do',
+          });
+          return rewriteToYouDoPrompt(seg, target);
+        }
+        return seg;
+
+      case 'mastery-check':
+        if (!style.hasExpect) {
+          strips.push({ segmentId: seg.id, from: 'instructive', to: 'mastery' });
+          return rewriteToMasteryItem(seg, target);
+        }
+        return seg;
+
+      default:
+        return seg;
+    }
+  });
+
+  return {
+    envelope: { ...envelope, segments },
+    strips,
+  };
+}
+
+module.exports = { rewrite, classifySegmentStyle };

--- a/utils/orchestrator/segmentationLayer.js
+++ b/utils/orchestrator/segmentationLayer.js
@@ -1,0 +1,262 @@
+// utils/orchestrator/segmentationLayer.js
+// Converts pipeline / voice-tutor verified output into the orchestrator
+// envelope shape. Two input flavors:
+//
+//   1. Voice tutor JSON  — already-structured {spoken, mathSteps[]} from
+//      routes/voiceTutor.js. Becomes one segment per "natural break"
+//      (sentence boundary or step boundary, whichever is coarser).
+//
+//   2. Pipeline verify output — text + visualCommands.{whiteboard,
+//      algebraTiles, ...}[]. Each visualCommand item becomes a boardOp;
+//      legacy inline tags survive as op:'inlineTag' so the existing
+//      visualTeachingHandler.js client code keeps working unchanged.
+//      (See plan §4 — bridge decision.)
+//
+// Backward compat: top-level `mathSteps` and `spoken` are auto-derived
+// from segments[] so renderMathSteps() in voice-tutor-session.js gets
+// the same shape it expects today.
+
+'use strict';
+
+const { v4: uuidv4 } = require('uuid');
+const logger = require('../logger').child({ module: 'segmentationLayer' });
+
+const SCHEMA_VERSION = '1.0';
+
+function newTurnId() { return `turn_${uuidv4().slice(0, 12)}`; }
+function newSegmentId() { return `seg_${uuidv4().slice(0, 12)}`; }
+
+// ── Input variant 1: voice tutor JSON envelope ──────────────────────
+
+/**
+ * Convert {spoken, mathSteps[]} to an OrchestratorEnvelope.
+ *
+ * Heuristic: split spoken into sentences; pair sentences with mathSteps
+ * by index when counts roughly align, otherwise fold all steps into the
+ * first segment. The voice tutor today emits 1-2 sentences and 1-3 steps
+ * per turn so most calls produce 1 segment.
+ *
+ * @param {Object} voiceOutput
+ * @param {string} voiceOutput.spoken
+ * @param {Array<{label?:string, latex:string, explanation?:string}>} [voiceOutput.mathSteps]
+ * @param {Object} [opts]
+ * @param {string} [opts.expectedPhase]
+ * @param {string} [opts.mode='teacher']
+ * @param {string} [opts.generator='voice']
+ * @param {string} [opts.pipelineRunId]
+ * @returns {import('./types').OrchestratorEnvelope}
+ */
+function fromVoiceTutorJSON(voiceOutput, opts = {}) {
+  const spoken = (voiceOutput?.spoken || '').trim();
+  const steps = Array.isArray(voiceOutput?.mathSteps) ? voiceOutput.mathSteps : [];
+  const turnId = opts.turnId || newTurnId();
+
+  // Always produce exactly one segment for now. Mid-turn splitting is a
+  // v1.1 optimization that doesn't change correctness — the client plays
+  // segments back-to-back either way.
+  const segment = {
+    id: newSegmentId(),
+    spoken,
+    mode: opts.mode || 'teacher',
+    boardOps: steps
+      .filter(s => s && s.latex)
+      .map(s => ({
+        op: 'writeStep',
+        label: s.label || undefined,
+        latex: s.latex,
+        explanation: s.explanation || undefined,
+      })),
+    emittedUnderPhase: opts.expectedPhase || null,
+  };
+
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    turnId,
+    segments: [segment],
+    mathSteps: deriveLegacyMathSteps([segment]),
+    spoken: deriveLegacySpoken([segment]),
+    meta: {
+      generator: opts.generator || 'voice',
+      pipelineRunId: opts.pipelineRunId || turnId,
+    },
+  };
+}
+
+// ── Input variant 2: pipeline verify output ─────────────────────────
+
+/**
+ * Convert pipeline verify() result into an OrchestratorEnvelope. The
+ * inline-tag bridge (§4 of plan): unrecognized command shapes pass
+ * through as op:'inlineTag' so the client's existing visualTeachingHandler
+ * can still consume them.
+ *
+ * @param {Object} verified                    Output of pipeline verify()
+ * @param {string} verified.text
+ * @param {Object} [verified.visualCommands]   {whiteboard:[], algebraTiles:[], ...}
+ * @param {Object} [opts]
+ * @returns {import('./types').OrchestratorEnvelope}
+ */
+function fromPipelineVerified(verified, opts = {}) {
+  const text = (verified?.text || '').trim();
+  const turnId = opts.turnId || newTurnId();
+
+  const boardOps = [];
+
+  const vc = verified?.visualCommands || {};
+
+  for (const wb of (vc.whiteboard || [])) {
+    boardOps.push(mapWhiteboardCommandToBoardOp(wb));
+  }
+  for (const at of (vc.algebraTiles || [])) {
+    boardOps.push({ op: 'algebraTiles', expr: at.expr || at.expression || '' });
+  }
+  // Manipulatives + images carry through as inlineTag for now — the
+  // client renderer for those is hooked up via visualTeachingHandler.
+  for (const m of (vc.manipulatives || [])) {
+    boardOps.push({ op: 'inlineTag', raw: JSON.stringify({ kind: 'manipulative', ...m }) });
+  }
+  for (const i of (vc.images || [])) {
+    boardOps.push({ op: 'inlineTag', raw: JSON.stringify({ kind: 'image', ...i }) });
+  }
+
+  // Filter out any falsy mappings (mapWhiteboardCommandToBoardOp returns
+  // null when shape is unrecognized; we'd rather drop than corrupt).
+  const cleanedOps = boardOps.filter(Boolean);
+
+  const segment = {
+    id: newSegmentId(),
+    spoken: text,
+    mode: opts.mode || 'teacher',
+    boardOps: cleanedOps,
+    emittedUnderPhase: opts.expectedPhase || null,
+  };
+
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    turnId,
+    segments: [segment],
+    mathSteps: deriveLegacyMathSteps([segment]),
+    spoken: deriveLegacySpoken([segment]),
+    meta: {
+      generator: opts.generator || 'chat',
+      pipelineRunId: opts.pipelineRunId || turnId,
+    },
+  };
+}
+
+/**
+ * Map one entry from visualCommands.whiteboard[] (as produced by
+ * utils/visualTeachingParser.js) to a BoardOp. Unrecognized shapes fall
+ * back to inlineTag so we don't drop content.
+ */
+function mapWhiteboardCommandToBoardOp(wb) {
+  if (!wb || typeof wb !== 'object') return null;
+  switch (wb.type) {
+    case 'write':
+      return { op: 'writeText', text: String(wb.text || '') };
+    case 'equation':
+      return { op: 'writeStep', latex: String(wb.latex || '') };
+    case 'clear':
+      return { op: 'clear' };
+    case 'drawing':
+      // Drawing sequences are complex — keep as inlineTag for now;
+      // visualTeachingHandler.js renders them via the existing path.
+      return { op: 'inlineTag', raw: JSON.stringify({ kind: 'drawing', sequence: wb.sequence }) };
+    case 'triangle_problem':
+      return { op: 'inlineTag', raw: JSON.stringify({ kind: 'triangle_problem', angles: wb.angles }) };
+    default:
+      // Unknown but well-formed: bridge through inlineTag
+      return { op: 'inlineTag', raw: JSON.stringify(wb) };
+  }
+}
+
+// ── Legacy mirror derivation ────────────────────────────────────────
+
+function deriveLegacyMathSteps(segments) {
+  const out = [];
+  for (const seg of segments) {
+    for (const op of (seg.boardOps || [])) {
+      if (op.op === 'writeStep' && op.latex) {
+        out.push({
+          label: op.label,
+          latex: op.latex,
+          explanation: op.explanation,
+        });
+      }
+    }
+  }
+  return out;
+}
+
+function deriveLegacySpoken(segments) {
+  return segments.map(s => s.spoken || '').filter(Boolean).join(' ').trim();
+}
+
+// ── Synthesizing fast-path clarification segments ───────────────────
+
+/**
+ * Build a one-segment envelope for a fast-path clarification answer.
+ * Used when the orchestrator can answer an interrupt locally without
+ * re-running the pipeline (segment had a populated `explanation` field).
+ */
+function buildClarificationSegment({ explanation, referentObjectId, turnId }) {
+  const segment = {
+    id: newSegmentId(),
+    spoken: `Good question — ${explanation}`.trim(),
+    mode: 'teacher',
+    boardOps: referentObjectId
+      ? [{ op: 'highlight', objectId: referentObjectId, durationMs: 2000 }]
+      : [],
+    emittedUnderPhase: null,
+  };
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    turnId: turnId || newTurnId(),
+    segments: [segment],
+    mathSteps: [],
+    spoken: segment.spoken,
+    meta: { generator: 'voice', pipelineRunId: 'fast-path-clarification' },
+  };
+}
+
+/**
+ * Build a one-segment "thinking ack" envelope. Plays while a slower
+ * substantive response is being generated. Keeps the acknowledgment
+ * latency budget within 600ms even when the substantive budget can't be.
+ */
+function buildThinkingAck({ turnId, phrase }) {
+  const phrases = [
+    'Good question, hold on a sec.',
+    'Let me think about that.',
+    'One sec — let me show you.',
+  ];
+  const spoken = phrase || phrases[Math.floor(Math.random() * phrases.length)];
+  const segment = {
+    id: newSegmentId(),
+    spoken,
+    mode: 'teacher',
+    boardOps: [],
+    emittedUnderPhase: null,
+  };
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    turnId: turnId || newTurnId(),
+    segments: [segment],
+    mathSteps: [],
+    spoken,
+    meta: { generator: 'voice', pipelineRunId: 'thinking-ack' },
+  };
+}
+
+module.exports = {
+  SCHEMA_VERSION,
+  newTurnId,
+  newSegmentId,
+  fromVoiceTutorJSON,
+  fromPipelineVerified,
+  buildClarificationSegment,
+  buildThinkingAck,
+  deriveLegacyMathSteps,
+  deriveLegacySpoken,
+  mapWhiteboardCommandToBoardOp,
+};

--- a/utils/orchestrator/sessionStore.js
+++ b/utils/orchestrator/sessionStore.js
@@ -1,0 +1,227 @@
+// utils/orchestrator/sessionStore.js
+// In-memory session registry for the segment orchestrator. Per the v1.1
+// plan: no Redis, no Mongo for hot path. Lost on restart is acceptable
+// because clients rehydrate from conversation history breadcrumbs (see
+// dispatcher.js + index.js).
+//
+// One Session per (sessionId) — keyed the same way voiceSession.js
+// registers active sessions, so lookups across the two layers can share
+// the same id space.
+
+'use strict';
+
+const logger = require('../logger').child({ module: 'orchestratorSessionStore' });
+
+const IDLE_TTL_MS = 30 * 60 * 1000;
+const SWEEP_INTERVAL_MS = 5 * 60 * 1000;
+
+/** @type {Map<string, OrchestratorSession>} */
+const sessions = new Map();
+
+class OrchestratorSession {
+  constructor(sessionId, userId) {
+    this.sessionId = sessionId;
+    this.userId = String(userId || '');
+    this.createdAt = Date.now();
+    this.lastTouched = Date.now();
+
+    // Turn-scope AbortController. Aborting this fires segmentAbort children
+    // implicitly via signal propagation when the turn dies. Re-created per turn.
+    this.turnAbort = null;
+    this.currentTurnId = null;
+
+    /** @type {Map<string, AbortController>} */
+    this.segmentAbort = new Map();
+    /** @type {Map<string, AbortController>} */
+    this.ttsPrefetch = new Map();
+
+    /** @type {import('./types').Segment[]} */
+    this.queue = [];
+    /** @type {number} */
+    this.queueIndex = 0;
+    /** @type {string|null} segment id currently in TTS or playback */
+    this.activeSegmentId = null;
+
+    // The interrupt chain for the active turn. Cleared when a new turn
+    // starts. The pipeline reads this on the NEXT turn via
+    // ctx.previousInterruptions.
+    /** @type {import('./types').InterruptionEvent[]} */
+    this.interruptionChain = [];
+
+    this.waitTimer = null;          // setTimeout handle for current WAIT
+    this.waitStartedAt = null;
+    this.waitSegmentId = null;
+
+    // Last persisted segment-end breadcrumb — written on every segment
+    // boundary so a client reconnect can rehydrate where playback left off.
+    this.lastBreadcrumb = null;
+
+    // Telemetry: when this turn started speaking — used to compute the
+    // ack/substantive split metrics on interrupt.
+    this.turnStartedAt = null;
+    this.firstAudioAt = null;
+  }
+
+  touch() {
+    this.lastTouched = Date.now();
+  }
+
+  /** Begin a new turn. Aborts any prior turn cleanly. */
+  startTurn(turnId) {
+    if (this.turnAbort) {
+      try { this.turnAbort.abort('superseded'); } catch (_) { /* node version variance */ }
+    }
+    this.turnAbort = new AbortController();
+    this.currentTurnId = turnId;
+    this.queue = [];
+    this.queueIndex = 0;
+    this.activeSegmentId = null;
+    this.segmentAbort.clear();
+    this.ttsPrefetch.clear();
+    this.interruptionChain = [];
+    this.clearWaitTimer();
+    this.turnStartedAt = Date.now();
+    this.firstAudioAt = null;
+    this.touch();
+    return this.turnAbort.signal;
+  }
+
+  registerSegmentAbort(segmentId) {
+    const ac = new AbortController();
+    this.segmentAbort.set(segmentId, ac);
+    // If the parent turn aborts, cascade to the segment.
+    if (this.turnAbort) {
+      const onTurnAbort = () => { try { ac.abort('turn_abort'); } catch (_) {} };
+      if (this.turnAbort.signal.aborted) onTurnAbort();
+      else this.turnAbort.signal.addEventListener('abort', onTurnAbort, { once: true });
+    }
+    return ac;
+  }
+
+  abortSegment(segmentId, reason = 'segment_abort') {
+    const ac = this.segmentAbort.get(segmentId);
+    if (!ac) return false;
+    try { ac.abort(reason); } catch (_) { /* swallow */ }
+    return true;
+  }
+
+  abortPrefetch(segmentId, reason = 'prefetch_abort') {
+    const ac = this.ttsPrefetch.get(segmentId);
+    if (!ac) return false;
+    try { ac.abort(reason); } catch (_) { /* swallow */ }
+    this.ttsPrefetch.delete(segmentId);
+    return true;
+  }
+
+  /** Flush remaining queued segments — drops everything past queueIndex. */
+  flushQueue(reason = 'flush') {
+    const flushed = this.queue.slice(this.queueIndex + 1).map(s => s.id);
+    // Abort prefetches for flushed segments
+    for (const id of flushed) this.abortPrefetch(id, reason);
+    this.queue = this.queue.slice(0, this.queueIndex + 1);
+    return flushed;
+  }
+
+  setWaitTimer(handle, segmentId) {
+    this.clearWaitTimer();
+    this.waitTimer = handle;
+    this.waitStartedAt = Date.now();
+    this.waitSegmentId = segmentId;
+  }
+
+  clearWaitTimer() {
+    if (this.waitTimer) {
+      try { clearTimeout(this.waitTimer); } catch (_) {}
+      try { clearInterval(this.waitTimer); } catch (_) {}
+    }
+    this.waitTimer = null;
+    this.waitStartedAt = null;
+    this.waitSegmentId = null;
+  }
+
+  appendInterruption(event) {
+    this.interruptionChain.push(event);
+    if (this.interruptionChain.length > 5) {
+      this.interruptionChain = this.interruptionChain.slice(-5);
+    }
+  }
+
+  /** Tear down everything. Idempotent. */
+  shutdown(reason = 'shutdown') {
+    if (this.turnAbort) {
+      try { this.turnAbort.abort(reason); } catch (_) {}
+    }
+    for (const ac of this.segmentAbort.values()) {
+      try { ac.abort(reason); } catch (_) {}
+    }
+    for (const ac of this.ttsPrefetch.values()) {
+      try { ac.abort(reason); } catch (_) {}
+    }
+    this.segmentAbort.clear();
+    this.ttsPrefetch.clear();
+    this.clearWaitTimer();
+    this.queue = [];
+  }
+}
+
+/** @param {string} sessionId @param {string} userId */
+function getOrCreate(sessionId, userId) {
+  let s = sessions.get(sessionId);
+  if (!s) {
+    s = new OrchestratorSession(sessionId, userId);
+    sessions.set(sessionId, s);
+  }
+  s.touch();
+  return s;
+}
+
+function get(sessionId) {
+  const s = sessions.get(sessionId);
+  if (s) s.touch();
+  return s || null;
+}
+
+function destroy(sessionId, reason = 'destroy') {
+  const s = sessions.get(sessionId);
+  if (!s) return false;
+  s.shutdown(reason);
+  sessions.delete(sessionId);
+  return true;
+}
+
+function size() { return sessions.size; }
+
+// Idle sweep — evict sessions inactive longer than IDLE_TTL_MS. Runs
+// only when something has registered with the store, so test/import-only
+// usage doesn't keep a process alive.
+let sweepHandle = null;
+function startSweep() {
+  if (sweepHandle) return;
+  sweepHandle = setInterval(() => {
+    const cutoff = Date.now() - IDLE_TTL_MS;
+    for (const [id, s] of sessions.entries()) {
+      if (s.lastTouched < cutoff) {
+        logger.info('evict idle orchestrator session', { sessionId: id, userId: s.userId });
+        s.shutdown('idle_evict');
+        sessions.delete(id);
+      }
+    }
+  }, SWEEP_INTERVAL_MS);
+  sweepHandle.unref?.();
+}
+function stopSweep() {
+  if (sweepHandle) {
+    clearInterval(sweepHandle);
+    sweepHandle = null;
+  }
+}
+
+module.exports = {
+  OrchestratorSession,
+  getOrCreate,
+  get,
+  destroy,
+  size,
+  startSweep,
+  stopSweep,
+};

--- a/utils/orchestrator/types.js
+++ b/utils/orchestrator/types.js
@@ -1,0 +1,141 @@
+// utils/orchestrator/types.js
+// Schema for the segment orchestrator. Pure JSDoc — no runtime code.
+// Extends the voice tutor's {spoken, mathSteps[]} contract additively so
+// renderMathSteps() in voice-tutor-session.js keeps working unchanged.
+
+'use strict';
+
+/**
+ * @typedef {'vocabulary'|'concept-intro'|'i-do'|'we-do'|'you-do'|'mastery-check'|'prerequisite-review'} Phase
+ * Aligned with tutorPlanManager.advanceInstructionPhase phase enum.
+ */
+
+/**
+ * @typedef {'teacher'|'student'|'collaborative'} Mode
+ * Maps to whiteboard.setBoardMode().
+ */
+
+/**
+ * @typedef {'clarification'|'answer_attempt'|'confusion'|'off_track'|'control'} InterruptLabel
+ */
+
+/**
+ * @typedef {'pause'|'flush-queue'|'abort-turn'} InterruptTier
+ * pause       — preserve queue, may rewind/zoom/disambiguate
+ * flush-queue — drop queued segments, replan via pipeline; turn lifecycle continues
+ * abort-turn  — fire turn AbortController, end conversational turn entirely
+ */
+
+/**
+ * @typedef {Object} ExpectSpec
+ * @property {'math-equiv'|'choice'|'free-text'|'any'} kind
+ * @property {string} [target]           Canonical answer (latex or plain).
+ * @property {string[]} [acceptable]     Alternate accepted forms.
+ * @property {{vars?: string[], tolerance?: number}} [domain]
+ */
+
+/**
+ * @typedef {Object} HintRung
+ * @property {number} delayMs            Ms since wait start when this rung fires.
+ * @property {string} spoken
+ * @property {BoardOp[]} [boardOps]
+ * @property {'nudge'|'reprompt'|'hint'|'abandon'} kind
+ */
+
+/**
+ * @typedef {Object} WaitDirective
+ * @property {ExpectSpec} [expect]
+ * @property {number} [timeoutMs]        Override default ladder.
+ * @property {HintRung[]} [hintLadder]   Caller-supplied; defaults applied if omitted.
+ */
+
+/**
+ * Discriminated union — `op` is the discriminator. inlineTag is the bridge
+ * for main-chat's existing tag vocabulary (FUNCTION_GRAPH, ALGEBRA_TILES,
+ * UNIT_CIRCLE, WHITEBOARD_WRITE, etc.); structured ops are the migration
+ * target for individual tag families.
+ *
+ * @typedef {(
+ *   { op: 'writeStep', id?: string, label?: string, latex: string,
+ *     explanation?: string, region?: 'working'|'scratch'|'given'|'answer' }
+ *   | { op: 'writeText', text: string, x?: number, y?: number }
+ *   | { op: 'graph', fn: string, xRange?: [number,number], yRange?: [number,number] }
+ *   | { op: 'algebraTiles', expr: string }
+ *   | { op: 'unitCircle', angle?: number }
+ *   | { op: 'highlight', objectId: string, color?: string, durationMs?: number }
+ *   | { op: 'circleWithQuestion', objectId: string, message: string }
+ *   | { op: 'drawArrowToBlank', fromId: string, message: string }
+ *   | { op: 'moveToRegion', objectId: string, region: 'working'|'scratch'|'given'|'answer' }
+ *   | { op: 'clear' }
+ *   | { op: 'inlineTag', raw: string }
+ * )} BoardOp
+ */
+
+/**
+ * One unit of orchestrated playback. Cumulative by default — boardOps add
+ * to existing board state unless an `op:'clear'` is included.
+ *
+ * @typedef {Object} Segment
+ * @property {string} id                      ULID-ish; uuid v4 in this build.
+ * @property {string} spoken                  TTS payload. May be '' for board-only.
+ * @property {Mode} mode
+ * @property {BoardOp[]} boardOps
+ * @property {WaitDirective} [wait]           Presence => block after this segment.
+ * @property {Phase} emittedUnderPhase        Server-stamped pre-phaseEnforcer.
+ * @property {number} [expectedDurationMs]    For TTS prefetch scheduling.
+ * @property {{onConfusion?: 'pause'|'flush-queue', onAnswerAttempt?: 'evaluate'|'flush-queue'}} [interruptPolicy]
+ */
+
+/**
+ * Top-level envelope. mathSteps + spoken are auto-derived legacy mirrors
+ * that keep voice-tutor-session.js renderMathSteps() and the chat
+ * transcript bubble functioning without changes.
+ *
+ * @typedef {Object} OrchestratorEnvelope
+ * @property {'1.0'} schemaVersion
+ * @property {string} turnId
+ * @property {Segment[]} segments
+ * @property {Array<{label?:string, latex:string, explanation?:string}>} [mathSteps]
+ * @property {string} [spoken]
+ * @property {{kind:'advance'|'stay'|'regress', toPhase?: Phase}} [phaseHint]
+ * @property {{generator:'voice'|'chat', pipelineRunId:string}} [meta]
+ */
+
+/**
+ * What the next pipeline turn sees. Plural — students chain interrupts
+ * (interrupt → clarification → "wait, but...") and observe.js needs the
+ * full chain, not just the most recent overwrite.
+ *
+ * @typedef {Object} InterruptionEvent
+ * @property {number} seq                     0-indexed within the turn.
+ * @property {string} turnId
+ * @property {string} segmentId
+ * @property {number} atMs                    Playback offset where stopped.
+ * @property {number} [atTokenN]
+ * @property {InterruptLabel} label
+ * @property {number} classifierConfidence
+ * @property {'unanimous'|'majority'|'split'} [classifierConsensus]
+ * @property {string} studentText
+ * @property {{boardObjectId:string, latex?:string}} [referent]
+ * @property {ExpectSpec} [pendingExpect]
+ * @property {InterruptTier} resolutionTier
+ * @property {string[]} flushedSegmentIds
+ * @property {string} [evaluatorVerdict]      'correct'|'incorrect'|'cannot-evaluate'
+ */
+
+module.exports = {
+  PHASES: [
+    'prerequisite-review',
+    'vocabulary',
+    'concept-intro',
+    'i-do',
+    'we-do',
+    'you-do',
+    'mastery-check',
+  ],
+  INTERRUPT_LABELS: ['clarification', 'answer_attempt', 'confusion', 'off_track', 'control'],
+  INTERRUPT_TIERS: ['pause', 'flush-queue', 'abort-turn'],
+  // Tiebreaker order when 3-vote is split — favors the lower-action label so
+  // an ambiguous classification doesn't auto-promote into "abort the turn".
+  LABEL_PRIORITY: ['clarification', 'answer_attempt', 'confusion', 'off_track', 'control'],
+};

--- a/utils/orchestrator/waitTimer.js
+++ b/utils/orchestrator/waitTimer.js
@@ -1,0 +1,113 @@
+// utils/orchestrator/waitTimer.js
+// Escalation ladder for WAIT directives. Runs as a single recursive
+// setTimeout chain on the OrchestratorSession; clears immediately on
+// any client speech onset (handled by the orchestrator entrypoint, not
+// here — this module just schedules and reports).
+//
+// Default ladder (ms-since-WAIT-entered):
+//   15000  — gentle nudge
+//   30000  — reprompt
+//   60000  — hint rung 1
+//   90000  — hint rung 2
+//  120000  — abandon
+//
+// Mastery-check override: cap at 30s, no hint rungs (hints defeat
+// assessment). Inconclusive at 30s — caller advances and lets FSRS
+// reschedule the item.
+
+'use strict';
+
+const DEFAULT_LADDER = [
+  { delayMs: 15000,  kind: 'nudge',
+    spoken: 'Take your time. Let me know when you are ready.' },
+  { delayMs: 30000,  kind: 'reprompt',
+    spoken: null /* caller fills in: rephrase the prompt */ },
+  { delayMs: 60000,  kind: 'hint',
+    spoken: 'Want a hint? Let me give you a small clue.' },
+  { delayMs: 90000,  kind: 'hint',
+    spoken: 'Here is another piece — does this help?' },
+  { delayMs: 120000, kind: 'abandon',
+    spoken: "Let's keep moving — we will come back to this." },
+];
+
+const MASTERY_LADDER = [
+  { delayMs: 30000, kind: 'abandon',
+    spoken: "Let's move on — we will come back to this one." },
+];
+
+/**
+ * Resolve the ladder for a given segment + phase. Caller-supplied
+ * hintLadder overrides defaults; mastery phase always uses the
+ * mastery-only ladder regardless of caller spec.
+ *
+ * @param {import('./types').Segment} segment
+ * @param {string} expectedPhase
+ * @returns {Array<{delayMs:number, kind:string, spoken:string|null, boardOps?:Array}>}
+ */
+function resolveLadder(segment, expectedPhase) {
+  if (expectedPhase === 'mastery-check') return MASTERY_LADDER;
+
+  const wait = segment?.wait;
+  if (wait?.hintLadder?.length) {
+    // Caller-supplied — sort ascending by delayMs in case author got it wrong
+    return [...wait.hintLadder].sort((a, b) => a.delayMs - b.delayMs);
+  }
+  if (wait?.timeoutMs) {
+    // Caller wanted a custom total timeout — scale the default abandon
+    // to match and keep the same shape for the rungs leading up to it.
+    return scaleLadderToTimeout(DEFAULT_LADDER, wait.timeoutMs);
+  }
+  return DEFAULT_LADDER;
+}
+
+function scaleLadderToTimeout(ladder, totalMs) {
+  const defaultTotal = ladder[ladder.length - 1].delayMs;
+  if (!defaultTotal || defaultTotal === totalMs) return ladder;
+  const factor = totalMs / defaultTotal;
+  return ladder.map(rung => ({ ...rung, delayMs: Math.round(rung.delayMs * factor) }));
+}
+
+/**
+ * Schedule the ladder. Returns a controller with .cancel() — the caller
+ * (orchestrator entry) keeps that handle on the OrchestratorSession.
+ *
+ * @param {Object} args
+ * @param {Array} args.ladder
+ * @param {Function} args.onRung    (rung) => void  -- emits the rung action
+ * @returns {{cancel: () => void}}
+ */
+function schedule({ ladder, onRung }) {
+  let idx = 0;
+  let timer = null;
+  let cancelled = false;
+
+  const fireNext = () => {
+    if (cancelled || idx >= ladder.length) return;
+    const rung = ladder[idx];
+    const prevDelay = idx > 0 ? ladder[idx - 1].delayMs : 0;
+    const wait = rung.delayMs - prevDelay;
+    timer = setTimeout(() => {
+      if (cancelled) return;
+      try { onRung(rung); } catch (_) { /* swallow handler errors */ }
+      idx += 1;
+      fireNext();
+    }, wait);
+    timer.unref?.();
+  };
+  fireNext();
+
+  return {
+    cancel: () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      timer = null;
+    },
+  };
+}
+
+module.exports = {
+  resolveLadder,
+  schedule,
+  DEFAULT_LADDER,
+  MASTERY_LADDER,
+};

--- a/utils/voiceMetrics.js
+++ b/utils/voiceMetrics.js
@@ -32,6 +32,12 @@ function newTurn(sessionId, userId, tutorId) {
         t_audio_play_started: null,
         t_interrupt_requested: null,
         t_audio_silenced: null,
+        // Orchestrator-era latency split: ack = first acknowledgment audio
+        // (templated thinking-ack or fast-path), substantive = first audio
+        // of the substantive response. Both measured from STT-final.
+        t_stt_final: null,
+        t_first_ack_audio: null,
+        t_first_substantive_audio: null,
         t_turn_end: null,
         sttSecondsBilled: 0,
         llmInputTokens: 0,
@@ -39,6 +45,56 @@ function newTurn(sessionId, userId, tutorId) {
         ttsChars: 0,
         abortReason: null,
         spokenChars: 0,
+    };
+}
+
+// ── Orchestrator counters ────────────────────────────────────────────
+// Lightweight counters for non-per-turn metrics. Reset on process restart;
+// scraped via /api/voice-tutor/metrics alongside aggregate().
+
+const counters = {
+    phase_strip:         { _total: 0 },   // keyed by `${phase}:${from}->${to}`
+    classifier_consensus: { unanimous: 0, majority: 0, split: 0 },
+    wait_abandon:        { _total: 0 },   // keyed by skillId or 'unknown'
+    fast_path_clarification: 0,
+};
+
+function recordPhaseStrip(phase, from, to) {
+    const k = `${phase || 'unknown'}:${from}->${to}`;
+    counters.phase_strip[k] = (counters.phase_strip[k] || 0) + 1;
+    counters.phase_strip._total++;
+}
+
+function recordClassifierConsensus(consensus) {
+    if (!consensus) return;
+    if (counters.classifier_consensus[consensus] != null) {
+        counters.classifier_consensus[consensus]++;
+    }
+}
+
+function recordWaitAbandon(skillId) {
+    const k = skillId || 'unknown';
+    counters.wait_abandon[k] = (counters.wait_abandon[k] || 0) + 1;
+    counters.wait_abandon._total++;
+}
+
+function recordFastPathClarification() {
+    counters.fast_path_clarification++;
+}
+
+function getCounters() {
+    // Compute consensus rate
+    const consTotal = counters.classifier_consensus.unanimous
+                    + counters.classifier_consensus.majority
+                    + counters.classifier_consensus.split;
+    const consensusRate = consTotal > 0
+        ? counters.classifier_consensus.unanimous / consTotal
+        : null;
+    return {
+        phase_strip: { ...counters.phase_strip },
+        classifier_consensus: { ...counters.classifier_consensus, rate_unanimous: consensusRate },
+        wait_abandon: { ...counters.wait_abandon },
+        fast_path_clarification: counters.fast_path_clarification,
     };
 }
 
@@ -56,6 +112,14 @@ function record(turn) {
             : null,
         interrupt_stop_ms: turn.t_audio_silenced && turn.t_interrupt_requested
             ? turn.t_audio_silenced - turn.t_interrupt_requested
+            : null,
+        // Orchestrator-era split — populated by orchestrator turns; null on
+        // legacy single-segment turns where the distinction doesn't apply.
+        interrupt_ack_ms: turn.t_first_ack_audio && turn.t_stt_final
+            ? turn.t_first_ack_audio - turn.t_stt_final
+            : null,
+        interrupt_substantive_ms: turn.t_first_substantive_audio && turn.t_stt_final
+            ? turn.t_first_substantive_audio - turn.t_stt_final
             : null,
         turn_duration_ms: turn.t_turn_end - turn.t_started,
         estimated_cost_usd: estimateCost(turn),
@@ -101,10 +165,12 @@ function snapshot(limit = 100) {
 function aggregate() {
     const turns = snapshot(RING_SIZE).filter(t => t.time_to_first_audio_ms != null);
     if (turns.length === 0) {
-        return { count: 0 };
+        return { count: 0, orchestrator: getCounters() };
     }
     const ttfa = turns.map(t => t.time_to_first_audio_ms).sort((a, b) => a - b);
     const interrupts = turns.map(t => t.interrupt_stop_ms).filter(x => x != null).sort((a, b) => a - b);
+    const ack = turns.map(t => t.interrupt_ack_ms).filter(x => x != null).sort((a, b) => a - b);
+    const sub = turns.map(t => t.interrupt_substantive_ms).filter(x => x != null).sort((a, b) => a - b);
     const costs = turns.map(t => t.estimated_cost_usd);
     const interrupted = turns.filter(t => t.abortReason === 'user_barge_in').length;
     return {
@@ -113,9 +179,14 @@ function aggregate() {
         ttfa_ms_p95: percentile(ttfa, 0.95),
         interrupt_stop_ms_p50: interrupts.length ? percentile(interrupts, 0.50) : null,
         interrupt_stop_ms_p95: interrupts.length ? percentile(interrupts, 0.95) : null,
+        interrupt_ack_ms_p50: ack.length ? percentile(ack, 0.50) : null,
+        interrupt_ack_ms_p95: ack.length ? percentile(ack, 0.95) : null,
+        interrupt_substantive_ms_p50: sub.length ? percentile(sub, 0.50) : null,
+        interrupt_substantive_ms_p95: sub.length ? percentile(sub, 0.95) : null,
         avg_cost_usd: costs.reduce((a, b) => a + b, 0) / costs.length,
         interrupt_rate: interrupted / turns.length,
         total_recorded: total,
+        orchestrator: getCounters(),
     };
 }
 
@@ -125,4 +196,12 @@ function percentile(sorted, p) {
     return sorted[idx];
 }
 
-module.exports = { newTurn, record, snapshot, aggregate, COST };
+module.exports = {
+    newTurn, record, snapshot, aggregate, COST,
+    // Orchestrator counters
+    recordPhaseStrip,
+    recordClassifierConsensus,
+    recordWaitAbandon,
+    recordFastPathClarification,
+    getCounters,
+};

--- a/utils/voiceSession.js
+++ b/utils/voiceSession.js
@@ -8,13 +8,16 @@ const User = require('../models/user');
 const Conversation = require('../models/conversation');
 const TUTOR_CONFIG = require('./tutorConfig');
 const { generateSystemPrompt } = require('./prompt');
-const { callLLMStream } = require('./llmGateway');
+const { callLLM, callLLMStream } = require('./llmGateway');
 const { verify: pipelineVerify } = require('./pipeline');
 const { checkReadingLevel } = require('./readability');
 const sttStream = require('./sttStream');
 const ttsStream = require('./ttsStream');
 const ttsProvider = require('./ttsProvider');
 const metrics = require('./voiceMetrics');
+const orchestrator = require('./orchestrator');
+const { Dispatcher } = require('./orchestrator/dispatcher');
+const { loadOrCreatePlan, resolveCurrentTarget } = require('./tutorPlanManager');
 const logger = require('./logger').child({ module: 'voiceSession' });
 
 const VOICE_MODEL = process.env.VOICE_LLM_MODEL || 'gpt-4o-mini';
@@ -119,7 +122,15 @@ class VoiceSession {
         this.user = user;                       // populated user doc (lean)
         this.userId = String(user._id);
         this.sessionId = sessionId || `${this.userId}-${Date.now()}`;
-        this.mode = mode === 'board-actions' ? 'board-actions' : 'math-steps';
+        // Three modes:
+        //   'math-steps'   — immersive voice-tutor.html, <math>JSON</math> trailer
+        //   'board-actions' — chat orb, inline [WRITE:...] tags
+        //   'orchestrated' — segment orchestrator path; trades streaming
+        //                    LLM TTFA (~250ms -> ~1.5s) for per-segment
+        //                    structure, WAIT semantics, and 3-tier interrupts
+        this.mode = mode === 'board-actions' ? 'board-actions'
+                  : mode === 'orchestrated'  ? 'orchestrated'
+                  : 'math-steps';
         this.tutorProfile = TUTOR_CONFIG[user.selectedTutorId || 'default'] || TUTOR_CONFIG['default'];
         this.voiceId = ttsProvider.getVoiceId(this.tutorProfile);
         this.langCode = ({
@@ -376,6 +387,13 @@ class VoiceSession {
     }
 
     async _driveTurn(turn) {
+        // Orchestrated mode replaces token-streaming with a JSON-mode
+        // call + segment orchestrator. Trades TTFA for segment-level
+        // playback control. See _driveTurnOrchestrated for the flow.
+        if (this.mode === 'orchestrated') {
+            return this._driveTurnOrchestrated(turn);
+        }
+
         // ── Build messages for LLM ──
         const modeInstructions = this.mode === 'board-actions'
             ? BOARD_ACTIONS_VOICE_INSTRUCTIONS
@@ -537,6 +555,199 @@ class VoiceSession {
         turn.metric.ttsChars = turn.tts ? turn.tts.charsSent() : 0;
         turn.metric.sttSecondsBilled = this.stt ? this.stt.billedSeconds : 0;
         turn.metric.llmOutputTokens = turn.tokensEmitted;
+    }
+
+    /**
+     * Orchestrated turn: JSON-mode LLM call -> verify -> orchestrator
+     * handleTurn with per-segment Cartesia synthesis. Same persistent
+     * pool, same _sendAudioChunk path — orchestrator just adds segment
+     * structure on top.
+     */
+    async _driveTurnOrchestrated(turn) {
+        const ORCH_VOICE_INSTRUCTIONS = `
+
+**VOICE TUTOR MODE — ACTIVE**
+
+You are in a real-time spoken math tutoring session. Respond with a JSON
+object in this exact shape:
+
+{
+  "spoken": "1-2 sentences, plain English, no LaTeX delimiters",
+  "mathSteps": [{"label":"...","latex":"...","explanation":"..."}]
+}
+
+The "spoken" field is what the student hears. The "mathSteps" field is
+the cumulative math board — include ONLY steps the student has worked
+through. Don't spoil the next step. On wrong answers, repeat the prior
+mathSteps unchanged (don't add the wrong step). For non-math turns,
+include the most recent prior mathSteps (or [] if none yet).
+
+Always include an "explanation" field on the most recent mathStep when
+possible — the orchestrator uses it to answer mid-explanation
+clarifications without a fresh pipeline pass.
+
+Never speak math notation. Never include system tags. Always valid JSON.`;
+
+        const messages = [
+            { role: 'system', content: this.systemPrompt + ORCH_VOICE_INSTRUCTIONS },
+            ...this.history,
+            { role: 'user', content: turn.userMessage },
+        ];
+
+        // ── 1. JSON-mode LLM call (non-streaming) ──
+        let parsed;
+        try {
+            const completion = await callLLM(VOICE_MODEL, messages, {
+                temperature: 0.45,
+                max_tokens: 600,
+                response_format: { type: 'json_object' },
+                signal: turn.ac.signal,
+            });
+            if (turn.ac.signal.aborted) return;
+            turn.metric.t_first_llm_token = Date.now();
+            const raw = completion.choices?.[0]?.message?.content || '{}';
+            try { parsed = JSON.parse(raw); } catch (_) { parsed = {}; }
+            turn.metric.llmOutputTokens = completion.usage?.completion_tokens || 0;
+            turn.metric.llmInputTokens = completion.usage?.prompt_tokens || 0;
+        } catch (err) {
+            if (turn.ac.signal.aborted) return;
+            throw err;
+        }
+
+        const spoken = (parsed.spoken || parsed.text || parsed.response || '').trim();
+        const mathSteps = Array.isArray(parsed.mathSteps)
+            ? parsed.mathSteps.filter(s => s && s.latex)
+            : Array.isArray(parsed.math_steps)
+              ? parsed.math_steps.filter(s => s && s.latex)
+              : [];
+
+        // ── 2. Pipeline verify (defense in depth) ──
+        let verifiedSpoken = spoken;
+        let verifiedSteps = mathSteps;
+        try {
+            const verified = await pipelineVerify(spoken, {
+                userId: this.userId,
+                userMessage: turn.userMessage,
+                iepReadingLevel: this.user.iepPlan?.readingLevel || null,
+                firstName: this.user.firstName,
+                isStreaming: false,
+            });
+            const flagged = (verified.flags || []).some(f =>
+                f.startsWith('answer_giveaway') || f.startsWith('answer_key') || f.startsWith('upload_')
+            );
+            if (flagged && verified.text && verified.text !== spoken) {
+                verifiedSpoken = verified.text;
+                verifiedSteps = []; // drop the board alongside the spoken redirect
+                turn.metric.abortReason = 'verify_redirect';
+            } else if (verified.text) {
+                verifiedSpoken = verified.text;
+            }
+        } catch (err) {
+            logger.warn('orch verify failed (using unverified)', { error: err.message });
+        }
+
+        // ── 3. Resolve current phase for phaseEnforcer ──
+        let expectedPhase = null;
+        let activeTarget = null;
+        try {
+            const plan = await loadOrCreatePlan(this.userId, { user: this.user });
+            const resolved = await resolveCurrentTarget(plan, { user: this.user });
+            expectedPhase = resolved?.plan?.currentTarget?.instructionPhase || null;
+            activeTarget = resolved?.plan?.currentTarget || null;
+        } catch (e) {
+            logger.warn('orch tutorplan load failed (non-fatal)', { error: e.message });
+        }
+
+        // ── 4. Build a WS transport for the dispatcher ──
+        // The dispatcher emits orchestrator frames as JSON WS messages.
+        // The legacy client events (response_final, math_steps,
+        // ai_speaking_started/ended) are still emitted alongside so older
+        // clients keep working without changes.
+        const wsTransport = {
+            send: (frame) => this._send({ type: 'orch', ...frame }),
+            end: () => { /* no-op — WS stays open across turns */ },
+        };
+        const session = orchestrator.sessionStore.getOrCreate(this.sessionId, this.userId);
+        const dispatcher = new Dispatcher({ transport: wsTransport, session, user: this.user });
+
+        // ── 5. Per-segment TTS hook — uses the persistent Cartesia pool ──
+        const onSegmentTTS = (segment, signal) => new Promise((resolve) => {
+            if (!this.ttsPool || !segment.spoken) { resolve(); return; }
+            // First-audio-chunk telemetry maps to the LEGACY metric and
+            // also feeds the orchestrator's interrupt_ack/substantive
+            // split (caller sets t_stt_final upstream when STT finalizes).
+            const ts = this.ttsPool.synthesize({
+                signal,
+                onChunk: (i16, sr) => {
+                    if (!turn.metric.t_first_audio_chunk) {
+                        turn.metric.t_first_audio_chunk = Date.now();
+                        if (turn.status === 'thinking') {
+                            turn.status = 'speaking';
+                            this._setStatus('speaking');
+                            this._send({ type: 'ai_speaking_started', turnId: turn.metric.turnId });
+                        }
+                    }
+                    // Mark first ack/substantive audio for orchestrator metrics
+                    if (turn.metric.t_stt_final && !turn.metric.t_first_substantive_audio) {
+                        turn.metric.t_first_substantive_audio = Date.now();
+                        if (!turn.metric.t_first_ack_audio) {
+                            turn.metric.t_first_ack_audio = turn.metric.t_first_substantive_audio;
+                        }
+                    }
+                    this._sendAudioChunk(i16, sr, turn.metric.turnId);
+                },
+                onDone: () => resolve(),
+                onError: (err) => {
+                    logger.warn('orch TTS chunk error', { error: err.message });
+                    resolve();
+                },
+            });
+            ts.appendText(segment.spoken);
+            ts.finalize();
+            // If the segment is aborted mid-stream, the synthesizer's
+            // signal listener will close the Cartesia context and onDone
+            // / onError will fire. Resolve eagerly on abort to unblock
+            // the dispatcher loop.
+            if (signal) {
+                if (signal.aborted) resolve();
+                else signal.addEventListener('abort', () => resolve(), { once: true });
+            }
+        });
+
+        // ── 6. Hand off to orchestrator (drives per-segment Cartesia via onSegmentTTS) ──
+        await orchestrator.handleTurn(
+            { kind: 'voice', voiceJson: { spoken: verifiedSpoken, mathSteps: verifiedSteps } },
+            { sessionId: this.sessionId, userId: this.userId, expectedPhase, activeTarget },
+            dispatcher,
+            { onSegmentTTS },
+        );
+
+        // ── 7. Legacy events for the existing client ──
+        // The old voice-stream-client.js consumes these; orchestrator
+        // frames coexist as type:'orch'.
+        this._send({
+            type: 'response_final',
+            turnId: turn.metric.turnId,
+            text: verifiedSpoken,
+            mathSteps: verifiedSteps,
+            boardActions: [],
+        });
+        if (verifiedSteps.length > 0) this.lastBoardSteps = verifiedSteps;
+
+        // ── 8. Persist turn ──
+        const assistantContent = verifiedSpoken
+            + (verifiedSteps.length ? ` <math>${JSON.stringify(verifiedSteps)}</math>` : '');
+        this.history.push({ role: 'user', content: turn.userMessage });
+        this.history.push({ role: 'assistant', content: assistantContent });
+        if (this.history.length > HISTORY_DEPTH * 2) {
+            this.history = this.history.slice(-HISTORY_DEPTH * 2);
+        }
+        this._persistTurn(turn.userMessage, assistantContent).catch(err => {
+            logger.warn('orch persist failed', { error: err.message });
+        });
+
+        turn.metric.spokenChars = verifiedSpoken.length;
+        this._send({ type: 'ai_speaking_ended', turnId: turn.metric.turnId });
     }
 
     /**


### PR DESCRIPTION
Wraps the existing pipeline + voice tutor JSON with a streaming layer
that handles segment-level playback, interrupts, phase enforcement,
and WAIT escalation. Sits AFTER verify, never bypasses the gate.

Modules:
- utils/orchestrator/types.js              schema + JSDoc
- utils/orchestrator/sessionStore.js       in-memory session map +
                                           per-turn/per-segment AbortControllers
- utils/orchestrator/segmentationLayer.js  pipeline output -> envelope;
                                           inlineTag bridge for legacy chat tags
- utils/orchestrator/phaseEnforcer.js      deterministic struct rewriter
                                           (no re-prompt loop)
- utils/orchestrator/interruptClassifier.js regex fast-path -> 3-vote
                                           gpt-4o-mini majority
- utils/orchestrator/answerEvaluator.js    parallel math/choice/free-text
                                           equivalence check
- utils/orchestrator/disambiguator.js      context-keyed soft-pause phrases
- utils/orchestrator/waitTimer.js          15/30/60/90/120s ladder w/
                                           mastery-check 30s override
- utils/orchestrator/dispatcher.js         NDJSON segment frames + speech-
                                           leads-pen offset metadata
- utils/orchestrator/index.js              handleTurn / handleInterrupt;
                                           3-tier action ladder
                                           (pause/flush-queue/abort-turn)
- public/js/segmentPlayer.js               client player; VAD-onset
                                           interrupt; legacy renderMathSteps
                                           backward compat via auto-derived
                                           mathSteps mirror

Wiring:
- routes/voiceTutor.js: opt-in /process-orchestrated and /interrupt
  endpoints; legacy /process untouched.
- utils/voiceMetrics.js: adds interrupt_ack_ms / interrupt_substantive_ms
  per-turn fields plus phase_strip / classifier_consensus / wait_abandon
  counters surfaced via aggregate().
- utils/openaiClient.js: forwards options.signal to the SDK so
  orchestrator AbortControllers actually cancel in-flight LLM calls.

Reuses tutorPlanManager.advanceInstructionPhase for phase changes.
Reuses pipelineVerify (already invoked inside generateResponse) so the
verify gate is enforced. No new infra: in-memory sessionStore, no
Redis, no message queues.

Implementation plan from prior session approved as v1.1 (latency split:
600ms ack / 2.5s substantive; 3-vote classifier; 3-tier action ladder;
previousInterruptions array; mastery-check overrides; rehydration as
v1 deliverable). Disambiguator lookup table included in v1.

https://claude.ai/code/session_01LDAC1z9Bhwh3kCA78HC17X