### PR TITLE
fix(chat): scale tutor portrait by panel height instead of width

### DIFF
--- a/public/css/chat-redesign.css
+++ b/public/css/chat-redesign.css
@@ -237,9 +237,9 @@ body.cr-mode #app-layout-wrapper { background: var(--cr-bg-0); }
   bottom: 0;
   left: 50%;
   transform: translateX(-50%);
-  max-width: 100%;
-  max-height: 92%;
-  object-fit: contain;
+  height: 100%;
+  width: auto;
+  max-width: none;
   z-index: 1;
   filter: drop-shadow(0 12px 24px rgba(0,0,0,0.45));
   pointer-events: none;


### PR DESCRIPTION
The hero portraits (maya-new2.png, mrnappier-new2.png, etc.) are 1536x1024 landscape PNGs with the character centered. With max-width:100% + object-fit:contain, the image was being letterboxed to the panel's narrow width, leaving the character rendered tiny at the bottom and the backdrop scene dominating the top of the panel.

Scale by height instead so the image fills the panel vertically and crops horizontally — the character is centered, so shoulders crop cleanly off the sides and the tutor now feels present, matching the mockup.