### PR TITLE
Mobile poster-chat hybrid for the chat UI

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -105,6 +105,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     });
   </script>
   <link rel="stylesheet" href="/css/demo-mode.css" />
+  <!-- Mobile poster-chat hybrid (phones only; loaded last to win the cascade) -->
+  <link rel="stylesheet" href="/css/mobile-poster-chat.css" />
   <script defer src="/js/i18n-translations.js"></script>
   <script defer src="/js/i18n.js"></script>
 </head>
@@ -2258,7 +2260,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <script src="/js/mobile-touch-fix.js"></script>
   <script src="/js/mobile-drawer.js"></script>
   <script src="/js/mobile-more-tools.js"></script>
-  <script src="/js/mobile-chat-nav.js"></script>
+  <!-- mobile-chat-nav.js (4-tab bottom nav) retired — replaced by the poster-chat hybrid -->
+  <script src="/js/mobile-poster-chat.js"></script>
   <script src="/js/inlineEquationBox.js"></script>
   <script src="/js/mathmatixKeyboard.js"></script>
   <script src="/js/auto-expand-textarea.js"></script>

--- a/public/css/mobile-poster-chat.css
+++ b/public/css/mobile-poster-chat.css
@@ -1,0 +1,434 @@
+/* ============================================================
+   mobile-poster-chat.css
+   Mobile "poster-chat hybrid" — the tutor sits behind the
+   conversation like an iOS contact poster. One continuous state:
+   idle greeting -> chat cards rise over the same fixed poster.
+
+   Scope: phones only (<=768px), and only when body.cr-mode is
+   active (the redesigned chat shell). Desktop is untouched.
+   Loaded LAST in chat.html so it wins the cascade.
+   ============================================================ */
+
+/* Desktop / tablet: the poster-chat elements are mobile-only.
+   They are built unconditionally by JS, so hide them above the
+   breakpoint — the @media block below re-enables them on phones. */
+#mpc-topbar,
+#mpc-greeting,
+.mpc-scrim,
+#mpc-sheet,
+#mpc-sheet-overlay { display: none; }
+
+@media (max-width: 768px) {
+
+  /* ---- 0. page base -------------------------------------------------- */
+  body.cr-mode.landing-page-body {
+    overflow: hidden;                 /* the message list scrolls, not the page */
+    background: #07090F !important;
+  }
+  body.cr-mode footer { display: none !important; }
+
+  /* ---- 1. POSTER (fixed, full-bleed, behind everything) -------------- */
+  body.cr-mode .cr-tutor-hero {
+    position: fixed !important;
+    inset: 0 !important;
+    width: 100vw !important;
+    height: 100dvh !important;
+    min-height: 0 !important;
+    margin: 0 !important;
+    border: none !important;
+    border-radius: 0 !important;
+    z-index: 0 !important;
+    display: block !important;
+    overflow: hidden !important;
+    background: #0B0F1A !important;
+  }
+  /* classroom / ambient backdrop */
+  body.cr-mode .cr-tutor-backdrop {
+    position: absolute !important;
+    inset: 0 !important;
+    background-size: cover !important;
+    background-position: center top !important;
+  }
+  body.cr-mode .cr-tutor-backdrop::after { display: none; } /* scrim handled below */
+
+  /* the tutor character — full-bleed cover poster.
+     The asset is a landscape PNG of the character on transparent;
+     `cover` fills the portrait viewport and crops the sides, leaving
+     the face in the upper third. Transparent areas reveal the
+     classroom backdrop behind, so the scene reads as composited. */
+  body.cr-mode .cr-tutor-portrait {
+    position: absolute !important;
+    inset: 0 !important;
+    left: 0 !important;
+    top: 0 !important;
+    bottom: auto !important;
+    width: 100% !important;
+    height: 100% !important;
+    max-width: none !important;
+    max-height: none !important;
+    transform: none !important;
+    object-fit: cover !important;
+    object-position: center top !important;
+    filter: none !important;
+  }
+
+  /* the readability scrim — a fixed gradient over the poster.
+     Deepens once the conversation has messages (.mpc-has-messages). */
+  body.cr-mode .mpc-scrim {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 1;
+    pointer-events: none;
+    background: linear-gradient(180deg,
+      rgba(7,9,15,.18) 0%,
+      rgba(7,9,15,.06) 32%,
+      rgba(7,9,15,.72) 74%,
+      rgba(7,9,15,.97) 100%);
+    transition: background .45s ease;
+  }
+  body.cr-mode.mpc-has-messages .mpc-scrim {
+    background: linear-gradient(180deg,
+      rgba(7,9,15,.30) 0%,
+      rgba(7,9,15,.34) 24%,
+      rgba(7,9,15,.86) 52%,
+      rgba(7,9,15,.98) 78%);
+  }
+
+  /* in-hero badge/card are replaced by #mpc-topbar + #mpc-greeting */
+  body.cr-mode .cr-live-badge,
+  body.cr-mode .cr-encourage-card { display: none !important; }
+
+  /* ---- 2. CHAT SHELL (transparent, above the poster) ----------------- */
+  body.cr-mode #app-layout-wrapper,
+  body.cr-mode #app-layout-wrapper.sidebar-layout {
+    margin: 0 !important;
+    padding: 0 !important;
+    max-width: 100vw !important;
+    background: transparent !important;
+  }
+  body.cr-mode .cr-stage {
+    display: block !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    gap: 0 !important;
+    min-height: 0 !important;
+    background: transparent !important;
+  }
+  body.cr-mode #chat-container {
+    position: fixed !important;
+    inset: 0 !important;
+    z-index: 2 !important;
+    display: flex !important;
+    flex-direction: column !important;
+    background: transparent !important;
+    border: none !important;
+    border-radius: 0 !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    overflow: hidden !important;
+  }
+
+  /* scrolling message list */
+  body.cr-mode #chat-messages-container {
+    flex: 1 1 auto !important;
+    overflow-y: auto !important;
+    -webkit-overflow-scrolling: touch;
+    background: transparent !important;
+    padding: 76px 14px 14px !important;   /* top clears the top chrome */
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+
+  /* ---- 3. HIDE mobile clutter (desktop keeps these) ------------------ */
+  body.cr-mode #mobile-stats-bar,
+  body.cr-mode #session-stats-bar,
+  body.cr-mode #hero-actions,
+  body.cr-mode #suggestion-chips-container,
+  body.cr-mode .cr-quick-actions,
+  body.cr-mode .cr-hint-card,
+  body.cr-mode .mobile-chat-nav,
+  body.cr-mode .chat-disclaimer { display: none !important; }
+
+  /* ---- 4. TOP CHROME (floats over poster) ---------------------------- */
+  #mpc-topbar {
+    position: fixed;
+    top: 0; left: 0; right: 0;
+    z-index: 30;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: calc(env(safe-area-inset-top, 0px) + 8px) 14px 8px;
+    pointer-events: none;             /* children re-enable */
+  }
+  #mpc-topbar > * { pointer-events: auto; }
+
+  .mpc-live-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 7px 13px;
+    border-radius: 999px;
+    background: rgba(13,17,28,.6);
+    border: 1px solid rgba(255,255,255,.13);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    color: #fff;
+    font-size: 13px;
+    font-weight: 600;
+    max-width: 62vw;
+    white-space: nowrap;
+  }
+  .mpc-live-pill .mpc-live-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .mpc-live-dot {
+    width: 7px; height: 7px; border-radius: 50%;
+    background: #2ECC71;
+    box-shadow: 0 0 7px rgba(46,204,113,.85);
+    flex-shrink: 0;
+    animation: mpcPulse 2s ease-in-out infinite;
+  }
+  @keyframes mpcPulse { 0%,100%{opacity:1} 50%{opacity:.5} }
+
+  .mpc-topbar-right { display: flex; align-items: center; gap: 9px; }
+  .mpc-streak {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    color: #FFC24B;
+    font-size: 13px;
+    font-weight: 700;
+    text-shadow: 0 1px 6px rgba(0,0,0,.7);
+  }
+  .mpc-menu-btn {
+    width: 38px; height: 38px;
+    border-radius: 50%;
+    background: rgba(13,17,28,.6);
+    border: 1px solid rgba(255,255,255,.14);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    display: flex; align-items: center; justify-content: center;
+    color: #fff; font-size: 16px;
+    cursor: pointer;
+  }
+  .mpc-menu-btn:active { transform: scale(.94); }
+
+  /* ---- 5. GREETING (idle only) --------------------------------------- */
+  #mpc-greeting {
+    display: block;
+    position: fixed;
+    left: 0; right: 0;
+    bottom: 150px;
+    z-index: 3;
+    padding: 0 22px;
+    pointer-events: none;
+    transition: opacity .35s ease;
+  }
+  #mpc-greeting h2 {
+    color: #fff;
+    font-size: 26px;
+    font-weight: 800;
+    line-height: 1.24;
+    margin: 0 0 8px;
+    text-shadow: 0 2px 14px rgba(0,0,0,.75);
+  }
+  #mpc-greeting p {
+    color: #d6dae6;
+    font-size: 15px;
+    margin: 0;
+    text-shadow: 0 1px 10px rgba(0,0,0,.85);
+  }
+  body.cr-mode.mpc-has-messages #mpc-greeting {
+    opacity: 0;
+    visibility: hidden;
+  }
+
+  /* ---- 6. MESSAGES — lesson cards ------------------------------------ */
+  body.cr-mode #chat-messages-container .message-container {
+    display: flex;
+    gap: 8px;
+    align-items: flex-start;
+    margin: 0 !important;
+  }
+  body.cr-mode #chat-messages-container .message-container.ai {
+    justify-content: flex-start;
+  }
+  body.cr-mode #chat-messages-container .message-container.user {
+    flex-direction: row-reverse;
+    justify-content: flex-end;
+  }
+  body.cr-mode #chat-messages-container .message-avatar img,
+  body.cr-mode #chat-messages-container .message-avatar > div {
+    width: 30px !important;
+    height: 30px !important;
+    border-radius: 50%;
+    object-fit: cover;
+    object-position: center top;
+    border: 1px solid rgba(255,255,255,.16);
+  }
+  /* student bubble */
+  body.cr-mode #chat-messages-container .message.user {
+    max-width: 80% !important;
+    background: #7C6BFF !important;
+    color: #fff !important;
+    border: none !important;
+    border-radius: 18px 18px 5px 18px !important;
+    padding: 10px 14px !important;
+    font-size: 14.5px !important;
+    line-height: 1.5 !important;
+    box-shadow: 0 4px 14px rgba(108,92,231,.32);
+  }
+  /* assistant = lesson card */
+  body.cr-mode #chat-messages-container .message.ai {
+    max-width: 88% !important;
+    background: rgba(22,27,46,.92) !important;
+    color: #E6E9F2 !important;
+    border: 1px solid rgba(124,107,255,.30) !important;
+    border-radius: 5px 18px 18px 18px !important;
+    padding: 13px 15px !important;
+    font-size: 14.5px !important;
+    line-height: 1.6 !important;
+    box-shadow: 0 8px 26px rgba(0,0,0,.45);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+  }
+  body.cr-mode #chat-messages-container .message.ai .message-text { color: #E6E9F2; }
+  body.cr-mode #chat-messages-container .message.system-error {
+    background: rgba(255,78,78,.16) !important;
+    border: 1px solid rgba(255,78,78,.4) !important;
+    color: #ffd9d9 !important;
+  }
+  body.cr-mode #chat-messages-container .message-timestamp {
+    font-size: 11px;
+    color: #8a93a8;
+    margin-top: 4px;
+  }
+  /* give rendered math room to breathe */
+  body.cr-mode #chat-messages-container .message.ai .katex-display {
+    margin: 10px 0;
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+  body.cr-mode #thinking-indicator {
+    margin: 4px 16px 10px !important;
+    color: #9aa3b8 !important;
+  }
+
+  /* ---- 7. COMPOSER (last flex child, sticky bottom) ------------------ */
+  body.cr-mode #input-container {
+    flex: 0 0 auto !important;
+    background: linear-gradient(180deg, rgba(7,9,15,0) 0%, rgba(7,9,15,.6) 22%, rgba(7,9,15,.92) 100%) !important;
+    border: none !important;
+    padding: 8px 12px calc(env(safe-area-inset-bottom, 0px) + 10px) !important;
+    margin: 0 !important;
+  }
+  body.cr-mode .imessage-compose-bar {
+    background: rgba(27,34,56,.94) !important;
+    border: 1px solid rgba(255,255,255,.12) !important;
+    border-radius: 20px !important;
+    padding: 4px 6px !important;
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+  }
+  body.cr-mode .imessage-tool-btns {
+    background: transparent !important;
+    border: none !important;
+    padding: 2px 2px 0 !important;
+    gap: 2px !important;
+  }
+  body.cr-mode .imessage-tool-btn {
+    background: transparent !important;
+    border: none !important;
+    color: #aab2c5 !important;
+    width: 38px !important; height: 38px !important;
+  }
+  body.cr-mode #insert-equation-btn { color: #9d8bff !important; }
+  body.cr-mode .imessage-input-row { background: transparent !important; }
+  body.cr-mode #user-input {
+    background: transparent !important;
+    color: #E6E9F2 !important;
+    border: none !important;
+    caret-color: #8B7BFF;
+  }
+  body.cr-mode #user-input:empty::before { color: #7e879b; }
+  body.cr-mode .imessage-send-btn {
+    background: linear-gradient(135deg,#8B7BFF,#6C5CE7) !important;
+    color: #fff !important;
+    border: none !important;
+    box-shadow: 0 4px 13px rgba(108,92,231,.5);
+  }
+
+  /* ---- 8. BOTTOM SHEET MENU ------------------------------------------ */
+  #mpc-sheet-overlay {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 3000;
+    background: rgba(0,0,0,.55);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity .25s ease, visibility .25s ease;
+  }
+  #mpc-sheet-overlay.open { opacity: 1; visibility: visible; }
+
+  #mpc-sheet {
+    display: block;
+    position: fixed;
+    left: 0; right: 0; bottom: 0;
+    z-index: 3001;
+    background: rgba(18,22,36,.98);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border-top: 1px solid rgba(255,255,255,.1);
+    border-radius: 24px 24px 0 0;
+    padding: 8px 14px calc(env(safe-area-inset-bottom, 0px) + 16px);
+    transform: translateY(100%);
+    transition: transform .3s cubic-bezier(.22,1,.36,1);
+  }
+  #mpc-sheet.open { transform: translateY(0); }
+  .mpc-sheet-grabber {
+    width: 38px; height: 5px; border-radius: 3px;
+    background: rgba(255,255,255,.22);
+    margin: 8px auto 10px;
+  }
+  .mpc-sheet-item {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    width: 100%;
+    padding: 13px 8px;
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid rgba(255,255,255,.06);
+    color: #E6E9F2;
+    text-align: left;
+    cursor: pointer;
+  }
+  .mpc-sheet-item:last-of-type { border-bottom: none; }
+  .mpc-sheet-item:active { background: rgba(255,255,255,.05); }
+  .mpc-sheet-icon {
+    width: 38px; height: 38px;
+    border-radius: 11px;
+    background: rgba(124,107,255,.16);
+    color: #9d8bff;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 16px;
+    flex-shrink: 0;
+  }
+  .mpc-sheet-label { flex: 1; }
+  .mpc-sheet-label b { display: block; font-size: 15px; font-weight: 600; }
+  .mpc-sheet-label span { display: block; font-size: 12px; color: #8a93a8; margin-top: 1px; }
+  .mpc-sheet-chevron { color: #5b6478; font-size: 13px; }
+  .mpc-sheet-item.mpc-danger .mpc-sheet-icon { background: rgba(255,78,78,.16); color: #ff7676; }
+  .mpc-sheet-item.mpc-danger .mpc-sheet-label b { color: #ff8a8a; }
+}
+
+/* keep the poster steady when the iOS keyboard opens */
+@media (max-width: 768px) {
+  body.cr-mode .cr-tutor-hero,
+  body.cr-mode .mpc-scrim { will-change: auto; }
+}

--- a/public/js/mobile-poster-chat.js
+++ b/public/js/mobile-poster-chat.js
@@ -1,0 +1,230 @@
+/* ============================================================
+   mobile-poster-chat.js
+   Drives the mobile "poster-chat hybrid":
+   - builds the readability scrim over the fixed tutor poster
+   - builds floating top chrome (Live pill / streak / hamburger)
+   - builds the idle greeting overlay
+   - builds the hamburger bottom-sheet menu
+   - toggles body.mpc-has-messages so the scrim deepens and the
+     greeting fades once a conversation begins
+
+   Additive only. Wires to existing buttons/IDs — never replaces
+   chat send/receive, voice, upload or equation logic. Replaces
+   the retired 4-tab mobile-chat-nav.js.
+   ============================================================ */
+
+(function () {
+  'use strict';
+
+  // Chat page only.
+  if (!document.body.classList.contains('cr-mode')) return;
+  if (!document.getElementById('chat-messages-container')) return;
+
+  function el(tag, cls, html) {
+    var n = document.createElement(tag);
+    if (cls) n.className = cls;
+    if (html != null) n.innerHTML = html;
+    return n;
+  }
+  function trigger(id) {
+    var t = document.getElementById(id);
+    if (t) t.click();
+  }
+
+  /* ---- scrim --------------------------------------------------------- */
+  function buildScrim() {
+    if (document.querySelector('.mpc-scrim')) return;
+    document.body.appendChild(el('div', 'mpc-scrim'));
+  }
+
+  /* ---- top chrome ---------------------------------------------------- */
+  function buildTopbar() {
+    if (document.getElementById('mpc-topbar')) return;
+    var bar = el('nav', null,
+      '<div class="mpc-live-pill">' +
+        '<span class="mpc-live-dot"></span>' +
+        '<span class="mpc-live-name">Live with Maya</span>' +
+      '</div>' +
+      '<div class="mpc-topbar-right">' +
+        '<span class="mpc-streak" id="mpc-streak" style="display:none">' +
+          '🔥 <span id="mpc-streak-value">0</span></span>' +
+        '<button class="mpc-menu-btn" id="mpc-menu-btn" aria-label="Menu" aria-haspopup="true">' +
+          '<i class="fas fa-bars"></i></button>' +
+      '</div>');
+    bar.id = 'mpc-topbar';
+    bar.setAttribute('aria-label', 'Chat controls');
+    document.body.appendChild(bar);
+
+    document.getElementById('mpc-menu-btn')
+      .addEventListener('click', openSheet);
+
+    syncTutorName();
+    syncStreak();
+  }
+
+  // Mirror the "Live with <tutor>" name from chat-redesign.js's #cr-tutor-name.
+  function syncTutorName() {
+    var src = document.getElementById('cr-tutor-name');
+    var dst = document.querySelector('.mpc-live-name');
+    if (!dst) return;
+    var apply = function () {
+      var name = (src && src.textContent || '').trim();
+      if (name) dst.textContent = 'Live with ' + name;
+    };
+    apply();
+    if (src) new MutationObserver(apply)
+      .observe(src, { childList: true, characterData: true, subtree: true });
+  }
+
+  // Mirror the streak from the (hidden) #msb-streak gamification value.
+  function syncStreak() {
+    var src = document.getElementById('msb-streak');
+    var wrap = document.getElementById('mpc-streak');
+    var val = document.getElementById('mpc-streak-value');
+    if (!wrap || !val) return;
+    var apply = function () {
+      var v = parseInt((src && src.textContent || '0').replace(/\D/g, ''), 10) || 0;
+      val.textContent = v;
+      wrap.style.display = v > 0 ? '' : 'none';
+    };
+    apply();
+    if (src) new MutationObserver(apply)
+      .observe(src, { childList: true, characterData: true, subtree: true });
+  }
+
+  /* ---- idle greeting ------------------------------------------------- */
+  function buildGreeting() {
+    if (document.getElementById('mpc-greeting')) return;
+    var g = el('div', null,
+      '<h2>Hey there 👋<br>What do you want to work on today?</h2>' +
+      '<p>I’ll help you step by step.</p>');
+    g.id = 'mpc-greeting';
+    document.body.appendChild(g);
+
+    // Personalise with the student's first name.
+    fetch('/user', { credentials: 'include' })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (data) {
+        var name = data && data.user && data.user.firstName;
+        if (!name) return;
+        var h2 = g.querySelector('h2');
+        if (h2) h2.innerHTML =
+          'Hey ' + name.replace(/[<>&]/g, '') + ' 👋<br>' +
+          'What do you want to work on today?';
+      })
+      .catch(function () { /* keep generic greeting */ });
+  }
+
+  /* ---- bottom sheet -------------------------------------------------- */
+  // label, subtitle, icon, and the action to run. Items whose target
+  // is missing are skipped rather than rendered as dead links.
+  var SHEET_ITEMS = [
+    { icon: 'fa-user', label: 'Profile', sub: 'Your progress and account',
+      run: function () { trigger('right-drawer-toggle'); } },
+    { icon: 'fa-gear', label: 'Settings', sub: 'Preferences and notifications',
+      need: 'open-settings-modal-btn',
+      run: function () { trigger('open-settings-modal-btn'); } },
+    { icon: 'fa-user-group', label: 'Switch Tutor', sub: 'Pick a different tutor',
+      need: 'change-tutor-btn',
+      run: function () { trigger('change-tutor-btn'); } },
+    { icon: 'fa-circle-question', label: 'Help', sub: 'Get help or send feedback',
+      run: function () { window.location.href = '/contact-support.html'; } },
+    { icon: 'fa-right-from-bracket', label: 'Log out', sub: null, danger: true,
+      need: 'logoutBtn',
+      run: function () { trigger('logoutBtn'); } }
+  ];
+
+  function buildSheet() {
+    if (document.getElementById('mpc-sheet')) return;
+
+    var overlay = el('div'); overlay.id = 'mpc-sheet-overlay';
+    var sheet = el('div'); sheet.id = 'mpc-sheet';
+    sheet.setAttribute('role', 'dialog');
+    sheet.setAttribute('aria-label', 'Menu');
+    sheet.appendChild(el('div', 'mpc-sheet-grabber'));
+
+    SHEET_ITEMS.forEach(function (item) {
+      if (item.need && !document.getElementById(item.need)) return; // skip dead link
+      var btn = el('button',
+        'mpc-sheet-item' + (item.danger ? ' mpc-danger' : ''),
+        '<span class="mpc-sheet-icon"><i class="fas ' + item.icon + '"></i></span>' +
+        '<span class="mpc-sheet-label"><b>' + item.label + '</b>' +
+          (item.sub ? '<span>' + item.sub + '</span>' : '') + '</span>' +
+        (item.danger ? '' : '<i class="fas fa-chevron-right mpc-sheet-chevron"></i>'));
+      btn.addEventListener('click', function () {
+        closeSheet();
+        setTimeout(item.run, 220); // let the sheet animate out first
+      });
+      sheet.appendChild(btn);
+    });
+
+    document.body.appendChild(overlay);
+    document.body.appendChild(sheet);
+
+    overlay.addEventListener('click', closeSheet);
+
+    // drag-down to dismiss
+    var startY = null;
+    sheet.addEventListener('touchstart', function (e) {
+      startY = e.touches[0].clientY;
+    }, { passive: true });
+    sheet.addEventListener('touchmove', function (e) {
+      if (startY == null) return;
+      var dy = e.touches[0].clientY - startY;
+      if (dy > 0) sheet.style.transform = 'translateY(' + dy + 'px)';
+    }, { passive: true });
+    sheet.addEventListener('touchend', function (e) {
+      if (startY == null) return;
+      var dy = e.changedTouches[0].clientY - startY;
+      sheet.style.transform = '';
+      if (dy > 60) closeSheet();
+      startY = null;
+    }, { passive: true });
+  }
+
+  function openSheet() {
+    var o = document.getElementById('mpc-sheet-overlay');
+    var s = document.getElementById('mpc-sheet');
+    if (!o || !s) return;
+    o.classList.add('open');
+    requestAnimationFrame(function () { s.classList.add('open'); });
+  }
+  function closeSheet() {
+    var o = document.getElementById('mpc-sheet-overlay');
+    var s = document.getElementById('mpc-sheet');
+    if (!o || !s) return;
+    s.classList.remove('open');
+    o.classList.remove('open');
+    s.style.transform = '';
+  }
+
+  /* ---- idle <-> conversation state ----------------------------------- */
+  function watchMessages() {
+    var box = document.getElementById('chat-messages-container');
+    if (!box) return;
+    var apply = function () {
+      var has = !!box.querySelector('.message-container, .message');
+      document.body.classList.toggle('mpc-has-messages', has);
+    };
+    apply();
+    new MutationObserver(apply).observe(box, { childList: true });
+  }
+
+  /* ---- boot ---------------------------------------------------------- */
+  function init() {
+    buildScrim();
+    buildTopbar();
+    buildGreeting();
+    buildSheet();
+    watchMessages();
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') closeSheet();
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Summary

Redesigns the **mobile** chat into a "poster-chat hybrid": the selected tutor sits behind the conversation as a fixed, iOS-style contact poster. One continuous state — the idle greeting gives way to chat cards rising over the same poster, with a readability scrim that deepens as the conversation grows. Nothing collapses jarringly.

Surgical and additive — desktop is untouched, and no chat/voice/upload/equation logic was modified.

## Files changed

| File | Change |
|------|--------|
| `public/css/mobile-poster-chat.css` | **New.** Phones-only (`≤768px`) layer, loaded last. Fixed full-bleed poster + scrim, floating top chrome, idle greeting, lesson-card message styling, dark composer, hamburger bottom-sheet. Hides mobile clutter (bottom nav, stats bars, quick-action rows). All rules scoped under `@media (max-width:768px)` + `body.cr-mode`. |
| `public/js/mobile-poster-chat.js` | **New.** Builds the scrim, top chrome (Live pill / streak / hamburger), idle greeting and the bottom-sheet menu; mirrors the tutor name + streak; toggles `body.mpc-has-messages`. Wires only to existing buttons. Replaces the retired 4-tab `mobile-chat-nav.js`. |
| `public/chat.html` | Links the new stylesheet; swaps the `mobile-chat-nav.js` script for `mobile-poster-chat.js` (2 lines). |

## Behaviour

- **Idle:** tutor poster fills the screen, personalized greeting floats over the scrim, composer pinned.
- **In conversation:** same fixed poster behind; assistant messages render as dark translucent "lesson cards" with a purple border, student messages as compact purple bubbles; scrim deepens; tutor face stays subtly visible.
- **Menu:** hamburger opens a bottom-sheet (Profile · Settings · Switch Tutor · Help · Log out) with drag-to-dismiss.

## Assumptions / notes

- **Text/Voice toggle dropped** per the spec — the existing composer mic button is kept; default mode stays text. (This diverges from an earlier mockup that had a segmented toggle.)
- **History** menu item omitted this pass — there is no clean standalone route; left out rather than shipping a dead link.
- Bottom-sheet items auto-skip if their target button is absent (no dead links).
- **Poster image optimization not done** — `maya-new2.png` is ~2.4 MB; recommend generating WebP variants with `sharp` as a follow-up.
- The pre-existing source-order bug in `chat-redesign.css` is left as-is; the new file overrides the mobile hero with higher specificity so it no longer manifests on phones.

## Test plan

- [ ] Mobile: poster fills background; greeting shows when idle; messages render; assistant = lesson cards, student = purple bubbles; send works; math renders; upload/equation/voice still work.
- [ ] Mobile: hamburger opens bottom sheet; Profile/Settings/Switch Tutor/Help/Log out work; no bottom nav / quests / session panels visible; safe-area spacing respected; keyboard does not cover input.
- [ ] Desktop: existing chat layout unchanged; no `mpc-*` elements visible.

🤖 Layout verified via headless render at 390×844; runtime chat/voice/upload flows preserved but not exercised (need an authenticated session).

https://claude.ai/code/session_01A2DRQ2G2m6fyWGtE859xtd

---
_Generated by [Claude Code](https://claude.ai/code/session_01A2DRQ2G2m6fyWGtE859xtd)_