### PR TITLE
fix(chat): keep the composer clear of the fixed footer

### DIFF
--- a/public/css/chat-redesign.css
+++ b/public/css/chat-redesign.css
@@ -297,7 +297,11 @@ body.cr-mode #chat-container {
   border: 1px solid var(--cr-border);
   border-radius: 22px;
   padding: 8px 0 0 !important;
-  margin-bottom: 60px !important;
+  /* Lifts the container clear of the fixed footer so the composer's input
+     row is fully visible. The old 60px let the bottom of the container —
+     and with it the message-entry row — slip into the fixed footer's
+     overlap zone. */
+  margin-bottom: 120px !important;
   overflow: hidden;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
#chat-container is overflow:hidden and the site footer is position:fixed at the viewport bottom. The container's 60px margin-bottom left its lower edge — and the message-entry row at the bottom of the composer — inside the footer's overlap zone, so the input row was clipped/hidden. The #session-stats-bar that previously sat below the composer had been absorbing that overhang; removing it exposed the clip. Raises margin-bottom to 120px so the composer sits fully above the footer.