### PR TITLE
Enable zero-downtime deploys via Render health check

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -6,6 +6,11 @@ services:
     region: oregon
     plan: pro
 
+    # HTTP health check — enables zero-downtime deploys. Render waits for this
+    # endpoint to return 200 on the new instance before routing traffic and
+    # draining the old one, which removes the 502 gap during normal deploys.
+    healthCheckPath: /api/health
+
     # Custom domain with SSL (Render auto-provisions Let's Encrypt certs)
     customDomains:
       - name: mathmatix.ai


### PR DESCRIPTION
## Summary
- Adds `healthCheckPath: /api/health` to `render.yaml` so Render waits for the new instance to return 200 before routing traffic, eliminating the 502 Bad Gateway gap users see during normal deploys.
- `/api/health` already exists (`config/routes.js:122`) and is used by the Dockerfile `HEALTHCHECK`, so no new route is needed.

## Context
This addresses the "be right back" 502 Bad Gateway page users see during deploys. The Render edge serves the 502, so a fully-branded BRB page can't come from the app itself — but enabling zero-downtime deploys removes the gap that causes most of these. If a branded fallback is still wanted for crashes/OOMs, the next step would be putting Cloudflare in front of Render and using a Worker / Custom Error Page on 5xx.

## Test plan
- [ ] After merge, trigger a deploy and confirm `mathmatix.ai` stays reachable throughout (no 502 window).
- [ ] Check Render dashboard shows the health check as `/api/health` and is passing.
- [ ] Confirm `/api/health` returns 200 from the new instance before old instance is drained.

https://claude.ai/code/session_01V4Q3KS4xwqeBmhFdZvyb39

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4Q3KS4xwqeBmhFdZvyb39)_