### PR TITLE
fix(voice-stream-client): align PCM payload before Int16Array view

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -2157,7 +2157,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <script src="/js/auto-logout.js"></script>
   <script src="/js/tutor-config-data.js"></script>
   <script src="/js/avatar-config-data.js"></script>
-  <script src="/js/voice-stream-client.js?v=1"></script>
+  <script src="/js/voice-stream-client.js?v=3"></script>
   <script src="/js/voice-controller.js"></script>
   <!-- Intelligent Whiteboard stack (Phase 0 wire-up — order matters: core → enhancements → integration) -->
   <script src="/js/whiteboard.js"></script>

--- a/public/js/voice-stream-client.js
+++ b/public/js/voice-stream-client.js
@@ -312,8 +312,14 @@
             if (u8.length < 7 || u8[0] !== 0x01) return;
             const sampleRate = (u8[5] << 8) | u8[6];
             const pcmStart = 7;
-            const byteLen = u8.byteLength - pcmStart;
-            const i16 = new Int16Array(u8.buffer, u8.byteOffset + pcmStart, byteLen / 2);
+            // Int16Array requires a 2-byte aligned byteOffset. The frame
+            // header is 7 bytes (odd), so the PCM payload starts on an
+            // odd offset inside the WebSocket buffer — constructing a
+            // view directly throws RangeError. Copy into a fresh buffer
+            // via slice() so the Int16Array sits at offset 0.
+            const pcmBytes = u8.slice(pcmStart);
+            const evenLen = pcmBytes.byteLength - (pcmBytes.byteLength % 2);
+            const i16 = new Int16Array(pcmBytes.buffer, 0, evenLen / 2);
             this._playPcmS16(i16, sampleRate);
         }
 

--- a/public/voice-tutor.html
+++ b/public/voice-tutor.html
@@ -259,7 +259,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
   <script src="/js/csrf.js"></script>
   <script src="/js/age-tier-standalone.js"></script>
-  <script src="/js/voice-stream-client.js?v=2"></script>
+  <script src="/js/voice-stream-client.js?v=3"></script>
   <script src="/js/segmentPlayer.js?v=1"></script>
   <script src="/js/voice-tutor-session.js?v=7"></script>
 </body>


### PR DESCRIPTION
WebSocket audio frames carry a 7-byte header followed by PCM s16le samples. Constructing `new Int16Array(buf, byteOffset + 7, ...)` throws `RangeError: start offset of Int16Array should be a multiple of 2` because the byte offset is odd. Every frame failed, so no audio was ever scheduled — voice tutor was silent on desktop.

Copy the PCM bytes into a fresh buffer via slice() (which always starts at offset 0) before creating the Int16Array view, and truncate to an even byte length defensively in case a partial sample slips through.

Bump the cache-bust query on voice-stream-client.js in chat.html and voice-tutor.html so users pick up the fix without a hard refresh.