### PR TITLE
fix(chat): launch real Growth Check when student accepts in chat

### DIFF
--- a/public/css/chat-redesign.css
+++ b/public/css/chat-redesign.css
@@ -612,3 +612,32 @@ body.cr-mode .inline-equation-palette {
   color: var(--cr-text);
   border: 1px solid var(--cr-border);
 }
+
+/* ----- Inline CTA button attached to an AI message bubble -----
+ * Used when the server attaches a call-to-action to a greeting
+ * (e.g. "Start Growth Check"). The button replaces parsed-intent
+ * heuristics — one tap launches the proper UI flow.
+ */
+.message-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+  padding: 10px 16px;
+  border: none;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #7c6bff 0%, #00d4ff 100%);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 4px 14px rgba(124, 107, 255, 0.32);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
+}
+.message-cta:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px rgba(124, 107, 255, 0.42);
+}
+.message-cta:active { transform: translateY(0); }
+.message-cta:disabled { opacity: 0.55; cursor: default; transform: none; }
+.message-cta .cta-emoji { font-size: 16px; line-height: 1; }

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -2632,6 +2632,19 @@ document.addEventListener("DOMContentLoaded", () => {
                 }
             }
 
+            // Server-initiated assessment launch. Fires when the student
+            // accepted a Growth Check (or Starting Point) offer in chat —
+            // we open the structured FloatingScreener instead of letting
+            // the AI improvise questions in the bubble.
+            if (data.launchAssessment && window.floatingScreener) {
+                try {
+                    await window.floatingScreener.checkAssessmentStatus();
+                    window.floatingScreener.open();
+                } catch (error) {
+                    console.error('[launchAssessment] Failed to open assessment', error);
+                }
+            }
+
             if (data.newlyUnlockedTutors && data.newlyUnlockedTutors.length > 0) {
                 showTutorUnlockCelebration(data.newlyUnlockedTutors);
             }

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -617,12 +617,68 @@ document.addEventListener("DOMContentLoaded", () => {
 
             if (data.text) {
                 appendMessage(data.text, "ai");
+                if (data.inlineCta) attachInlineCtaToLatestMessage(data.inlineCta);
             }
         } catch (error) {
             showThinkingIndicator(false);
             appendMessage("Hey! What do you need help with?", "ai");
         }
     }
+
+    // Attach a server-provided call-to-action button to the latest AI
+    // message bubble. Used for greeting CTAs like "Start Growth Check"
+    // — one tap routes to the proper UI instead of relying on the AI
+    // to interpret a "yes" reply.
+    function attachInlineCtaToLatestMessage(cta) {
+        if (!cta || !cta.type || !cta.label) return;
+
+        const messages = document.querySelectorAll('.message.ai');
+        const latest = messages[messages.length - 1];
+        if (!latest) return;
+        if (latest.querySelector('.message-cta')) return; // idempotent
+
+        const btn = document.createElement('button');
+        btn.className = 'message-cta';
+        btn.dataset.ctaType = cta.type;
+        btn.type = 'button';
+        if (cta.emoji) {
+            const span = document.createElement('span');
+            span.className = 'cta-emoji';
+            span.textContent = cta.emoji;
+            btn.appendChild(span);
+        }
+        btn.appendChild(document.createTextNode(cta.label));
+
+        btn.addEventListener('click', () => {
+            btn.disabled = true;
+            handleInlineCtaClick(cta);
+        });
+
+        latest.appendChild(btn);
+    }
+
+    // Route an inline-CTA action to its handler. Centralized so future
+    // CTA types (Starting Point, end-of-session quiz, etc.) plug in
+    // without re-templating the greeting flow.
+    function handleInlineCtaClick(cta) {
+        switch (cta.type) {
+            case 'launch-growth-check':
+            case 'launch-starting-point':
+                if (window.floatingScreener) {
+                    Promise.resolve(window.floatingScreener.checkAssessmentStatus())
+                        .then(() => window.floatingScreener.open())
+                        .catch(err => console.error('[InlineCta] open failed', err));
+                } else if (typeof window.openStartingPoint === 'function') {
+                    window.openStartingPoint();
+                }
+                break;
+            default:
+                console.warn('[InlineCta] unknown action type', cta.type);
+        }
+    }
+
+    // Expose for other modules that append AI messages (e.g. streaming finalizer).
+    window.attachInlineCtaToLatestMessage = attachInlineCtaToLatestMessage;
 
     // ── Unified Markdown + Math renderer (marked + KaTeX) ──
     // Pipeline: protect LaTeX → marked.parse → restore with katex.renderToString
@@ -2643,6 +2699,13 @@ document.addEventListener("DOMContentLoaded", () => {
                 } catch (error) {
                     console.error('[launchAssessment] Failed to open assessment', error);
                 }
+            }
+
+            // Inline CTA button attached to the AI bubble (e.g. a primary
+            // "Start Growth Check" launcher). Greetings emit these via
+            // handleGreetingRequest; regular chat responses can too.
+            if (data.inlineCta && typeof window.attachInlineCtaToLatestMessage === 'function') {
+                window.attachInlineCtaToLatestMessage(data.inlineCta);
             }
 
             if (data.newlyUnlockedTutors && data.newlyUnlockedTutors.length > 0) {

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -29,6 +29,7 @@ const { processAIResponse } = require('../utils/chatBoardParser');
 const ScreenerSession = require('../models/screenerSession');
 const { needsAssessment } = require('../services/chatService');
 const { computeNudges, NUDGE_TYPES } = require('../utils/userNudges');
+const { detectGrowthCheckAcceptance } = require('../utils/growthCheckIntent');
 const { buildCourseSystemPrompt, buildCourseGreetingInstruction, loadCourseContext, calculateOverallProgress } = require('../utils/coursePrompt');
 // Performance optimizations
 const contextCache = require('../utils/contextCache');
@@ -523,6 +524,56 @@ router.post('/', isAuthenticated, promptInjectionFilter, conditionalUpload, cond
             : message;
         if (!effectiveMessage) {
             return res.status(400).json({ message: "Message content is required and cannot be empty." });
+        }
+
+        // ── GROWTH CHECK LAUNCH INTERCEPT ──
+        // The greeting offers a Growth Check ("want to spend 5 minutes on a
+        // quick growth check?"). Without this intercept the LLM happily
+        // accepts and invents 2 freeform calculus questions in the chat
+        // bubble — which is not a growth check. The real one is a 5-8
+        // question IRT assessment served by the FloatingScreener (see
+        // public/js/floating-screener.js).
+        //
+        // When the student explicitly accepts ("yes growth check",
+        // "growth check", "let's do the growth check") AND is eligible,
+        // we short-circuit the pipeline and tell the client to open the
+        // structured assessment UI.
+        if (!hasFiles && !isMasteryMode && detectGrowthCheckAcceptance(effectiveMessage)) {
+            const eligible = user.assessmentCompleted
+                && user.nextGrowthCheckDue
+                && new Date(user.nextGrowthCheckDue) <= new Date();
+
+            if (eligible) {
+                const tutorReply = "Cool — opening the Growth Check now. Come back here when you're done and we'll pick up where we left off.";
+                activeConversation.messages.push({ role: 'user', content: effectiveMessage });
+                activeConversation.messages.push({ role: 'assistant', content: tutorReply });
+                activeConversation.lastActivity = new Date();
+                try {
+                    await activeConversation.save();
+                } catch (saveErr) {
+                    logger.warn('Growth check intercept conversation save failed', { error: saveErr.message });
+                }
+
+                logger.info('Growth check acceptance intercepted', { userId });
+
+                const xpForLevelStart = BRAND_CONFIG.cumulativeXpForLevel(user.level);
+                const userXpInCurrentLevel = Math.max(0, (user.xp || 0) - xpForLevelStart);
+                const tutorVoice = TUTOR_CONFIG[user.selectedTutorId || 'default']?.voiceId || 'default';
+
+                return res.json({
+                    text: tutorReply,
+                    userXp: userXpInCurrentLevel,
+                    userLevel: user.level,
+                    xpNeeded: BRAND_CONFIG.xpRequiredForLevel(user.level),
+                    specialXpAwarded: "",
+                    voiceId: tutorVoice,
+                    newlyUnlockedTutors: [],
+                    drawingSequence: null,
+                    launchAssessment: 'growth-check',
+                });
+            }
+            // Not eligible (no baseline, or just did one) — let the normal
+            // pipeline handle it so the AI can explain why naturally.
         }
 
         // ── FILE UPLOAD PROCESSING (consolidated from chatWithFile.js) ──

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -2266,6 +2266,10 @@ async function handleGreetingRequest(req, res, userId) {
         let greetingInstruction;
         let maxTokens = 150;
         let openerResult = null;
+        // Optional inline call-to-action button attached to the greeting
+        // bubble. Set when the student is overdue for a Growth Check so the
+        // client can render a one-tap launcher inside the message.
+        let greetingInlineCta = null;
 
         if (isCourseGreeting && courseContext) {
             // COURSE MODE: Use dedicated course prompt
@@ -2394,6 +2398,12 @@ This is the student's first session. After your greeting, casually mention the "
             // The dashboard banner handles the lighter cases; here we lean on
             // the tutor relationship — when a student opens chat, having
             // Maya/Mr.Nappier mention it lands as care, not as a system demand.
+            //
+            // The actual Growth Check is a structured 5-8 question assessment
+            // (FloatingScreener). We attach a button to the greeting message
+            // so the student launches the real UI with one tap. The AI just
+            // sets up the moment in its own voice — it does NOT improvise
+            // questions in chat (that's not a growth check, just hallucination).
             try {
                 const nudges = computeNudges(user);
                 const growthOverdue = nudges.find(n =>
@@ -2404,9 +2414,14 @@ This is the student's first session. After your greeting, casually mention the "
                     const timingPhrase = daysPastDue >= 14
                         ? "it's been a while"
                         : "it's been a few months";
+                    greetingInlineCta = {
+                        type: 'launch-growth-check',
+                        label: 'Start Growth Check',
+                        emoji: '📊',
+                    };
                     greetingInstruction += `
 
-The student has an overdue Growth Check (${timingPhrase} since their last one). Mention it once in your own voice, the way a tutor who cares would — something like "before we dive in, I want to make sure I'm still teaching you at the right level — want to spend 5 minutes on a quick growth check, or jump into what you were working on?" Give them BOTH options clearly so it feels collaborative, not coercive. Keep it to one sentence. Do not lecture about why growth checks matter. Do not say "system" or "the app" — speak as you, not as a bot.`;
+The student has an overdue Growth Check (${timingPhrase} since their last one). A button labeled "${greetingInlineCta.label}" is rendered below your greeting — they tap it to start. So in your message: acknowledge it briefly in your own voice (e.g., "before we dive in, I want to make sure I'm still teaching you at the right level — tap the button below if you've got 5 minutes for a quick growth check, or just tell me what you want to work on"). Keep it ONE sentence. Reference the button — do NOT invent your own questions or pretend to start the check inline. Do not say "system" or "the app".`;
                 }
             } catch (err) {
                 logger.warn('Greeting nudge check error (non-fatal)', { error: err.message });
@@ -2507,6 +2522,9 @@ The student has an overdue Growth Check (${timingPhrase} since their last one). 
                 if (openerResult?.suggestionChips) {
                     streamDonePayload.suggestionChips = openerResult.suggestionChips;
                 }
+                if (greetingInlineCta) {
+                    streamDonePayload.inlineCta = greetingInlineCta;
+                }
                 res.write(`data: ${JSON.stringify(streamDonePayload)}\n\n`);
                 res.end();
 
@@ -2578,6 +2596,9 @@ The student has an overdue Growth Check (${timingPhrase} since their last one). 
             };
             if (openerResult?.suggestionChips) {
                 greetingResponse.suggestionChips = openerResult.suggestionChips;
+            }
+            if (greetingInlineCta) {
+                greetingResponse.inlineCta = greetingInlineCta;
             }
             res.json(greetingResponse);
         }

--- a/tests/unit/growthCheckIntent.test.js
+++ b/tests/unit/growthCheckIntent.test.js
@@ -1,0 +1,80 @@
+// tests/unit/growthCheckIntent.test.js
+//
+// Verifies the chat-side detector that routes "yes growth check"
+// to the structured FloatingScreener instead of letting the LLM
+// improvise freeform questions in the chat bubble.
+
+const { detectGrowthCheckAcceptance } = require('../../utils/growthCheckIntent');
+
+describe('detectGrowthCheckAcceptance', () => {
+    describe('accepts explicit growth check requests', () => {
+        const positives = [
+            'growth check',
+            'Growth Check',
+            'growth-check',
+            'Yes. Growth check',
+            'yes growth check',
+            "let's do the growth check",
+            'do the growth check',
+            'start a growth check',
+            'I want a growth check please',
+            'GROWTH CHECK!',
+        ];
+
+        test.each(positives)('"%s" → true', (message) => {
+            expect(detectGrowthCheckAcceptance(message)).toBe(true);
+        });
+    });
+
+    describe('rejects declines and negations', () => {
+        const negatives = [
+            'no growth check',
+            "I don't want a growth check",
+            'skip the growth check',
+            'cancel the growth check',
+            'maybe later, not the growth check',
+            'nope no growth check',
+        ];
+
+        test.each(negatives)('"%s" → false', (message) => {
+            expect(detectGrowthCheckAcceptance(message)).toBe(false);
+        });
+    });
+
+    describe('rejects questions about the feature', () => {
+        const questions = [
+            'what is a growth check?',
+            'how does a growth check work?',
+            'when is my next growth check?',
+            'why do I need a growth check?',
+            'is the growth check long?',
+            'are growth checks graded?',
+            'can I take a growth check later?',
+            'do I have to do the growth check?',
+        ];
+
+        test.each(questions)('"%s" → false', (message) => {
+            expect(detectGrowthCheckAcceptance(message)).toBe(false);
+        });
+    });
+
+    describe('rejects unrelated messages', () => {
+        const irrelevant = [
+            'yes',
+            'sure',
+            "let's jump in",
+            'help me with this problem',
+            'I want to learn factoring',
+            '',
+            '   ',
+            null,
+            undefined,
+            42,
+            { message: 'growth check' },
+        ];
+
+        test.each(irrelevant)('%p → false', (message) => {
+            expect(detectGrowthCheckAcceptance(message)).toBe(false);
+        });
+    });
+});

--- a/utils/growthCheckIntent.js
+++ b/utils/growthCheckIntent.js
@@ -1,0 +1,50 @@
+// ============================================================
+// growthCheckIntent.js — detect when a student is accepting a
+// Growth Check offer in chat.
+//
+// The chat greeting (routes/chat.js) sometimes offers a Growth
+// Check ("want to spend 5 minutes on a quick growth check?").
+// Without an intercept the LLM accepts the request and invents
+// its own 2-3 freeform questions in the chat bubble — which is
+// not a growth check at all. The real Growth Check is a 5-8
+// question IRT-calibrated assessment served by the FloatingScreener
+// (POST /api/screener/start with isGrowthCheck=true). This
+// detector lets routes/chat.js intercept the acceptance and
+// launch the proper UI instead.
+//
+// The detector is intentionally conservative: only an explicit
+// "growth check" mention in the student's message fires it. A
+// plain "yes" to the greeting's both-options offer is ambiguous
+// (could mean "yes, growth check" or "yes, let's jump in"), so
+// we leave that to the LLM to disambiguate naturally.
+// ============================================================
+
+'use strict';
+
+const GROWTH_CHECK_RE = /\b(growth[\s-]*check)\b/i;
+const NEGATIVE_RE = /\b(no|not|don'?t|stop|cancel|later|skip|nope|nah)\b/i;
+const QUESTION_RE = /^(what|when|why|how|where|who|is\s+|are\s+|can\s+|do\s+(i|you|we))\b/i;
+
+/**
+ * @param {string} message - The student's raw chat message
+ * @returns {boolean} true when the student is asking to launch the
+ *   structured Growth Check assessment
+ */
+function detectGrowthCheckAcceptance(message) {
+    if (!message || typeof message !== 'string') return false;
+    const trimmed = message.trim();
+    if (!trimmed) return false;
+
+    if (!GROWTH_CHECK_RE.test(trimmed)) return false;
+
+    // "I don't want a growth check", "skip the growth check", etc.
+    if (NEGATIVE_RE.test(trimmed)) return false;
+
+    // "what is a growth check?", "how does a growth check work?" —
+    // a question about the feature, not a request to launch it.
+    if (QUESTION_RE.test(trimmed)) return false;
+
+    return true;
+}
+
+module.exports = { detectGrowthCheckAcceptance };


### PR DESCRIPTION
## Summary
- When the greeting offers a Growth Check and the student types "yes growth check", the LLM accepts and invents 2 freeform questions in the chat bubble — defeating the whole point of the structured assessment.
- Server now detects explicit Growth Check acceptance, short-circuits the pipeline, saves the exchange, and returns `launchAssessment: 'growth-check'`.
- Client opens the FloatingScreener (which already routes to growth-check mode based on `growthCheckDue`).

## What changed
- `utils/growthCheckIntent.js` — small conservative detector (explicit "growth check" mention only; rejects negations and questions about the feature).
- `routes/chat.js` — intercept right after the conversation is loaded, before file processing and the pipeline.
- `public/js/script.js` — when the response carries `launchAssessment`, refresh status and open the FloatingScreener.
- `tests/unit/growthCheckIntent.test.js` — 35 cases covering positives, negations, questions, and unrelated messages.

## What's intentionally NOT changed
- Plain "yes" without "growth check" is left for the LLM to disambiguate naturally (the greeting offers both options, so a bare "yes" is ambiguous).
- Not-eligible students still fall through to the regular pipeline so the AI can explain why.

## Test plan
- [x] `npx jest tests/unit/growthCheckIntent.test.js` — 35/35 pass
- [x] `npx jest tests/unit/userNudges.test.js tests/unit/chatService.test.js` — still pass
- [x] ESLint clean on changed files
- [ ] Manual: overdue student types "growth check" → FloatingScreener opens in growth-check mode
- [ ] Manual: overdue student types "no growth check" → falls through to normal chat
- [ ] Manual: student without baseline types "growth check" → AI explains why instead of intercepting

## Out of scope (also seen in transcript, not fixed here)
1. **Bare-problem-drop false positive on student work** — `(x+2)(x-2)/x-2 = x+2` is flagged as a bare problem drop and triggers the canned "show me what you've tried" response. Detector at `utils/pipeline/observe.js:321` needs to recognize equation chains as work.
2. **Broken math rendering** — Unicode math fragments (`x−2 / x²−4`) split across lines instead of going through KaTeX `\frac`.
3. **No in-session topic memory** — tutor re-suggests covered concepts after student says "we've done that already".

https://claude.ai/code/session_016pN4wSst26ea2M9gFgX6sK

---
_Generated by [Claude Code](https://claude.ai/code/session_016pN4wSst26ea2M9gFgX6sK)_