### PR TITLE
feat(show-my-work): interlace work checks with chat tutor

### DIFF
--- a/models/conversation.js
+++ b/models/conversation.js
@@ -21,6 +21,11 @@ const messageSchema = new Schema({
         type: { type: String },       // e.g. 'derivative', 'arithmetic', 'linear_equation'
         correctAnswer: { type: String },
     },
+    // Show My Work integration: when a student submits work for grading,
+    // a 'user' message is appended with workCheckId pointing to the GradingResult.
+    // The frontend renders these messages as rich work-check cards rather than
+    // plain bubbles; the LLM still sees the human-readable summary in `content`.
+    workCheckId: { type: Schema.Types.ObjectId, ref: 'GradingResult', default: null },
 }, { _id: false });
 
 const conversationSchema = new Schema({

--- a/public/css/show-your-work.css
+++ b/public/css/show-your-work.css
@@ -606,3 +606,113 @@
     color: #8b5cf6;
     margin-top: 6px;
 }
+
+/* ---- Inline Work-Check Card (full breakdown in chat) ---- */
+.work-check-message {
+    width: 100%;
+    margin: 14px 0;
+    display: flex;
+    justify-content: stretch;
+}
+
+.work-check-card {
+    background: linear-gradient(180deg, #ffffff 0%, #faf9ff 100%);
+    border: 1px solid #d8d3f0;
+    border-left: 4px solid #8b5cf6;
+    border-radius: 14px;
+    padding: 18px 20px;
+    width: 100%;
+    box-shadow: 0 2px 10px rgba(139, 92, 246, 0.08);
+}
+
+.work-check-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 15px;
+    color: #4c1d95;
+    margin-bottom: 10px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid #ede9fe;
+}
+
+.work-check-header i {
+    font-size: 18px;
+    color: #8b5cf6;
+}
+
+.work-check-time {
+    margin-left: auto;
+    font-size: 12px;
+    color: #9ca3af;
+    font-weight: 400;
+}
+
+.work-check-empty .work-check-empty-body {
+    padding: 8px 0;
+    color: #6b7280;
+    font-size: 14px;
+}
+
+.work-check-actions {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    margin-top: 14px;
+    padding-top: 12px;
+    border-top: 1px solid #ede9fe;
+}
+
+.work-check-actions .syw-btn {
+    flex: 1 1 auto;
+    min-width: 140px;
+    font-size: 13px;
+    padding: 8px 14px;
+}
+
+.work-check-loading .work-check-card em {
+    color: #9ca3af;
+    font-style: italic;
+}
+
+/* ---- "Check my work" button on attached image cards ---- */
+.file-card {
+    position: relative;
+}
+
+.file-card-check-work {
+    position: absolute;
+    bottom: 6px;
+    left: 6px;
+    right: 6px;
+    background: rgba(139, 92, 246, 0.95);
+    color: white;
+    border: none;
+    border-radius: 6px;
+    padding: 6px 10px;
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    opacity: 0;
+    transition: opacity 0.15s, background 0.15s;
+    z-index: 2;
+}
+
+.file-card:hover .file-card-check-work,
+.file-card-check-work:focus,
+.file-card-check-work:disabled {
+    opacity: 1;
+}
+
+.file-card-check-work:hover {
+    background: #7c3aed;
+}
+
+.file-card-check-work:disabled {
+    background: #a78bfa;
+    cursor: wait;
+}

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -945,14 +945,21 @@ document.addEventListener("DOMContentLoaded", () => {
         </div>
       `;
     } else {
-      // Image preview card
+      // Image preview card with inline "Check my work" action
       card.style.padding = '0'; // Remove padding for images
       const reader = new FileReader();
       reader.onload = (e) => {
         card.innerHTML = `
           <button class="file-card-remove" onclick="removeFile('${file.uploadId}')" title="Remove">×</button>
           <img src="${e.target.result}" class="file-card-preview" alt="${escapeHtml(file.name)}" title="${escapeHtml(file.name)}"/>
+          <button class="file-card-check-work" data-file-id="${file.uploadId}" title="Have my tutor check this work">
+            <i class="fas fa-clipboard-check"></i> Check my work
+          </button>
         `;
+        const checkBtn = card.querySelector('.file-card-check-work');
+        if (checkBtn) {
+          checkBtn.addEventListener('click', () => runWorkCheckFromChat(file));
+        }
       };
       reader.readAsDataURL(file);
     }
@@ -989,6 +996,104 @@ document.addEventListener("DOMContentLoaded", () => {
     const container = document.getElementById('file-grid-container');
     if (container) container.innerHTML = '';
   }
+
+  /**
+   * Render a work-check breakdown for a historical conversation message.
+   * Fetches the GradingResult by id and asks show-your-work.js to render
+   * the same inline card as fresh submissions.
+   */
+  window.renderHistoricalWorkCheck = async function(resultId) {
+    if (!resultId) return;
+    // Reserve a placeholder slot so the card lands in the right chronological spot.
+    const placeholder = document.createElement('div');
+    placeholder.className = 'work-check-message work-check-loading';
+    placeholder.innerHTML = '<div class="work-check-card"><em>Loading work check…</em></div>';
+    const chatContainer = document.getElementById('chat-messages-container') || document.getElementById('chat-messages');
+    chatContainer?.appendChild(placeholder);
+
+    try {
+      const response = await csrfFetch(`/api/grade-work/${resultId}`, { credentials: 'include' });
+      if (!response.ok) throw new Error('Failed to load work check');
+      const data = await response.json();
+      if (!data.success || !data.result) throw new Error('Missing result');
+
+      if (window.showYourWork && typeof window.showYourWork.buildInlineWorkCard === 'function') {
+        const card = window.showYourWork.buildInlineWorkCard(data.result);
+        if (card) {
+          placeholder.replaceWith(card);
+          if (typeof window.showYourWork.typesetMath === 'function') {
+            window.showYourWork.typesetMath(card);
+          }
+        } else {
+          placeholder.remove();
+        }
+      } else {
+        placeholder.remove();
+      }
+    } catch (err) {
+      console.warn('[renderHistoricalWorkCheck] failed:', err);
+      placeholder.remove();
+    }
+  };
+
+  /**
+   * Route an attached image through /api/grade-work without leaving the chat.
+   * On success the server appends a work-check message and tutor greeting to
+   * the active conversation; show-your-work.js renders the breakdown card.
+   */
+  window.runWorkCheckFromChat = async function(file) {
+    if (!file) return;
+    const card = document.querySelector(`[data-file-id="${file.uploadId}"]`);
+    const checkBtn = card?.querySelector('.file-card-check-work');
+    if (checkBtn) {
+      checkBtn.disabled = true;
+      checkBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Checking…';
+    }
+
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+      const prevId = window.showYourWork?.lastResultId;
+      if (prevId) formData.append('previousAttemptId', prevId);
+
+      const response = await csrfFetch('/api/grade-work', {
+        method: 'POST',
+        credentials: 'include',
+        body: formData
+      });
+
+      if (!response.ok) {
+        let errMsg = 'Failed to check your work.';
+        if (response.status === 429) errMsg = 'Too many requests — wait a moment and try again.';
+        else { try { const err = await response.json(); errMsg = err.message || errMsg; } catch {} }
+        throw new Error(errMsg);
+      }
+
+      const result = await response.json();
+
+      // Remove the file from the attach queue so it doesn't get double-sent.
+      attachedFiles = attachedFiles.filter(f => f.uploadId !== file.uploadId);
+      if (card) card.remove();
+
+      // Render the breakdown inline (same content as the modal) and surface
+      // the tutor greeting. Reuses the show-your-work instance so the modal
+      // stays in sync for "Open full view".
+      if (window.showYourWork && typeof window.showYourWork.addWorkSnippetToChat === 'function') {
+        window.showYourWork.analysisResult = result;
+        window.showYourWork.lastResultId = result.id || null;
+        if (!window.showYourWork._renderedInChatIds) window.showYourWork._renderedInChatIds = new Set();
+        if (result.id) window.showYourWork._renderedInChatIds.add(result.id);
+        window.showYourWork.addWorkSnippetToChat(result);
+      }
+    } catch (err) {
+      console.error('[runWorkCheckFromChat] error:', err);
+      if (typeof showToast === 'function') showToast(err.message || 'Could not check your work right now.', 4000);
+      if (checkBtn) {
+        checkBtn.disabled = false;
+        checkBtn.innerHTML = '<i class="fas fa-clipboard-check"></i> Check my work';
+      }
+    }
+  };
 
   /**
    * Escape HTML to prevent XSS
@@ -4681,6 +4786,12 @@ document.addEventListener("DOMContentLoaded", () => {
         // Load and display messages
         if (messages && messages.length > 0) {
             messages.forEach(msg => {
+                // Work-check messages render as full breakdown cards
+                // instead of plain user bubbles.
+                if (msg.workCheckId) {
+                    renderHistoricalWorkCheck(msg.workCheckId);
+                    return;
+                }
                 const sender = msg.role === 'user' ? 'user' : 'ai';
                 appendMessage(msg.content, sender);
             });

--- a/public/js/show-your-work.js
+++ b/public/js/show-your-work.js
@@ -373,71 +373,26 @@ class ShowYourWorkManager {
         // Render any LaTeX in the feedback
         this.typesetMath(this.resultsContainer);
 
-        // Bind per-problem "Ask my tutor about this" buttons
+        // Bind per-problem "Ask my tutor about this" buttons inside the modal
         this.resultsContainer.querySelectorAll('.syw-ask-tutor-problem').forEach(btn => {
             btn.addEventListener('click', () => {
                 const num = btn.dataset.problem;
-                const statement = btn.dataset.statement;
                 const isUnsure = btn.dataset.unsure === 'true';
-
-                let msg;
-                if (isUnsure) {
-                    msg = `Can we go over problem #${num} from my work? You weren't sure about it. The problem was: ${statement}`;
-                } else {
-                    msg = `Can you help me with problem #${num} from my work? I got it wrong. The problem was: ${statement}`;
-                }
-
+                const msg = isUnsure
+                    ? `Can we go over problem #${num} together? You weren't sure about it.`
+                    : `Can you help me with problem #${num}? I got it wrong.`;
                 this.closeModal();
-                const userInput = document.getElementById('user-input');
-                if (userInput) {
-                    userInput.textContent = msg;
-                    userInput.dispatchEvent(new Event('input', { bubbles: true }));
-                    setTimeout(() => {
-                        const sendBtn = document.getElementById('send-button');
-                        if (sendBtn && !sendBtn.disabled) sendBtn.click();
-                    }, 100);
-                }
+                this.sendChatMessage(msg);
             });
         });
 
-        // Add snippet to chat
-        this.addWorkSnippetToChat(result);
-
-        // If there are unsure problems, auto-send a ghost message to the tutor
-        // so the conversation picks up immediately when the student returns to chat
-        const hasUnsure = (result.problems || []).some(p => p.isCorrect === null);
-        if (hasUnsure) {
-            this.sendGhostMessage(result);
-        }
-    }
-
-    /**
-     * Send a silent message to the tutor with grading context so the
-     * conversation picks up immediately when the student closes Show My Work.
-     */
-    sendGhostMessage(result) {
-        const unsure = (result.problems || []).filter(p => p.isCorrect === null);
-        const incorrect = (result.problems || []).filter(p => p.isCorrect === false);
-
-        let parts = [`I just submitted my work (${result.correctCount}/${result.problemCount} correct).`];
-        if (unsure.length > 0) {
-            parts.push(`You weren't sure about problem${unsure.length > 1 ? 's' : ''} ${unsure.map(p => '#' + p.problemNumber).join(', ')} — can we go over ${unsure.length > 1 ? 'those' : 'that one'} together?`);
-        }
-        if (incorrect.length > 0) {
-            parts.push(`I also got ${incorrect.map(p => '#' + p.problemNumber).join(', ')} wrong.`);
-        }
-
-        const msg = parts.join(' ');
-        const userInput = document.getElementById('user-input');
-        if (userInput) {
-            userInput.textContent = msg;
-            userInput.dispatchEvent(new Event('input', { bubbles: true }));
-            setTimeout(() => {
-                const sendBtn = document.getElementById('send-button');
-                if (sendBtn && !sendBtn.disabled) {
-                    sendBtn.click();
-                }
-            }, 100);
+        // Render the same breakdown inline in chat so it stays visible
+        // alongside the conversation. Skip if this is just a re-render
+        // of a result already shown in chat (avoid duplicate cards).
+        if (!this._renderedInChatIds) this._renderedInChatIds = new Set();
+        if (result.id && !this._renderedInChatIds.has(result.id)) {
+            this._renderedInChatIds.add(result.id);
+            this.addWorkSnippetToChat(result);
         }
     }
 
@@ -709,40 +664,146 @@ class ShowYourWorkManager {
     // ----------------------------------------------------------------
 
     addWorkSnippetToChat(result) {
-        const chatContainer = document.getElementById('chat-messages');
+        const chatContainer = document.getElementById('chat-messages-container')
+            || document.getElementById('chat-messages');
         if (!chatContainer) return;
 
-        const card = document.createElement('div');
-        card.className = 'work-snippet-card';
+        const card = this.buildInlineWorkCard(result);
+        if (!card) return;
 
-        const time = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-        const feedbackPreview = (result.overallFeedback || '').substring(0, 120);
+        chatContainer.appendChild(card);
+        chatContainer.scrollTop = chatContainer.scrollHeight;
+        this.typesetMath(card);
 
-        card.innerHTML = `
-            <div class="work-snippet-header">
-                <div class="work-snippet-icon">📝</div>
-                <div class="work-snippet-title">
-                    <strong>Work Analyzed</strong>
-                    <span class="work-snippet-time">${time}</span>
+        // Surface the AI-generated tutor greeting as a real assistant message
+        // (already persisted server-side; this just renders it client-side).
+        if (result.tutorGreeting && typeof window.appendMessage === 'function') {
+            window.appendMessage(result.tutorGreeting, 'ai');
+        }
+    }
+
+    /**
+     * Build the full breakdown card (same content as the modal results)
+     * for inline rendering inside the chat history.
+     */
+    buildInlineWorkCard(result) {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'message-container work-check-message';
+        wrapper.setAttribute('data-work-check-id', result.id || '');
+
+        if (result.noWorkDetected) {
+            wrapper.innerHTML = `
+                <div class="work-check-card work-check-empty">
+                    <div class="work-check-header">
+                        <i class="fas fa-pencil-alt"></i>
+                        <strong>Work Check</strong>
+                    </div>
+                    <div class="work-check-empty-body">
+                        ${this.escapeHtml(result.overallFeedback || "Looks like the worksheet isn't filled in yet — give it a try first, then snap another photo.")}
+                    </div>
                 </div>
-            </div>
-            <div class="work-snippet-body">
-                <div class="work-snippet-details">
-                    <div class="work-snippet-counts">${result.correctCount}/${result.problemCount} correct${(result.problems || []).some(p => p.isCorrect === null) ? ' · ' + (result.problems || []).filter(p => p.isCorrect === null).length + ' to discuss' : ''}</div>
-                    <div class="work-snippet-feedback">${this.escapeHtml(feedbackPreview)}</div>
-                    <div class="work-snippet-xp">+${result.xpEarned || 0} XP</div>
+            `;
+            return wrapper;
+        }
+
+        const total = result.problemCount || 0;
+        const correct = result.correctCount || 0;
+        const allCorrect = total > 0 && correct === total;
+        const imp = result.improvement;
+        const attempt = result.attemptNumber || 1;
+        const time = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+
+        wrapper.innerHTML = `
+            <div class="work-check-card">
+                <div class="work-check-header">
+                    <i class="fas fa-clipboard-check"></i>
+                    <strong>Work Check</strong>
+                    <span class="work-check-time">${time}</span>
+                </div>
+
+                ${imp ? `<div class="syw-improvement-banner ${imp.improved ? 'syw-improved' : 'syw-no-change'}" style="padding: 10px 14px; border-radius: 8px; margin: 8px 0; text-align: center; font-weight: 600; ${imp.improved ? 'background: linear-gradient(135deg, #d4edda, #c3e6cb); color: #155724;' : 'background: #fff3cd; color: #856404;'}">
+                    ${imp.improved
+                        ? `Attempt #${attempt}: ${imp.previousCorrect}/${imp.previousTotal} → ${correct}/${total} — Nice improvement!`
+                        : `Attempt #${attempt}: Keep at it! Review the feedback and try again.`}
+                </div>` : ''}
+
+                <div class="syw-summary-header ${allCorrect ? 'syw-all-correct' : ''}">
+                    <div class="syw-summary-counts">
+                        <span class="syw-count-correct">${correct}</span>
+                        <span class="syw-count-sep">of</span>
+                        <span class="syw-count-total">${total}</span>
+                        <span class="syw-count-label">correct</span>
+                    </div>
+                    ${result.whatWentWell ? `<div class="syw-went-well">${this.escapeHtml(result.whatWentWell)}</div>` : ''}
+                    <div class="syw-xp-badge">+${result.xpEarned || 0} XP</div>
+                </div>
+
+                <div class="syw-problems-list">
+                    <h4 class="syw-section-title"><i class="fas fa-list-ol"></i> Problem-by-Problem Feedback</h4>
+                    ${(result.problems || []).map(p => this.renderProblemCard(p)).join('')}
+                </div>
+
+                ${result.overallFeedback ? `<div class="syw-overall-feedback">
+                    <h4 class="syw-section-title"><i class="fas fa-comment-alt"></i> Overall</h4>
+                    <div class="syw-overall-feedback-body">${this.renderMath(result.overallFeedback)}</div>
+                </div>` : ''}
+
+                ${result.practiceRecommendations?.length ? `<div class="syw-practice-recs">
+                    <h4 class="syw-section-title"><i class="fas fa-dumbbell"></i> What to Practice</h4>
+                    <ul>${result.practiceRecommendations.map(r => `<li>${this.escapeHtml(r)}</li>`).join('')}</ul>
+                </div>` : ''}
+
+                <div class="work-check-actions">
+                    <button class="syw-btn syw-btn-secondary work-check-open-modal" type="button">
+                        <i class="fas fa-expand"></i> Open full view
+                    </button>
+                    ${!allCorrect ? `<button class="syw-btn syw-btn-primary work-check-discuss" type="button">
+                        <i class="fas fa-comments"></i> Discuss with tutor
+                    </button>` : ''}
                 </div>
             </div>
         `;
 
-        card.style.cursor = 'pointer';
-        card.addEventListener('click', () => {
-            this.modal?.classList.add('is-visible');
-            this.displayResults(this.analysisResult);
+        // Bind per-problem "Ask my tutor about this" buttons inside the chat card
+        wrapper.querySelectorAll('.syw-ask-tutor-problem').forEach(btn => {
+            btn.addEventListener('click', () => {
+                const num = btn.dataset.problem;
+                const statement = btn.dataset.statement;
+                const isUnsure = btn.dataset.unsure === 'true';
+                const msg = isUnsure
+                    ? `Can we go over problem #${num} together? You weren't sure about it.`
+                    : `Can you help me with problem #${num}? I got it wrong.`;
+                this.sendChatMessage(msg);
+            });
         });
 
-        chatContainer.appendChild(card);
-        chatContainer.scrollTop = chatContainer.scrollHeight;
+        wrapper.querySelector('.work-check-open-modal')?.addEventListener('click', () => {
+            this.analysisResult = result;
+            this.modal?.classList.add('is-visible');
+            this.displayResults(result);
+        });
+
+        wrapper.querySelector('.work-check-discuss')?.addEventListener('click', () => {
+            this.analysisResult = result;
+            this.askTutorAboutWork();
+        });
+
+        return wrapper;
+    }
+
+    /**
+     * Send a chat message via the existing chat send pipeline.
+     * Used by "Ask my tutor" buttons on inline cards and inside the modal.
+     */
+    sendChatMessage(msg) {
+        const userInput = document.getElementById('user-input');
+        if (!userInput) return;
+        userInput.textContent = msg;
+        userInput.dispatchEvent(new Event('input', { bubbles: true }));
+        setTimeout(() => {
+            const sendBtn = document.getElementById('send-button');
+            if (sendBtn && !sendBtn.disabled) sendBtn.click();
+        }, 100);
     }
 
     askTutorAboutWork() {
@@ -751,44 +812,22 @@ class ShowYourWorkManager {
 
         const r = this.analysisResult;
 
-        // Build a clean, natural message instead of dumping raw data.
-        // The tutor already has gradingContext in its system prompt, so
-        // it knows the details — the student just needs to reference the work.
-        const incorrectProblems = (r.problems || [])
-            .filter(p => p.isCorrect === false)
-            .map(p => `#${p.problemNumber}`)
-            .join(', ');
-
-        const unsureProblems = (r.problems || [])
-            .filter(p => p.isCorrect === null || p.isCorrect === undefined)
-            .map(p => `#${p.problemNumber}`)
-            .join(', ');
+        // The work-check card and tutor greeting are already in the
+        // conversation history, so this is just a short follow-up nudge.
+        const incorrect = (r.problems || []).filter(p => p.isCorrect === false).map(p => `#${p.problemNumber}`);
+        const unsure = (r.problems || []).filter(p => p.isCorrect === null || p.isCorrect === undefined).map(p => `#${p.problemNumber}`);
 
         let msg;
-        if (unsureProblems && incorrectProblems) {
-            msg = `I just checked my work and got ${r.correctCount} out of ${r.problemCount} right. Can you help me with the ones I got wrong (${incorrectProblems})? Also, you weren't sure about ${unsureProblems} — can we go over those together?`;
-        } else if (unsureProblems) {
-            msg = `I just checked my work and got ${r.correctCount} out of ${r.problemCount} right. You weren't sure about ${unsureProblems} — can we go over those together?`;
-        } else if (incorrectProblems) {
-            msg = `I just checked my work and got ${r.correctCount} out of ${r.problemCount} right. Can you help me with the ones I got wrong? (${incorrectProblems})`;
+        if (unsure.length && incorrect.length) {
+            msg = `Let's start with ${unsure.join(', ')} — I want to walk through those with you.`;
+        } else if (unsure.length) {
+            msg = `Can we go through ${unsure.join(', ')} together?`;
+        } else if (incorrect.length) {
+            msg = `Help me with ${incorrect.join(', ')} please.`;
         } else {
-            msg = `I just checked my work and got them all right! What should I work on next?`;
+            msg = `I got them all — what should I try next?`;
         }
-
-        // Auto-send the message so the tutor picks up immediately
-        const userInput = document.getElementById('user-input');
-        if (userInput) {
-            userInput.textContent = msg;
-            userInput.dispatchEvent(new Event('input', { bubbles: true }));
-
-            // Trigger send after a brief delay so the input registers
-            setTimeout(() => {
-                const sendBtn = document.getElementById('send-button');
-                if (sendBtn && !sendBtn.disabled) {
-                    sendBtn.click();
-                }
-            }, 100);
-        }
+        this.sendChatMessage(msg);
     }
 
     // ----------------------------------------------------------------
@@ -964,4 +1003,6 @@ class ShowYourWorkManager {
 // Initialize on DOM ready
 document.addEventListener('DOMContentLoaded', () => {
     window.showYourWorkManager = new ShowYourWorkManager();
+    // Convenience alias used by chat integrations (e.g. file-card "Check my work").
+    window.showYourWork = window.showYourWorkManager;
 });

--- a/routes/gradeWork.js
+++ b/routes/gradeWork.js
@@ -7,11 +7,115 @@ const sharp = require('sharp');
 const { isAuthenticated } = require('../middleware/auth');
 const User = require('../models/user');
 const GradingResult = require('../models/gradingResult');
-const { gradeWithVision } = require('../utils/llmGateway');
+const { gradeWithVision, callLLM } = require('../utils/llmGateway');
 const { validateUpload, uploadRateLimiter } = require('../middleware/uploadSecurity');
 const { detectBlankWork, stripCorrectAnswers } = require('../utils/worksheetGuard');
 const pdfOcr = require('../utils/pdfOcr');
 const { checkUnpluggedBadges } = require('../utils/unpluggedBadges');
+const Conversation = require('../models/conversation');
+const TUTOR_CONFIG = require('../utils/tutorConfig');
+
+// ============================================================================
+// Chat interlacing helpers — link Show My Work into the active conversation
+// ============================================================================
+
+async function getOrCreateActiveConversation(user) {
+    let conversation = null;
+    if (user.activeConversationId) {
+        conversation = await Conversation.findById(user.activeConversationId);
+        if (conversation && !conversation.isActive) conversation = null;
+    }
+    if (!conversation) {
+        conversation = new Conversation({ userId: user._id, messages: [], isMastery: false });
+        user.activeConversationId = conversation._id;
+        await user.save();
+    }
+    return conversation;
+}
+
+function buildWorkCheckSummary(result, attemptNumber, improvement) {
+    const problems = result.problems || [];
+    const incorrect = problems.filter(p => p.isCorrect === false).map(p => '#' + p.problemNumber);
+    const unsure = problems.filter(p => p.isCorrect === null || p.isCorrect === undefined).map(p => '#' + p.problemNumber);
+    const correct = problems.filter(p => p.isCorrect === true).map(p => '#' + p.problemNumber);
+
+    const lines = [`[WORK CHECK] I submitted my work for review — ${result.correctCount}/${result.problemCount} correct (attempt #${attemptNumber || 1}).`];
+    if (correct.length)   lines.push(`Correct: ${correct.join(', ')}.`);
+    if (incorrect.length) lines.push(`Incorrect: ${incorrect.join(', ')}.`);
+    if (unsure.length)    lines.push(`Need to discuss (unsure): ${unsure.join(', ')}.`);
+
+    const focus = problems.filter(p => p.isCorrect !== true).slice(0, 4);
+    if (focus.length) {
+        lines.push('');
+        lines.push('Per-problem detail:');
+        focus.forEach(p => {
+            const status = p.isCorrect === false ? 'incorrect' : 'unsure';
+            const stmt = (p.problemStatement || '').toString().substring(0, 160);
+            const ans = (p.studentAnswer || '').toString().substring(0, 80);
+            const fb = (p.feedback || '').toString().substring(0, 200);
+            lines.push(`  • Problem ${p.problemNumber} (${status}): "${stmt}" — student wrote: ${ans}. ${fb}`);
+        });
+    }
+
+    if (improvement && improvement.improved) {
+        lines.push('');
+        lines.push(`Improved from ${improvement.previousCorrect}/${improvement.previousTotal} to ${improvement.currentCorrect}/${improvement.currentTotal}.`);
+    }
+
+    return lines.join('\n');
+}
+
+async function generateTutorGreeting(user, result, improvement) {
+    try {
+        const tutorKey = user.selectedTutorId && TUTOR_CONFIG[user.selectedTutorId] ? user.selectedTutorId : 'default';
+        const tutor = TUTOR_CONFIG[tutorKey] || {};
+        const tutorName = tutor.name || 'your tutor';
+        const tutorPersona = tutor.persona || tutor.systemPrompt || '';
+        const firstName = user.firstName || 'there';
+
+        const problems = result.problems || [];
+        const incorrect = problems.filter(p => p.isCorrect === false);
+        const unsure = problems.filter(p => p.isCorrect === null || p.isCorrect === undefined);
+        const correct = problems.filter(p => p.isCorrect === true);
+
+        const detailBlock = problems.slice(0, 6).map(p => {
+            const status = p.isCorrect === true ? 'correct' : p.isCorrect === false ? 'incorrect' : 'unsure';
+            return `- Problem ${p.problemNumber} (${status}): ${p.problemStatement || ''} — student wrote: ${p.studentAnswer || '(blank)'}. Feedback: ${p.feedback || ''}`;
+        }).join('\n');
+
+        const systemMsg = `You are ${tutorName}, a warm math tutor.${tutorPersona ? ' ' + tutorPersona : ''}
+${firstName} just submitted handwritten work for you to review. The analysis is below.
+Write a SHORT (2-3 sentences max), warm, in-character follow-up message in chat that:
+1. Acknowledges what you saw (specific — name a problem or pattern).
+2. Picks ONE concrete next step to discuss (prioritize "unsure" problems, then incorrect).
+3. Ends with an open question inviting them to start.
+
+Do NOT list every problem. Do NOT give the answer. No headers, no bullet points. Just a natural chat message.`;
+
+        const userMsg = `Work analysis:
+Score: ${result.correctCount}/${result.problemCount}
+Correct: ${correct.length} (${correct.map(p => '#' + p.problemNumber).join(', ') || 'none'})
+Incorrect: ${incorrect.length} (${incorrect.map(p => '#' + p.problemNumber).join(', ') || 'none'})
+Unsure: ${unsure.length} (${unsure.map(p => '#' + p.problemNumber).join(', ') || 'none'})
+Overall feedback: ${result.overallFeedback || ''}
+${improvement && improvement.improved ? `Improved from ${improvement.previousCorrect}/${improvement.previousTotal} to ${improvement.currentCorrect}/${improvement.currentTotal}.` : ''}
+
+Per-problem detail:
+${detailBlock}
+
+Write your short greeting now:`;
+
+        const completion = await callLLM('gpt-4o', [
+            { role: 'system', content: systemMsg },
+            { role: 'user', content: userMsg }
+        ], { max_tokens: 220, temperature: 0.7 });
+
+        return completion.choices[0]?.message?.content?.trim() || '';
+    } catch (err) {
+        console.warn('[gradeWork] Tutor greeting generation failed (non-fatal):', err.message);
+        return '';
+    }
+}
 
 // Disk storage to avoid memory bloat on large uploads
 const upload = multer({
@@ -418,6 +522,38 @@ router.post('/',
 
         console.log(`[gradeWork] Saved analysis ${result._id} (attempt #${attemptNumber})`);
 
+        // ── Interlace with chat: append a work-check message + tutor greeting ──
+        // Stays in conversation history so the tutor (and student) can refer
+        // back to it later. Frontend renders the user message as a rich card.
+        let tutorGreeting = null;
+        try {
+            const conversation = await getOrCreateActiveConversation(user);
+            if (conversation) {
+                const summary = buildWorkCheckSummary(result, attemptNumber, improvement);
+                conversation.messages.push({
+                    role: 'user',
+                    content: summary,
+                    timestamp: new Date(),
+                    workCheckId: result._id
+                });
+
+                tutorGreeting = await generateTutorGreeting(user, result, improvement);
+                if (tutorGreeting && tutorGreeting.trim()) {
+                    conversation.messages.push({
+                        role: 'assistant',
+                        content: tutorGreeting,
+                        timestamp: new Date()
+                    });
+                }
+
+                conversation.lastActivity = new Date();
+                await conversation.save();
+                console.log(`[gradeWork] Appended work-check + greeting to conversation ${conversation._id}`);
+            }
+        } catch (convErr) {
+            console.warn('[gradeWork] Could not interlace with chat (non-fatal):', convErr.message);
+        }
+
         // Track paper practice submission for Unplugged badges
         let newUnpluggedBadges = [];
         try {
@@ -479,6 +615,7 @@ router.post('/',
             whatWentWell: parsed.whatWentWell || '',
             practiceRecommendations: parsed.practiceRecommendations || [],
             xpEarned,
+            tutorGreeting: tutorGreeting || null,
             unpluggedBadgesEarned: newUnpluggedBadges.length > 0 ? newUnpluggedBadges : undefined,
             message: improvement && improvement.improved
                 ? `Nice improvement! ${improvement.previousCorrect}/${improvement.previousTotal} → ${correctCount}/${parsed.problems.length}`


### PR DESCRIPTION
Make Show My Work a first-class chat citizen so the tutor and student
share one timeline instead of two separate flows.

- After /api/grade-work saves a result, push a work-check message
  (with workCheckId pointer) and an AI-generated tutor greeting into
  the active conversation so context survives across turns and reloads.
- Render the full per-problem breakdown card inline in chat (same UI
  as the modal), with per-problem "Ask my tutor" buttons and an
  "Open full view" action to reopen the modal.
- Replace the auto-typed paragraph with a short, natural follow-up;
  the breakdown card already provides the visible context.
- Add a "Check my work" button to attached image cards in chat so
  students can trigger OCR grading without opening the Show My Work
  modal. The result lands in chat the same way.
- Hydrate historical work-check messages on conversation switch by
  fetching the GradingResult by id and rendering the inline card.