### PR TITLE
fix(tutor): self-heal stale activeBadge at pipeline load

### DIFF
--- a/utils/pipeline/index.js
+++ b/utils/pipeline/index.js
@@ -138,6 +138,22 @@ async function runPipeline(message, ctx) {
     console.log(`[Pipeline] Mood: ${sessionMood.trajectory} (energy: ${sessionMood.energy}, momentum: ${sessionMood.momentum}${sessionMood.inFlow ? ', IN FLOW' : ''}${sessionMood.fatigueSignal ? ', FATIGUE' : ''}${emotionalTag})`);
   }
 
+  // ── Self-heal: clear an activeBadge pointing to an already-mastered skill ──
+  // Cheap, idempotent, runs once per pipeline turn. Catches users whose
+  // masteryProgress.activeBadge was set before we hardened badge selection
+  // (or who got mastered via a different code path while a badge was open).
+  // Without this, applyMasteryOverrides in suggestions.js keeps nudging the
+  // student toward a topic they're already done with.
+  try {
+    const { isSkillMastered, clearActiveBadge } = require('../masteryGuard');
+    const badge = ctx.user.masteryProgress?.activeBadge;
+    if (badge?.skillId && isSkillMastered(ctx.user, badge.skillId)) {
+      clearActiveBadge(ctx.user, 'self-heal: activeBadge pointed to an already-mastered skill');
+    }
+  } catch (err) {
+    console.error('[Pipeline] activeBadge self-heal error (non-fatal):', err.message);
+  }
+
   // ── Backbone: Load Tutor Plan ──
   // The tutor's persistent mental model of this student. Loaded at the start
   // of every interaction so the decide stage knows the instructional mode.


### PR DESCRIPTION
Closes the last gap from the previous fix. Without this, a user whose masteryProgress.activeBadge points to a now-mastered skill would still see "X to go!" suggestion chips (via applyMasteryOverrides in utils/pipeline/suggestions.js) until they happened to answer enough mastery-mode problems to trip the staleness valve in updateBadgeProgress.

With this self-heal, every pipeline turn checks once whether the open badge points to a skill the student has already mastered. If so, we clear the badge (logged into masteryProgress.attempts via the existing clearActiveBadge helper). Cheap, idempotent, no-op when state is clean.

Combined with the TutorPlan auto-advance from c54e635a, this means any existing stuck user self-heals on their next session — no repair script required for the common case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)