### PR TITLE
test: restore global function coverage above the 24% threshold

### DIFF
--- a/tests/unit/unlockTutors.test.js
+++ b/tests/unit/unlockTutors.test.js
@@ -1,0 +1,43 @@
+// tests/unit/unlockTutors.test.js
+const { getTutorsToUnlock } = require('../../utils/unlockTutors');
+
+describe('getTutorsToUnlock', () => {
+  test('returns [] for an invalid userLevel', () => {
+    expect(getTutorsToUnlock(0)).toEqual([]);
+    expect(getTutorsToUnlock(-5)).toEqual([]);
+    expect(getTutorsToUnlock('7')).toEqual([]);
+    expect(getTutorsToUnlock(undefined)).toEqual([]);
+  });
+
+  test('returns [] at level 1 (below every unlock threshold)', () => {
+    expect(getTutorsToUnlock(1, [])).toEqual([]);
+  });
+
+  test('always returns an array of string tutor IDs', () => {
+    const result = getTutorsToUnlock(15, []);
+    expect(Array.isArray(result)).toBe(true);
+    result.forEach((id) => expect(typeof id).toBe('string'));
+  });
+
+  test('is deterministic for identical inputs', () => {
+    expect(getTutorsToUnlock(6, [])).toEqual(getTutorsToUnlock(6, []));
+  });
+
+  test('guarantees unlocks at a very high level', () => {
+    const result = getTutorsToUnlock(99, []);
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  test('never returns a tutor that is already unlocked', () => {
+    const all = getTutorsToUnlock(99, []);
+    const result = getTutorsToUnlock(99, [all[0]]);
+    expect(result).not.toContain(all[0]);
+  });
+
+  test('a met behavior trigger produces an early unlock', () => {
+    const behaviorStats = [{ behavior: 'persistence', count: 50 }];
+    const result = getTutorsToUnlock(6, [], behaviorStats);
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/unpluggedBadges.test.js
+++ b/tests/unit/unpluggedBadges.test.js
@@ -1,0 +1,87 @@
+// tests/unit/unpluggedBadges.test.js
+const {
+  UNPLUGGED_BADGE_CATALOG,
+  checkUnpluggedBadges,
+  getUnpluggedBadgeProgress,
+} = require('../../utils/unpluggedBadges');
+
+describe('unpluggedBadges', () => {
+  test('catalog is a non-empty array of well-formed badges', () => {
+    expect(Array.isArray(UNPLUGGED_BADGE_CATALOG)).toBe(true);
+    expect(UNPLUGGED_BADGE_CATALOG.length).toBeGreaterThan(0);
+    UNPLUGGED_BADGE_CATALOG.forEach((badge) => {
+      expect(typeof badge.badgeId).toBe('string');
+      expect(typeof badge.badgeName).toBe('string');
+      expect(typeof badge.xpReward).toBe('number');
+      expect(badge.threshold).toHaveProperty('type');
+      expect(badge.threshold).toHaveProperty('value');
+    });
+  });
+
+  describe('getUnpluggedBadgeProgress', () => {
+    test('reports zero progress for a brand-new user', () => {
+      const progress = getUnpluggedBadgeProgress({});
+      expect(progress).toHaveLength(UNPLUGGED_BADGE_CATALOG.length);
+      progress.forEach((p) => {
+        expect(p.isEarned).toBe(false);
+        expect(p.progress).toBe(0);
+        expect(p.progressPercent).toBe(0);
+      });
+    });
+
+    test('reflects partial progress and earned badges', () => {
+      const user = {
+        paperPractice: { totalSubmissions: 10 },
+        habitBadges: [{ badgeId: 'unplugged-first-upload' }],
+      };
+      const progress = getUnpluggedBadgeProgress(user);
+
+      const first = progress.find((p) => p.badgeId === 'unplugged-first-upload');
+      expect(first.isEarned).toBe(true);
+
+      const tenth = progress.find((p) => p.badgeId === 'unplugged-10-uploads');
+      expect(tenth.progress).toBe(10);
+      expect(tenth.progressPercent).toBe(100);
+    });
+  });
+
+  describe('checkUnpluggedBadges', () => {
+    test('awards nothing for a user below every threshold', async () => {
+      const user = { paperPractice: {}, habitBadges: [], save: jest.fn() };
+      const earned = await checkUnpluggedBadges(user);
+
+      expect(earned).toEqual([]);
+      expect(user.save).not.toHaveBeenCalled();
+    });
+
+    test('awards a milestone badge, grants XP, logs history, and persists', async () => {
+      const user = {
+        firstName: 'Test',
+        paperPractice: { totalSubmissions: 1 },
+        habitBadges: [],
+        xp: 0,
+        save: jest.fn().mockResolvedValue(true),
+      };
+      const earned = await checkUnpluggedBadges(user);
+
+      expect(earned.length).toBeGreaterThan(0);
+      expect(earned[0].badgeId).toBe('unplugged-first-upload');
+      expect(user.xp).toBe(15);
+      expect(user.habitBadges).toHaveLength(1);
+      expect(user.xpHistory).toHaveLength(1);
+      expect(user.save).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not re-award a badge the user already has', async () => {
+      const user = {
+        paperPractice: { totalSubmissions: 1 },
+        habitBadges: [{ badgeId: 'unplugged-first-upload' }],
+        save: jest.fn(),
+      };
+      const earned = await checkUnpluggedBadges(user);
+
+      expect(earned).toEqual([]);
+      expect(user.save).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/visualCommandExamples.test.js
+++ b/tests/unit/visualCommandExamples.test.js
@@ -1,0 +1,56 @@
+// tests/unit/visualCommandExamples.test.js
+const {
+  getVisualCommandInstruction,
+  injectFewShotExamples,
+  shouldInjectExamples,
+} = require('../../utils/visualCommandExamples');
+
+describe('visualCommandExamples', () => {
+  describe('getVisualCommandInstruction', () => {
+    test('returns a non-empty instruction string', () => {
+      const out = getVisualCommandInstruction();
+      expect(typeof out).toBe('string');
+      expect(out.length).toBeGreaterThan(0);
+    });
+
+    test('documents the available visual command tags', () => {
+      const out = getVisualCommandInstruction();
+      expect(out).toContain('VISUAL COMMAND USAGE');
+      expect(out).toContain('[LONG_DIVISION:');
+      expect(out).toContain('[FRACTION_ADD:');
+      expect(out).toContain('[TRIANGLE_PROBLEM:');
+    });
+  });
+
+  describe('shouldInjectExamples', () => {
+    test('true for short conversations (< 6 messages)', () => {
+      expect(shouldInjectExamples([])).toBe(true);
+      expect(shouldInjectExamples([{}, {}, {}, {}, {}])).toBe(true);
+    });
+
+    test('false once the conversation reaches 6+ messages', () => {
+      expect(shouldInjectExamples(new Array(6).fill({}))).toBe(false);
+      expect(shouldInjectExamples(new Array(12).fill({}))).toBe(false);
+    });
+  });
+
+  describe('injectFewShotExamples', () => {
+    test('prepends a system instruction for short conversations', () => {
+      const convo = [{ role: 'user', content: 'hi' }];
+      const result = injectFewShotExamples(convo);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].role).toBe('system');
+      expect(result[0].content).toContain('VISUAL COMMAND USAGE');
+      expect(result[1]).toBe(convo[0]);
+    });
+
+    test('leaves long conversations (6+ messages) untouched', () => {
+      const convo = new Array(6).fill({ role: 'user', content: 'x' });
+      const result = injectFewShotExamples(convo);
+
+      expect(result).toBe(convo);
+      expect(result).toHaveLength(6);
+    });
+  });
+});


### PR DESCRIPTION
## Why

CI `test (20)` is failing on `main` (and therefore on every open PR). The failure is **not** a test failure — all suites pass — it is `jest --coverage` exiting `1` because global **function coverage drifted to 23.92%**, just under the **24%** floor in `jest.config.js`.

That threshold is documented in the config as never-to-be-lowered ("ratchet up as coverage improves"), so the correct fix is to raise coverage, not relax the gate.

## What

Adds unit tests for three previously **0%-covered** pure utilities:

- `utils/visualCommandExamples.js` — visual-command few-shot instruction builder
- `utils/unlockTutors.js` — variable-ratio tutor unlock logic
- `utils/unpluggedBadges.js` — paper-practice badge catalog, progress, and awarding

These are genuine tests of real logic (no mocks beyond a `save()` stub), not coverage filler.

## Result

- Global function coverage: **23.92% → 24.30%** (850/3498) — clears the 24% floor with margin.
- `npm test` exits `0` locally: **121 suites / 2113 tests passing**.
- Statements / branches / lines thresholds were already met and only move up.

## Notes

This is a standalone fix targeting `main` so it unblocks CI for everyone; it is intentionally separate from in-flight feature PRs (e.g. #954) and touches only `tests/`.

https://claude.ai/code/session_01A2DRQ2G2m6fyWGtE859xtd

---
_Generated by [Claude Code](https://claude.ai/code/session_01A2DRQ2G2m6fyWGtE859xtd)_