### PR TITLE
feat(onboarding): voice-first intent capture for new users

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -113,6 +113,7 @@ const browserLockRoutes = require('../routes/browserLock');
 const practicePackRoutes = require('../routes/practicePack');
 const transcriptFlagsRoutes = require('../routes/transcriptFlags');
 const notificationsRoutes = require('../routes/notifications');
+const onboardingRoutes = require('../routes/onboarding');
 const TUTOR_CONFIG = require('../utils/tutorConfig');
 
 function registerRoutes(app, { authLimiter, signupLimiter }) {
@@ -242,6 +243,7 @@ function registerRoutes(app, { authLimiter, signupLimiter }) {
   app.use('/api/transcript-flags', isAuthenticated, transcriptFlagsRoutes);
   app.use('/api/notifications', isAuthenticated, notificationsRoutes);
   app.use('/api/role-switch', isAuthenticated, roleSwitchRoutes);
+  app.use('/api/onboarding', onboardingRoutes);
 
   // --- Inline Routes (User Profile & Settings) ---
   registerUserRoutes(app);
@@ -323,6 +325,8 @@ function oauthCallback(strategy) {
 
         req.session.save((saveErr) => {
           if (saveErr) return next(saveErr);
+          const onboardingDone = !!(user.onboarding && user.onboarding.completed);
+          if (user.needsProfileCompletion && !onboardingDone) return res.redirect('/onboarding.html');
           if (user.needsProfileCompletion) return res.redirect('/complete-profile.html');
           const userRoles = (user.roles && user.roles.length > 0) ? user.roles : [user.role];
           if (userRoles.length > 1) return res.redirect('/role-picker.html');
@@ -377,6 +381,8 @@ function registerOAuthRoutes(app, authLimiter) {
 
             req.session.save((saveErr) => {
               if (saveErr) return next(saveErr);
+              const onboardingDone = !!(user.onboarding && user.onboarding.completed);
+              if (user.needsProfileCompletion && !onboardingDone) return res.redirect('/onboarding.html');
               if (user.needsProfileCompletion) return res.redirect('/complete-profile.html');
               if (user.role === 'student' && !user.selectedTutorId) return res.redirect('/pick-tutor.html');
               const dashboardMap = { student: '/chat.html', teacher: '/teacher-dashboard.html', admin: '/admin-dashboard.html', parent: '/parent-dashboard.html' };
@@ -565,6 +571,7 @@ function registerHtmlRoutes(app) {
   app.get('/reset-password.html', sendHtml('reset-password.html'));
   app.get('/privacy.html', sendHtml('privacy.html'));
   app.get('/terms.html', sendHtml('terms.html'));
+  app.get('/onboarding.html', sendHtml('onboarding.html'));
   app.get('/demo.html', sendHtml('demo.html'));
   app.get('/pricing.html', sendHtml('pricing.html'));
   // Protected HTML routes

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -43,7 +43,13 @@ function ensureNotAuthenticated(req, res, next) {
         let redirectUrl = '/chat.html'; // Default for students
         const userRoles = (req.user.roles && req.user.roles.length > 0) ? req.user.roles : [req.user.role];
 
-        if (req.user.needsProfileCompletion) {
+        // Voice-first onboarding intent capture comes BEFORE profile completion
+        // for brand-new users. Existing users with completed profiles skip it
+        // automatically (so they don't get an onboarding screen on every login).
+        const onboardingDone = !!(req.user.onboarding && req.user.onboarding.completed);
+        if (req.user.needsProfileCompletion && !onboardingDone) {
+            redirectUrl = '/onboarding.html';
+        } else if (req.user.needsProfileCompletion) {
             redirectUrl = '/complete-profile.html';
         } else if (userRoles.length > 1) {
             redirectUrl = '/role-picker.html';

--- a/models/user.js
+++ b/models/user.js
@@ -671,6 +671,27 @@ const userSchema = new Schema({
   /* Onboarding */
   needsProfileCompletion: { type: Boolean, default: true },
 
+  /* Voice-first intent onboarding (Speak-style open-ended prompt) */
+  onboarding: {
+    completed:      { type: Boolean, default: false },
+    intentText:     { type: String, trim: true, maxlength: 2000 },
+    intentCategory: {
+      type: String,
+      enum: [
+        'student_homework',
+        'student_test_prep',
+        'act_sat_prep',
+        'parent_support',
+        'teacher_exploring',
+        'general_math_help',
+        'just_exploring',
+        'unknown'
+      ]
+    },
+    capturedVia:    { type: String, enum: ['voice', 'text'] },
+    completedAt:    { type: Date }
+  },
+
   /* Terms of Service / Privacy Policy acceptance */
   termsAcceptedAt: { type: Date, default: null },
 

--- a/public/css/onboarding.css
+++ b/public/css/onboarding.css
@@ -1,0 +1,277 @@
+/* css/onboarding.css — Voice-first intent capture screen
+ * Mobile-first. Big mic, low-pressure typing fallback, lots of breathing room.
+ */
+
+.onboarding-wrap {
+  min-height: calc(100dvh - var(--header-height, 72px) - var(--footer-height, 48px));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-6, 24px) var(--space-5, 20px);
+  background:
+    radial-gradient(circle at 20% -10%, rgba(var(--clr-primary-teal-rgb), 0.10) 0%, transparent 55%),
+    radial-gradient(circle at 80% 110%, rgba(var(--clr-accent-hotpink-rgb), 0.06) 0%, transparent 50%),
+    var(--clr-bg-light, #fff);
+}
+
+.onboarding-card {
+  width: 100%;
+  max-width: 560px;
+  background: var(--clr-bg-light, #fff);
+  border: 1px solid var(--clr-border-light, #f1f5f9);
+  border-radius: var(--radius-lg, 16px);
+  box-shadow: var(--shadow-lg, 0 10px 15px -3px rgba(0,0,0,0.08));
+  padding: clamp(20px, 5vw, 36px);
+  text-align: center;
+}
+
+.onboarding-prompt {
+  font-size: clamp(1.5rem, 5vw, 2rem);
+  font-weight: var(--font-weight-headlines, 700);
+  letter-spacing: var(--letter-spacing-tight, -0.02em);
+  line-height: 1.2;
+  color: var(--clr-text, #18202b);
+  margin: 0 0 var(--space-3, 12px) 0;
+}
+
+.onboarding-subtle {
+  color: var(--clr-text-dim, #5b6876);
+  font-size: 1rem;
+  line-height: 1.5;
+  margin: 0 0 var(--space-6, 24px) 0;
+}
+
+.onboarding-subtle small {
+  display: block;
+  margin-top: var(--space-1, 4px);
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+
+/* --- Mic button: large, friendly, primary affordance --- */
+.onboarding-mic-area {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-3, 12px);
+  margin: var(--space-4, 16px) 0 var(--space-5, 20px) 0;
+}
+
+.onboarding-mic-btn {
+  --mic-size: clamp(120px, 32vw, 160px);
+  width: var(--mic-size);
+  height: var(--mic-size);
+  border-radius: var(--radius-full, 9999px);
+  border: none;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: clamp(2.5rem, 9vw, 3.5rem);
+  background: linear-gradient(135deg, var(--clr-primary-teal, #12B3B3), var(--clr-primary-teal-dark, #0E8F8F));
+  box-shadow:
+    0 12px 32px rgba(var(--clr-primary-teal-rgb), 0.35),
+    0 0 0 0 rgba(var(--clr-primary-teal-rgb), 0.40);
+  transition: transform var(--transition-base, 200ms), box-shadow var(--transition-base, 200ms);
+  position: relative;
+}
+
+.onboarding-mic-btn:hover { transform: translateY(-2px); }
+.onboarding-mic-btn:active { transform: translateY(0); }
+
+.onboarding-mic-btn[disabled] {
+  opacity: 0.55;
+  cursor: not-allowed;
+  filter: grayscale(0.3);
+}
+
+.onboarding-mic-btn.recording {
+  background: linear-gradient(135deg, var(--clr-accent-hotpink, #FF3B7F), #d6346d);
+  animation: onboarding-mic-pulse 1.4s ease-out infinite;
+}
+
+@keyframes onboarding-mic-pulse {
+  0%   { box-shadow: 0 12px 32px rgba(var(--clr-accent-hotpink-rgb), 0.40), 0 0 0 0 rgba(var(--clr-accent-hotpink-rgb), 0.45); }
+  70%  { box-shadow: 0 12px 32px rgba(var(--clr-accent-hotpink-rgb), 0.40), 0 0 0 28px rgba(var(--clr-accent-hotpink-rgb), 0); }
+  100% { box-shadow: 0 12px 32px rgba(var(--clr-accent-hotpink-rgb), 0.40), 0 0 0 0 rgba(var(--clr-accent-hotpink-rgb), 0); }
+}
+
+.onboarding-mic-hint {
+  font-size: 0.95rem;
+  color: var(--clr-text-dim, #5b6876);
+  min-height: 1.4em;
+}
+
+/* --- Transcript / typing area --- */
+.onboarding-answer-box {
+  width: 100%;
+  margin: var(--space-3, 12px) 0;
+  text-align: left;
+}
+
+.onboarding-answer-box label {
+  display: block;
+  font-size: 0.85rem;
+  color: var(--clr-text-dim, #5b6876);
+  margin-bottom: var(--space-1, 4px);
+}
+
+.onboarding-answer-box textarea {
+  width: 100%;
+  min-height: 110px;
+  padding: var(--space-3, 12px) var(--space-4, 16px);
+  font-size: 1rem;
+  line-height: 1.5;
+  font-family: inherit;
+  color: var(--clr-text, #18202b);
+  background: var(--clr-bg-subtle, #f8fafb);
+  border: 1px solid var(--clr-border, #e2e8f0);
+  border-radius: var(--radius-base, 10px);
+  resize: vertical;
+  transition: border-color var(--transition-fast, 150ms), box-shadow var(--transition-fast, 150ms);
+}
+
+.onboarding-answer-box textarea:focus {
+  border-color: var(--clr-primary-teal, #12B3B3);
+  box-shadow: 0 0 0 3px rgba(var(--clr-primary-teal-rgb), 0.18);
+  outline: none;
+}
+
+/* "Prefer typing?" link — explicitly low-pressure */
+.onboarding-typing-toggle {
+  background: none;
+  border: none;
+  color: var(--clr-text-dim, #5b6876);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  font-size: 0.95rem;
+  cursor: pointer;
+  padding: var(--space-2, 8px) var(--space-3, 12px);
+}
+
+.onboarding-typing-toggle:hover { color: var(--clr-primary-teal, #12B3B3); }
+
+/* --- Action row --- */
+.onboarding-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3, 12px);
+  margin-top: var(--space-5, 20px);
+}
+
+.onboarding-submit-btn {
+  width: 100%;
+  padding: var(--space-4, 16px);
+  font-size: 1.05rem;
+  font-weight: var(--font-weight-semibold, 600);
+  color: #fff;
+  background: var(--clr-primary-teal, #12B3B3);
+  border: none;
+  border-radius: var(--radius-base, 10px);
+  cursor: pointer;
+  transition: background var(--transition-fast, 150ms), transform var(--transition-fast, 150ms);
+}
+
+.onboarding-submit-btn:hover:not([disabled]) { background: var(--clr-primary-teal-dark, #0E8F8F); }
+.onboarding-submit-btn:active:not([disabled]) { transform: translateY(1px); }
+.onboarding-submit-btn[disabled] {
+  background: #c4cdd5;
+  cursor: not-allowed;
+}
+
+.onboarding-skip-btn {
+  background: none;
+  border: none;
+  color: var(--clr-text-dim, #5b6876);
+  font-size: 0.9rem;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+/* --- Warm response stage --- */
+.onboarding-response {
+  display: none;
+}
+
+.onboarding-response.active {
+  display: block;
+  animation: onboarding-fade-in 400ms ease-out;
+}
+
+.onboarding-stage1.fade-out {
+  animation: onboarding-fade-out 250ms ease-in forwards;
+}
+
+@keyframes onboarding-fade-in {
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes onboarding-fade-out {
+  from { opacity: 1; }
+  to   { opacity: 0; }
+}
+
+.onboarding-response-text {
+  font-size: clamp(1.1rem, 3.5vw, 1.3rem);
+  line-height: 1.5;
+  color: var(--clr-text, #18202b);
+  margin: var(--space-4, 16px) 0 var(--space-6, 24px) 0;
+}
+
+.onboarding-tutor-avatar {
+  width: 96px;
+  height: 96px;
+  border-radius: var(--radius-full, 9999px);
+  margin: 0 auto var(--space-4, 16px) auto;
+  object-fit: cover;
+  background: var(--clr-bg-subtle, #f8fafb);
+  border: 2px solid var(--clr-border-light, #f1f5f9);
+}
+
+/* --- Status / error notes --- */
+.onboarding-status {
+  font-size: 0.85rem;
+  color: var(--clr-text-dim, #5b6876);
+  min-height: 1.2em;
+  margin-top: var(--space-2, 8px);
+}
+
+.onboarding-status.error {
+  color: var(--clr-error-red, #FF4E4E);
+}
+
+/* --- Very small screens --- */
+@media (max-width: 360px) {
+  .onboarding-card { padding: 18px 16px; }
+  .onboarding-prompt { font-size: 1.35rem; }
+}
+
+/* --- Dark-mode shim (uses existing variables when dark-mode is active) --- */
+body.dark-mode .onboarding-wrap,
+html[data-theme="dark"] .onboarding-wrap {
+  background:
+    radial-gradient(circle at 20% -10%, rgba(var(--clr-primary-teal-rgb), 0.14) 0%, transparent 55%),
+    var(--clr-bg-dark, #0F1A24);
+}
+
+body.dark-mode .onboarding-card,
+html[data-theme="dark"] .onboarding-card {
+  background: #182532;
+  border-color: #233140;
+  color: #E2E8F0;
+}
+
+body.dark-mode .onboarding-prompt,
+html[data-theme="dark"] .onboarding-prompt {
+  color: #F8FAFB;
+}
+
+body.dark-mode .onboarding-answer-box textarea,
+html[data-theme="dark"] .onboarding-answer-box textarea {
+  background: #0F1A24;
+  border-color: #233140;
+  color: #F8FAFB;
+}

--- a/public/js/onboarding.js
+++ b/public/js/onboarding.js
@@ -1,0 +1,377 @@
+/* public/js/onboarding.js — Voice-first intent capture
+ *
+ * Flow:
+ *   1. Ask "What brings you to Mathmatix today?" (open-ended).
+ *   2. Capture via Web Speech API (preferred) with low-pressure typing fallback.
+ *   3. Infer a category client-side; server re-validates and stores authoritative.
+ *   4. Show a warm role-aware response, then continue to the existing flow
+ *      (complete-profile / pick-tutor / dashboard).
+ *
+ * If the user is anonymous, the answer is stored in localStorage under
+ * `mathmatix.pendingOnboardingIntent` and attached after signup/login by
+ * the post-auth bootstrap snippet (see attachPendingIntent in script.js).
+ */
+(function () {
+  'use strict';
+
+  const STORAGE_KEY = 'mathmatix.pendingOnboardingIntent';
+
+  // --- Intent inference (mirrors server-side logic in routes/onboarding.js) ---
+  function inferIntent(rawText) {
+    if (!rawText) return 'unknown';
+    const t = String(rawText).toLowerCase();
+
+    if (/\b(teacher|teach my|my class|my students|classroom|professor|educator|i teach)\b/.test(t)) return 'teacher_exploring';
+    if (/\b(parent|mom|dad|mother|father|my (kid|son|daughter|child|children))\b|\bhelp my (kid|son|daughter|child)\b/.test(t)) return 'parent_support';
+    if (/\b(act\b|\bsat\b|act prep|sat prep|standardized test|admissions test)\b/.test(t)) return 'act_sat_prep';
+    if (/\b(test|quiz|exam|final|midterm|state test|benchmark)\b/.test(t)) return 'student_test_prep';
+    if (/\b(homework|assignment|problem set|worksheet|due tomorrow|due tonight)\b/.test(t)) return 'student_homework';
+    if (/(bad at math|failing|struggling|confused|don'?t (get|understand)|stuck on|hate math|behind in math|rusty)/.test(t)) return 'general_math_help';
+    if (/(check(ing)? (it|this) out|just (looking|curious|exploring|seeing|trying|browsing)|see what (this|it) is|trying it out|poke around)/.test(t)) return 'just_exploring';
+    return 'unknown';
+  }
+
+  const WARM_RESPONSES = {
+    teacher_exploring:  "Perfect. I’ll show you what the student experience feels like first.",
+    parent_support:     "That’s a great reason to be here. We can help you feel less rusty.",
+    student_homework:   "Got it. We’ll work through it without just giving answers.",
+    student_test_prep:  "Got it. We’ll focus on speed, accuracy, and patterns.",
+    act_sat_prep:       "Got it. We’ll focus on speed, accuracy, and patterns.",
+    general_math_help:  "Thanks for being honest. We’ll start where it makes sense and build from there.",
+    just_exploring:     "Cool. Take your time poking around — I’ll be here.",
+    unknown:            "Got it. I’ll use that to help decide where we start."
+  };
+
+  // ---- Element refs ----
+  const $ = (id) => document.getElementById(id);
+  const stage1     = $('onboarding-stage1');
+  const stage2     = $('onboarding-stage2');
+  const micBtn     = $('onboarding-mic-btn');
+  const micHint    = $('onboarding-mic-hint');
+  const typingToggle = $('onboarding-typing-toggle');
+  const answerBox  = $('onboarding-answer-box');
+  const textarea   = $('onboarding-textarea');
+  const submitBtn  = $('onboarding-submit');
+  const skipBtn    = $('onboarding-skip');
+  const statusEl   = $('onboarding-status');
+  const responseEl = $('onboarding-response-text');
+  const continueBtn = $('onboarding-continue');
+  const tutorAvatar = $('onboarding-tutor-avatar');
+
+  // ---- Speech recognition setup (feature-detected) ----
+  const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+  let recognition = null;
+  let isRecognizing = false;
+  let interimText = '';
+  let finalText = '';
+
+  if (SpeechRecognition) {
+    try {
+      recognition = new SpeechRecognition();
+      recognition.continuous = true;
+      recognition.interimResults = true;
+      recognition.lang = (navigator.language || 'en-US');
+      recognition.maxAlternatives = 1;
+
+      recognition.onresult = (event) => {
+        let interim = '';
+        for (let i = event.resultIndex; i < event.results.length; i++) {
+          const r = event.results[i];
+          if (r.isFinal) finalText += r[0].transcript;
+          else interim += r[0].transcript;
+        }
+        interimText = interim;
+        const combined = (finalText + ' ' + interim).trim();
+        textarea.value = combined;
+        updateSubmitState();
+      };
+
+      recognition.onerror = (e) => {
+        // Don't block the user — graceful fallback to typing.
+        console.warn('[onboarding] speech recognition error:', e.error);
+        stopListening();
+        if (e.error === 'not-allowed' || e.error === 'service-not-allowed') {
+          showStatus('Mic blocked — you can type your answer below.', false);
+          revealTypingUI(true);
+        } else if (e.error === 'no-speech') {
+          showStatus('Didn’t catch that — tap the mic and try again, or type instead.', false);
+        } else if (e.error === 'network') {
+          showStatus('Voice is offline right now. Typing works just as well.', false);
+          revealTypingUI(true);
+        }
+      };
+
+      recognition.onend = () => {
+        isRecognizing = false;
+        micBtn.classList.remove('recording');
+        micBtn.setAttribute('aria-pressed', 'false');
+        micHint.textContent = textarea.value.trim()
+          ? 'Tap the mic to add more, or tap Continue.'
+          : 'Tap the mic when you’re ready.';
+      };
+    } catch (err) {
+      console.warn('[onboarding] failed to init SpeechRecognition:', err);
+      recognition = null;
+    }
+  }
+
+  // ---- UI helpers ----
+  function showStatus(msg, isError) {
+    if (!statusEl) return;
+    statusEl.textContent = msg || '';
+    statusEl.classList.toggle('error', !!isError);
+  }
+
+  function updateSubmitState() {
+    const hasText = textarea.value.trim().length > 0;
+    submitBtn.disabled = !hasText;
+  }
+
+  function startListening() {
+    if (!recognition || isRecognizing) return;
+    finalText = textarea.value || ''; // preserve anything already typed
+    if (finalText && !finalText.endsWith(' ')) finalText += ' ';
+    try {
+      recognition.start();
+      isRecognizing = true;
+      micBtn.classList.add('recording');
+      micBtn.setAttribute('aria-pressed', 'true');
+      micHint.textContent = 'Listening… tap again to stop.';
+      showStatus('', false);
+    } catch (err) {
+      console.warn('[onboarding] start() failed:', err);
+      // Could already be running; restart cleanly.
+      try { recognition.stop(); } catch (_) {}
+      isRecognizing = false;
+    }
+  }
+
+  function stopListening() {
+    if (!recognition || !isRecognizing) return;
+    try { recognition.stop(); } catch (_) {}
+    isRecognizing = false;
+    micBtn.classList.remove('recording');
+    micBtn.setAttribute('aria-pressed', 'false');
+  }
+
+  function revealTypingUI(focusIt) {
+    answerBox.hidden = false;
+    if (focusIt) {
+      // Slight delay so the keyboard doesn't jump in immediately on mobile
+      setTimeout(() => textarea.focus(), 50);
+    }
+  }
+
+  // ---- CSRF-aware POST that does NOT trigger session-expired redirects.
+  // We need to handle 401 ourselves (anonymous flow stores to localStorage).
+  function readCsrfCookie() {
+    const match = document.cookie.split(';').map(s => s.trim()).find(s => s.startsWith('_csrf='));
+    return match ? decodeURIComponent(match.slice('_csrf='.length)) : null;
+  }
+  async function postJson(url, body) {
+    let token = readCsrfCookie();
+    if (!token) {
+      // Fetch a fresh token first to satisfy CSRF middleware
+      try { await fetch('/api/csrf-token', { credentials: 'include' }); } catch (_) { /* noop */ }
+      token = readCsrfCookie();
+    }
+    const headers = { 'Content-Type': 'application/json' };
+    if (token) headers['X-CSRF-Token'] = token;
+    return fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      credentials: 'include'
+    });
+  }
+
+  // ---- Submit handler ----
+  async function submitAnswer() {
+    const intentText = (textarea.value || '').trim();
+    if (!intentText) {
+      showStatus('Type or say something first — even a few words help.', true);
+      return;
+    }
+    stopListening();
+
+    const intentCategory = inferIntent(intentText);
+    const capturedVia = isRecognizing || finalText.trim().length > 0 ? 'voice' : 'text';
+
+    submitBtn.disabled = true;
+    submitBtn.textContent = 'Saving…';
+
+    // Try to save server-side. If unauthenticated, persist to localStorage
+    // so the post-auth bootstrap can attach it after signup/login.
+    let serverResponse = null;
+    try {
+      const res = await postJson('/api/onboarding/intent', {
+        intentText,
+        intentCategory,
+        capturedVia
+      });
+
+      if (res.status === 401) {
+        // Anonymous flow — save locally and route to signup.
+        saveLocally({ intentText, intentCategory, capturedVia });
+        showWarmResponse(intentCategory, /* anon */ true);
+        return;
+      }
+
+      if (!res.ok) {
+        throw new Error('Save failed (' + res.status + ')');
+      }
+      serverResponse = await res.json();
+    } catch (err) {
+      console.warn('[onboarding] save error, falling back to local:', err);
+      saveLocally({ intentText, intentCategory, capturedVia });
+      showWarmResponse(intentCategory, /* anon */ true);
+      return;
+    }
+
+    // Server returns the authoritative category + next redirect.
+    showWarmResponse(serverResponse.intentCategory || intentCategory, false, serverResponse.redirect);
+  }
+
+  function saveLocally(payload) {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({
+        ...payload,
+        capturedAt: new Date().toISOString()
+      }));
+    } catch (_) { /* storage disabled — best effort only */ }
+  }
+
+  function showWarmResponse(category, isAnon, redirectUrl) {
+    const text = WARM_RESPONSES[category] || WARM_RESPONSES.unknown;
+    if (responseEl) responseEl.textContent = text;
+
+    // Transition stages
+    stage1.classList.add('fade-out');
+    setTimeout(() => {
+      stage1.hidden = true;
+      stage2.classList.add('active');
+    }, 250);
+
+    // Configure the Continue button
+    if (isAnon) {
+      continueBtn.textContent = 'Continue to sign up';
+      continueBtn.dataset.redirect = '/signup.html';
+    } else {
+      continueBtn.textContent = 'Continue';
+      continueBtn.dataset.redirect = redirectUrl || '/chat.html';
+    }
+  }
+
+  // ---- Wire up events ----
+  function init() {
+    // Mic feature-detect: hide mic + auto-reveal typing if not supported.
+    if (!SpeechRecognition || !recognition) {
+      if (micBtn) {
+        micBtn.disabled = true;
+        micBtn.title = 'Voice input is not supported in this browser';
+      }
+      if (micHint) micHint.textContent = 'Voice isn’t available here — go ahead and type your answer.';
+      revealTypingUI(false);
+    }
+
+    if (micBtn) {
+      micBtn.addEventListener('click', () => {
+        if (!recognition) return revealTypingUI(true);
+        if (isRecognizing) stopListening();
+        else startListening();
+      });
+    }
+
+    if (typingToggle) {
+      typingToggle.addEventListener('click', (e) => {
+        e.preventDefault();
+        revealTypingUI(true);
+      });
+    }
+
+    if (textarea) {
+      textarea.addEventListener('input', updateSubmitState);
+    }
+
+    if (submitBtn) submitBtn.addEventListener('click', submitAnswer);
+
+    if (skipBtn) {
+      skipBtn.addEventListener('click', async () => {
+        // Skip = save an empty/unknown answer so we don't re-prompt.
+        textarea.value = '';
+        const res = await postJson('/api/onboarding/intent', {
+          intentText: '',
+          intentCategory: 'unknown',
+          capturedVia: 'text'
+        }).catch(() => null);
+
+        if (res && res.ok) {
+          const json = await res.json().catch(() => null);
+          window.location.href = (json && json.redirect) || '/chat.html';
+        } else {
+          // Anonymous — just move to signup.
+          window.location.href = '/signup.html';
+        }
+      });
+    }
+
+    if (continueBtn) {
+      continueBtn.addEventListener('click', () => {
+        const next = continueBtn.dataset.redirect || '/chat.html';
+        window.location.href = next;
+      });
+    }
+
+    // If a returning authenticated user lands here with onboarding already
+    // done, send them on without making them re-answer. If they have a
+    // pending anonymous answer in localStorage, attach it now and skip
+    // straight to the warm response.
+    fetch('/api/onboarding/status', { credentials: 'include' })
+      .then(r => r.ok ? r.json() : null)
+      .then(async (data) => {
+        if (!data) return;
+
+        if (data.authenticated && data.onboarding && data.onboarding.completed) {
+          window.location.replace('/chat.html');
+          return;
+        }
+
+        if (data.authenticated) {
+          const pending = readPendingIntent();
+          if (pending && (pending.intentText || '').trim()) {
+            try {
+              const res = await postJson('/api/onboarding/intent', {
+                intentText:     pending.intentText,
+                intentCategory: pending.intentCategory,
+                capturedVia:    pending.capturedVia || 'text'
+              });
+              if (res.ok) {
+                const json = await res.json().catch(() => ({}));
+                clearPendingIntent();
+                showWarmResponse(json.intentCategory || pending.intentCategory, false, json.redirect);
+              }
+            } catch (err) {
+              console.warn('[onboarding] attach pending intent failed:', err);
+            }
+          }
+        }
+      })
+      .catch(() => { /* non-fatal */ });
+  }
+
+  function readPendingIntent() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      return raw ? JSON.parse(raw) : null;
+    } catch (_) { return null; }
+  }
+  function clearPendingIntent() {
+    try { localStorage.removeItem(STORAGE_KEY); } catch (_) { /* noop */ }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/public/onboarding.html
+++ b/public/onboarding.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <title>Welcome | M∆THM∆TIΧ AI</title>
+  <meta name="description" content="Tell us what brings you here today — we'll start there." />
+  <meta name="robots" content="noindex, follow" />
+
+  <link rel="stylesheet" href="/style.css" />
+  <link rel="stylesheet" href="/css/dark-mode.css" />
+  <link rel="stylesheet" href="/css/onboarding.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" referrerpolicy="no-referrer" />
+
+  <script src="/js/csrf.js"></script>
+</head>
+<body class="landing-page-body">
+  <header class="landing-header">
+    <div class="header-logo-container">
+      <img src="/images/mathmatix-ai-logo.png" alt="Mathmatix AI" class="main-logo-hero" />
+    </div>
+    <nav class="landing-nav">
+      <button id="logoutBtn" class="btn btn-tertiary" type="button" style="display:none;">Log out</button>
+    </nav>
+  </header>
+
+  <main class="onboarding-wrap" role="main">
+    <section class="onboarding-card" aria-labelledby="onboarding-prompt-heading">
+
+      <!-- STAGE 1: open-ended capture -->
+      <div id="onboarding-stage1">
+        <h1 id="onboarding-prompt-heading" class="onboarding-prompt">
+          What brings you to Mathmatix today?
+        </h1>
+        <p class="onboarding-subtle">
+          Answer however you want — there’s no wrong answer.
+          <small>Take a second if you need to.</small>
+        </p>
+
+        <div class="onboarding-mic-area">
+          <button
+            id="onboarding-mic-btn"
+            type="button"
+            class="onboarding-mic-btn"
+            aria-label="Tap to speak your answer"
+            aria-pressed="false"
+          >
+            <i class="fas fa-microphone" aria-hidden="true"></i>
+          </button>
+          <div id="onboarding-mic-hint" class="onboarding-mic-hint">
+            Tap the mic when you’re ready.
+          </div>
+        </div>
+
+        <!-- Low-pressure typing fallback -->
+        <button
+          id="onboarding-typing-toggle"
+          type="button"
+          class="onboarding-typing-toggle"
+        >Prefer typing?</button>
+
+        <div id="onboarding-answer-box" class="onboarding-answer-box" hidden>
+          <label for="onboarding-textarea">Type your answer</label>
+          <textarea
+            id="onboarding-textarea"
+            rows="3"
+            placeholder="For example: I’m a parent trying to help my kid, I need homework help, I’m prepping for the ACT…"
+            autocomplete="off"
+            autocapitalize="sentences"
+            spellcheck="true"
+          ></textarea>
+        </div>
+
+        <div class="onboarding-actions">
+          <button
+            id="onboarding-submit"
+            type="button"
+            class="onboarding-submit-btn"
+            disabled
+          >Continue</button>
+          <button
+            id="onboarding-skip"
+            type="button"
+            class="onboarding-skip-btn"
+          >Skip for now</button>
+        </div>
+
+        <div id="onboarding-status" class="onboarding-status" aria-live="polite"></div>
+      </div>
+
+      <!-- STAGE 2: warm response + continue -->
+      <div id="onboarding-stage2" class="onboarding-response" aria-live="polite">
+        <img
+          id="onboarding-tutor-avatar"
+          class="onboarding-tutor-avatar"
+          src="/images/mathmatix-ai-logo.png"
+          alt=""
+        />
+        <p id="onboarding-response-text" class="onboarding-response-text">
+          Got it. I’ll use that to help decide where we start.
+        </p>
+        <button
+          id="onboarding-continue"
+          type="button"
+          class="onboarding-submit-btn"
+        >Continue</button>
+      </div>
+
+    </section>
+  </main>
+
+  <footer>
+    <p>&copy; 2026 M∆THM∆TIΧ AI. <a href="/privacy.html">Privacy</a> | <a href="/terms.html">Terms</a></p>
+  </footer>
+
+  <script src="/js/onboarding.js"></script>
+</body>
+</html>

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -287,10 +287,11 @@ router.post('/complete-oauth-enrollment', async (req, res) => {
         });
       }
 
-      // Determine redirect
-      let redirect = '/complete-profile.html';
-      if (!newUser.needsProfileCompletion) {
-        redirect = '/pick-tutor.html';
+      // Determine redirect — new users always start with voice-first
+      // onboarding intent capture, then continue to profile/tutor flow.
+      let redirect = '/onboarding.html';
+      if (newUser.onboarding && newUser.onboarding.completed) {
+        redirect = newUser.needsProfileCompletion ? '/complete-profile.html' : '/pick-tutor.html';
       }
 
       logger.info('OAuth user logged in after enrollment', { userId: newUser._id.toString(), redirect });

--- a/routes/login.js
+++ b/routes/login.js
@@ -44,7 +44,11 @@ router.post('/', loginValidation, handleValidationErrors, (req, res, next) => {
             let redirectUrl = '/chat.html'; // Default for students
             const userRoles = (user.roles && user.roles.length > 0) ? user.roles : [user.role];
 
-            if (user.needsProfileCompletion) {
+            // Voice-first onboarding precedes profile completion for new users.
+            const onboardingDone = !!(user.onboarding && user.onboarding.completed);
+            if (user.needsProfileCompletion && !onboardingDone) {
+                redirectUrl = "/onboarding.html";
+            } else if (user.needsProfileCompletion) {
                 redirectUrl = "/complete-profile.html";
             } else if (userRoles.length > 1) {
                 // Multi-role user: let them pick which role to enter as

--- a/routes/onboarding.js
+++ b/routes/onboarding.js
@@ -1,0 +1,155 @@
+// routes/onboarding.js — Voice-first intent capture for new users
+// Stores an open-ended answer to "What brings you to Mathmatix today?"
+// Used to personalize the warm response and routing on first session.
+
+const express = require('express');
+const router = express.Router();
+const User = require('../models/user');
+const logger = require('../utils/logger');
+
+const ALLOWED_CATEGORIES = [
+  'student_homework',
+  'student_test_prep',
+  'act_sat_prep',
+  'parent_support',
+  'teacher_exploring',
+  'general_math_help',
+  'just_exploring',
+  'unknown'
+];
+
+/**
+ * Server-side intent classifier — keyword based.
+ * Mirrors the client-side logic so anonymous answers attached after signup
+ * still get a category even if the client didn't send one.
+ */
+function inferIntent(rawText) {
+  if (!rawText || typeof rawText !== 'string') return 'unknown';
+  const t = rawText.toLowerCase();
+
+  if (/\b(teacher|teach my|my class|my students|classroom|professor|educator|i teach)\b/.test(t)) {
+    return 'teacher_exploring';
+  }
+  if (/\b(parent|mom|dad|mother|father|my (kid|son|daughter|child|children))\b|\bhelp my (kid|son|daughter|child)\b/.test(t)) {
+    return 'parent_support';
+  }
+  if (/\b(act\b|\bsat\b|act prep|sat prep|standardized test|admissions test)\b/.test(t)) {
+    return 'act_sat_prep';
+  }
+  if (/\b(test|quiz|exam|final|midterm|state test|benchmark)\b/.test(t)) {
+    return 'student_test_prep';
+  }
+  if (/\b(homework|assignment|problem set|worksheet|due tomorrow|due tonight)\b/.test(t)) {
+    return 'student_homework';
+  }
+  if (/(bad at math|failing|struggling|confused|don'?t (get|understand)|stuck on|hate math|behind in math|rusty)/.test(t)) {
+    return 'general_math_help';
+  }
+  if (/(check(ing)? (it|this) out|just (looking|curious|exploring|seeing|trying|browsing)|see what (this|it) is|trying it out|poke around)/.test(t)) {
+    return 'just_exploring';
+  }
+  return 'unknown';
+}
+
+/**
+ * Compute the next URL for the user after onboarding intent is captured.
+ * Mirrors the post-login redirect logic in middleware/auth.js and login.js.
+ */
+function computeNextUrl(user) {
+  const roles = (user.roles && user.roles.length > 0) ? user.roles : [user.role];
+
+  if (user.needsProfileCompletion) return '/complete-profile.html';
+  if (roles.length > 1) return '/role-picker.html';
+  if (user.role === 'teacher') return '/teacher-dashboard.html';
+  if (user.role === 'admin')   return '/admin-dashboard.html';
+  if (user.role === 'parent')  return '/parent-dashboard.html';
+  if (user.role === 'student' && !user.selectedTutorId) return '/pick-tutor.html';
+  return '/chat.html';
+}
+
+/**
+ * GET /api/onboarding/status
+ * Authenticated only. Tells the client whether the current user has
+ * completed onboarding and (if so) what their captured intent was.
+ */
+router.get('/status', (req, res) => {
+  if (!req.isAuthenticated || !req.isAuthenticated() || !req.user) {
+    return res.json({
+      authenticated: false,
+      onboarding: { completed: false }
+    });
+  }
+
+  const ob = req.user.onboarding || {};
+  res.json({
+    authenticated: true,
+    onboarding: {
+      completed:      !!ob.completed,
+      intentText:     ob.intentText || null,
+      intentCategory: ob.intentCategory || null,
+      capturedVia:    ob.capturedVia || null,
+      completedAt:    ob.completedAt || null
+    }
+  });
+});
+
+/**
+ * POST /api/onboarding/intent
+ * Authenticated only. Saves the user's open-ended onboarding answer.
+ * Body: { intentText: string, intentCategory?: string, capturedVia?: 'voice'|'text' }
+ * Returns: { success, redirect, intentCategory }
+ */
+router.post('/intent', async (req, res) => {
+  if (!req.isAuthenticated || !req.isAuthenticated() || !req.user) {
+    return res.status(401).json({ success: false, message: 'Authentication required.' });
+  }
+
+  try {
+    const rawText = (req.body?.intentText || '').toString().trim().slice(0, 2000);
+    let category = (req.body?.intentCategory || '').toString().trim();
+    const capturedVia = ['voice', 'text'].includes(req.body?.capturedVia) ? req.body.capturedVia : 'text';
+
+    // Re-infer server-side if client didn't send a valid category. The
+    // client value is treated as a hint, not authoritative.
+    if (!ALLOWED_CATEGORIES.includes(category)) {
+      category = inferIntent(rawText);
+    }
+
+    const user = await User.findById(req.user._id);
+    if (!user) return res.status(404).json({ success: false, message: 'User not found.' });
+
+    user.onboarding = {
+      completed:      true,
+      intentText:     rawText || null,
+      intentCategory: category,
+      capturedVia,
+      completedAt:    new Date()
+    };
+
+    await user.save();
+
+    const redirect = computeNextUrl(user);
+
+    logger.info('Onboarding intent captured', {
+      userId: user._id.toString(),
+      role: user.role,
+      intentCategory: category,
+      capturedVia,
+      textLength: rawText.length
+    });
+
+    return res.json({
+      success: true,
+      intentCategory: category,
+      capturedVia,
+      redirect
+    });
+  } catch (err) {
+    logger.error('Failed to save onboarding intent', { error: err.message });
+    return res.status(500).json({ success: false, message: 'Failed to save your answer.' });
+  }
+});
+
+module.exports = router;
+module.exports.inferIntent = inferIntent;
+module.exports.computeNextUrl = computeNextUrl;

--- a/routes/signup.js
+++ b/routes/signup.js
@@ -314,8 +314,11 @@ router.post('/', ensureNotAuthenticated, signupValidation, handleValidationError
                 return res.status(500).json({ success: true, message: 'Account created successfully, but auto-login failed. Please try logging in manually.' });
             }
             // --- 7. Determine Redirect URL ---
-            let redirectUrl = '/complete-profile.html'; // Default for new users
-            if (newUser.role === 'student' && !newUser.selectedTutorId) {
+            // New users always start with voice-first onboarding (open-ended
+            // "What brings you to Mathmatix today?"). After answering, the
+            // onboarding page routes them to complete-profile / pick-tutor.
+            let redirectUrl = '/onboarding.html';
+            if (!newUser.needsProfileCompletion && newUser.role === 'student' && !newUser.selectedTutorId) {
                 redirectUrl = '/pick-tutor.html'; // Student needs to pick a tutor
             }
             // Other roles redirect to their dashboards if profile completion not needed

--- a/tests/integration/login.test.js
+++ b/tests/integration/login.test.js
@@ -111,8 +111,15 @@ describe('POST /login (passport flow)', () => {
     expect(r.body.redirect).toBe('/chat.html');
   });
 
-  test('redirect for needsProfileCompletion → /complete-profile.html', async () => {
+  test('redirect for needsProfileCompletion without onboarding → /onboarding.html', async () => {
     setupPassport({ user: makeUser({ needsProfileCompletion: true }) });
+    const r = await supertest(appWithLogin((u, cb) => cb(null)))
+      .post('/login').send({ email: 'a@b.io', password: 'p' });
+    expect(r.body.redirect).toBe('/onboarding.html');
+  });
+
+  test('redirect for needsProfileCompletion with onboarding done → /complete-profile.html', async () => {
+    setupPassport({ user: makeUser({ needsProfileCompletion: true, onboarding: { completed: true } }) });
     const r = await supertest(appWithLogin((u, cb) => cb(null)))
       .post('/login').send({ email: 'a@b.io', password: 'p' });
     expect(r.body.redirect).toBe('/complete-profile.html');

--- a/tests/unit/authMiddleware.test.js
+++ b/tests/unit/authMiddleware.test.js
@@ -102,10 +102,20 @@ describe('ensureNotAuthenticated', () => {
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ alreadyLoggedIn: true }));
   });
 
-  test('redirects student needing profile completion', () => {
+  test('redirects student needing onboarding to onboarding intent page', () => {
     const req = makeReq({
       authenticated: true,
       user: { needsProfileCompletion: true, role: 'student' }
+    });
+    const res = makeRes();
+    ensureNotAuthenticated(req, res, jest.fn());
+    expect(res.redirect).toHaveBeenCalledWith('/onboarding.html');
+  });
+
+  test('redirects student needing profile completion (onboarding done) to complete-profile', () => {
+    const req = makeReq({
+      authenticated: true,
+      user: { needsProfileCompletion: true, role: 'student', onboarding: { completed: true } }
     });
     const res = makeRes();
     ensureNotAuthenticated(req, res, jest.fn());


### PR DESCRIPTION
Adds a Speak-style open-ended intro: a big mic, a low-pressure
"Prefer typing?" fallback, supportive copy, and an inferred intent
category that personalizes a short warm response before routing
the user into the existing complete-profile / pick-tutor flow.

- New User.onboarding subdocument: completed, intentText,
  intentCategory (enum), capturedVia, completedAt
- New /api/onboarding routes (status, intent) with server-side
  keyword classifier mirroring the client logic
- New /onboarding.html with Web Speech API (feature-detected),
  graceful typing fallback, anonymous → localStorage attach after auth
- Signup / login / OAuth callbacks redirect new users to
  /onboarding.html before complete-profile; existing users skip it
- Tests updated for the new redirect ordering