### PR TITLE
fix(test): streakFreeze week-boundary flake (Sunday-morning UTC)

### DIFF
--- a/tests/unit/streakFreeze.test.js
+++ b/tests/unit/streakFreeze.test.js
@@ -68,9 +68,21 @@ describe('Streak Freeze Mechanic', () => {
     });
 
     test('missing 1 day with freeze already used this week resets streak', () => {
-        // Set freeze used at a time that's guaranteed to be in the current week
-        // (1 hour ago is always within this calendar week)
-        const recentFreezeTime = new Date(Date.now() - 60 * 60 * 1000);
+        // Pick a timestamp "recently in the current week", computed against
+        // production's week boundary (Sunday 00:00 UTC, matching
+        // canUseStreakFreeze in utils/gamificationEvents.js). The naive
+        // "1 hour ago" lands in last week if CI runs in the first hour of
+        // a new calendar week — May 24 2026 Sunday tripped this assertion.
+        const now = new Date();
+        const weekStartMs = Date.UTC(
+            now.getUTCFullYear(),
+            now.getUTCMonth(),
+            now.getUTCDate() - now.getUTCDay()
+        );
+        const recentFreezeTime = new Date(Math.max(
+            weekStartMs + 1000,           // safely inside this week
+            Date.now() - 60 * 60 * 1000   // or 1 hour ago, whichever is later
+        ));
         const user = makeUser({
             lastPracticeDate: daysAgo(2),
             currentStreak: 7,


### PR DESCRIPTION
## Summary

Pre-existing test flake — surfaced via CI on #987 but not caused by it. `tests/unit/streakFreeze.test.js` → *"missing 1 day with freeze already used this week resets streak"* sets `streakFreezeUsedAt: 1 hour ago` and asserts production sees it as in-the-current-week.

Production's `canUseStreakFreeze()` in `utils/gamificationEvents.js:17-29` uses **Sunday 00:00 UTC** as the week boundary:

```js
const daysSinceSunday = now.getUTCDay();
const weekStart = new Date(now);
weekStart.setUTCDate(weekStart.getUTCDate() - daysSinceSunday);
weekStart.setUTCHours(0, 0, 0, 0);
return new Date(lastUsed) < weekStart;
```

If CI runs in the first hour of a new calendar week — e.g. `2026-05-24 00:39:55 UTC`, a Sunday, which is what bit #987 — then "1 hour ago" lands in *last* week. Production correctly reports the freeze as "available again," it auto-applies, streak goes 7→8 instead of resetting to 1, assertion fails.

## Fix

Pick the freeze timestamp using `max(weekStart + 1s, now - 1h)`. The "recentness" of the freeze is irrelevant to `canUseStreakFreeze` — it only checks the calendar-week boundary. The fix is one variable in one test.

No production code change.

## Test plan

- [x] `npx jest tests/unit/streakFreeze.test.js` — all 10 pass locally
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMX7qmsgB5gUKjpbsJzsRk)_