### PR TITLE
fix(voice): enforce premium paywall on WebSocket upgrade

### DIFF
--- a/middleware/usageGate.js
+++ b/middleware/usageGate.js
@@ -164,6 +164,47 @@ async function usageGate(req, res, next) {
 }
 
 /**
+ * Pure access check — does this user qualify for premium features?
+ * Mirrors the gating logic of paidFeatureGate / premiumFeatureGate but
+ * exposed as a function so non-Express callers (e.g. WebSocket upgrades
+ * in utils/voiceUpgrade.js) can enforce the same paywall. Without this,
+ * the WS endpoints leak past the HTTP-level premiumFeatureGate.
+ *
+ * @param {Object} user - req.user / hydrated user doc (mongoose or lean)
+ * @returns {Promise<boolean>} true if the user should be allowed in
+ */
+async function hasPremiumAccess(user) {
+  // Master switch — pre-launch mode opens everything
+  if (!BILLING_ENABLED) return true;
+  if (!user) return false;
+
+  // Role bypasses (drive adoption; teachers/parents/admins never paywalled)
+  if (user.role === 'teacher' || user.role === 'parent' || user.role === 'admin') {
+    return true;
+  }
+
+  // Unlimited individual subscribers
+  if (user.subscriptionTier === 'unlimited') return true;
+
+  // Active school license
+  if (user.schoolLicenseId) {
+    const valid = await isLicenseValid(user.schoolLicenseId);
+    if (valid) return true;
+  }
+
+  // Linked parent with active Mathmatix+ subscription (parent pays → child gets in)
+  if (user.parentIds && user.parentIds.length > 0) {
+    const subscribedParent = await User.findOne({
+      _id: { $in: user.parentIds },
+      subscriptionTier: 'unlimited'
+    }).lean();
+    if (subscribedParent) return true;
+  }
+
+  return false;
+}
+
+/**
  * Feature gate for premium-only features (voice, uploads, Show My Work).
  * School-licensed students and unlimited subscribers get full access.
  * Free users get a limited taste: 1 free upload and 1 free Show My Work,
@@ -286,4 +327,4 @@ function paidFeatureGate(featureName) {
   };
 }
 
-module.exports = { usageGate, premiumFeatureGate, paidFeatureGate, FREE_WEEKLY_SECONDS, isLicenseValid };
+module.exports = { usageGate, premiumFeatureGate, paidFeatureGate, hasPremiumAccess, FREE_WEEKLY_SECONDS, isLicenseValid };

--- a/utils/voiceUpgrade.js
+++ b/utils/voiceUpgrade.js
@@ -8,6 +8,7 @@ const logger = require('./logger').child({ module: 'voiceUpgrade' });
 
 const sttStream = require('./sttStream');
 const ttsProvider = require('./ttsProvider');
+const { hasPremiumAccess } = require('../middleware/usageGate');
 
 const ALLOWED_ORIGINS = (process.env.VOICE_WS_ALLOWED_ORIGINS || '')
     .split(',')
@@ -101,7 +102,7 @@ function handleUpgrade({ request, socket, head, app, wss, streamPath }) {
 
     sessionMw(request, fakeRes, () => {
         passportInit(request, fakeRes, () => {
-            passportSession(request, fakeRes, () => {
+            passportSession(request, fakeRes, async () => {
                 if (!request.user) {
                     socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
                     socket.destroy();
@@ -109,6 +110,29 @@ function handleUpgrade({ request, socket, head, app, wss, streamPath }) {
                 }
                 if (isUnder13(request.user)) {
                     socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
+                    socket.destroy();
+                    return;
+                }
+                // Premium-tier paywall — mirrors premiumFeatureGate('Voice chat')
+                // on the HTTP routes (config/routes.js). Without this, a logged-in
+                // free-tier user who knows the WS path could open a session
+                // directly and burn unlimited Cartesia minutes, bypassing the
+                // HTTP-level gate entirely.
+                try {
+                    const allowed = await hasPremiumAccess(request.user);
+                    if (!allowed) {
+                        logger.warn('voice ws upgrade: paywall blocked', {
+                            userId: String(request.user._id),
+                            tier: request.user.subscriptionTier || 'free',
+                            path: streamPath,
+                        });
+                        socket.write('HTTP/1.1 402 Payment Required\r\n\r\n');
+                        socket.destroy();
+                        return;
+                    }
+                } catch (err) {
+                    logger.error('voice ws upgrade: paywall check failed', { error: err.message });
+                    socket.write('HTTP/1.1 500 Internal Server Error\r\n\r\n');
                     socket.destroy();
                     return;
                 }


### PR DESCRIPTION
## Summary

Closes a paywall bypass on the voice WebSocket endpoints.

The HTTP routes `/api/voice` and `/api/voice-tutor` are gated by `premiumFeatureGate('Voice chat')` in `config/routes.js:187,189`. The companion WebSocket endpoints — `/api/voice/stream` and `/api/voice-tutor/stream` — share `utils/voiceUpgrade.js`, which only checks auth + under-13 + origin. A logged-in free-tier user who knows the WS path can open a streaming session directly and bypass the HTTP paywall entirely. Cartesia bills per character, so this is both an entitlement leak and an unbounded cost vector.

### Fix

- Extracted the premium-access logic from `paidFeatureGate` / `premiumFeatureGate` into a pure `hasPremiumAccess(user)` function in `middleware/usageGate.js`. Same rules: `BILLING_ENABLED` master switch, role bypasses (teacher/parent/admin), `subscriptionTier === 'unlimited'`, active school license, linked-parent subscription.
- Called `hasPremiumAccess(request.user)` from `voiceUpgrade.js` after the existing under-13 check; reject with `402 Payment Required` if not allowed. Wrapped in try/catch so a gate error fails closed (`500`), not open.

Both `/api/voice/stream` and `/api/voice-tutor/stream` are fixed in one change because they share the upgrade helper.

Pre-launch behavior (`BILLING_ENABLED` unset) is unchanged — the function returns `true` and everyone passes.

### How this was found

Stack audit before scoping a voice-first redesign. The HTTP routes' tier check is explicit and visible in `config/routes.js`, but the WS counterparts were silently inheriting only the auth/under-13 portion of the upgrade flow.

## Test plan

- [ ] **Free-tier WS attempt:** open a logged-in session with `subscriptionTier='free'`, hit `wss://.../api/voice-tutor/stream` directly, confirm `HTTP/1.1 402 Payment Required` and socket closed
- [ ] **Unlimited-tier WS:** same path with `subscriptionTier='unlimited'`, confirm normal connection
- [ ] **School-licensed student:** valid `schoolLicenseId`, confirm pass
- [ ] **Linked-parent student:** child whose `parentIds[]` includes a parent with `subscriptionTier='unlimited'`, confirm pass
- [ ] **Teacher / parent / admin roles:** all confirm pass regardless of tier
- [ ] **`BILLING_ENABLED=false` (pre-launch):** all users pass — no behavior change
- [ ] **Existing HTTP `/api/voice-tutor/process` endpoint:** unchanged — `premiumFeatureGate` still applies via `config/routes.js`

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMX7qmsgB5gUKjpbsJzsRk)_