### PR TITLE
fix(landing): rebrand chat preview to match chat + three defect fixes

### DIFF
--- a/public/css/landing-page.css
+++ b/public/css/landing-page.css
@@ -803,21 +803,25 @@
   position: relative;
   border-radius: 16px;
   overflow: hidden;
-  max-height: 380px;
+  /* aspect-ratio gives the wrap a deterministic height regardless of the
+     image's intrinsic dimensions — replaces the old max-height clip which
+     left the headline crashing into the viewport edge on tall phones. */
+  aspect-ratio: 16 / 9;
 }
 
 .lp-photo-banner-img {
   width: 100%;
   height: 100%;
   object-fit: cover;
+  object-position: center 35%;
   display: block;
 }
 
 .lp-photo-banner-overlay {
   position: absolute;
   bottom: 0; left: 0; right: 0;
-  background: linear-gradient(to top, rgba(0, 0, 0, 0.6) 0%, transparent 100%);
-  padding: 2.5rem 2rem 1.5rem;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.75) 0%, rgba(0, 0, 0, 0.15) 60%, transparent 100%);
+  padding: 3rem 2rem 1.5rem;
 }
 
 .lp-photo-banner-text {
@@ -830,13 +834,13 @@
 
 @media (max-width: 768px) {
   .lp-photo-banner { padding: 1.5rem var(--page-horizontal-padding) 0; }
-  .lp-photo-banner-wrap { max-height: 240px; border-radius: 12px; }
+  .lp-photo-banner-wrap { aspect-ratio: 4 / 3; border-radius: 12px; }
   .lp-photo-banner-text { font-size: 1.05rem; }
-  .lp-photo-banner-overlay { padding: 2rem 1.25rem 1rem; }
+  .lp-photo-banner-overlay { padding: 2.25rem 1.25rem 1.1rem; }
 }
 
 @media (max-width: 375px) {
-  .lp-photo-banner-wrap { max-height: 200px; }
+  .lp-photo-banner-wrap { aspect-ratio: 4 / 3; }
   .lp-photo-banner-text { font-size: 0.95rem; }
 }
 
@@ -1553,6 +1557,184 @@
   padding: 4rem var(--page-horizontal-padding);
 }
 
+/* ── Chat Preview: window into the real /chat.html (cr-mode) ───
+   Mirrors the actual product so the marketing demo IS the product
+   visual identity — dark navy panel, "Live with [tutor]" pill, streak,
+   purple bubbles. Uses the --cr-* tokens from design-system.css.
+   ──────────────────────────────────────────────────────────── */
+.lp-preview-chat {
+  background: var(--cr-bg-panel, #161B2C);
+  border: 1px solid var(--cr-border, rgba(255,255,255,0.08));
+  border-radius: 22px;
+  padding: 0;
+  max-width: 480px;
+  margin: 0 auto;
+  overflow: hidden;
+  box-shadow: 0 12px 40px rgba(11, 15, 26, 0.35), 0 2px 8px rgba(0,0,0,0.2);
+}
+
+.lp-preview-chat .lp-preview-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 12px 14px;
+  margin: 0;
+  border: 0;
+  border-bottom: 1px solid var(--cr-border, rgba(255,255,255,0.08));
+  background: linear-gradient(180deg, rgba(11,15,26,0.65), rgba(11,15,26,0.35));
+  font-size: 13px;
+  color: var(--cr-text, #E6E9F2);
+}
+
+.lp-preview-live-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(15, 20, 35, 0.65);
+  border: 1px solid var(--cr-border, rgba(255,255,255,0.08));
+  color: var(--cr-text, #E6E9F2);
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.lp-preview-live-dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--cr-success, #2ECC71);
+  box-shadow: 0 0 8px rgba(46, 204, 113, 0.6);
+  animation: lpPreviewPulse 2s ease-in-out infinite;
+}
+
+@keyframes lpPreviewPulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.65; transform: scale(0.88); }
+}
+
+.lp-preview-header-right {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.lp-preview-streak-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--cr-border, rgba(255,255,255,0.08));
+  color: var(--cr-warning, #FFD66B);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.lp-preview-flame {
+  filter: drop-shadow(0 0 6px rgba(255, 140, 40, 0.55));
+}
+
+.lp-preview-menu-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px; height: 30px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--cr-border, rgba(255,255,255,0.08));
+  color: var(--cr-text, #E6E9F2);
+  font-size: 13px;
+}
+
+/* Stage: tutor portrait backdrop behind the chat messages, scrim on top. */
+.lp-preview-stage {
+  position: relative;
+  background: linear-gradient(180deg, #1A1F35 0%, #0E1322 100%);
+  min-height: 320px;
+  overflow: hidden;
+}
+
+.lp-preview-backdrop {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center 30%;
+  opacity: 0.55;
+  filter: blur(2px);
+  transform: scale(1.05);
+  transition: opacity 0.5s ease;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.lp-preview-scrim {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(11,15,26,0.25) 0%, rgba(11,15,26,0.78) 100%);
+  z-index: 1;
+  pointer-events: none;
+}
+
+.lp-preview-chat .lp-chat-messages {
+  position: relative;
+  z-index: 2;
+  height: auto;
+  max-height: 320px;
+  min-height: 240px;
+  padding: 16px 16px 12px;
+  gap: 10px;
+  overflow-y: auto;
+}
+
+/* Bubble palette overrides — tutor bubble goes dark navy, student bubble
+   goes deep purple. Matches body.cr-mode .message colors in chat-redesign.css. */
+.lp-preview-chat .lp-chat-tutor {
+  background: var(--cr-bubble-ai, #1F2742);
+  color: var(--cr-text, #E6E9F2);
+  border: 1px solid var(--cr-border, rgba(255,255,255,0.08));
+  box-shadow: none;
+}
+
+.lp-preview-chat .lp-chat-student {
+  background: var(--cr-bubble-user, #2A2255);
+  color: var(--cr-text, #E6E9F2);
+  border: 1px solid rgba(124, 107, 255, 0.35);
+  box-shadow: 0 2px 8px rgba(44, 33, 100, 0.4);
+}
+
+.lp-preview-chat .lp-chat-avatar {
+  border: 1px solid var(--cr-border, rgba(255,255,255,0.08));
+  background: var(--cr-bg-1, #121829);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
+}
+
+.lp-preview-chat .lp-typing {
+  position: relative;
+  z-index: 2;
+  background: var(--cr-bubble-ai, #1F2742);
+  border: 1px solid var(--cr-border, rgba(255,255,255,0.08));
+  margin: 0 0 12px 50px;
+  border-bottom-left-radius: 4px;
+}
+
+.lp-preview-chat .lp-typing-dot {
+  background: var(--cr-accent, #8B7BFF);
+}
+
+@media (max-width: 600px) {
+  .lp-preview-chat { max-width: 100%; border-radius: 18px; }
+  .lp-preview-chat .lp-preview-header { padding: 10px 12px; }
+  .lp-preview-live-pill { font-size: 11px; padding: 5px 10px; }
+  .lp-preview-streak-pill { font-size: 11px; padding: 4px 8px; }
+  .lp-preview-menu-btn { width: 28px; height: 28px; font-size: 12px; }
+  .lp-preview-stage { min-height: 280px; }
+  .lp-preview-chat .lp-chat-messages { max-height: 280px; min-height: 220px; padding: 12px 12px 8px; }
+}
+
 /* ═══════════════════════════════════════════════════════
    TRIAL CHAT: Tutor Cards, Celebration, Chat UI, Gate
    ═══════════════════════════════════════════════════════ */
@@ -1610,6 +1792,18 @@
   font-family: inherit;
   font-size: inherit;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04), 0 4px 12px rgba(0, 0, 0, 0.03);
+  /* Stretch the info block so .lp-tutor-card-hear (margin-top:auto) pins to
+     the card bottom. Without this, a longer spec line (Ms. Maria) pushes
+     "Hear me" up into the spec text on narrow mobile cards. */
+  justify-content: flex-start;
+}
+
+.lp-tutor-card-info {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  flex: 1 1 auto;
 }
 
 .lp-tutor-card:hover {
@@ -1662,12 +1856,18 @@
   color: var(--clr-text-dim);
   margin: 0;
   line-height: 1.5;
+  /* Reserve room for the longest spec line (Ms. Maria's bilingual + 3 subjects)
+     so cards stay the same height and "Hear me" never crashes into the spec. */
+  min-height: calc(0.78rem * 1.5 * 2);
 }
 
 .lp-tutor-card-hear {
   display: inline-flex;
   align-items: center;
   gap: 5px;
+  /* Combined with .lp-tutor-card-info{flex:1 1 auto}, this margin guarantees
+     visible breathing room above the pill even when the spec text wraps to
+     two lines on narrow mobile cards. */
   margin-top: 0.85rem;
   font-size: 0.75rem;
   color: var(--clr-accent-hotpink);
@@ -1676,6 +1876,7 @@
   border-radius: 20px;
   background: rgba(255, 59, 127, 0.05);
   transition: background 0.2s, transform 0.2s;
+  flex-shrink: 0;
 }
 
 .lp-tutor-card-hear:hover {

--- a/public/index.html
+++ b/public/index.html
@@ -88,6 +88,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <script src="/js/csrf.js"></script>
   <script src="/js/landing.js" defer></script>
   <script src="/js/analytics.js" data-ga="G-EMX73QXF5H" data-fbp=""></script>
+  <!-- Chat design tokens (--cr-*) so the chat preview block can mirror the real product. -->
+  <link rel="stylesheet" href="/css/design-system.css" />
   <link rel="stylesheet" href="/css/landing-page.css" />
 </head>
 <body>
@@ -293,21 +295,38 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </div>
     </section>
 
-    <!-- ── Chat Preview (moved below fold from hero) ────────── -->
+    <!-- ── Chat Preview (mirrors the real cr-mode chat) ────────── -->
     <section class="lp-chat-preview-section lp-reveal lp-section-alt">
       <div class="lp-inner">
         <h2 class="lp-section-heading">See How a Session Works</h2>
         <p class="lp-section-sub">Real conversations with our AI tutors. No scripts &mdash; every session is personalized.</p>
-        <div class="lp-hero-preview" style="margin: 0 auto;">
+        <!-- Branded as a window into the actual product: dark navy panel,
+             "Live with [tutor]" pill, streak, hamburger — matches /chat.html. -->
+        <div class="lp-hero-preview lp-preview-chat" aria-label="Example tutoring session">
           <div class="lp-preview-header">
-            <div class="lp-preview-dot"></div>
-            <span id="lp-tutor-name">Mr. Nappier</span> &mdash; Mathmatix AI Tutor
+            <div class="lp-preview-live-pill">
+              <span class="lp-preview-live-dot" aria-hidden="true"></span>
+              <span>Live with <span id="lp-tutor-name">Mr. Nappier</span></span>
+            </div>
+            <div class="lp-preview-header-right">
+              <span class="lp-preview-streak-pill" title="Daily streak">
+                <span class="lp-preview-flame" aria-hidden="true">🔥</span>
+                <span>2</span>
+              </span>
+              <span class="lp-preview-menu-btn" aria-hidden="true">
+                <i class="fas fa-bars"></i>
+              </span>
+            </div>
           </div>
-          <div class="lp-chat-messages" id="lp-chat"></div>
-          <div class="lp-typing" id="lp-typing">
-            <div class="lp-typing-dot"></div>
-            <div class="lp-typing-dot"></div>
-            <div class="lp-typing-dot"></div>
+          <div class="lp-preview-stage">
+            <img id="lp-preview-backdrop" class="lp-preview-backdrop" src="/images/tutor_avatars/mr-nappier.png" alt="" aria-hidden="true" />
+            <div class="lp-preview-scrim" aria-hidden="true"></div>
+            <div class="lp-chat-messages" id="lp-chat"></div>
+            <div class="lp-typing" id="lp-typing">
+              <div class="lp-typing-dot"></div>
+              <div class="lp-typing-dot"></div>
+              <div class="lp-typing-dot"></div>
+            </div>
           </div>
         </div>
       </div>
@@ -927,6 +946,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       var chatContainer = document.getElementById('lp-chat');
       var typingEl = document.getElementById('lp-typing');
       var tutorNameEl = document.getElementById('lp-tutor-name');
+      var backdropEl = document.getElementById('lp-preview-backdrop');
 
       if (chatContainer && typingEl) {
         var conversations = [
@@ -992,24 +1012,42 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         var convoIndex = 0;
         // Generation token — every playConversation() increments it; every
         // setTimeout callback below stamps the gen it was scheduled in and
-        // bails out if a newer generation has started. Without this guard,
-        // a callback from the previous conversation could fire after the
-        // next one has begun (most reliably when the tab is backgrounded
-        // and browsers throttle/batch setTimeouts) and call appendMessage
-        // with the OLD convo into the NEW container — that's the bug from
-        // the UI review where two students' avatars and topics appeared
-        // interleaved during a transition.
+        // bails out if a newer generation has started.
         var convoGen = 0;
+        // Track every pending timeout so a new conversation can cancel
+        // them outright instead of relying on gen-guards alone. Without
+        // this, throttled tabs could fire a stale typing-finish callback
+        // that appends a duplicate of the message just rendered.
+        var pendingTimers = [];
+        function schedule(fn, ms) {
+          var id = setTimeout(function () {
+            // Remove ourselves from the list before running.
+            var i = pendingTimers.indexOf(id);
+            if (i !== -1) pendingTimers.splice(i, 1);
+            fn();
+          }, ms);
+          pendingTimers.push(id);
+          return id;
+        }
+        function cancelAllTimers() {
+          for (var i = 0; i < pendingTimers.length; i++) clearTimeout(pendingTimers[i]);
+          pendingTimers.length = 0;
+        }
 
         function playConversation() {
           var convo = conversations[convoIndex % conversations.length];
           convoIndex++;
-          var gen = ++convoGen; // closure-captured; all callbacks below check against the live convoGen
+          var gen = ++convoGen;
 
-          // Update tutor name
+          // Cancel any timers from the previous cycle BEFORE clearing the
+          // DOM. Otherwise a stale typing-finish callback could fire after
+          // the new conversation starts and re-render a message that's
+          // already on screen (the duplicate-bubble bug).
+          cancelAllTimers();
+
           if (tutorNameEl) tutorNameEl.textContent = convo.tutor;
+          if (backdropEl && convo.tutorAvatar) backdropEl.src = convo.tutorAvatar;
 
-          // Clear previous messages
           chatContainer.innerHTML = '';
           typingEl.style.display = 'none';
 
@@ -1018,13 +1056,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           function showNextMessage() {
             if (gen !== convoGen) return; // stale — a newer conversation owns the stage
             if (msgIdx >= convo.messages.length) {
-              // Pause on completed conversation, then start next
-              setTimeout(function () {
+              schedule(function () {
                 if (gen !== convoGen) return;
-                // Fade out current messages
                 var allRows = chatContainer.querySelectorAll('.lp-chat-row');
                 allRows.forEach(function (r) { r.style.opacity = '0'; r.style.transform = 'translateY(-8px)'; });
-                setTimeout(function () {
+                schedule(function () {
                   if (gen !== convoGen) return;
                   playConversation();
                 }, 400);
@@ -1036,23 +1072,33 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             var isStudent = msg.from === 'student';
 
             if (!isStudent) {
-              // Show typing indicator before tutor message
               typingEl.style.display = 'flex';
-              setTimeout(function () {
+              schedule(function () {
                 if (gen !== convoGen) return;
                 typingEl.style.display = 'none';
                 appendMessage(msg, isStudent, convo);
                 msgIdx++;
-                setTimeout(showNextMessage, 900);
+                schedule(showNextMessage, 900);
               }, 1100);
             } else {
               appendMessage(msg, isStudent, convo);
               msgIdx++;
-              setTimeout(showNextMessage, 800);
+              schedule(showNextMessage, 800);
             }
           }
 
           function appendMessage(msg, isStudent, c) {
+            // Dedup guard: if the last row already shows this exact (from + text),
+            // skip. Belt-and-suspenders against any race that slipped past the
+            // timer cancel.
+            var lastRow = chatContainer.lastElementChild;
+            if (lastRow && lastRow.classList && lastRow.classList.contains('lp-chat-row')) {
+              var lastIsStudent = lastRow.classList.contains('lp-chat-row--student');
+              var lastBubble = lastRow.querySelector('.lp-chat-bubble');
+              if (lastIsStudent === isStudent && lastBubble && lastBubble.textContent === msg.text) {
+                return;
+              }
+            }
             var row = document.createElement('div');
             row.className = 'lp-chat-row' + (isStudent ? ' lp-chat-row--student' : '');
 
@@ -1079,7 +1125,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             });
           }
 
-          setTimeout(showNextMessage, 600);
+          schedule(showNextMessage, 600);
         }
 
         setTimeout(playConversation, 700);

--- a/public/index.html
+++ b/public/index.html
@@ -146,7 +146,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               <img src="/images/tutor_avatars/mr-nappier.png" alt="Mr. Nappier" class="lp-tutor-card-img" loading="eager" />
               <div class="lp-tutor-card-info">
                 <h3>Mr. Nappier</h3>
-                <p class="lp-tutor-card-catch">Math is about patterns!</p>
+                <p class="lp-tutor-card-catch">Math is about patterns &mdash; once you see them, it&rsquo;s easy.</p>
                 <p class="lp-tutor-card-spec">Arithmetic, Pre-Algebra, Algebra 1</p>
               </div>
               <span class="lp-tutor-card-hear"><i class="fas fa-volume-up"></i> Hear me</span>


### PR DESCRIPTION
## Summary

Tightens visual cohesion between the marketing landing page and the actual `/chat.html` product, and fixes three defects called out in mobile screenshots.

### Rebrand: chat preview now mirrors the real chat

The "See How a Session Works" block was a generic chat mockup with a teal-tinted shadow, light bubbles, and a "Tutor — Mathmatix AI Tutor" caption. It didn't look like the product anyone signs up for.

Replaced with a window into the real chat:
- Dark navy panel (`--cr-bg-panel`) with the chat's border + shadow ramp
- "Live with [Tutor]" pill (green pulsing dot) on the left
- Streak pill (🔥 2) + hamburger glyph on the right
- Tutor portrait as a blurred backdrop, scrim on top
- Bubbles use `--cr-bubble-ai` / `--cr-bubble-user` so they match the real product exactly
- Backdrop image swaps when the cycling conversation switches tutor

Linked `design-system.css` on the landing page so the marketing demo consumes the same `--cr-*` tokens as the chat. Zero new tokens introduced.

### Defect fixes

1. **Duplicate "Subtract 7?" bubble** in the chat preview. The existing gen-counter wasn't catching stale typing-finish callbacks under tab throttling. Added a tracked timer list cancelled at `playConversation` start, plus a dedup guard in `appendMessage` that bails if the last row already shows the same `(from, text)`.
2. **"Hear me" pill crashing into the spec line** on Ms. Maria's tutor card (longest spec: "Bilingual, Algebra I & II, Test Prep"). Wrapped h3/catch/spec in a `.lp-tutor-card-info` block with `flex:1 1 auto` and gave `.lp-tutor-card-spec` a 2-line `min-height` so the pill pins to the card bottom with reliable breathing room across all four cards.
3. **Photo banner headline cut off** by `max-height: 240px` clip on tall phones. Switched `.lp-photo-banner-wrap` to `aspect-ratio` (16/9 desktop, 4/3 mobile) so the crop is deterministic and the scrim/text always sit above the fold.

## Test plan

- [ ] Open landing on mobile (≤600px); chat preview shows "Live with [Tutor]" pill with green dot, streak, hamburger, dark panel
- [ ] Watch chat preview cycle through all 5 conversations; no duplicate bubbles, backdrop swaps per tutor
- [ ] Verify Ms. Maria card (longest spec text) shows "Hear me" pill with clear gap above; all 4 cards align in 2x2 grid
- [ ] Scroll to "Built for the way kids actually learn" — full headline visible above viewport edge on iPhone-size screens
- [ ] Throttle CPU 4x in DevTools and let preview run for ~60s — confirm no duplicate bubbles even under timer pressure

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMX7qmsgB5gUKjpbsJzsRk)_