### PR TITLE
fix(mobile): clear top chrome with safe-area-aware padding

### DIFF
--- a/public/css/mobile-poster-chat.css
+++ b/public/css/mobile-poster-chat.css
@@ -138,7 +138,10 @@
     overflow-y: auto !important;
     -webkit-overflow-scrolling: touch;
     background: transparent !important;
-    padding: 76px 14px 14px !important;   /* top clears the top chrome */
+    /* Top padding must clear the full top chrome, including the device's
+       safe-area inset. The topbar = safe-area-top + ~48px (pill + its own
+       padding); 64px gives a ~16px buffer below the pill on every device. */
+    padding: calc(env(safe-area-inset-top, 0px) + 64px) 14px 14px !important;
     display: flex;
     flex-direction: column;
     gap: 14px;


### PR DESCRIPTION
## Summary

The floating "Live with <tutor>" pill was overlapping the first line of the topmost message on iPhones with a notch or Dynamic Island (visible in current production screenshots).

**Root cause:** `public/css/mobile-poster-chat.css` reserved a hardcoded `76px` of top padding on `#chat-messages-container`, but the topbar above it uses `calc(env(safe-area-inset-top, 0px) + 8px)` for its top inset. On a Dynamic Island device (`safe-area-inset-top ≈ 59pt`) the topbar grows to ~107px tall while the message list still only reserves 76px → ~20px of message text disappears behind the pill.

**Fix:** Track the safe area in the padding:

```css
padding: calc(env(safe-area-inset-top, 0px) + 64px) 14px 14px !important;
```

`64px` = topbar's own padding (8 + 8) + pill height (~32) + ~16px breathing room below the pill. Works on no-notch devices too (no safe-area inset → 64px, still clears the 48px topbar with a 16px buffer).

## Test plan

- [ ] iPhone with Dynamic Island (15 Pro / 16): open `/chat`, scroll to top of conversation — first line of topmost AI message fully visible below the pill.
- [ ] iPhone with notch (X–14 / Plus / SE-with-notch): same check.
- [ ] iPhone SE 2nd/3rd gen (no notch): pill no longer overlaps; padding still looks reasonable (not over-tall).
- [ ] Android Chrome (typically no safe-area): padding falls back to 64px, no visual regression.
- [ ] Desktop / tablet >768px: no change (the entire rule lives inside `@media (max-width: 768px)`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01RJiSDQ6fpqUJKS8gaUSJtp)_