### PR TITLE
feat(voice-tutor): allow image/PDF uploads and fix math TTS

### DIFF
--- a/public/css/voice-tutor.css
+++ b/public/css/voice-tutor.css
@@ -1052,6 +1052,147 @@ button { font-family: inherit; }
 .vt-send-btn:active { transform: scale(0.96); }
 .vt-send-btn:focus-visible { outline: 2px solid var(--vt-teal); outline-offset: 2px; }
 
+/* ─── Attachments: paperclip button, hidden file input, file cards ─── */
+.vt-attach-btn {
+  width: 38px;
+  height: 38px;
+  border: 1px solid var(--vt-glass-border);
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--vt-ink-3);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  flex-shrink: 0;
+  transition: background 0.2s, color 0.2s, transform 0.15s, border-color 0.2s;
+}
+.vt-attach-btn:hover { background: rgba(18, 179, 179, 0.12); color: var(--vt-teal); border-color: rgba(18, 179, 179, 0.5); }
+.vt-attach-btn:active { transform: scale(0.94); }
+.vt-attach-btn:focus-visible { outline: 2px solid var(--vt-teal); outline-offset: 2px; }
+.vt-attach-btn[disabled] { opacity: 0.5; cursor: not-allowed; }
+
+.vt-hidden-file-input {
+  position: absolute;
+  width: 1px; height: 1px;
+  opacity: 0;
+  pointer-events: none;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+}
+
+.vt-attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 8px 16px 0;
+  max-height: 120px;
+  overflow-y: auto;
+}
+.vt-attachments[hidden] { display: none; }
+
+.vt-file-card {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--vt-glass-border);
+  border-radius: 10px;
+  padding: 6px 10px 6px 6px;
+  max-width: 220px;
+  position: relative;
+}
+.vt-file-card-thumb {
+  width: 32px; height: 32px;
+  border-radius: 6px;
+  background: rgba(18, 179, 179, 0.18);
+  color: var(--vt-teal);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  flex-shrink: 0;
+  overflow: hidden;
+}
+.vt-file-card-thumb img {
+  width: 100%; height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.vt-file-card-meta {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
+}
+.vt-file-card-name {
+  font-size: 12px;
+  color: var(--vt-ink);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.vt-file-card-size {
+  font-size: 10px;
+  color: var(--vt-ink-4);
+}
+.vt-file-card-remove {
+  width: 20px; height: 20px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--vt-ink-3);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  flex-shrink: 0;
+  transition: background 0.2s, color 0.2s;
+}
+.vt-file-card-remove:hover { background: rgba(255, 80, 80, 0.2); color: #ff8080; }
+.vt-file-card-remove:focus-visible { outline: 2px solid var(--vt-teal); outline-offset: 2px; }
+
+/* ─── Drag-drop overlay ─── */
+.vt-drag-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(8, 10, 22, 0.75);
+  backdrop-filter: blur(20px) saturate(1.4);
+  -webkit-backdrop-filter: blur(20px) saturate(1.4);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+.vt-drag-overlay.visible { display: flex; pointer-events: auto; }
+.vt-drag-overlay-inner {
+  border: 2px dashed rgba(18, 179, 179, 0.6);
+  border-radius: 24px;
+  padding: 48px 64px;
+  text-align: center;
+  background: rgba(18, 179, 179, 0.08);
+}
+.vt-drag-overlay-inner i {
+  font-size: 56px;
+  color: var(--vt-teal);
+  display: block;
+  margin-bottom: 12px;
+}
+.vt-drag-overlay-title {
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--vt-ink);
+  margin-bottom: 4px;
+}
+.vt-drag-overlay-hint {
+  font-size: 13px;
+  color: var(--vt-ink-3);
+}
+
 /* ═══════════════════════════════════════════════════════════
    FOOTER CONTROLS — single primary, restrained secondaries
    ═══════════════════════════════════════════════════════════ */
@@ -1401,6 +1542,9 @@ button { font-family: inherit; }
   .vt-controls { padding-bottom: max(22px, env(safe-area-inset-bottom)); gap: 24px; }
   .vt-text-input { font-size: 16px; padding: 12px 16px; }
   .vt-send-btn { width: 42px; height: 42px; }
+  .vt-attach-btn { width: 42px; height: 42px; }
+  .vt-drag-overlay-inner { padding: 32px 28px; }
+  .vt-drag-overlay-inner i { font-size: 44px; }
 
   .vt-settings-drawer { width: 100%; max-width: 380px; right: -100%; padding: 22px 20px 28px; }
   .vt-live-transcript { max-width: 92vw; word-wrap: break-word; }

--- a/public/js/voice-tutor-session.js
+++ b/public/js/voice-tutor-session.js
@@ -9,6 +9,9 @@
 
   // --- State ---
   const MAX_RECORDING_DURATION = 60000; // 60s max recording to prevent runaway captures
+  const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB — matches server-side multer limit
+  const MAX_FILES = 4;
+  const ALLOWED_FILE_TYPES = ['image/png', 'image/jpeg', 'image/jpg', 'image/webp', 'application/pdf'];
   const state = {
     mode: 'idle',          // idle | listening | thinking | speaking
     handsFree: true,
@@ -48,6 +51,9 @@
     useOrchestrator: false,
     orchestratorSessionId: null,
     segmentPlayer: null,
+    // File attachments queued for the next text message
+    attachedFiles: [],
+    dragDepth: 0,
   };
 
   // --- DOM refs ---
@@ -71,6 +77,10 @@
     dom.closeChat = $('#vt-close-chat');
     dom.textInput = $('#vt-text-input');
     dom.sendText = $('#vt-send-text');
+    dom.attachBtn = $('#vt-attach-btn');
+    dom.fileInput = $('#vt-file-input');
+    dom.attachments = $('#vt-attachments');
+    dom.dragOverlay = $('#vt-drag-overlay');
     dom.settingsBtn = $('#vt-settings-btn');
     dom.settingsDrawer = $('#vt-settings-drawer');
     dom.settingsClose = $('#vt-settings-close');
@@ -572,6 +582,18 @@
         sendTextMessage();
       }
     });
+
+    // File attachments — paperclip button + hidden file input + drag-drop
+    if (dom.attachBtn && dom.fileInput) {
+      dom.attachBtn.addEventListener('click', () => dom.fileInput.click());
+      dom.fileInput.addEventListener('change', (e) => {
+        const files = Array.from(e.target.files || []);
+        if (files.length) handleSelectedFiles(files);
+        dom.fileInput.value = '';
+      });
+    }
+    setupFileDragDrop();
+    setupClipboardPaste();
 
     // Settings
     function openSettings() {
@@ -1117,10 +1139,223 @@
     }
   }
 
+  // ═══════════════════════════════════════
+  // FILE ATTACHMENTS — paperclip / drag-drop / paste
+  // Files are queued client-side and sent with the next text message
+  // via multipart/form-data to /api/voice-tutor/process-text.
+  // ═══════════════════════════════════════
+
+  function formatFileSize(bytes) {
+    if (bytes < 1024) return bytes + ' B';
+    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+    return (bytes / 1024 / 1024).toFixed(1) + ' MB';
+  }
+
+  function handleSelectedFiles(files) {
+    for (const file of files) {
+      if (state.attachedFiles.length >= MAX_FILES) {
+        showToast(`Up to ${MAX_FILES} files at a time.`, 3500, { force: true });
+        break;
+      }
+      if (!ALLOWED_FILE_TYPES.includes(file.type)) {
+        showToast(`${file.name}: unsupported type. Use PNG, JPG, WebP, or PDF.`, 4000, { force: true });
+        continue;
+      }
+      if (file.size > MAX_FILE_SIZE) {
+        showToast(`${file.name}: over 10MB.`, 4000, { force: true });
+        continue;
+      }
+      if (state.attachedFiles.some(f => f.name === file.name && f.size === file.size)) {
+        continue; // skip exact duplicates
+      }
+      const id = `att-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      state.attachedFiles.push({ id, file, name: file.name, size: file.size, type: file.type });
+    }
+    renderAttachments();
+  }
+
+  function removeAttachment(id) {
+    state.attachedFiles = state.attachedFiles.filter(f => f.id !== id);
+    renderAttachments();
+  }
+
+  function clearAttachments() {
+    state.attachedFiles = [];
+    renderAttachments();
+  }
+
+  function renderAttachments() {
+    if (!dom.attachments) return;
+    if (state.attachedFiles.length === 0) {
+      dom.attachments.innerHTML = '';
+      dom.attachments.hidden = true;
+      return;
+    }
+    dom.attachments.hidden = false;
+    dom.attachments.innerHTML = '';
+    state.attachedFiles.forEach(entry => {
+      const card = document.createElement('div');
+      card.className = 'vt-file-card';
+      card.dataset.id = entry.id;
+
+      const thumb = document.createElement('div');
+      thumb.className = 'vt-file-card-thumb';
+
+      if (entry.type.startsWith('image/')) {
+        const img = document.createElement('img');
+        const reader = new FileReader();
+        reader.onload = e => { img.src = e.target.result; };
+        reader.readAsDataURL(entry.file);
+        img.alt = '';
+        thumb.appendChild(img);
+      } else {
+        thumb.innerHTML = '<i class="fas fa-file-pdf"></i>';
+      }
+
+      const meta = document.createElement('div');
+      meta.className = 'vt-file-card-meta';
+      const name = document.createElement('span');
+      name.className = 'vt-file-card-name';
+      name.title = entry.name;
+      name.textContent = entry.name;
+      const size = document.createElement('span');
+      size.className = 'vt-file-card-size';
+      size.textContent = formatFileSize(entry.size);
+      meta.appendChild(name);
+      meta.appendChild(size);
+
+      const removeBtn = document.createElement('button');
+      removeBtn.className = 'vt-file-card-remove';
+      removeBtn.type = 'button';
+      removeBtn.setAttribute('aria-label', `Remove ${entry.name}`);
+      removeBtn.innerHTML = '<i class="fas fa-times"></i>';
+      removeBtn.addEventListener('click', () => removeAttachment(entry.id));
+
+      card.appendChild(thumb);
+      card.appendChild(meta);
+      card.appendChild(removeBtn);
+      dom.attachments.appendChild(card);
+    });
+  }
+
+  function setupFileDragDrop() {
+    if (!dom.dragOverlay) return;
+    const prevent = (e) => { e.preventDefault(); e.stopPropagation(); };
+
+    ['dragenter', 'dragover', 'dragleave', 'drop'].forEach(ev => {
+      window.addEventListener(ev, prevent, false);
+    });
+
+    window.addEventListener('dragenter', (e) => {
+      if (!e.dataTransfer || !e.dataTransfer.types) return;
+      if (!Array.from(e.dataTransfer.types).includes('Files')) return;
+      state.dragDepth++;
+      dom.dragOverlay.classList.add('visible');
+      dom.dragOverlay.setAttribute('aria-hidden', 'false');
+    });
+
+    window.addEventListener('dragleave', () => {
+      state.dragDepth = Math.max(0, state.dragDepth - 1);
+      if (state.dragDepth === 0) {
+        dom.dragOverlay.classList.remove('visible');
+        dom.dragOverlay.setAttribute('aria-hidden', 'true');
+      }
+    });
+
+    window.addEventListener('drop', (e) => {
+      state.dragDepth = 0;
+      dom.dragOverlay.classList.remove('visible');
+      dom.dragOverlay.setAttribute('aria-hidden', 'true');
+      const files = Array.from((e.dataTransfer && e.dataTransfer.files) || []);
+      if (files.length) handleSelectedFiles(files);
+    });
+  }
+
+  function setupClipboardPaste() {
+    document.addEventListener('paste', (e) => {
+      if (!e.clipboardData || !e.clipboardData.items) return;
+      const files = [];
+      for (const item of e.clipboardData.items) {
+        if (item.kind === 'file') {
+          const f = item.getAsFile();
+          if (f) files.push(f);
+        }
+      }
+      if (files.length) handleSelectedFiles(files);
+    });
+  }
+
+  async function sendTextWithFiles(text) {
+    // Visual user message — mention attachments if any
+    const attachmentSummary = state.attachedFiles.length
+      ? `[${state.attachedFiles.length} file${state.attachedFiles.length === 1 ? '' : 's'} attached] `
+      : '';
+    addMessage(`${attachmentSummary}${text || '(uploaded files)'}`, 'user');
+    setMode('thinking');
+
+    const formData = new FormData();
+    formData.append('text', text);
+    state.attachedFiles.forEach(entry => {
+      formData.append('files', entry.file, entry.name);
+    });
+
+    const filesToClear = state.attachedFiles.slice();
+    clearAttachments();
+
+    try {
+      const fetchFn = window.csrfFetch || fetch;
+      const res = await fetchFn('/api/voice-tutor/process-text', {
+        method: 'POST',
+        credentials: 'include',
+        body: formData
+      });
+
+      if (!res.ok) {
+        let msg = 'Upload processing failed';
+        try { const err = await res.json(); if (err.message || err.error) msg = err.message || err.error; } catch (_) {}
+        throw new Error(msg);
+      }
+
+      const data = await res.json();
+
+      if (data.response) addMessage(data.response, 'ai');
+      if (state.showVisuals) {
+        if (data.mathSteps && data.mathSteps.length > 0) {
+          renderMathSteps(data.mathSteps);
+        } else {
+          const extracted = extractEquationsFromText(data.response || '');
+          if (extracted.length > 0) renderMathSteps(extracted);
+        }
+      }
+
+      if (data.audioUrl && !state.muted) {
+        await playResponse(data.audioUrl, data.response || '');
+      } else {
+        setMode('idle');
+      }
+    } catch (err) {
+      console.error('[VoiceTutor] File upload error:', err);
+      addSystemMessage(err.message || 'Could not process the uploaded files. Try again.');
+      // Restore attachments so the user can retry without re-picking them
+      state.attachedFiles = filesToClear;
+      renderAttachments();
+      setMode('idle');
+    }
+  }
+
   async function sendTextMessage() {
     const text = dom.textInput.value.trim();
-    if (!text) return;
+    const hasFiles = state.attachedFiles.length > 0;
+    if (!text && !hasFiles) return;
     dom.textInput.value = '';
+
+    // Files require multipart — bypass the streaming/orchestrator paths
+    // (those use JSON/WebSocket transports that don't carry binary).
+    if (hasFiles) {
+      const effectiveText = text || 'Can you help me with this?';
+      await sendTextWithFiles(effectiveText);
+      return;
+    }
 
     // ── Streaming pipeline: route text through the open WebSocket so
     //    response audio plays via the same chunk queue as voice turns ──

--- a/public/voice-tutor.html
+++ b/public/voice-tutor.html
@@ -13,7 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <meta name="theme-color" content="#06070f" />
   <title>Mathmatix+ — Voice Tutor</title>
   <link rel="stylesheet" href="/css/base/variables.css?v=3" />
-  <link rel="stylesheet" href="/css/voice-tutor.css?v=5" />
+  <link rel="stylesheet" href="/css/voice-tutor.css?v=6" />
   <link rel="stylesheet" href="/css/dark-mode.css?v=3" />
   <link rel="stylesheet" href="/css/age-adaptive.css" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" referrerpolicy="no-referrer" />
@@ -140,7 +140,12 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <div class="vt-chat-messages" id="vt-chat-messages" role="log" aria-live="polite">
         <!-- Messages will be appended here -->
       </div>
+      <div class="vt-attachments" id="vt-attachments" hidden aria-label="Attached files"></div>
       <div class="vt-chat-input-bar">
+        <button id="vt-attach-btn" class="vt-attach-btn" title="Attach image or PDF" aria-label="Attach image or PDF">
+          <i class="fas fa-paperclip"></i>
+        </button>
+        <input type="file" id="vt-file-input" class="vt-hidden-file-input" accept="image/png,image/jpeg,image/jpg,image/webp,application/pdf" multiple aria-hidden="true" tabindex="-1" />
         <input type="text" id="vt-text-input" placeholder="Type if you prefer…" class="vt-text-input" aria-label="Type a message" />
         <button id="vt-send-text" class="vt-send-btn" title="Send" aria-label="Send message">
           <i class="fas fa-arrow-up"></i>
@@ -148,6 +153,15 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
     </aside>
   </main>
+
+  <!-- Drag-drop overlay for files -->
+  <div id="vt-drag-overlay" class="vt-drag-overlay" aria-hidden="true">
+    <div class="vt-drag-overlay-inner">
+      <i class="fas fa-cloud-arrow-up"></i>
+      <div class="vt-drag-overlay-title">Drop to attach</div>
+      <div class="vt-drag-overlay-hint">Images (PNG, JPG, WebP) or PDFs &middot; 10MB max</div>
+    </div>
+  </div>
 
   <!-- Bottom controls — single primary affordance + minimal secondaries -->
   <footer class="vt-controls" aria-label="Voice controls">
@@ -261,6 +275,6 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <script src="/js/age-tier-standalone.js"></script>
   <script src="/js/voice-stream-client.js?v=3"></script>
   <script src="/js/segmentPlayer.js?v=1"></script>
-  <script src="/js/voice-tutor-session.js?v=7"></script>
+  <script src="/js/voice-tutor-session.js?v=8"></script>
 </body>
 </html>

--- a/routes/voiceTutor.js
+++ b/routes/voiceTutor.js
@@ -5,6 +5,10 @@
 const express = require('express');
 const router = express.Router();
 const { WebSocketServer } = require('ws');
+const multer = require('multer');
+const sharp = require('sharp');
+const pdfOcr = require('../utils/pdfOcr');
+const { validateUpload } = require('../middleware/uploadSecurity');
 const { isAuthenticated } = require('../middleware/auth');
 const User = require('../models/user');
 const Conversation = require('../models/conversation');
@@ -22,6 +26,44 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 const logger = require('../utils/logger').child({ route: 'voice-tutor' });
+
+// Multer for voice-tutor file uploads — disk storage matches chat.js
+const ALLOWED_UPLOAD_MIMETYPES = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp', 'application/pdf'];
+const vtUpload = multer({
+  storage: multer.diskStorage({
+    destination: '/tmp',
+    filename: (req, file, cb) => {
+      const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1E9);
+      cb(null, file.fieldname + '-' + uniqueSuffix + path.extname(file.originalname));
+    }
+  }),
+  limits: { fileSize: 10 * 1024 * 1024 }, // 10MB per file
+  fileFilter: (req, file, cb) => {
+    if (ALLOWED_UPLOAD_MIMETYPES.includes(file.mimetype)) cb(null, true);
+    else cb(new Error('Invalid file type. Only images (JPG, PNG, WEBP) and PDFs are allowed.'), false);
+  }
+});
+
+// Run multer only on multipart requests; JSON requests pass through unchanged.
+const conditionalVtUpload = (req, res, next) => {
+  if (req.is('multipart/form-data')) {
+    vtUpload.any()(req, res, (err) => {
+      if (err) {
+        if (err.code === 'LIMIT_FILE_SIZE') {
+          return res.status(413).json({ error: 'File too large (max 10MB per file).' });
+        }
+        return res.status(400).json({ error: `Upload error: ${err.message}` });
+      }
+      next();
+    });
+  } else {
+    next();
+  }
+};
+const conditionalVtValidate = (req, res, next) => {
+  if (req.files && req.files.length > 0) validateUpload(req, res, next);
+  else next();
+};
 
 const VOICE_MODEL = 'gpt-4o-mini';
 
@@ -73,6 +115,12 @@ CRITICAL RULES FOR THE "spoken" FIELD:
 3. Be warm and natural — like a real tutor sitting next to the student
 4. NEVER use LaTeX delimiters ($, $$, \\(, \\[) — use plain English. Say "x squared plus 3x" not "$x^2 + 3x$"
 5. NEVER use markdown formatting (**, *, #)
+6. SPELL OUT MATH IN WORDS so text-to-speech reads it correctly:
+   - "3y minus 2 equals 24" — NOT "3y-2=24"
+   - "two x plus 5" — NOT "2x+5"
+   - "x squared" — NOT "x^2"
+   - Always insert a space between a number and a variable ("3 y", not "3y")
+   - Use "equals", "plus", "minus", "times", "over", "squared", "cubed" instead of symbols
 
 CRITICAL RULES FOR THE "mathSteps" FIELD:
 The student's math board ONLY updates from this field. If you omit it or leave it empty when math has been discussed, the board goes blank and the student loses all visual context.
@@ -156,7 +204,48 @@ function convertLatexToSpeech(latex) {
   speech = speech.replace(/=/g, ' equals ');
   speech = speech.replace(/[{}]/g, '');
   speech = speech.replace(/\\/g, '');
+  // Insert space between digit and variable so TTS doesn't slur "3y" into "three-ey"
+  speech = speech.replace(/(\d)([a-zA-Z])/g, '$1 $2');
+  speech = speech.replace(/([a-zA-Z])(\d)/g, '$1 $2');
   return speech;
+}
+
+/**
+ * Normalize bare math notation in plain text (no LaTeX delimiters) so TTS
+ * pronounces it naturally. Handles digit-letter glue ("3y" → "3 y"),
+ * comparison operators, and arithmetic symbols between alphanumerics.
+ */
+function normalizeBareMathForSpeech(text) {
+  let out = text;
+  // Multi-char comparison operators first (longest match wins)
+  out = out.replace(/<=|≤/g, ' less than or equal to ');
+  out = out.replace(/>=|≥/g, ' greater than or equal to ');
+  out = out.replace(/!=|≠/g, ' not equal to ');
+  out = out.replace(/≈/g, ' approximately ');
+  out = out.replace(/±/g, ' plus or minus ');
+  // Arithmetic operators: convert only when at least one side is a digit
+  // (skip hyphenated words like "well-known", sentence dashes, em-dashes,
+  // and "x + y" prose unless it's recognizable math). Allow optional spaces.
+  // Equals — fairly safe: only between alphanumeric on both sides.
+  out = out.replace(/([0-9A-Za-z\)\]])\s*=\s*([0-9A-Za-z\(\[\-+])/g, '$1 equals $2');
+  // Minus — require a digit adjacent to avoid mangling "well-known".
+  out = out.replace(/(\d)\s*-\s*([0-9A-Za-z\(\[])/g, '$1 minus $2');
+  out = out.replace(/([A-Za-z\)\]])\s*-\s*(\d)/g, '$1 minus $2');
+  // Plus — require a digit adjacent.
+  out = out.replace(/(\d)\s*\+\s*([0-9A-Za-z\(\[])/g, '$1 plus $2');
+  out = out.replace(/([A-Za-z\)\]])\s*\+\s*(\d)/g, '$1 plus $2');
+  // Times — explicit math symbols are always safe; bare "*" between alphanumerics
+  out = out.replace(/([0-9A-Za-z\)\]])\s*\*\s*([0-9A-Za-z\(\[])/g, '$1 times $2');
+  out = out.replace(/([0-9A-Za-z\)\]])\s*[×·]\s*([0-9A-Za-z\(\[])/g, '$1 times $2');
+  // Division: numeric fractions only (avoid URLs and file paths)
+  out = out.replace(/(\d)\s*\/\s*(\d)/g, '$1 over $2');
+  out = out.replace(/÷/g, ' divided by ');
+  // Stragglers — bare "=" at boundaries (e.g. " =24" or "x= 24")
+  out = out.replace(/=/g, ' equals ');
+  // Digit-letter glue and letter-digit glue (3y → "3 y", y3 → "y 3")
+  out = out.replace(/(\d)([a-zA-Z])/g, '$1 $2');
+  out = out.replace(/([a-zA-Z])(\d)/g, '$1 $2');
+  return out;
 }
 
 /**
@@ -192,9 +281,8 @@ function cleanForTTS(text) {
   // Function notation: f(x) → "f of x", f'(x) → "f prime of x"
   cleaned = cleaned.replace(/\b([a-zA-Z])'\(([^)]+)\)/g, '$1 prime of $2');
   cleaned = cleaned.replace(/\b([a-zA-Z])\(([^)]{1,20})\)/g, '$1 of $2');
-  // Equals sign: "x = 5" → "x equals 5"
-  cleaned = cleaned.replace(/(\w)\s*=\s*(\w)/g, '$1 equals $2');
-  // Caret exponents
+  // Caret exponents — convert before normalizing operators so "x^2 + 3"
+  // becomes "x squared plus 3" rather than tripping the bare-minus rule.
   cleaned = cleaned.replace(/\^\{([^}]+)\}/g, ' to the $1 power');
   cleaned = cleaned.replace(/\^2(?=\b|[^0-9]|$)/g, ' squared');
   cleaned = cleaned.replace(/\^3(?=\b|[^0-9]|$)/g, ' cubed');
@@ -203,6 +291,9 @@ function cleanForTTS(text) {
   cleaned = cleaned.replace(/_\{([^}]+)\}/g, ' sub $1');
   cleaned = cleaned.replace(/_(\d)/g, ' sub $1');
   cleaned = cleaned.replace(/[{}]/g, '');
+  // Normalize bare arithmetic so TTS speaks "3 y minus 2 equals 24"
+  // instead of "three-ey minus 2 equal sign twenty four".
+  cleaned = normalizeBareMathForSpeech(cleaned);
   // Strip emoji
   cleaned = cleaned.replace(/[\u{1F300}-\u{1F9FF}\u{2600}-\u{27BF}\u{FE00}-\u{FE0F}\u{200D}\u{20E3}\u{E0020}-\u{E007F}]/gu, '');
   // Clean up whitespace
@@ -413,20 +504,80 @@ router.post('/process', isAuthenticated, async (req, res) => {
 // POST /api/voice-tutor/process-text
 // Text input fallback (typed messages)
 // ═══════════════════════════════════════
-router.post('/process-text', isAuthenticated, async (req, res) => {
-  const { text } = req.body;
+router.post('/process-text', isAuthenticated, conditionalVtUpload, conditionalVtValidate, async (req, res) => {
   const userId = req.user._id;
+  const rawText = (req.body && req.body.text) || '';
+  const uploadedFiles = req.files || [];
+  const hasFiles = uploadedFiles.length > 0;
 
-  if (!text || !text.trim()) {
-    return res.status(400).json({ error: 'Text is required' });
+  if (!rawText.trim() && !hasFiles) {
+    return res.status(400).json({ error: 'Text or file is required' });
   }
 
-  if (text.length > 5000) {
+  if (rawText.length > 5000) {
+    // Clean up files before bailing out
+    uploadedFiles.forEach(f => { if (f.path) try { fs.unlinkSync(f.path); } catch (_) {} });
     return res.status(400).json({ error: 'Message too long' });
   }
 
+  // ── Process attached files: extract PDF text + build image content blocks ──
+  let combinedText = rawText.trim() || (hasFiles ? 'Can you help me with this?' : '');
+  let imageContents = [];
+  let pdfTexts = [];
+
+  if (hasFiles) {
+    try {
+      const fileResults = await Promise.all(uploadedFiles.map(async (file) => {
+        if (file.mimetype === 'application/pdf') {
+          const buf = fs.readFileSync(file.path);
+          const extracted = await pdfOcr(buf, file.originalname);
+          return { type: 'pdf', filename: file.originalname, text: extracted || `[Could not extract text from ${file.originalname}]` };
+        }
+        let buf = fs.readFileSync(file.path);
+        try {
+          buf = await sharp(buf).rotate().withMetadata({}).toBuffer();
+        } catch (e) {
+          logger.warn('EXIF strip failed', { error: e.message });
+        }
+        const base64 = buf.toString('base64');
+        return {
+          type: 'image',
+          content: { type: 'image_url', image_url: { url: `data:${file.mimetype};base64,${base64}`, detail: 'high' } }
+        };
+      }));
+
+      for (const r of fileResults) {
+        if (r.type === 'pdf') pdfTexts.push({ filename: r.filename, text: r.text });
+        else imageContents.push(r.content);
+      }
+
+      if (pdfTexts.length > 0) {
+        const MAX_PDF_CHARS = 12000;
+        const pdfBlock = pdfTexts.map(({ filename, text }) => {
+          if (text.length > MAX_PDF_CHARS) {
+            return `[Content from ${filename} — first ${MAX_PDF_CHARS} of ${text.length} characters]\n${text.substring(0, MAX_PDF_CHARS)}\n[... truncated]`;
+          }
+          return `[Content from ${filename}]\n${text}`;
+        }).join('\n\n');
+        combinedText = `${combinedText}\n\n${pdfBlock}`;
+      }
+
+      logger.info('voice-tutor: files prepared', { userId, imageCount: imageContents.length, pdfCount: pdfTexts.length });
+    } catch (procErr) {
+      logger.error('voice-tutor: file processing failed', { userId, error: procErr.message });
+      return res.status(500).json({ error: 'FILE_PROCESSING_ERROR', message: `Failed to process files: ${procErr.message}` });
+    } finally {
+      uploadedFiles.forEach(f => { if (f.path) try { fs.unlinkSync(f.path); } catch (_) {} });
+    }
+  }
+
   try {
-    const { spoken, mathSteps, raw: aiRaw } = await generateResponse(userId, text.trim());
+    const { spoken, mathSteps, raw: aiRaw } = await generateResponse(
+      userId,
+      combinedText,
+      null,
+      { imageContents }
+    );
 
     let audioUrl = null;
     if (ttsProvider.isConfigured()) {
@@ -437,7 +588,8 @@ router.post('/process-text', isAuthenticated, async (req, res) => {
       }
     }
 
-    await saveToHistory(userId, text.trim(), aiRaw);
+    // Save the user-facing text (without giant base64 image blobs) to history
+    await saveToHistory(userId, combinedText, aiRaw);
 
     res.json({
       response: spoken,
@@ -681,7 +833,7 @@ router.post('/interrupt', isAuthenticated, async (req, res) => {
  * Generate a voice tutor response using structured JSON output.
  * Returns { spoken, mathSteps, raw } — no dependency on LLM tags.
  */
-async function generateResponse(userId, userMessage, preloadedUser) {
+async function generateResponse(userId, userMessage, preloadedUser, opts = {}) {
   const user = preloadedUser || await User.findById(userId).lean();
   if (!user) throw new Error('User not found');
 
@@ -703,10 +855,16 @@ async function generateResponse(userId, userMessage, preloadedUser) {
 
   const systemPrompt = await generateSystemPrompt(user, tutorProfile);
 
+  // Build the user turn — multimodal if images were attached (vision API)
+  const imageContents = Array.isArray(opts.imageContents) ? opts.imageContents : [];
+  const userContent = imageContents.length > 0
+    ? [{ type: 'text', text: userMessage }, ...imageContents]
+    : userMessage;
+
   const messages = [
     { role: 'system', content: systemPrompt + VOICE_TUTOR_INSTRUCTIONS },
     ...history,
-    { role: 'user', content: userMessage }
+    { role: 'user', content: userContent }
   ];
 
   const completion = await callLLM(VOICE_MODEL, messages, {


### PR DESCRIPTION
- Add paperclip attach button, hidden file input, file cards, and
  drag/drop + paste support to the voice tutor chat panel
- Wire client-side queue + multipart submission via the existing
  /api/voice-tutor/process-text endpoint
- Extend the route with multer-backed multipart handling: OCR PDFs,
  strip EXIF + base64-encode images, build a multimodal user turn
  with image_url blocks (same shape as /api/chat)
- Fix TTS pronunciation of bare math like "3y-2=24" so it reads
  "three y minus 2 equals 24" — adds digit/letter spacing and
  hyphenated-word-safe operator normalization
- Tell the LLM to spell math in words so the spoken field is
  natural before sanitization runs

https://claude.ai/code/session_01MTXhxPQofV8VrsWF6bZo73