### PR TITLE
docs(env): document the ENABLE_VISUAL_TOOLS feature flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,6 +87,14 @@ MATHPIX_APP_KEY=your_mathpix_app_key
 GOOGLE_SEARCH_API_KEY=your_google_api_key
 GOOGLE_SEARCH_ENGINE_ID=your_search_engine_id
 
+# --- FEATURE FLAGS ---
+# ENABLE_VISUAL_TOOLS — when 'true', the tutor emits graphs and other visuals
+# as validated, schema-checked function-calls instead of free-text bracket
+# tags, which is far more reliable. The legacy text-tag path still runs as a
+# fallback during the rollout window. Leave 'false' until verified on a deploy
+# — turning it on changes live AI behavior.
+ENABLE_VISUAL_TOOLS=false
+
 # --- STRIPE BILLING ---
 # MASTER SWITCH: Set to 'true' to activate billing, usage limits, and paywall.
 # When false (or missing), all users get unlimited free access (pre-launch mode).


### PR DESCRIPTION
ENABLE_VISUAL_TOOLS gates structured visual tool-calls — the tutor emitting graphs as validated, schema-checked function-calls instead of free-text bracket tags. The code path (generate.js, verify.js, visualTools.js, frontend renderFromToolCall) is fully wired on main but the flag was undocumented and never set.

Surfacing it in .env.example as an intentional, documented toggle (default false). Enabling it in an environment is a separate, verification-gated step — it changes live AI behavior.