### PR TITLE
fix(docker): make the chrome smoke test exit 0 on success

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,10 @@ USER appuser
 # 10. Smoke-test chrome-headless-shell as the runtime user. If a system lib is
 #     missing or the binary didn't download, this fails the BUILD with a clear
 #     error instead of letting the first PDF request 500 in production.
-RUN node -e "require('puppeteer').launch({headless:'shell',args:['--no-sandbox','--disable-setuid-sandbox','--disable-dev-shm-usage']}).then(b=>b.close()).then(()=>console.log('chrome-headless-shell OK')).catch(e=>{console.error('SMOKE FAIL:',e.message);process.exit(1)})"
+#     The success branch exits 0 explicitly: once launch + close succeed the
+#     test has passed, so we terminate before any stray async rejection from
+#     Puppeteer's teardown can flip Node's exit code and fail the build.
+RUN node -e "require('puppeteer').launch({headless:'shell',args:['--no-sandbox','--disable-setuid-sandbox','--disable-dev-shm-usage']}).then(b=>b.close()).then(()=>{console.log('chrome-headless-shell OK');process.exit(0)}).catch(e=>{console.error('SMOKE FAIL:',e.message);process.exit(1)})"
 
 # 11. Tell Docker what port the app will run on
 EXPOSE 3000


### PR DESCRIPTION
The build-time chrome-headless-shell smoke test printed "chrome-headless-shell OK" yet the RUN step still failed the build. Its success branch only logged and let Node exit on its own, so a stray unhandled rejection from Puppeteer's browser teardown (fired after close() had already resolved) flipped the exit code — Node 20 exits 1 on an unhandled rejection.

The success branch now calls process.exit(0) the moment launch + close have both succeeded, before any teardown noise can crash the process. The catch path already exits 1.