### PR TITLE
feat(surface): add form-factor-aware surface preference helper (voice-first PR 0)

### DIFF
--- a/config/middleware.js
+++ b/config/middleware.js
@@ -144,6 +144,13 @@ function configureMiddleware(app) {
   app.use(express.urlencoded({ extended: true, limit: '1mb' }));
   app.use(cookieParser());
 
+  // Surface preference — resolves the user's preferred chat UI (voice
+  // orb vs bubble chat) into req.surface so downstream routes can do
+  // form-factor-aware redirects. Helper-only today; routing follows
+  // in the next PR. Needs cookie-parser; does not depend on session.
+  const { surfaceMiddleware } = require('../utils/surfacePreference');
+  app.use(surfaceMiddleware);
+
   // Session middleware — constructed once and shared with the WebSocket
   // upgrade handler (utils/voiceSession) so cookie-auth works for /api/voice-tutor/stream.
   const sessionMiddleware = session({

--- a/tests/unit/surfacePreference.test.js
+++ b/tests/unit/surfacePreference.test.js
@@ -1,0 +1,174 @@
+// tests/unit/surfacePreference.test.js
+// Unit tests for utils/surfacePreference — device detection, cookie
+// preference resolution, and the middleware wiring.
+
+const {
+  COOKIE_NAME,
+  detectDefaultSurface,
+  getSurfacePreference,
+  resolveSurface,
+  setSurfaceCookie,
+  surfaceMiddleware,
+} = require('../../utils/surfacePreference');
+
+// Minimal request/response stubs — these functions only touch
+// req.headers, req.cookies, and res.cookie/setHeader.
+const reqWith = (overrides = {}) => ({
+  headers: {},
+  cookies: {},
+  ...overrides,
+});
+
+const PHONE_UA = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15';
+const ANDROID_UA = 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36';
+const IPAD_UA = 'Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15';
+const DESKTOP_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36';
+
+describe('detectDefaultSurface()', () => {
+  test('returns "voice" for iPhone UA', () => {
+    expect(detectDefaultSurface(reqWith({ headers: { 'user-agent': PHONE_UA } }))).toBe('voice');
+  });
+
+  test('returns "voice" for Android phone UA', () => {
+    expect(detectDefaultSurface(reqWith({ headers: { 'user-agent': ANDROID_UA } }))).toBe('voice');
+  });
+
+  test('returns "voice" for iPad UA (tablets count as mobile)', () => {
+    expect(detectDefaultSurface(reqWith({ headers: { 'user-agent': IPAD_UA } }))).toBe('voice');
+  });
+
+  test('returns "text" for desktop UA', () => {
+    expect(detectDefaultSurface(reqWith({ headers: { 'user-agent': DESKTOP_UA } }))).toBe('text');
+  });
+
+  test('Sec-CH-UA-Mobile: ?1 forces "voice" even on desktop UA', () => {
+    const req = reqWith({ headers: { 'user-agent': DESKTOP_UA, 'sec-ch-ua-mobile': '?1' } });
+    expect(detectDefaultSurface(req)).toBe('voice');
+  });
+
+  test('Sec-CH-UA-Mobile: ?0 forces "text" even on phone UA', () => {
+    const req = reqWith({ headers: { 'user-agent': PHONE_UA, 'sec-ch-ua-mobile': '?0' } });
+    expect(detectDefaultSurface(req)).toBe('text');
+  });
+
+  test('falls back to "text" when no UA and no client hint', () => {
+    expect(detectDefaultSurface(reqWith())).toBe('text');
+  });
+});
+
+describe('getSurfacePreference()', () => {
+  test('returns "voice" when cookie is "voice"', () => {
+    expect(getSurfacePreference(reqWith({ cookies: { [COOKIE_NAME]: 'voice' } }))).toBe('voice');
+  });
+
+  test('returns "text" when cookie is "text"', () => {
+    expect(getSurfacePreference(reqWith({ cookies: { [COOKIE_NAME]: 'text' } }))).toBe('text');
+  });
+
+  test('returns null when cookie missing', () => {
+    expect(getSurfacePreference(reqWith())).toBeNull();
+  });
+
+  test('returns null for invalid cookie value (rejects junk)', () => {
+    expect(getSurfacePreference(reqWith({ cookies: { [COOKIE_NAME]: 'orb' } }))).toBeNull();
+  });
+
+  test('returns null when req.cookies is undefined (no cookie-parser)', () => {
+    expect(getSurfacePreference({ headers: {} })).toBeNull();
+  });
+});
+
+describe('resolveSurface()', () => {
+  test('cookie "text" beats mobile UA default', () => {
+    const req = reqWith({
+      headers: { 'user-agent': PHONE_UA },
+      cookies: { [COOKIE_NAME]: 'text' },
+    });
+    expect(resolveSurface(req)).toBe('text');
+  });
+
+  test('cookie "voice" beats desktop UA default', () => {
+    const req = reqWith({
+      headers: { 'user-agent': DESKTOP_UA },
+      cookies: { [COOKIE_NAME]: 'voice' },
+    });
+    expect(resolveSurface(req)).toBe('voice');
+  });
+
+  test('falls through to device default when no cookie set', () => {
+    expect(resolveSurface(reqWith({ headers: { 'user-agent': PHONE_UA } }))).toBe('voice');
+    expect(resolveSurface(reqWith({ headers: { 'user-agent': DESKTOP_UA } }))).toBe('text');
+  });
+
+  test('invalid cookie does not poison resolution — falls back to default', () => {
+    const req = reqWith({
+      headers: { 'user-agent': PHONE_UA },
+      cookies: { [COOKIE_NAME]: 'rubbish' },
+    });
+    expect(resolveSurface(req)).toBe('voice');
+  });
+});
+
+describe('setSurfaceCookie()', () => {
+  test('writes a cookie with the expected options for valid value', () => {
+    const res = { cookie: jest.fn() };
+    setSurfaceCookie(res, 'voice');
+    expect(res.cookie).toHaveBeenCalledWith(COOKIE_NAME, 'voice', expect.objectContaining({
+      httpOnly: true,
+      sameSite: 'lax',
+      path: '/',
+    }));
+  });
+
+  test('silently drops invalid values (does not throw, does not write)', () => {
+    const res = { cookie: jest.fn() };
+    setSurfaceCookie(res, 'orb');
+    expect(res.cookie).not.toHaveBeenCalled();
+  });
+
+  test('uses secure: true in production', () => {
+    const prev = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    const res = { cookie: jest.fn() };
+    setSurfaceCookie(res, 'text');
+    expect(res.cookie).toHaveBeenCalledWith(COOKIE_NAME, 'text', expect.objectContaining({ secure: true }));
+    process.env.NODE_ENV = prev;
+  });
+
+  test('uses secure: false outside production', () => {
+    const prev = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+    const res = { cookie: jest.fn() };
+    setSurfaceCookie(res, 'text');
+    expect(res.cookie).toHaveBeenCalledWith(COOKIE_NAME, 'text', expect.objectContaining({ secure: false }));
+    process.env.NODE_ENV = prev;
+  });
+});
+
+describe('surfaceMiddleware()', () => {
+  test('attaches req.surface based on device detection', () => {
+    const req = reqWith({ headers: { 'user-agent': PHONE_UA } });
+    const res = { setHeader: jest.fn() };
+    const next = jest.fn();
+    surfaceMiddleware(req, res, next);
+    expect(req.surface).toBe('voice');
+    expect(next).toHaveBeenCalled();
+  });
+
+  test('cookie preference overrides device detection on req.surface', () => {
+    const req = reqWith({
+      headers: { 'user-agent': PHONE_UA },
+      cookies: { [COOKIE_NAME]: 'text' },
+    });
+    const res = { setHeader: jest.fn() };
+    surfaceMiddleware(req, res, () => {});
+    expect(req.surface).toBe('text');
+  });
+
+  test('sends Accept-CH: Sec-CH-UA-Mobile so future requests get the hint', () => {
+    const req = reqWith();
+    const res = { setHeader: jest.fn() };
+    surfaceMiddleware(req, res, () => {});
+    expect(res.setHeader).toHaveBeenCalledWith('Accept-CH', 'Sec-CH-UA-Mobile');
+  });
+});

--- a/utils/surfacePreference.js
+++ b/utils/surfacePreference.js
@@ -1,0 +1,116 @@
+// utils/surfacePreference.js
+// Tracks the user's preferred chat surface.
+//
+// "Surface" is the rendered UI a user lands on after login:
+//   - 'voice' → /voice-tutor.html (immersive orb + captions)
+//   - 'text'  → /chat.html (bubble chat)
+//
+// The default is form-factor-aware: phones and tablets get 'voice',
+// laptops/desktops get 'text'. A user override (toggling from the
+// surface header UI) is stored in a long-lived cookie and beats the
+// device default thereafter.
+//
+// This module ships the helpers + middleware only. The routes that
+// actually consume req.surface to redirect post-login, and the toggle
+// endpoint that calls setSurfaceCookie(), land in a follow-up PR.
+
+const COOKIE_NAME = 'surface';
+const VALID_VALUES = new Set(['voice', 'text']);
+const COOKIE_MAX_AGE_MS = 365 * 24 * 60 * 60 * 1000; // 1 year
+
+// Conservative UA regex — covers the major phone + tablet vendors.
+// Tablets count as mobile here because the touch/voice ergonomics are
+// closer to a phone than a laptop for this product.
+const MOBILE_UA_PATTERN = /Mobi|Android|iPhone|iPad|iPod|Windows Phone|BlackBerry|webOS|Opera Mini/i;
+
+/**
+ * Determine the default surface for a request based on device form factor.
+ * Prefers the Sec-CH-UA-Mobile client hint when present (modern browsers
+ * after we've asked for it via Accept-CH); falls back to a User-Agent
+ * regex otherwise.
+ *
+ * @param {import('http').IncomingMessage} req
+ * @returns {'voice' | 'text'}
+ */
+function detectDefaultSurface(req) {
+  // Sec-CH-UA-Mobile is '?1' (mobile) or '?0' (not). Browsers only
+  // send it once we've responded with Accept-CH: Sec-CH-UA-Mobile on
+  // a prior request — the middleware below sets that header.
+  const chMobile = req.headers && req.headers['sec-ch-ua-mobile'];
+  if (chMobile === '?1') return 'voice';
+  if (chMobile === '?0') return 'text';
+
+  const ua = (req.headers && req.headers['user-agent']) || '';
+  return MOBILE_UA_PATTERN.test(ua) ? 'voice' : 'text';
+}
+
+/**
+ * Read the user's persisted surface preference from cookies. Returns
+ * null if no preference is set or the cookie value is invalid.
+ *
+ * Requires cookie-parser to have run earlier in the middleware chain.
+ *
+ * @param {import('http').IncomingMessage} req
+ * @returns {'voice' | 'text' | null}
+ */
+function getSurfacePreference(req) {
+  const value = req.cookies && req.cookies[COOKIE_NAME];
+  return VALID_VALUES.has(value) ? value : null;
+}
+
+/**
+ * Resolve the effective surface for this request. Cookie override beats
+ * device default; this is what consumers should call.
+ *
+ * @param {import('http').IncomingMessage} req
+ * @returns {'voice' | 'text'}
+ */
+function resolveSurface(req) {
+  return getSurfacePreference(req) || detectDefaultSurface(req);
+}
+
+/**
+ * Persist a surface preference. Invalid values are silently dropped
+ * rather than throwing so a malformed client request can't 500.
+ *
+ * httpOnly: true — the client UI derives its current surface from the
+ * URL it's on, not from this cookie. Toggling happens via a server
+ * endpoint (future PR), not document.cookie writes.
+ *
+ * @param {import('express').Response} res
+ * @param {'voice' | 'text'} value
+ */
+function setSurfaceCookie(res, value) {
+  if (!VALID_VALUES.has(value)) return;
+  const isProduction = process.env.NODE_ENV === 'production';
+  res.cookie(COOKIE_NAME, value, {
+    httpOnly: true,
+    secure: isProduction,
+    sameSite: 'lax',
+    maxAge: COOKIE_MAX_AGE_MS,
+    path: '/',
+  });
+}
+
+/**
+ * Express middleware that attaches the resolved surface to req.surface
+ * and asks the browser to send Sec-CH-UA-Mobile on subsequent requests
+ * for more accurate detection than UA-string sniffing.
+ *
+ * Register once after cookie-parser. Idempotent and dependency-free.
+ */
+function surfaceMiddleware(req, res, next) {
+  res.setHeader('Accept-CH', 'Sec-CH-UA-Mobile');
+  req.surface = resolveSurface(req);
+  next();
+}
+
+module.exports = {
+  COOKIE_NAME,
+  VALID_VALUES: Array.from(VALID_VALUES),
+  detectDefaultSurface,
+  getSurfacePreference,
+  resolveSurface,
+  setSurfaceCookie,
+  surfaceMiddleware,
+};


### PR DESCRIPTION
## Summary

PR 0 of the voice-first redesign — pure infrastructure, no behavior change. Adds a helper that resolves the user's preferred chat surface (`voice` orb vs `text` bubble chat) into `req.surface` so the follow-up PR can do device-aware post-login routing and wire a header toggle.

### Resolution order

1. **Persisted cookie preference** — wins. Written by the future toggle UI via `setSurfaceCookie(res, value)`.
2. **`Sec-CH-UA-Mobile` client hint** — modern, accurate. The middleware sends `Accept-CH: Sec-CH-UA-Mobile` so subsequent requests carry it.
3. **User-Agent regex fallback** — works on first visit before any client-hint negotiation completes.

Tablets are treated as mobile — the touch/voice ergonomics favor an orb over bubble chat regardless of screen size.

### What's in this PR

- **`utils/surfacePreference.js`** — five small, pure functions plus the Express middleware
  - `detectDefaultSurface(req)` — device classification
  - `getSurfacePreference(req)` — cookie reader, validates the value
  - `resolveSurface(req)` — combines the two with cookie precedence
  - `setSurfaceCookie(res, value)` — httpOnly, secure-in-prod, 1-year max age, silently drops invalid values
  - `surfaceMiddleware(req, res, next)` — attaches `req.surface`, sends `Accept-CH`
- **`config/middleware.js`** — registers the middleware after `cookie-parser`, before session/passport. Surface resolution doesn't depend on auth, so it runs early.
- **`tests/unit/surfacePreference.test.js`** — full coverage of the four pure functions and the middleware, including the cookie-beats-device-default invariant, invalid-cookie rejection, and the `secure: true` flip in production.

### Why this lands first

The follow-up PR (adaptive routing + bidirectional header toggle) is the visible change. Splitting the infra out lets that PR focus on the routing logic and the UI without also adding device-detection plumbing for review. Also lets the toggle endpoint reuse `setSurfaceCookie` from day one.

## Test plan

- [ ] `npm run test:unit -- tests/unit/surfacePreference.test.js` passes
- [ ] CI lint + build + full test suite green
- [ ] Smoke: hit any authenticated route on staging, confirm `Accept-CH: Sec-CH-UA-Mobile` is set on the response
- [ ] Smoke: hit a route from a mobile UA, confirm `req.surface` resolves to `voice` if logged via a debug log temporarily
- [ ] Smoke: write a `surface=text` cookie manually, hit same route on phone UA, confirm `req.surface` resolves to `text`

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMX7qmsgB5gUKjpbsJzsRk)_