### PR TITLE
fix(tutor): stop re-recommending mastered skills

### DIFF
--- a/models/tutorPlan.js
+++ b/models/tutorPlan.js
@@ -261,30 +261,48 @@ tutorPlanSchema.statics.familiarityToMode = function (familiarity) {
 /**
  * Determine familiarity from existing skill mastery data.
  * This bridges the existing user.skillMastery map to the new plan system.
+ *
+ * masteryScore is normalized: values in [0, 1] are treated as fractions,
+ * values > 1 are treated as percentages. The screener writes fractions
+ * (e.g. masteryScore: 1), older code paths write percentages (e.g. 92).
  */
 tutorPlanSchema.statics.inferFamiliarity = function (skillMasteryEntry) {
   if (!skillMasteryEntry) return 'never-seen';
 
-  const { status, masteryScore, totalAttempts, pillars } = skillMasteryEntry;
+  const { status, masteryScore, totalAttempts, pillars, masteredDate } = skillMasteryEntry;
+
+  // Normalize masteryScore to 0-100 percentage. Treat values <= 1 as
+  // fractions (the screener writes 0..1) so the threshold checks below
+  // work regardless of which producer wrote the field.
+  const scorePct = typeof masteryScore === 'number'
+    ? (masteryScore <= 1 ? masteryScore * 100 : masteryScore)
+    : 0;
+
+  // Verified mastery short-circuits attempt-count gates.
+  // The screener can mark a skill mastered with totalAttempts: 0 (it
+  // judges via the adaptive items, not the per-skill attempt counter).
+  // If status says mastered and there's a masteredDate as evidence,
+  // trust it regardless of attempts.
+  if (status === 'mastered' && masteredDate) return 'mastered';
 
   // Never attempted
   if (!totalAttempts || totalAttempts === 0) return 'never-seen';
 
   // Mastered — status + strong score + sufficient evidence
-  if (status === 'mastered' && masteryScore >= 80) return 'mastered';
+  if (status === 'mastered' && scorePct >= 80) return 'mastered';
 
   // Proficient — high score AND enough attempts to trust it.
   // A 75% score on 2 attempts is noise. A 75% on 8 attempts is signal.
   // Also check pillar accuracy if available — raw score can be inflated
   // by easy problems or lucky guesses.
   const accuracyPct = pillars?.accuracy?.percentage;
-  if (masteryScore >= 75 && totalAttempts >= 5) return 'proficient';
+  if (scorePct >= 75 && totalAttempts >= 5) return 'proficient';
   if (accuracyPct >= 0.80 && totalAttempts >= 5) return 'proficient';
 
   // Developing — student has real experience but is not solid.
   // 'practicing' status alone is NOT enough for proficient — a student
   // who's practiced 3 times at 40% accuracy is developing, not proficient.
-  if (status === 'practicing' && masteryScore >= 50 && totalAttempts >= 3) return 'developing';
+  if (status === 'practicing' && scorePct >= 50 && totalAttempts >= 3) return 'developing';
   if (status === 'learning' && totalAttempts >= 3) return 'developing';
 
   // Introduced — minimal exposure, not enough to guide

--- a/routes/mastery.js
+++ b/routes/mastery.js
@@ -17,6 +17,7 @@ const { generatePhaseProblem, recordPhaseAttempt, getPhaseInstructions } = requi
 const { generateHint, trackHintUsage, analyzeHintUsage, shouldReteach } = require('../utils/hintSystem'); // TEACHING ENHANCEMENT
 const { analyzeError, generateReteaching, recordMisconception, markMisconceptionAddressed, analyzeMisconceptionPattern } = require('../utils/misconceptionDetector'); // TEACHING ENHANCEMENT
 const { getUnpluggedBadgeProgress } = require('../utils/unpluggedBadges');
+const { isSkillMastered } = require('../utils/masteryGuard');
 // ============================================================================
 // MASTERY BADGES
 // ============================================================================
@@ -556,6 +557,17 @@ router.post('/select-badge', isAuthenticated, async (req, res) => {
       return res.status(400).json({ error: 'Badge already earned' });
     }
 
+    // Don't open a badge for a skill the student has already mastered.
+    // Otherwise the badge would pin the tutor's focus to that skill and
+    // the student would be re-recommended a topic they're done with.
+    if (badge.skillId && isSkillMastered(user, badge.skillId)) {
+      return res.status(409).json({
+        error: 'Skill already mastered',
+        skillId: badge.skillId,
+        message: `${badge.skillName || badge.skillId} is already marked mastered. Pick a new skill to work on.`,
+      });
+    }
+
     // TEACHING ENHANCEMENT: Prepare comprehensive launch information
     const launchInfo = await prepareBadgeLaunch(badge, user);
 
@@ -620,6 +632,17 @@ router.post('/start-skill-practice', isAuthenticated, async (req, res) => {
       return res.status(404).json({ error: 'Skill not found' });
     }
 
+    // Skip skills the student has already mastered — practicing a mastered
+    // skill via this entry point would create an activeBadge that the
+    // tutor would then keep recommending.
+    if (isSkillMastered(user, skillId)) {
+      return res.status(409).json({
+        error: 'Skill already mastered',
+        skillId,
+        message: `${skill.skillName || skillId} is already mastered. Choose a new skill to practice.`,
+      });
+    }
+
     // Initialize masteryProgress if needed
     if (!user.masteryProgress) {
       user.masteryProgress = { activeBadge: null, attempts: [] };
@@ -674,6 +697,14 @@ router.post('/start-badge', isAuthenticated, async (req, res) => {
 
     if (!badge) {
       return res.status(404).json({ error: 'Badge not found or not available' });
+    }
+
+    if (badge.skillId && isSkillMastered(user, badge.skillId)) {
+      return res.status(409).json({
+        error: 'Skill already mastered',
+        skillId: badge.skillId,
+        message: `${badge.skillName || badge.skillId} is already mastered. Pick a new badge.`,
+      });
     }
 
     // Initialize badge attempt in user profile

--- a/scripts/unstickMasteredFocus.js
+++ b/scripts/unstickMasteredFocus.js
@@ -1,0 +1,110 @@
+// scripts/unstickMasteredFocus.js
+//
+// One-off (and idempotent) repair: for each user, resolve focus-queue
+// entries whose underlying skill is already mastered, and clear an
+// activeBadge that points to an already-mastered skill OR has gone past
+// the staleness threshold without earning.
+//
+// Usage:
+//   node scripts/unstickMasteredFocus.js                  # all users, dry run
+//   node scripts/unstickMasteredFocus.js --apply          # write changes
+//   node scripts/unstickMasteredFocus.js --user <email>   # single user
+//
+// Safe to re-run: it only ever transitions entries from active/in-progress
+// → resolved, and only ever nulls an activeBadge. It never re-opens a
+// resolved focus entry.
+
+const mongoose = require('mongoose');
+const User = require('../models/user');
+const TutorPlan = require('../models/tutorPlan');
+const { isSkillMastered, isBadgeStuck, clearActiveBadge } = require('../utils/masteryGuard');
+
+const APPLY = process.argv.includes('--apply');
+const userArgIdx = process.argv.indexOf('--user');
+const USER_EMAIL = userArgIdx >= 0 ? process.argv[userArgIdx + 1] : null;
+
+async function main() {
+  const uri = process.env.MONGODB_URI || 'mongodb://localhost:27017/mathmatix';
+  await mongoose.connect(uri);
+  console.log(`Connected to MongoDB. mode=${APPLY ? 'APPLY' : 'DRY-RUN'}${USER_EMAIL ? ` user=${USER_EMAIL}` : ''}`);
+
+  const userQuery = USER_EMAIL ? { email: USER_EMAIL } : {};
+  const users = await User.find(userQuery).select('_id email skillMastery masteryProgress').lean(false);
+  console.log(`Scanning ${users.length} user(s)...`);
+
+  let usersTouched = 0;
+  let focusEntriesResolved = 0;
+  let badgesCleared = 0;
+
+  for (const user of users) {
+    const changes = [];
+
+    // 1. Clear an activeBadge whose skill is already mastered, or one that
+    //    has burned past the staleness threshold without earning.
+    const badge = user.masteryProgress?.activeBadge;
+    if (badge) {
+      const skillAlreadyDone = badge.skillId && isSkillMastered(user, badge.skillId);
+      const stuck = isBadgeStuck(badge);
+      if (skillAlreadyDone || stuck) {
+        const reason = skillAlreadyDone ? 'skill already mastered' : 'staleness valve';
+        changes.push(`clear activeBadge "${badge.badgeId}" (skill=${badge.skillId}, ${badge.problemsCorrect}/${badge.problemsCompleted}): ${reason}`);
+        if (APPLY) {
+          clearActiveBadge(user, `repair script: ${reason}`);
+          badgesCleared++;
+        }
+      }
+    }
+
+    // 2. Resolve mastered skills in the user's TutorPlan focus queue.
+    const plan = await TutorPlan.findOne({ userId: user._id });
+    if (plan) {
+      let planChanged = false;
+      for (const entry of plan.skillFocus) {
+        if (entry.status === 'resolved' || entry.status === 'deferred') continue;
+        if (isSkillMastered(user, entry.skillId)) {
+          changes.push(`focus: ${entry.skillId} → resolved (mastered)`);
+          if (APPLY) {
+            entry.status = 'resolved';
+            entry.resolvedAt = new Date();
+            planChanged = true;
+            focusEntriesResolved++;
+          }
+        }
+      }
+      // 3. Clear a currentTarget that points to a mastered skill so the
+      //    next session re-resolves from the queue.
+      if (plan.currentTarget?.skillId && isSkillMastered(user, plan.currentTarget.skillId)) {
+        changes.push(`currentTarget "${plan.currentTarget.skillId}" → cleared (mastered)`);
+        if (APPLY) {
+          plan.currentTarget = { skillId: null, displayName: null, instructionalMode: null };
+          planChanged = true;
+        }
+      }
+      if (APPLY && planChanged) {
+        plan.lastUpdated = new Date();
+        await plan.save();
+      }
+    }
+
+    if (changes.length === 0) continue;
+    usersTouched++;
+    console.log(`\n${user.email} (${user._id}):`);
+    for (const c of changes) console.log(`  - ${c}`);
+
+    if (APPLY) {
+      await user.save();
+    }
+  }
+
+  console.log(`\n--- Summary (${APPLY ? 'APPLIED' : 'dry run'}) ---`);
+  console.log(`Users with changes:    ${usersTouched}`);
+  console.log(`Focus entries resolved: ${focusEntriesResolved}`);
+  console.log(`Active badges cleared:  ${badgesCleared}`);
+
+  await mongoose.disconnect();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/unit/masteryGuard.test.js
+++ b/tests/unit/masteryGuard.test.js
@@ -1,0 +1,147 @@
+// tests/unit/masteryGuard.test.js
+// Unit tests for the small helpers that decide:
+//  - whether a skill is already mastered (so badges shouldn't open)
+//  - whether an activeBadge is stuck (so the safety valve should fire)
+//  - how to clear an activeBadge into the attempts log
+
+const {
+  isSkillMastered,
+  isBadgeStuck,
+  clearActiveBadge,
+  STUCK_BADGE_ATTEMPT_MULTIPLIER,
+} = require('../../utils/masteryGuard');
+
+function userWithSkill(skillId, entry) {
+  // Test against both the Map and plain-object shapes — User.skillMastery is
+  // declared as Mixed, so we see both in the wild.
+  return {
+    map: { skillMastery: new Map([[skillId, entry]]) },
+    obj: { skillMastery: { [skillId]: entry } },
+  };
+}
+
+describe('isSkillMastered', () => {
+  test('returns false for a user with no skillMastery', () => {
+    expect(isSkillMastered({}, 'anything')).toBe(false);
+  });
+
+  test('returns true for a screener-mastered skill (totalAttempts: 0)', () => {
+    // The exact shape from Jason's MongoDB profile for simple-probability
+    const entry = {
+      status: 'mastered',
+      masteryScore: 1,
+      totalAttempts: 0,
+      masteredDate: new Date('2026-02-15'),
+    };
+    const { map, obj } = userWithSkill('simple-probability', entry);
+    expect(isSkillMastered(map, 'simple-probability')).toBe(true);
+    expect(isSkillMastered(obj, 'simple-probability')).toBe(true);
+  });
+
+  test('returns false for a skill in learning status', () => {
+    const { map } = userWithSkill('probability-basics', {
+      status: 'learning',
+      masteryScore: 0.5,
+      totalAttempts: 0,
+    });
+    expect(isSkillMastered(map, 'probability-basics')).toBe(false);
+  });
+
+  test('returns false for unknown skills', () => {
+    const { map } = userWithSkill('foo', { status: 'mastered', masteredDate: new Date(), masteryScore: 1 });
+    expect(isSkillMastered(map, 'bar')).toBe(false);
+  });
+});
+
+describe('isBadgeStuck', () => {
+  test('returns false for null badge', () => {
+    expect(isBadgeStuck(null)).toBe(false);
+  });
+
+  test('returns false when problemsCompleted < threshold', () => {
+    expect(isBadgeStuck({
+      requiredProblems: 12,
+      requiredAccuracy: 0.8,
+      problemsCompleted: 10,
+      problemsCorrect: 4,
+    })).toBe(false);
+  });
+
+  test('returns true at multiplier x required with low accuracy', () => {
+    expect(isBadgeStuck({
+      requiredProblems: 12,
+      requiredAccuracy: 0.8,
+      problemsCompleted: 12 * STUCK_BADGE_ATTEMPT_MULTIPLIER,
+      problemsCorrect: 8, // 33%, well under 80%
+    })).toBe(true);
+  });
+
+  test('returns false when accuracy is on track even at high attempt count', () => {
+    // 95% accuracy at 24 attempts on a 12-required badge is "earned, just
+    // not flushed yet" territory — not stuck.
+    expect(isBadgeStuck({
+      requiredProblems: 12,
+      requiredAccuracy: 0.8,
+      problemsCompleted: 24,
+      problemsCorrect: 23,
+    })).toBe(false);
+  });
+
+  test('matches Jason’s real stuck-badge shape (39/18 on a 12-required badge)', () => {
+    // The exact case that motivated this code — verifies the valve fires.
+    expect(isBadgeStuck({
+      requiredProblems: 12,
+      requiredAccuracy: 0.8,
+      problemsCompleted: 39,
+      problemsCorrect: 18,
+    })).toBe(true);
+  });
+});
+
+describe('clearActiveBadge', () => {
+  test('is a no-op when there is no activeBadge', () => {
+    const user = { masteryProgress: { activeBadge: null, attempts: [] } };
+    expect(clearActiveBadge(user, 'reason')).toBeNull();
+    expect(user.masteryProgress.activeBadge).toBeNull();
+    expect(user.masteryProgress.attempts).toEqual([]);
+  });
+
+  test('nulls the activeBadge and appends to attempts log', () => {
+    const user = {
+      masteryProgress: {
+        activeBadge: {
+          badgeId: 'uncertainty-simple-probability',
+          skillId: 'simple-probability',
+          problemsCompleted: 39,
+          problemsCorrect: 18,
+        },
+        attempts: [],
+      },
+      markModified: jest.fn(),
+    };
+    const prior = clearActiveBadge(user, 'staleness valve');
+    expect(prior.badgeId).toBe('uncertainty-simple-probability');
+    expect(user.masteryProgress.activeBadge).toBeNull();
+    expect(user.masteryProgress.attempts).toHaveLength(1);
+    expect(user.masteryProgress.attempts[0]).toMatchObject({
+      badgeId: 'uncertainty-simple-probability',
+      completed: false,
+      score: 46, // round(18/39 * 100)
+    });
+    expect(user.markModified).toHaveBeenCalledWith('masteryProgress');
+  });
+
+  test('initializes attempts array if missing', () => {
+    const user = {
+      masteryProgress: {
+        activeBadge: { badgeId: 'b', skillId: 's', problemsCompleted: 0, problemsCorrect: 0 },
+      },
+      markModified: jest.fn(),
+    };
+    clearActiveBadge(user, 'reason');
+    expect(Array.isArray(user.masteryProgress.attempts)).toBe(true);
+    expect(user.masteryProgress.attempts).toHaveLength(1);
+    // 0/0 accuracy guard
+    expect(user.masteryProgress.attempts[0].score).toBe(0);
+  });
+});

--- a/tests/unit/tutorPlanManagerAutoAdvance.test.js
+++ b/tests/unit/tutorPlanManagerAutoAdvance.test.js
@@ -1,0 +1,136 @@
+// tests/unit/tutorPlanManagerAutoAdvance.test.js
+//
+// Tests that resolveCurrentTarget skips over mastered skills in the focus
+// queue, marks them resolved, and advances to the next-priority candidate.
+//
+// Without this behavior, a user can be permanently pinned to a mastered
+// skill (Jason's `simple-probability` case from May 2026).
+
+// Stub the Skill model before requiring code that imports it. We only need
+// findOne to return minimal shape — the queue-advance logic does not care
+// about prerequisites for already-mastered skills.
+jest.mock('../../models/skill', () => ({
+  findOne: jest.fn(({ skillId }) => ({
+    lean: () => Promise.resolve({
+      skillId,
+      displayName: skillId,
+      prerequisites: [],
+    }),
+  })),
+}));
+
+const { resolveCurrentTarget } = require('../../utils/tutorPlanManager');
+
+function planWith(skillFocus, currentTarget = {}) {
+  // Mock TutorPlan document — just an object with the fields the manager
+  // reads/writes. We don't need a real mongoose doc for this unit test.
+  return {
+    skillFocus,
+    currentTarget,
+    lastUpdated: null,
+  };
+}
+
+function userWith(skillMastery = {}) {
+  return { skillMastery };
+}
+
+describe('resolveCurrentTarget — auto-advance past mastered skills', () => {
+  test('advances to the next-priority skill when current target is mastered', async () => {
+    const plan = planWith(
+      [
+        {
+          skillId: 'simple-probability',
+          status: 'in-progress',
+          priority: 8,
+        },
+        {
+          skillId: 'quadratic-formula',
+          status: 'active',
+          priority: 5,
+        },
+      ],
+      { skillId: 'simple-probability' }
+    );
+
+    const user = userWith({
+      'simple-probability': {
+        status: 'mastered',
+        masteryScore: 1,
+        totalAttempts: 0,
+        masteredDate: new Date('2026-02-15'),
+      },
+      // quadratic-formula has no mastery entry — fresh skill
+    });
+
+    const { skillResolution } = await resolveCurrentTarget(plan, { user });
+
+    expect(skillResolution.skillId).toBe('quadratic-formula');
+    expect(plan.currentTarget.skillId).toBe('quadratic-formula');
+
+    // The mastered skill should be marked resolved with a timestamp
+    const stale = plan.skillFocus.find(sf => sf.skillId === 'simple-probability');
+    expect(stale.status).toBe('resolved');
+    expect(stale.resolvedAt).toBeInstanceOf(Date);
+  });
+
+  test('drains a queue of all-mastered skills and returns null resolution', async () => {
+    const plan = planWith([
+      { skillId: 'a', status: 'active', priority: 3 },
+      { skillId: 'b', status: 'active', priority: 2 },
+    ]);
+    const masteredEntry = { status: 'mastered', masteryScore: 1, totalAttempts: 0, masteredDate: new Date() };
+    const user = userWith({ a: masteredEntry, b: masteredEntry });
+
+    const { skillResolution } = await resolveCurrentTarget(plan, { user });
+
+    expect(skillResolution).toBeNull();
+    expect(plan.skillFocus.every(sf => sf.status === 'resolved')).toBe(true);
+  });
+
+  test('does NOT skip a mastered skill when caller passes explicit activeSkillId', async () => {
+    // The student asked to work on this specific skill (e.g. opened a course
+    // session on it). We still resolve, just in leverage mode.
+    const plan = planWith([
+      { skillId: 'simple-probability', status: 'active', priority: 5 },
+    ]);
+    const user = userWith({
+      'simple-probability': {
+        status: 'mastered',
+        masteryScore: 1,
+        totalAttempts: 0,
+        masteredDate: new Date(),
+      },
+    });
+
+    const { skillResolution } = await resolveCurrentTarget(plan, {
+      user,
+      activeSkillId: 'simple-probability',
+    });
+
+    expect(skillResolution.skillId).toBe('simple-probability');
+    expect(skillResolution.instructionalMode).toBe('leverage');
+  });
+
+  test('leaves a non-mastered current target alone', async () => {
+    const plan = planWith(
+      [{ skillId: 'limits', status: 'in-progress', priority: 5 }],
+      { skillId: 'limits' }
+    );
+    const user = userWith({
+      limits: {
+        status: 'learning',
+        masteryScore: 0.4,
+        totalAttempts: 3,
+      },
+    });
+
+    const { skillResolution } = await resolveCurrentTarget(plan, { user });
+
+    expect(skillResolution.skillId).toBe('limits');
+    expect(skillResolution.familiarity).toBe('developing');
+    const entry = plan.skillFocus[0];
+    expect(entry.status).toBe('in-progress');
+    expect(entry.resolvedAt).toBeUndefined();
+  });
+});

--- a/tests/unit/tutorPlanModel.test.js
+++ b/tests/unit/tutorPlanModel.test.js
@@ -90,6 +90,34 @@ describe('TutorPlan.statics.inferFamiliarity', () => {
     })).toBe('mastered');
   });
 
+  test('trusts screener-verified mastery even with totalAttempts: 0', () => {
+    // The screener marks skills mastered without per-skill attempts —
+    // it judges via the adaptive item bank. If status+masteredDate are
+    // set, we trust it regardless of the attempt counter.
+    expect(statics.inferFamiliarity({
+      status: 'mastered',
+      masteryScore: 1,
+      totalAttempts: 0,
+      masteredDate: new Date('2026-02-15'),
+    })).toBe('mastered');
+  });
+
+  test('accepts mastery on a 0-1 score scale', () => {
+    // Some producers write masteryScore as a fraction (0..1), others as
+    // a percentage (0..100). Both should be honored.
+    expect(statics.inferFamiliarity({
+      status: 'mastered',
+      masteryScore: 0.95,
+      totalAttempts: 10,
+    })).toBe('mastered');
+  });
+
+  test('accepts proficient on a 0-1 score scale', () => {
+    expect(statics.inferFamiliarity({
+      status: 'practicing', masteryScore: 0.82, totalAttempts: 6
+    })).toBe('proficient');
+  });
+
   test('"proficient" when score ≥75 and totalAttempts ≥5', () => {
     expect(statics.inferFamiliarity({
       status: 'practicing', masteryScore: 80, totalAttempts: 6

--- a/utils/masteryGuard.js
+++ b/utils/masteryGuard.js
@@ -1,0 +1,92 @@
+/**
+ * MASTERY GUARD — small, shared helpers for "is this skill done?" decisions.
+ *
+ * Centralizes the logic that prevents:
+ * - Starting a badge for a skill the student has already mastered
+ * - Leaving a stuck activeBadge (high attempt count, low accuracy) pinned
+ *   to the student's profile, which would keep dominating the tutor's
+ *   focus queue and suggestion chips
+ *
+ * Shares the familiarity model with TutorPlan so badges and the tutor
+ * agree on what "mastered" means.
+ */
+
+const TutorPlan = require('../models/tutorPlan');
+
+// If a badge has been attempted this many times its requirement without
+// being earned, we consider it stuck and clear it so the student can pick
+// (or be routed to) a fresh target. 2x is conservative — it gives plenty
+// of room for normal struggle before intervening.
+const STUCK_BADGE_ATTEMPT_MULTIPLIER = 2;
+
+function getSkillMasteryEntry(user, skillId) {
+  if (!user || !skillId) return null;
+  const sm = user.skillMastery;
+  if (!sm) return null;
+  if (typeof sm.get === 'function') return sm.get(skillId) || null;
+  return sm[skillId] || null;
+}
+
+/**
+ * Is this skill already mastered for this user?
+ * Uses the same TutorPlan.inferFamiliarity rule the tutor uses, so the
+ * answer here is consistent with the tutor's instructional-mode pick.
+ */
+function isSkillMastered(user, skillId) {
+  const entry = getSkillMasteryEntry(user, skillId);
+  return TutorPlan.inferFamiliarity(entry) === 'mastered';
+}
+
+/**
+ * Has an activeBadge attempted enough problems that we should consider it
+ * stuck and clear it? Only fires when accuracy is still below requirement.
+ */
+function isBadgeStuck(badge) {
+  if (!badge) return false;
+  const required = badge.requiredProblems || 0;
+  if (required <= 0) return false;
+  const completed = badge.problemsCompleted || 0;
+  if (completed < required * STUCK_BADGE_ATTEMPT_MULTIPLIER) return false;
+  const accuracy = completed > 0 ? (badge.problemsCorrect || 0) / completed : 0;
+  return accuracy < (badge.requiredAccuracy || 0);
+}
+
+/**
+ * Clear the user's activeBadge and record the abandoned attempt.
+ * Returns the previously-active badge for logging/telemetry, or null.
+ *
+ * `reason` is logged for observability; it isn't persisted on the attempt
+ * subdoc because the User.masteryProgress.attempts schema only stores
+ * { badgeId, attemptDate, completed, score }.
+ */
+function clearActiveBadge(user, reason) {
+  if (!user?.masteryProgress?.activeBadge) return null;
+  const prior = user.masteryProgress.activeBadge;
+  const completed = prior.problemsCompleted || 0;
+  const correct = prior.problemsCorrect || 0;
+  const accuracy = completed > 0 ? correct / completed : 0;
+
+  user.masteryProgress.activeBadge = null;
+  if (!Array.isArray(user.masteryProgress.attempts)) {
+    user.masteryProgress.attempts = [];
+  }
+  user.masteryProgress.attempts.push({
+    badgeId: prior.badgeId,
+    attemptDate: new Date(),
+    completed: false,
+    score: Math.round(accuracy * 100),
+  });
+  user.markModified('masteryProgress');
+
+  if (reason && typeof console !== 'undefined') {
+    console.log(`[masteryGuard] cleared activeBadge ${prior.badgeId} (skill=${prior.skillId}, ${correct}/${completed} = ${Math.round(accuracy * 100)}%): ${reason}`);
+  }
+  return prior;
+}
+
+module.exports = {
+  STUCK_BADGE_ATTEMPT_MULTIPLIER,
+  isSkillMastered,
+  isBadgeStuck,
+  clearActiveBadge,
+};

--- a/utils/pipeline/persist.js
+++ b/utils/pipeline/persist.js
@@ -528,9 +528,16 @@ function processIepGoalUpdate(user, goalIdentifier, progressChange) {
  * Update badge progress when a problem is answered.
  * Returns mastery completion info so chat.js can send celebration data.
  *
- * @returns {{ completed: boolean, success: boolean, badgeAwarded: Object|null }}
+ * Also enforces a staleness valve: if a badge has been attempted well past
+ * its required number of problems without reaching the accuracy threshold,
+ * we clear it. Otherwise it would stay pinned to the user forever and keep
+ * dominating the tutor's focus and the suggestion chips.
+ *
+ * @returns {{ completed: boolean, success: boolean, badgeAwarded: Object|null, stuckCleared?: boolean }}
  */
 function updateBadgeProgress(user, wasCorrect) {
+  const { isBadgeStuck, clearActiveBadge } = require('../masteryGuard');
+
   const badge = user.masteryProgress.activeBadge;
   badge.problemsCompleted = (badge.problemsCompleted || 0) + 1;
   if (wasCorrect) badge.problemsCorrect = (badge.problemsCorrect || 0) + 1;
@@ -540,6 +547,12 @@ function updateBadgeProgress(user, wasCorrect) {
   // Check for badge completion
   const accuracy = badge.problemsCorrect / badge.problemsCompleted;
   if (badge.problemsCompleted < badge.requiredProblems || accuracy < badge.requiredAccuracy) {
+    // Not earned yet — but check if we've been hammering this badge with
+    // no path to success. If so, clear it so the next session starts fresh.
+    if (isBadgeStuck(badge)) {
+      clearActiveBadge(user, 'staleness valve: attempts exceeded threshold without earning');
+      return { completed: false, success: false, badgeAwarded: null, stuckCleared: true };
+    }
     return { completed: false, success: false, badgeAwarded: null };
   }
 

--- a/utils/tutorPlanManager.js
+++ b/utils/tutorPlanManager.js
@@ -67,6 +67,10 @@ async function loadOrCreatePlan(userId, options = {}) {
  * Called after the plan is loaded, before the decide stage runs.
  * Determines the instructional mode for whatever the tutor is about to teach.
  *
+ * If the resolved skill is already mastered (and no explicit override forced
+ * it), the focus entry is marked resolved and we pick the next-priority skill
+ * instead. This prevents the tutor from re-recommending mastered skills.
+ *
  * @param {Object} plan - The TutorPlan document
  * @param {Object} context
  * @param {Object} context.user - User document (for skillMastery)
@@ -78,35 +82,87 @@ async function resolveCurrentTarget(plan, context) {
   const { user, activeSkillId, courseSkillId } = context;
   const skillMastery = user.skillMastery || new Map();
 
-  // Determine which skill to target
-  // Priority: explicit active skill > course skill > highest-priority plan item
-  const targetSkillId = activeSkillId
-    || courseSkillId
+  // Skills the caller explicitly asked us to focus on (e.g. student opened a
+  // course session or asked about a specific topic). These bypass the
+  // auto-resolve-when-mastered behavior — if the student is asking about it,
+  // we still resolve it, just in 'leverage' mode.
+  const explicitOverride = activeSkillId || courseSkillId;
+
+  // Try up to N candidates so a queue full of already-mastered skills can be
+  // drained in a single resolution pass without recursion blowing the stack.
+  const MAX_AUTO_ADVANCE = 25;
+  const visited = new Set();
+  let targetSkillId = explicitOverride
     || plan.currentTarget?.skillId
     || getHighestPrioritySkill(plan);
 
   if (!targetSkillId) return { plan, skillResolution: null };
 
-  // Resolve familiarity and prerequisites
-  const skillResolution = await resolveSkill(targetSkillId, skillMastery);
+  let skillResolution = null;
+  for (let i = 0; i < MAX_AUTO_ADVANCE; i++) {
+    if (visited.has(targetSkillId)) {
+      // Defensive — should never happen, but guarantees termination
+      break;
+    }
+    visited.add(targetSkillId);
+
+    skillResolution = await resolveSkill(targetSkillId, skillMastery);
+
+    const isMastered = skillResolution.familiarity === FAMILIARITY.MASTERED;
+
+    // If the student didn't explicitly ask for this skill and it's already
+    // mastered, retire it from the focus queue and try the next candidate.
+    if (isMastered && !explicitOverride) {
+      const focusEntry = plan.skillFocus.find(sf => sf.skillId === targetSkillId);
+      if (focusEntry && focusEntry.status !== 'resolved') {
+        focusEntry.status = 'resolved';
+        focusEntry.resolvedAt = new Date();
+        focusEntry.familiarity = skillResolution.familiarity;
+        focusEntry.instructionalMode = skillResolution.instructionalMode;
+      }
+      // Clear stale currentTarget so the next lookup uses the queue
+      if (plan.currentTarget?.skillId === targetSkillId) {
+        plan.currentTarget = { skillId: null, displayName: null, instructionalMode: null };
+      }
+
+      const nextId = getHighestPrioritySkill(plan);
+      if (!nextId || nextId === targetSkillId) {
+        // Queue is empty or every remaining entry is already mastered.
+        // Return a null resolution so the caller surfaces a "pick a new
+        // topic" prompt rather than re-running the same mastered skill
+        // in leverage mode (which is itself a stuck-loop pattern).
+        skillResolution = null;
+        break;
+      }
+      targetSkillId = nextId;
+      skillResolution = null;
+      continue;
+    }
+
+    break;
+  }
+
+  if (!skillResolution) {
+    return { plan, skillResolution: null };
+  }
 
   // Update the plan's current target
   plan.currentTarget = {
     skillId: skillResolution.skillId,
     displayName: skillResolution.displayName,
     instructionalMode: skillResolution.instructionalMode,
-    startedAt: plan.currentTarget?.skillId === targetSkillId
+    startedAt: plan.currentTarget?.skillId === skillResolution.skillId
       ? plan.currentTarget.startedAt
       : new Date(),
     instructionPhase: determineInstructionPhase(
       skillResolution.instructionalMode,
       plan.currentTarget,
-      targetSkillId
+      skillResolution.skillId
     ),
   };
 
   // Update skill focus entry if it exists
-  const focusEntry = plan.skillFocus.find(sf => sf.skillId === targetSkillId);
+  const focusEntry = plan.skillFocus.find(sf => sf.skillId === skillResolution.skillId);
   if (focusEntry) {
     focusEntry.familiarity = skillResolution.familiarity;
     focusEntry.instructionalMode = skillResolution.instructionalMode;


### PR DESCRIPTION
Diagnosed from a real user (Jason's profile) repeatedly being told to work on Simple Probability across many sessions. Root causes:

1. inferFamiliarity returned 'never-seen' for screener-mastered skills (totalAttempts: 0 short-circuited before the status check) and compared masteryScore against 80 even though the screener writes values on a 0-1 scale. Net effect: every screener-mastered skill looked like 'never-seen' → instructional mode 'instruct' → tutor re-taught it from scratch each turn.

2. TutorPlan.resolveCurrentTarget never advanced past a mastered skill. No code transitioned skillFocus entries from active/in-progress to resolved based on mastery, so the queue stayed pinned forever.

3. The badge selection endpoints opened activeBadge for skills already marked mastered in skillMastery, and there was no safety valve for a badge that had been hammered well past its attempt threshold without reaching required accuracy.

Changes:
- models/tutorPlan.js: trust mastered+masteredDate regardless of totalAttempts; normalize masteryScore (0-1 fraction OR 0-100 percent)
- utils/tutorPlanManager.js: in resolveCurrentTarget, when the resolved skill is mastered and not an explicit caller override, mark the focus entry resolved and recurse to the next-priority candidate (bounded loop). If the queue drains, return null so the UI prompts for new content rather than re-running mastered skills in leverage mode.
- utils/masteryGuard.js (new): shared helpers — isSkillMastered, isBadgeStuck, clearActiveBadge — so badge routes and persist agree on what "done" means.
- routes/mastery.js: block select-badge, start-skill-practice, and start-badge when the underlying skill is already mastered (409).
- utils/pipeline/persist.js: in updateBadgeProgress, fire the staleness valve after 2× requiredProblems without earning, clearing the badge.
- scripts/unstickMasteredFocus.js (new): idempotent repair script for existing users — resolves mastered focus entries and clears stuck or obsolete activeBadges. Defaults to dry-run; --apply to write.
- Tests for inferFamiliarity, the queue advance behavior, and the guard helpers (all 1971 unit tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)