### PR TITLE
feat(workspace): embedded WorkBoard as the home base — Phase A

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -1049,11 +1049,13 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
           <i class="fas fa-times" aria-hidden="true"></i>
         </button>
         <div class="cr-ws-tabs" role="tablist" aria-label="Workspace tools">
-          <button class="cr-ws-tab is-active" type="button" data-tool="graph" role="tab" aria-selected="true">
-            <i class="fas fa-chart-line" aria-hidden="true"></i> Graph
-          </button>
-          <button class="cr-ws-tab" type="button" data-tool="board" role="tab" aria-selected="false">
+          <!-- Board is the home base. Graph / Tiles / Calc are excursions
+               the tutor (or student) can drive into. -->
+          <button class="cr-ws-tab is-active" type="button" data-tool="board" role="tab" aria-selected="true">
             <i class="fas fa-pen" aria-hidden="true"></i> Board
+          </button>
+          <button class="cr-ws-tab" type="button" data-tool="graph" role="tab" aria-selected="false">
+            <i class="fas fa-chart-line" aria-hidden="true"></i> Graph
           </button>
           <button class="cr-ws-tab" type="button" data-tool="tiles" role="tab" aria-selected="false">
             <i class="fas fa-shapes" aria-hidden="true"></i> Tiles

--- a/public/css/workspace.css
+++ b/public/css/workspace.css
@@ -229,3 +229,179 @@
 @media (prefers-reduced-motion: reduce) {
   .cr-workspace { transition: none; }
 }
+
+/* ============================================================
+   WORK BOARD — embedded step-stack on the Board tab.
+
+   Cards stack vertically. Each card is its own visual unit:
+     - pose    → the starting problem (top of the stack)
+     - apply   → narrow transition row ("subtract 4 from both sides")
+     - resolve → the resulting equation after the student's move
+     - verify  → the proven solution + verification check line
+
+   Slide-in via the .cr-ws-board-card--enter class added the frame the
+   card is mounted, then removed the next frame to play the transition.
+   Respects prefers-reduced-motion.
+   ============================================================ */
+.cr-ws-board-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 4px 12px;
+  border-bottom: 1px solid var(--cr-border);
+  margin-bottom: 12px;
+}
+.cr-ws-board-title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  color: var(--cr-text);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.cr-ws-board-title i { color: var(--cr-accent); }
+
+.cr-ws-board-clear {
+  background: var(--cr-pill-bg);
+  border: 1px solid var(--cr-border);
+  color: var(--cr-text-dim);
+  width: 30px;
+  height: 30px;
+  border-radius: var(--cr-radius-pill);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  transition: background var(--cr-transition-fast), color var(--cr-transition-fast);
+}
+.cr-ws-board-clear:hover {
+  background: var(--cr-pill-bg-hover);
+  color: var(--cr-text);
+}
+
+.cr-ws-board-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.cr-ws-board-empty {
+  text-align: center;
+  padding: 28px 14px;
+  color: var(--cr-text-dim);
+  font-size: 13px;
+  line-height: 1.5;
+  border: 1px dashed var(--cr-border);
+  border-radius: var(--cr-radius-md);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+/* Common card chrome */
+.cr-ws-board-card {
+  border-radius: var(--cr-radius-md);
+  padding: 14px 16px;
+  background: var(--cr-bg-panel);
+  border: 1px solid var(--cr-border);
+  box-shadow: var(--cr-shadow-sm);
+  transition: opacity 0.28s var(--cr-ease), transform 0.28s var(--cr-ease);
+  position: relative;
+}
+
+/* Slide-in entry — class is added then removed on the next frame so the
+   transition runs. The from-state is opacity 0 + translateY 6px. */
+.cr-ws-board-card--enter {
+  opacity: 0;
+  transform: translateY(6px);
+}
+
+/* The pose (starting problem) — slightly more accent presence so the
+   eye lands here first. */
+.cr-ws-board-card--pose {
+  border-color: rgba(139, 123, 255, 0.30);
+  background: linear-gradient(180deg,
+    rgba(139, 123, 255, 0.06) 0%,
+    var(--cr-bg-panel) 100%);
+}
+.cr-ws-board-card--pose::before {
+  content: "PROBLEM";
+  position: absolute;
+  top: 8px;
+  left: 14px;
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.10em;
+  color: var(--cr-accent);
+  opacity: 0.85;
+}
+
+/* Verify — proven solution. Green presence, eyebrow label. */
+.cr-ws-board-card--verify {
+  border-color: rgba(46, 204, 113, 0.35);
+  background: linear-gradient(180deg,
+    rgba(46, 204, 113, 0.08) 0%,
+    var(--cr-bg-panel) 100%);
+}
+.cr-ws-board-card--verify::before {
+  content: "SOLVED";
+  position: absolute;
+  top: 8px;
+  left: 14px;
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.10em;
+  color: var(--cr-success);
+}
+
+/* Math display inside cards — KaTeX renders into here. */
+.cr-ws-board-card-math {
+  padding-top: 14px;
+  font-size: 18px;
+  color: var(--cr-text);
+  text-align: center;
+  overflow-x: auto;
+}
+.cr-ws-board-card-math .katex { font-size: 1.15em; }
+
+/* Verify card: secondary "check" math line under the solution */
+.cr-ws-board-card-check {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px dashed rgba(46, 204, 113, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  color: var(--cr-success);
+  font-size: 13px;
+}
+.cr-ws-board-card-check i { font-size: 14px; }
+.cr-ws-board-card-check-math .katex { font-size: 0.95em; color: var(--cr-text); }
+
+/* Apply — narrow transition row between equation cards. */
+.cr-ws-board-card--apply {
+  padding: 6px 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  border-style: dashed;
+  background: transparent;
+  box-shadow: none;
+  color: var(--cr-text-dim);
+  font-size: 12.5px;
+  font-style: italic;
+  letter-spacing: 0.01em;
+}
+.cr-ws-board-apply-arrow {
+  color: var(--cr-accent);
+  font-style: normal;
+  font-weight: 700;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cr-ws-board-card { transition: none; }
+  .cr-ws-board-card--enter { opacity: 1; transform: none; }
+}

--- a/public/js/workspace.js
+++ b/public/js/workspace.js
@@ -20,7 +20,15 @@
 (function () {
   'use strict';
 
-  var WS = { el: null, body: null, current: null, graph: null };
+  var WS = {
+    el: null,
+    body: null,
+    current: null,
+    graph: null,
+    // Persistent board state — steps survive tab switches. The DOM is
+    // rebuilt from this when the user returns to the Board tab.
+    board: { steps: [] }
+  };
 
   function el(tag, cls, html) {
     var n = document.createElement(tag);
@@ -29,15 +37,28 @@
     return n;
   }
 
+  // KaTeX renderer with a safe text fallback if KaTeX hasn't loaded yet
+  // (very early in page life) or the expression doesn't parse.
+  function renderTex(target, tex) {
+    if (!target) return;
+    if (window.katex && typeof window.katex.render === 'function') {
+      try {
+        window.katex.render(String(tex || ''), target, {
+          throwOnError: false,
+          displayMode: true,
+          output: 'html'
+        });
+        return;
+      } catch (_) { /* fall through to text */ }
+    }
+    target.textContent = String(tex || '');
+  }
+
   // ---- Launcher tools (open an existing floating surface) --------------
+  // Board used to be a launcher into the floating whiteboard; it's now
+  // the embedded home base (see renderBoard below). Tiles + Calc stay
+  // as launchers since they're full floating UIs of their own.
   var LAUNCHERS = {
-    board: {
-      icon: 'fa-pen',
-      title: 'Scratchpad',
-      blurb: 'A resizable board for working problems by hand — drawing, handwriting and step-by-step layout.',
-      btn: 'Open scratchpad',
-      open: function () { if (window.whiteboard && window.whiteboard.show) window.whiteboard.show(); }
-    },
     tiles: {
       icon: 'fa-shapes',
       title: 'Algebra tiles',
@@ -77,6 +98,109 @@
       card.appendChild(btn);
       body.appendChild(card);
     };
+  }
+
+  // ---- Board tool (embedded WorkBoard) ---------------------------------
+  // The Board is now the home base: an embedded step-stack that reflects
+  // the in-progress work. Cards are appended via the public API
+  // (boardPose / boardApply / boardResolve / boardVerify) which the chat
+  // pipeline will drive via <BOARD ...> tags in a future PR. For now the
+  // API is callable from the console for manual testing.
+  //
+  // PEDAGOGY RULE (the #1 product rule, restated): cards on the board
+  // mirror the starting problem and the moves the STUDENT has stated.
+  // The board never previews a step the student hasn't said. Callers
+  // are responsible for honoring this; the rule will be backstopped by
+  // a server-side guard in the next phase.
+  function renderBoard(body) {
+    var head = el('div', 'cr-ws-board-head');
+    head.innerHTML =
+      '<h4 class="cr-ws-board-title"><i class="fas fa-pen" aria-hidden="true"></i> Work Board</h4>' +
+      '<button type="button" class="cr-ws-board-clear" aria-label="Clear board">' +
+        '<i class="fas fa-eraser" aria-hidden="true"></i></button>';
+    body.appendChild(head);
+
+    var stack = el('div', 'cr-ws-board-stack');
+    body.appendChild(stack);
+
+    var empty = el('div', 'cr-ws-empty cr-ws-board-empty',
+      'Your working solution will appear here as you and your tutor reason through it together.');
+    if (WS.board.steps.length === 0) stack.appendChild(empty);
+
+    // Rebuild any persisted steps (e.g. when re-entering the tab).
+    WS.board.steps.forEach(function (step) { appendStepCard(stack, step, /*animate*/ false); });
+
+    head.querySelector('.cr-ws-board-clear').addEventListener('click', function () {
+      WS.board.steps = [];
+      var s = WS.body && WS.body.querySelector('.cr-ws-board-stack');
+      if (s) s.innerHTML = '';
+      if (s) s.appendChild(empty.cloneNode(true));
+    });
+  }
+
+  function teardownBoard() {
+    // DOM is discarded by switchTool. State persists in WS.board.steps
+    // so re-entering the tab restores the same cards.
+  }
+
+  function appendStepCard(stack, step, animate) {
+    if (!stack) return;
+    // First real card replaces the empty hint.
+    var emptyHint = stack.querySelector('.cr-ws-board-empty');
+    if (emptyHint) emptyHint.remove();
+
+    var card;
+    if (step.type === 'apply') {
+      // Transition card — narrow, italicized, sits between equation
+      // cards and reads as "what we just did".
+      card = el('div', 'cr-ws-board-card cr-ws-board-card--apply');
+      card.innerHTML =
+        '<span class="cr-ws-board-apply-arrow" aria-hidden="true">↓</span>' +
+        '<span class="cr-ws-board-apply-op"></span>';
+      card.querySelector('.cr-ws-board-apply-op').textContent = step.op || '';
+    } else {
+      // Equation card — pose / resolve / verify all share the same shape;
+      // verify gets a badge + an expanded check line.
+      var variant =
+        step.type === 'pose'    ? 'cr-ws-board-card--pose' :
+        step.type === 'verify'  ? 'cr-ws-board-card--verify' :
+                                  'cr-ws-board-card--resolve';
+      card = el('div', 'cr-ws-board-card ' + variant);
+
+      var math = el('div', 'cr-ws-board-card-math');
+      card.appendChild(math);
+      renderTex(math, step.tex);
+
+      if (step.type === 'verify' && step.check) {
+        var checkRow = el('div', 'cr-ws-board-card-check');
+        checkRow.innerHTML =
+          '<i class="fas fa-check-circle" aria-hidden="true"></i> ' +
+          '<span class="cr-ws-board-card-check-math"></span>';
+        card.appendChild(checkRow);
+        renderTex(checkRow.querySelector('.cr-ws-board-card-check-math'), step.check);
+      }
+    }
+
+    if (animate) card.classList.add('cr-ws-board-card--enter');
+    stack.appendChild(card);
+    // Scroll the new card into view (smooth so the eye follows the work).
+    try { card.scrollIntoView({ behavior: 'smooth', block: 'nearest' }); } catch (_) { /* old browser */ }
+    if (animate) {
+      // Next frame: remove the enter class to play the transition.
+      requestAnimationFrame(function () {
+        requestAnimationFrame(function () { card.classList.remove('cr-ws-board-card--enter'); });
+      });
+    }
+  }
+
+  function pushBoardStep(step) {
+    WS.board.steps.push(step);
+    // If the user is currently looking at a different tab, the cards
+    // will materialize when they return — no need to switch them.
+    if (WS.current === 'board' && WS.body) {
+      var stack = WS.body.querySelector('.cr-ws-board-stack');
+      appendStepCard(stack, step, /*animate*/ true);
+    }
   }
 
   // ---- Graph tool (live embed) -----------------------------------------
@@ -154,9 +278,11 @@
   }
 
   // ---- Tool registry ----------------------------------------------------
+  // Board is now first — it's the home base. Graph/Tiles/Calc are
+  // excursions the tutor can drive into for specific visuals.
   var TOOLS = {
+    board: { render: renderBoard, teardown: teardownBoard },
     graph: { render: renderGraph, teardown: destroyGraph },
-    board: { render: renderLauncher('board') },
     tiles: { render: renderLauncher('tiles') },
     calc:  { render: renderLauncher('calc') }
   };
@@ -228,6 +354,81 @@
       setGraphCaption(WS.body, opts && opts.caption);
       drawGraph(area, expr);
       return true;
+    },
+
+    // ---- Board API ------------------------------------------------------
+    // Drive the embedded WorkBoard. Each call appends a card to the
+    // step stack and (if the Board tab isn't active) keeps the state
+    // ready for when the student returns to it. Callers MUST honor the
+    // pedagogy rule: only post the starting problem and steps the
+    // student has stated.
+
+    /**
+     * Render the starting problem as the top card.
+     * @param {string} tex  LaTeX expression, e.g. "2x + 4 = 20"
+     * @param {object} [opts] reserved for future caption/parallel marks
+     */
+    boardPose: function (tex, opts) {
+      tex = (tex == null ? '' : String(tex)).trim();
+      if (!tex) return false;
+      openWorkspace();
+      // Switching only if the user isn't actively in another tab. For
+      // now we DO switch — Board is the natural home and a fresh pose
+      // is a new conversation move. Revisit if telemetry shows focus
+      // stealing is annoying.
+      this.showTool('board');
+      pushBoardStep({ type: 'pose', tex: tex, opts: opts || null });
+      return true;
+    },
+
+    /**
+     * Visualize a transformation the student just announced.
+     * @param {string} op  human-readable operation, e.g.
+     *                     "subtract 4 from both sides"
+     */
+    boardApply: function (op) {
+      op = (op == null ? '' : String(op)).trim();
+      if (!op) return false;
+      pushBoardStep({ type: 'apply', op: op });
+      return true;
+    },
+
+    /**
+     * Lock the result the student arrived at.
+     * @param {string} tex  LaTeX of the resulting equation/expression
+     */
+    boardResolve: function (tex) {
+      tex = (tex == null ? '' : String(tex)).trim();
+      if (!tex) return false;
+      pushBoardStep({ type: 'resolve', tex: tex });
+      return true;
+    },
+
+    /**
+     * Confirm a verified solution the student proved.
+     * @param {string} tex    LaTeX of the solution, e.g. "x = 8"
+     * @param {string} check  LaTeX of the verification, e.g. "2(8) + 4 = 20"
+     */
+    boardVerify: function (tex, check) {
+      tex = (tex == null ? '' : String(tex)).trim();
+      if (!tex) return false;
+      pushBoardStep({
+        type: 'verify',
+        tex: tex,
+        check: check == null ? '' : String(check).trim()
+      });
+      return true;
+    },
+
+    /** Wipe the board to a clean slate (e.g. new problem). */
+    boardClear: function () {
+      WS.board.steps = [];
+      if (WS.current === 'board' && WS.body) {
+        // Re-render from now-empty state to bring the placeholder back.
+        WS.body.innerHTML = '';
+        TOOLS.board.render(WS.body);
+      }
+      return true;
     }
   };
 
@@ -249,7 +450,9 @@
     }
 
     buildFab();
-    switchTool('graph');
+    // Board is the home base. Graph/Tiles/Calc are excursions the tutor
+    // (or the student) can drive into via tabs or the public API.
+    switchTool('board');
   }
 
   if (document.readyState === 'loading') {


### PR DESCRIPTION
First slice of the math-workspace vision. The Board tab is no longer a launcher card that opens the floating whiteboard — it's an embedded step-stack that will reflect the in-progress work as the tutor and student reason through a problem together. Graph, Tiles, and Calc remain as excursion tools the tutor can drive into when a moment calls for them.

Scope of this PR: client-side foundation. No prompt changes yet; the tutor doesn't yet emit board commands. Phase B (server-side tag protocol + prompt engineering) is queued separately.

Board UI (public/js/workspace.js + public/css/workspace.css)
  - Replaces the Board launcher with renderBoard() — an embedded panel with a step-stack. Persistent state in WS.board.steps so cards survive tab switches (re-renders from state on re-entry).
  - Four card variants:
      pose    → starting equation, accent halo + "PROBLEM" eyebrow
      apply   → narrow dashed transition row ("subtract 4 from
                both sides"), italic, centered down-arrow
      resolve → quiet equation card (the student's result)
      verify  → green halo + "SOLVED" eyebrow + checkmark line
                showing the verification math
  - KaTeX is already in the bundle (loaded eagerly for chat); cards
    use window.katex.render with a safe text fallback if KaTeX hasn't
    loaded yet or the expression doesn't parse.
  - Slide-in entry via a one-frame .cr-ws-board-card--enter class
    swapped off the next frame so the CSS transition plays. Respects
    prefers-reduced-motion.
  - Clear button (eraser icon) in the head wipes the stack.

Default tab + tab order (public/chat.html + workspace.js)
  - Board is now first in the tab strip and pre-selected (data-tool="board" + is-active + aria-selected="true").
  - init() ends with switchTool('board') instead of 'graph'.
  - LAUNCHERS map drops the board entry (now embedded); Tiles + Calc stay as launchers — they're full floating UIs.

Public API additions (window.MathWorkspace)
  - boardPose(tex, opts)       — render the starting problem
  - boardApply(op)             — visualize the transformation
  - boardResolve(tex)          — lock the result
  - boardVerify(tex, check)    — confirm the proven solution
  - boardClear()               — wipe to a clean slate
  - showTool('board'|'graph'|'tiles'|'calc')  — already existed,
                                                still works
  - showGraph(expr, {caption}) — already existed for example/parallel
                                 plots; verified still works (the
                                 tutor's <GRAPH> tag will drive this
                                 in a later PR).

Pedagogy guard (header comments)
  - The Mathmatix #1 rule is restated in the renderBoard JSDoc: cards on the board mirror the starting problem and the moves the student has stated. The board never previews a step the student hasn't said. Callers (the chat pipeline, future <BOARD> tag handler) are responsible for honoring this; a server-side guard is queued for Phase D.

Verified locally with the example dialog from Jason's vision:
  W.boardPose('2x + 4 = 20');
  W.boardApply('subtract 4 from both sides');
  W.boardResolve('2x = 16');
  W.boardApply('divide both sides by 2');
  W.boardVerify('x = 8', '2(8) + 4 = 20');
  → 5 cards, all KaTeX-rendered, slide-in plays, state persists
    across Graph→Board tab switch, console clean.

What's next (separate PRs)
  - Phase B: <BOARD action="…"> inline tag protocol + server pipeline handler that strips tags from visible text and emits client events.
  - Phase C: animations + XP/celebration system (<XP size="…">, confetti, fireworks + "Clean Solution!" + streak shake).
  - Phase D: <GRAPH> and <TILES> tag handlers — wire to the existing showGraph + openAlgebraTiles APIs with tab auto-switch.
  - Phase E: prompt engineering — tag rules into utils/promptCompact.js and a server-side verify guard against tutor-emitted "next step" leaks.