### PR TITLE
fix(chat): stop the mobile poster scrim from veiling the conversation

### DIFF
--- a/public/css/mobile-poster-chat.css
+++ b/public/css/mobile-poster-chat.css
@@ -72,13 +72,16 @@
     filter: none !important;
   }
 
-  /* the readability scrim — a fixed gradient over the poster.
-     Deepens once the conversation has messages (.mpc-has-messages). */
+  /* the readability scrim — a gradient over the poster.
+     Deepens once the conversation has messages (.mpc-has-messages).
+     It is a child of .cr-tutor-hero (see mobile-poster-chat.js), so it is
+     absolutely positioned within the fixed, full-bleed poster and stacks
+     above the portrait but always BELOW the chat. */
   body.cr-mode .mpc-scrim {
     display: block;
-    position: fixed;
+    position: absolute;
     inset: 0;
-    z-index: 1;
+    z-index: 2;
     pointer-events: none;
     background: linear-gradient(180deg,
       rgba(7,9,15,.18) 0%,

--- a/public/js/chat-redesign.js
+++ b/public/js/chat-redesign.js
@@ -58,8 +58,9 @@
       backdrop.style.backgroundImage = 'url("' + url + '")';
     }
 
-    // Live-with label
-    if (nameEl) nameEl.textContent = (tutor.name || 'Tutor').split(' ')[0];
+    // Live-with label — full name, so titled tutors read "Mr. Nappier"
+    // rather than being truncated to just "Mr.".
+    if (nameEl) nameEl.textContent = (tutor.name || 'Tutor');
 
     // Small avatar in the hint card
     if (hintAvatar && tutor.image) {

--- a/public/js/mobile-poster-chat.js
+++ b/public/js/mobile-poster-chat.js
@@ -32,9 +32,15 @@
   }
 
   /* ---- scrim --------------------------------------------------------- */
+  // The scrim must live INSIDE the poster (.cr-tutor-hero), not as a body
+  // sibling. mobile-fixes.css makes #app-layout-wrapper a z-index:1 stacking
+  // context, which traps #chat-container's z-index — so a body-level scrim
+  // paints OVER the chat instead of behind it. As a hero child it can only
+  // ever darken the poster.
   function buildScrim() {
     if (document.querySelector('.mpc-scrim')) return;
-    document.body.appendChild(el('div', 'mpc-scrim'));
+    var host = document.querySelector('.cr-tutor-hero') || document.body;
+    host.appendChild(el('div', 'mpc-scrim'));
   }
 
   /* ---- top chrome ---------------------------------------------------- */


### PR DESCRIPTION
## The bug

On mobile, the chat conversation and composer fade to nearly unreadable toward the bottom of the screen — a dark veil over the content. (Reported live from an iPhone.)

## Root cause

The readability scrim was built as a **fixed `<body>` child at `z-index: 1`**. But `mobile-fixes.css` gives `#app-layout-wrapper` `position: relative; z-index: 1`, which creates a **stacking context** that traps `#chat-container`'s `z-index: 2` *inside* it. So `#chat-container` no longer competes with the scrim at the root level — `#app-layout-wrapper` does, at `z-index: 1`.

The scrim is appended to `<body>` *after* the wrapper, so at equal `z-index` it paints **last → on top of the entire chat**. The scrim's gradient (light at top, near-opaque at the bottom) is exactly the fade seen on the messages and composer.

## The fix

Move the scrim **inside `.cr-tutor-hero`** (the poster) and position it `absolute`. The scrim now stacks above the portrait but always *below* the chat — it can only ever darken the poster, never the bubbles. This is robust regardless of ancestor stacking contexts, because the scrim and the chat are in separate subtrees with an unambiguous order.

Also: dropped `.split(' ')[0]` on the tutor name so the "Live with" pill reads **"Mr. Nappier"** instead of being truncated to **"Mr."**.

## Scope

3 files, +17/-7 — `mobile-poster-chat.js` (scrim host), `mobile-poster-chat.css` (`fixed`→`absolute`), `chat-redesign.js` (name). No change to chat send/receive, voice, upload, equation input, or desktop.

## Verify on device

- Messages and composer are fully readable top-to-bottom over the poster.
- The poster itself still darkens toward the bottom for contrast.
- "Live with Mr. Nappier" shows the full name.

https://claude.ai/code/session_01A2DRQ2G2m6fyWGtE859xtd

---
_Generated by [Claude Code](https://claude.ai/code/session_01A2DRQ2G2m6fyWGtE859xtd)_