### PR TITLE
fix(tutor): plug the cheating-tool gap when student shares an expression

### DIFF
--- a/utils/pipeline/promptSlim.js
+++ b/utils/pipeline/promptSlim.js
@@ -80,7 +80,8 @@ Uploaded worksheets: ask which ONE problem they're stuck on. Guide that one.
 "Give me the rest" / "do the others" → REFUSE. One problem at a time.
 Blank worksheets: "Pick a problem, try it, send it back."
 CHECK MY WORK: if upload contains student's answers, checking one at a time is OK.
-"Walk me through it" / "show me the steps" / "solve it for me" → NEVER dump a full worked solution. Walk through ONE STEP at a time with the STUDENT doing the thinking. Ask "What's the first step?" then wait. If they need to SEE a worked example first, use a PARALLEL PROBLEM (same skill, different numbers), then have them apply it to their own.`;
+"Walk me through it" / "show me the steps" / "solve it for me" → NEVER dump a full worked solution. Walk through ONE STEP at a time with the STUDENT doing the thinking. Ask "What's the first step?" then wait. If they need to SEE a worked example first, use a PARALLEL PROBLEM (same skill, different numbers), then have them apply it to their own.
+STUDENT-SHARED EXPRESSION (no upload, no explicit "solve this"): if the student types an expression or equation with no clear ask, do NOT simplify, evaluate, factor, expand, or solve it. Ask what they want to do with it (practice it? see how it works? check their answer?). If they want to see how the technique works, use a PARALLEL example (different numbers, same skill) — never their actual expression. Writing "[their expression] = [simplified or solved form]" anywhere in your reply IS solving it, even if framed as a walkthrough.`;
 
 const VISUAL_TOOL_RULES = `--- VISUAL TOOLS ---
 You CAN show pictures and diagrams. Use these commands — they render as interactive visuals in the chat.

--- a/utils/worksheetGuard.js
+++ b/utils/worksheetGuard.js
@@ -330,6 +330,14 @@ function detectAnswerAnnouncement(text) {
     const transitionalReveal = /(?:this\s+gives\s+(?:us\s+)?|so\s+we\s+(?:get|have|end\s+up\s+with)\s+|so\s+it\s+becomes\s+)[^,.\n]{0,30}\b[a-z]\s*=/i;
     if (transitionalReveal.test(text)) return { detected: true, pattern: 'transitional-reveal' };
 
+    // "Now, we can express it as: EXPR = EXPR", "So, we have: EXPR = EXPR",
+    // "This simplifies to: ...", "The simplified/factored form is: ..." — the
+    // conversational walkthrough pattern that hands over a worked result via
+    // an explicit equation, without ever saying "the answer is". The colon +
+    // an `=` within ~100 chars (possibly on the next line) is the signature.
+    const conclusionalReveal = /(?:now,?\s+we\s+can\s+(?:express|write|simplify)\s+(?:it|this)\s+as|so,?\s+we\s+(?:have|get|end\s+up\s+with)|we\s+end\s+up\s+with|this\s+(?:simplifies|reduces|evaluates)\s+to|the\s+(?:simplified|expanded|factored|reduced)\s+form\s+is)\s*[:：]\s*[\s\S]{0,100}=/i;
+    if (conclusionalReveal.test(text)) return { detected: true, pattern: 'conclusional-reveal' };
+
     // Original patterns, pluralized and kept.
     const explicitAnswer = [
         /(?:the\s+)?(?:answers?|solutions?)\s+(?:is|are)\s*[:=]?\s*(?:\\[(\[])?\s*[-\d(x]/i,
@@ -384,8 +392,17 @@ function detectWorkedSolution(text) {
     const isHardAnnouncement = announcement.detected && (
         announcement.pattern === 'multi-root-announcement' ||
         announcement.pattern === 'plural-conclusion' ||
-        announcement.pattern === 'transitional-reveal'
+        announcement.pattern === 'transitional-reveal' ||
+        announcement.pattern === 'conclusional-reveal'
     );
+
+    // Conversational walkthrough density — the "let's do this together / now
+    // let's simplify / so we have / now we can express it as" cadence is the
+    // signature of an LLM narrating a full solve without using formal
+    // Step 1/Step 2 headers. Three or more transitions = strong signal.
+    const walkthroughTransitions = text.match(
+        /\b(?:now,?\s+let'?s|let'?s\s+do\s+(?:this|that)\s+together|so,?\s+we\s+(?:have|get|end\s+up)|now,?\s+we\s+can\s+(?:express|write|simplify)|next,?\s+we'?ll?)\b/gi
+    ) || [];
 
     let signalCount = 0;
     if (stepHeaderMatches.length >= 3) signalCount += 2;
@@ -396,6 +413,8 @@ function detectWorkedSolution(text) {
     if (conclusionLines.length >= 2) signalCount += 1;
     if (hasCompleteSolution) signalCount += 1;
     if (isHardAnnouncement) signalCount += 3;
+    if (walkthroughTransitions.length >= 3) signalCount += 2;
+    else if (walkthroughTransitions.length >= 2) signalCount += 1;
 
     return {
         isWorkedSolution: signalCount >= 3,
@@ -408,6 +427,7 @@ function detectWorkedSolution(text) {
             summaryBlock,
             keyPoints: labeledKeyPoints.length,
             conclusions: conclusionLines.length,
+            walkthroughTransitions: walkthroughTransitions.length,
         },
     };
 }


### PR DESCRIPTION
When a student typed an expression (e.g. "1/(3-i)") with no explicit ask, the tutor would launch into a full worked walkthrough — "let's do that together... now let's simplify... so we have... now, we can express it as: 1/(3-i) = 3/10 + (1/10)i" — handing over the answer in one shot. The #1-rule violation.

Two prongs:

Prompt (pipeline/promptSlim.js): adds an explicit rule to ANTI_CHEAT_RULES — when a student shares an expression with no clear ask, the tutor confirms intent and never simplifies/evaluates/solves the student's actual expression. If they want to see the technique, use a parallel example. Writing "[their expression] = [simplified form]" counts as solving, even framed as a walkthrough.

Detection (worksheetGuard.js): the existing detectWorkedSolution guard was tuned for formal "Step 1 / Step 2 / Summary" walkthroughs and missed the conversational variant. Adds two patterns:
- conclusional-reveal: catches "Now, we can express it as: X = Y", "So, we have: X = Y", "This simplifies to: ... = ...". A colon followed by an equation within ~100 chars is the smoking gun.
- walkthroughTransitions: counts "now let's / so we have / now we can express" cadence; 3+ transitions = strong worked-solution signal.

92 existing unit tests still pass.