### PR TITLE
feat(onboarding): make tutor selection aware of onboarding vs switching

### DIFF
--- a/public/js/pick-tutor.js
+++ b/public/js/pick-tutor.js
@@ -1,12 +1,26 @@
-// public/js/pick-tutor.js  –  Tutor selection with inline voice preview on each card
+// public/js/pick-tutor.js  –  Tutor selection (onboarding + switching)
+//
+// One page, two modes:
+//   onboarding — the student has no tutor yet; show the step indicator
+//                and finish with "Start Learning".
+//   switching  — the student already has a tutor and came here to change
+//                it; hide the stepper, pre-select their current tutor,
+//                offer a "Back to Chat" escape, finish with "Switch to X".
+// Mode is derived from currentUser.selectedTutorId — no caller plumbing.
 document.addEventListener('DOMContentLoaded', () => {
-  let allTutors    = [];
-  let currentUser  = null;
-  const tutorSelectionGrid = document.getElementById('tutor-selection-grid');
+  let allTutors   = [];
+  let currentUser = null;
+  let isSwitching = false;
+  let selectedTutorId = null;
+  let currentAudio    = null; // currently playing voice preview
+  let currentAudioUrl = null; // object URL to revoke
+
+  const tutorSelectionGrid   = document.getElementById('tutor-selection-grid');
   const completeSelectionBtn = document.getElementById('complete-selection-btn');
-  let selectedTutorId      = null;
-  let currentAudio         = null; // Track currently playing voice preview
-  let currentAudioUrl      = null; // Track object URL for revocation
+  const stepperEl  = document.getElementById('onboarding-stepper');
+  const titleEl    = document.getElementById('selection-title');
+  const subtitleEl = document.getElementById('selection-subtitle');
+  const backLink   = document.getElementById('back-to-chat-link');
 
   function esc(str) {
     const d = document.createElement('div');
@@ -14,37 +28,65 @@ document.addEventListener('DOMContentLoaded', () => {
     return d.innerHTML;
   }
 
+  function tutorName(id) {
+    const t = allTutors.find(x => x.id === id);
+    return t ? t.name : 'this tutor';
+  }
+
+  /* -------- PRIMARY BUTTON -------- */
+  function refreshPrimary() {
+    completeSelectionBtn.disabled = !selectedTutorId;
+    if (!selectedTutorId) {
+      completeSelectionBtn.innerHTML = '<i class="fas fa-arrow-right"></i> Choose a tutor';
+    } else if (isSwitching) {
+      completeSelectionBtn.innerHTML =
+        '<i class="fas fa-check"></i> Switch to ' + esc(tutorName(selectedTutorId));
+    } else {
+      completeSelectionBtn.innerHTML = '<i class="fas fa-arrow-right"></i> Start Learning';
+    }
+  }
+
+  /* -------- MODE -------- */
+  function applyMode() {
+    isSwitching = !!(currentUser && currentUser.selectedTutorId);
+    if (isSwitching) {
+      if (stepperEl)  stepperEl.style.display = 'none';
+      if (titleEl)    titleEl.textContent = 'Switch Your Tutor';
+      if (subtitleEl) subtitleEl.textContent =
+        'Pick a different coach whenever you like — your progress and XP stay with you.';
+      if (backLink)   backLink.style.display = '';
+      selectedTutorId = currentUser.selectedTutorId;
+    }
+  }
+
   /* -------- INITIAL DATA LOAD -------- */
   async function fetchData() {
     try {
       const userRes = await fetch('/user', { credentials: 'include' });
-
       if (!userRes.ok) return window.location.href = '/login.html';
 
-      const userData   = await userRes.json();
-      currentUser      = userData.user;
-
-      // Fallback in case older accounts have empty unlockedItems
-      if (!Array.isArray(currentUser.unlockedItems) || currentUser.unlockedItems.length === 0) {
-        currentUser.unlockedItems = ['mr-nappier', 'maya', 'ms-maria', 'bob'];
-      }
+      const userData = await userRes.json();
+      currentUser = userData.user;
 
       const tutorsData = window.TUTOR_CONFIG;
       if (!tutorsData) throw new Error('Tutor configuration not loaded.');
 
+      // Only active tutors are selectable; inactive ones are held back
+      // as future "specials" (see `active` in tutorConfig.js).
       allTutors = Object.keys(tutorsData)
         .filter(key => key !== 'default' && tutorsData[key].active !== false)
         .map(key => ({ id: key, ...tutorsData[key] }));
 
-      // If coming from trial chat, pre-select that tutor
-      const params = new URLSearchParams(window.location.search);
-      const trialTutor = params.get('trial_tutor');
+      applyMode();
+
+      // Coming straight from a trial chat — pre-select that tutor.
+      const trialTutor = new URLSearchParams(window.location.search).get('trial_tutor');
       if (trialTutor && allTutors.some(t => t.id === trialTutor)) {
         selectedTutorId = trialTutor;
-        completeSelectionBtn.disabled = false;
       }
 
       renderTutors();
+      refreshPrimary();
     } catch (err) {
       console.error('Error fetching initial data:', err);
       tutorSelectionGrid.innerHTML = '<p>Error loading tutors. Please refresh.</p>';
@@ -53,56 +95,41 @@ document.addEventListener('DOMContentLoaded', () => {
 
   /* -------- UI RENDER -------- */
   function renderTutors() {
-    if (!tutorSelectionGrid || !currentUser) return;
+    if (!tutorSelectionGrid) return;
     tutorSelectionGrid.innerHTML = '';
 
     allTutors.forEach(tutor => {
-      const isUnlocked = currentUser.unlockedItems.includes(tutor.id);
-      const card       = document.createElement('div');
-      card.classList.add('tutor-card', 'card-style-1', isUnlocked ? 'unlocked' : 'locked');
+      const card = document.createElement('div');
+      card.classList.add('tutor-card', 'card-style-1', 'unlocked');
       card.dataset.tutorId = tutor.id;
+      if (tutor.id === selectedTutorId) card.classList.add('selected');
 
-      // Pre-select from trial chat
-      if (isUnlocked && tutor.id === selectedTutorId) {
-        card.classList.add('selected');
-      }
-
-      if (isUnlocked) {
-        card.innerHTML =
-          '<img src="/images/tutor_avatars/' + esc(tutor.image) + '" alt="' + esc(tutor.name) + '" class="tutor-card-image" loading="lazy">' +
-          '<h3 class="tutor-card-name">' + esc(tutor.name) + '</h3>' +
-          '<p class="tutor-card-tagline">' + esc(tutor.catchphrase || '') + '</p>' +
-          '<button class="tutor-card-hear-btn" data-tutor-id="' + esc(tutor.id) + '">' +
-            '<i class="fas fa-volume-up"></i> Hear me' +
-          '</button>' +
-          '<div class="tutor-card-details-overlay">' +
-            '<h4>About ' + esc(tutor.name) + ':</h4><p>' + esc(tutor.about || '') + '</p>' +
-            '<h4>Specializes In:</h4><p>' + esc(tutor.specialties || '') + '</p>' +
-          '</div>';
-      } else {
-        const hint = tutor.unlockHint || 'Keep going — you\'ll meet me soon';
-        card.innerHTML =
-          '<img src="/images/tutor_avatars/' + esc(tutor.image) + '" alt="Locked Tutor" class="tutor-card-image silhouette">' +
-          '<h3 class="tutor-card-name locked-name">?????</h3>' +
-          '<p class="tutor-card-tagline"><i class="fas fa-lock"></i> ' + esc(hint) + '</p>';
-      }
+      card.innerHTML =
+        '<img src="/images/tutor_avatars/' + esc(tutor.image) + '" alt="' + esc(tutor.name) + '" class="tutor-card-image" loading="lazy">' +
+        '<h3 class="tutor-card-name">' + esc(tutor.name) + '</h3>' +
+        '<p class="tutor-card-tagline">' + esc(tutor.catchphrase || '') + '</p>' +
+        '<button class="tutor-card-hear-btn" data-tutor-id="' + esc(tutor.id) + '">' +
+          '<i class="fas fa-volume-up"></i> Hear me' +
+        '</button>' +
+        '<div class="tutor-card-details-overlay">' +
+          '<h4>About ' + esc(tutor.name) + ':</h4><p>' + esc(tutor.about || '') + '</p>' +
+          '<h4>Specializes In:</h4><p>' + esc(tutor.specialties || '') + '</p>' +
+        '</div>';
       tutorSelectionGrid.appendChild(card);
     });
   }
 
   /* -------- CARD SELECTION -------- */
   tutorSelectionGrid.addEventListener('click', e => {
-    // Ignore clicks on the hear button
-    if (e.target.closest('.tutor-card-hear-btn')) return;
+    if (e.target.closest('.tutor-card-hear-btn')) return; // handled below
 
     const card = e.target.closest('.tutor-card');
-    if (!card || card.classList.contains('locked')) return;
+    if (!card) return;
 
     document.querySelectorAll('.tutor-card').forEach(c => c.classList.remove('selected'));
     card.classList.add('selected');
     selectedTutorId = card.dataset.tutorId;
-    completeSelectionBtn.disabled = false;
-    completeSelectionBtn.innerHTML = '<i class="fas fa-arrow-right"></i> Next: Choose Your Avatar';
+    refreshPrimary();
   });
 
   /* -------- INLINE VOICE PREVIEW -------- */
@@ -120,7 +147,6 @@ document.addEventListener('DOMContentLoaded', () => {
       currentAudio.pause();
       if (currentAudioUrl) { URL.revokeObjectURL(currentAudioUrl); currentAudioUrl = null; }
       currentAudio = null;
-      // Reset all hear buttons
       document.querySelectorAll('.tutor-card-hear-btn').forEach(btn => {
         btn.innerHTML = '<i class="fas fa-volume-up"></i> Hear me';
         btn.disabled = false;
@@ -128,7 +154,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     hearBtn.disabled = true;
-    hearBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Playing\u2026';
+    hearBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Playing…';
 
     try {
       const resp = await csrfFetch('/api/speak', {
@@ -162,7 +188,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!selectedTutorId) return;
 
     completeSelectionBtn.disabled = true;
-    completeSelectionBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Saving\u2026';
+    completeSelectionBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Saving…';
     try {
       const res = await csrfFetch('/api/user/settings', {
         method: 'PATCH',
@@ -175,7 +201,7 @@ document.addEventListener('DOMContentLoaded', () => {
     } catch (err) {
       console.error(err);
       completeSelectionBtn.disabled = false;
-      completeSelectionBtn.innerHTML = '<i class="fas fa-times"></i> Save Failed \u2013 Retry';
+      completeSelectionBtn.innerHTML = '<i class="fas fa-times"></i> Save Failed – Retry';
     }
   });
 

--- a/public/pick-tutor.html
+++ b/public/pick-tutor.html
@@ -30,7 +30,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
   <main id="main-content" class="pick-tutor-main" style="min-height: calc(100vh - 140px); overflow-y: auto; padding-bottom: 3rem;">
     <!-- Onboarding Stepper -->
-    <div class="onboarding-stepper" style="margin-top: 2rem;">
+    <div class="onboarding-stepper" id="onboarding-stepper" style="margin-top: 2rem;">
       <div class="stepper-step completed">
         <div class="stepper-circle"></div>
         <span class="stepper-label">Profile</span>
@@ -40,17 +40,12 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <div class="stepper-circle">2</div>
         <span class="stepper-label">Tutor</span>
       </div>
-      <div class="stepper-connector"></div>
-      <div class="stepper-step">
-        <div class="stepper-circle">3</div>
-        <span class="stepper-label">Avatar</span>
-      </div>
     </div>
 
     <!-- TUTOR SELECTION -->
     <section class="selection-section">
-      <h1 class="section-title">Select Your Personal Math Coach.</h1>
-      <p class="subtitle">Your choice defines their voice and style. You can change your tutor anytime in settings!</p>
+      <h1 class="section-title" id="selection-title">Select Your Personal Math Coach.</h1>
+      <p class="subtitle" id="selection-subtitle">Your choice defines their voice and style. You can change your tutor anytime.</p>
 
       <div id="tutor-selection-grid" class="tutor-selection-grid">
         <p style="text-align: center; color: var(--clr-text-dim);">Loading tutors...</p>
@@ -61,8 +56,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <!-- NEXT BUTTON -->
     <div class="tutor-actions-bar" style="margin-top: 3rem;">
+      <a href="/chat.html" id="back-to-chat-link" class="btn btn-tertiary" style="display:none;">
+        <i class="fas fa-arrow-left"></i> Back to Chat
+      </a>
       <button id="complete-selection-btn" class="btn btn-select btn-large" disabled>
-        <i class="fas fa-arrow-right"></i> Next: Choose Your Avatar
+        <i class="fas fa-arrow-right"></i> Choose a tutor
       </button>
     </div>
   </main>


### PR DESCRIPTION
pick-tutor.html served both first-run onboarding and later tutor switching with the same chrome. It now derives the mode from currentUser.selectedTutorId:
- onboarding: step indicator shown, primary button "Start Learning"
- switching: stepper hidden, "Switch Your Tutor" heading, current tutor pre-selected, a "Back to Chat" escape, button "Switch to X"

Also removes stale leftovers: the dead "Choose Your Avatar" step and button label (the avatar onboarding step no longer exists — signup auto-assigns an avatar), and the locked-tutor silhouette code path (nothing is unlockable now that the 7 non-core tutors are inactive).