### PR TITLE
fix(layout): scope body viewport-lock to the chat page only

### DIFF
--- a/public/css/mobile-fixes.css
+++ b/public/css/mobile-fixes.css
@@ -1560,13 +1560,16 @@ a {
    ------------------------------------------------------------------- */
 
 @media (max-width: 768px) {
-    /* Hide footer — copyright is not needed in chat */
-    body.landing-page-body footer {
+    /* Hide footer — copyright is not needed on the chat page */
+    body.landing-page-body:has(#chat-container) footer {
         display: none !important;
     }
 
-    /* ---- THE FLEX COLUMN ---- */
-    body.landing-page-body {
+    /* ---- THE FLEX COLUMN ----
+       Scoped to the chat page only. Other landing-page-body pages
+       (signup, dashboards, onboarding, terms, etc.) must keep their
+       natural document scroll on mobile. */
+    body.landing-page-body:has(#chat-container) {
         display: flex !important;
         flex-direction: column !important;
         height: 100vh !important;
@@ -1576,8 +1579,8 @@ a {
         padding: 0 !important;
     }
 
-    /* Header hidden — no flex space needed */
-    body.landing-page-body .landing-header {
+    /* Header hidden — no flex space needed (chat only) */
+    body.landing-page-body:has(#chat-container) .landing-header {
         flex: 0 0 0px !important;
         display: none !important;
     }

--- a/public/style.css
+++ b/public/style.css
@@ -1280,16 +1280,17 @@ form label, .password-label-row label {
 
 /* --- UI Layout Fix for Scrollable Chat --- */
 
-/* 1. Constrain the body to the viewport height and prevent it from scrolling. */
-/* Only apply to pages with landing-page-body class (chat page) */
-body.landing-page-body {
+/* 1. Constrain the body to the viewport height and prevent it from scrolling.
+   Scoped to the chat page only (detected by #chat-container). Other pages
+   that happen to share landing-page-body (signup, onboarding, dashboards,
+   terms, etc.) must scroll their own content naturally. */
+body.landing-page-body:has(#chat-container) {
     height: 100vh;
     overflow: hidden;
 }
 
 /* 2. Ensure the main content area properly fills the space between the header and footer. */
-/* Only apply to chat page main element */
-body.landing-page-body main {
+body.landing-page-body:has(#chat-container) main {
     flex-grow: 1;
     display: flex;
     flex-direction: column;
@@ -1297,8 +1298,9 @@ body.landing-page-body main {
     overflow: hidden;
 }
 
-/* Allow other pages (badge-map, mastery-chat, etc.) to scroll normally */
-body:not(.landing-page-body) {
+/* Everything that isn't the chat viewport-lock should scroll normally. */
+body:not(.landing-page-body),
+body.landing-page-body:not(:has(#chat-container)) {
     min-height: 100vh;
     overflow-y: auto;
 }


### PR DESCRIPTION
body.landing-page-body { height: 100vh; overflow: hidden } and its mobile !important variant were applied to every page tagged with landing-page-body — signup, onboarding, dashboards, role pickers, terms/privacy, growth check, etc. — even though only the chat page actually needs a fixed viewport with internal scrolling.

A handful of pages had been rescued via :has(.login-container), :has(.content-page-wrapper), etc., but most stayed locked: the student dashboard, signup, complete-profile, the onboarding card, role/avatar pickers, and the various auth pages all refused to scroll past the first screenful.

Tighten the rules to :has(#chat-container) so the viewport lock only fires on chat.html (the only page with that wrapper). Add an explicit scroll-allow for landing-page-body pages that don't have #chat-container so they behave like the rest of the site.

Mobile-fixes.css gets the same scoping for the !important variant, plus its footer-hide and header-hide companions.