### PR TITLE
feat(workboard): graph + image cards in the board timeline

### DIFF
--- a/public/css/workspace.css
+++ b/public/css/workspace.css
@@ -401,6 +401,57 @@
   font-weight: 700;
 }
 
+/* Graph card — inline live plot inside the board timeline. */
+.cr-ws-board-card--graph {
+  padding: 10px;
+}
+.cr-ws-board-card-graph {
+  width: 100%;
+  height: 220px;
+  border-radius: var(--cr-radius-sm);
+  background: var(--cr-bg-deep, var(--cr-bg-panel));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--cr-text-dim);
+  font-size: 12px;
+  overflow: hidden;
+}
+
+/* Image card — educational reference image from the safe-search API. */
+.cr-ws-board-card--image {
+  padding: 10px;
+}
+.cr-ws-board-card-image-host {
+  width: 100%;
+  min-height: 120px;
+  border-radius: var(--cr-radius-sm);
+  background: var(--cr-bg-deep, var(--cr-bg-panel));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--cr-text-dim);
+  font-size: 12px;
+  overflow: hidden;
+}
+.cr-ws-board-card-image-img {
+  display: block;
+  max-width: 100%;
+  max-height: 280px;
+  width: auto;
+  height: auto;
+  border-radius: var(--cr-radius-sm);
+}
+
+/* Shared caption styling for graph + image cards. */
+.cr-ws-board-card-caption {
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--cr-text-dim);
+  text-align: center;
+  font-style: italic;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .cr-ws-board-card { transition: none; }
   .cr-ws-board-card--enter { opacity: 1; transform: none; }

--- a/public/js/boardCommandHandler.js
+++ b/public/js/boardCommandHandler.js
@@ -21,7 +21,7 @@
     'use strict';
 
     var STAGGER_MS = 250;
-    var STAGGER_ACTIONS = { apply: true, resolve: true, verify: true };
+    var STAGGER_ACTIONS = { apply: true, resolve: true, verify: true, graph: true, image: true };
 
     function getWorkspace() {
         return typeof window !== 'undefined' ? window.MathWorkspace : null;
@@ -49,6 +49,12 @@
                     break;
                 case 'clear':
                     W.boardClear();
+                    break;
+                case 'graph':
+                    if (command.fn) W.boardGraph(command.fn, command.caption || '');
+                    break;
+                case 'image':
+                    if (command.query) W.boardImage(command.query, command.caption || '');
                     break;
                 default:
                     console.warn('[BoardCommandHandler] Unknown action', command.action);

--- a/public/js/workspace.js
+++ b/public/js/workspace.js
@@ -158,6 +158,64 @@
         '<span class="cr-ws-board-apply-arrow" aria-hidden="true">↓</span>' +
         '<span class="cr-ws-board-apply-op"></span>';
       card.querySelector('.cr-ws-board-apply-op').textContent = step.op || '';
+    } else if (step.type === 'graph') {
+      card = el('div', 'cr-ws-board-card cr-ws-board-card--graph');
+      var graphHost = el('div', 'cr-ws-board-card-graph');
+      card.appendChild(graphHost);
+      if (step.caption) {
+        var graphCap = el('div', 'cr-ws-board-card-caption');
+        graphCap.textContent = step.caption;
+        card.appendChild(graphCap);
+      }
+      // Defer instantiation until the card is attached; MathGraph reads
+      // container dimensions at construction time.
+      requestAnimationFrame(function () {
+        if (!window.MathGraph) {
+          graphHost.textContent = 'Graphing engine still loading.';
+          return;
+        }
+        try {
+          new window.MathGraph(graphHost, {
+            fn: step.fn,
+            animate: true,
+            showKeyPoints: false,
+            showInfoBar: false
+          });
+        } catch (e) {
+          graphHost.textContent = "Couldn't graph " + step.fn;
+        }
+      });
+    } else if (step.type === 'image') {
+      card = el('div', 'cr-ws-board-card cr-ws-board-card--image');
+      var imgHost = el('div', 'cr-ws-board-card-image-host');
+      imgHost.textContent = 'Loading image…';
+      card.appendChild(imgHost);
+      if (step.caption) {
+        var imgCap = el('div', 'cr-ws-board-card-caption');
+        imgCap.textContent = step.caption;
+        card.appendChild(imgCap);
+      }
+      // Hit the existing safe image search; render the first result.
+      fetch('/api/images/search?q=' + encodeURIComponent(step.query), {
+        credentials: 'same-origin'
+      })
+        .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
+        .then(function (data) {
+          var first = data && data.results && data.results[0];
+          if (!first || !first.url) {
+            imgHost.textContent = 'No image found for "' + step.query + '".';
+            return;
+          }
+          imgHost.innerHTML = '';
+          var img = el('img', 'cr-ws-board-card-image-img');
+          img.src = first.url;
+          img.alt = first.title || step.query;
+          img.loading = 'lazy';
+          imgHost.appendChild(img);
+        })
+        .catch(function () {
+          imgHost.textContent = 'Image unavailable.';
+        });
     } else {
       // Equation card — pose / resolve / verify all share the same shape;
       // verify gets a badge + an expanded check line.
@@ -417,6 +475,39 @@
         tex: tex,
         check: check == null ? '' : String(check).trim()
       });
+      return true;
+    },
+
+    /**
+     * Drop a graph card into the board timeline.
+     * @param {string} fn       function of x, e.g. "x^2 - 4"
+     * @param {string} [caption] short label rendered under the graph
+     */
+    boardGraph: function (fn, caption) {
+      fn = (fn == null ? '' : String(fn)).trim();
+      if (!fn) return false;
+      openWorkspace();
+      this.showTool('board');
+      var step = { type: 'graph', fn: fn };
+      if (caption) step.caption = String(caption).trim();
+      pushBoardStep(step);
+      return true;
+    },
+
+    /**
+     * Drop an image card into the board timeline. Hits the existing
+     * safe-image-search endpoint; the first whitelisted result renders.
+     * @param {string} query    educational image query
+     * @param {string} [caption] short label rendered under the image
+     */
+    boardImage: function (query, caption) {
+      query = (query == null ? '' : String(query)).trim();
+      if (!query) return false;
+      openWorkspace();
+      this.showTool('board');
+      var step = { type: 'image', query: query };
+      if (caption) step.caption = String(caption).trim();
+      pushBoardStep(step);
       return true;
     },
 

--- a/tests/unit/boardCommandGuard.test.js
+++ b/tests/unit/boardCommandGuard.test.js
@@ -146,6 +146,48 @@ describe('boardCommandGuard', () => {
     });
   });
 
+  describe('graph (tutor-emitted reference content)', () => {
+    it('is always allowed when fn is present, regardless of student message', () => {
+      const { allowed, dropped } = enforcePedagogyRule({
+        commands: [{ action: 'graph', fn: 'x^2 - 4', caption: 'Where it crosses zero' }],
+        userMessage: 'idk where to start',
+      });
+      expect(allowed).toEqual([
+        { action: 'graph', fn: 'x^2 - 4', caption: 'Where it crosses zero' },
+      ]);
+      expect(dropped).toHaveLength(0);
+    });
+
+    it('is dropped when fn is missing', () => {
+      const { allowed, dropped } = enforcePedagogyRule({
+        commands: [{ action: 'graph' }],
+        userMessage: 'graph it for me',
+      });
+      expect(allowed).toHaveLength(0);
+      expect(dropped[0].reason).toBe('graph_missing_fn');
+    });
+  });
+
+  describe('image (tutor-emitted reference content)', () => {
+    it('is always allowed when query is present', () => {
+      const { allowed, dropped } = enforcePedagogyRule({
+        commands: [{ action: 'image', query: 'unit circle labeled' }],
+        userMessage: 'what do you mean by reference angle',
+      });
+      expect(allowed).toEqual([{ action: 'image', query: 'unit circle labeled' }]);
+      expect(dropped).toHaveLength(0);
+    });
+
+    it('is dropped when query is missing', () => {
+      const { allowed, dropped } = enforcePedagogyRule({
+        commands: [{ action: 'image' }],
+        userMessage: 'show me a picture',
+      });
+      expect(allowed).toHaveLength(0);
+      expect(dropped[0].reason).toBe('image_missing_query');
+    });
+  });
+
   describe('full drop scenario', () => {
     it('drops every move-tag when the student message is unrelated', () => {
       const { allowed, dropped } = enforcePedagogyRule({

--- a/tests/unit/boardTagParser.test.js
+++ b/tests/unit/boardTagParser.test.js
@@ -37,6 +37,42 @@ describe('boardTagParser', () => {
       expect(parseBoardTags('Time for a fresh one. <BOARD action="clear" /> What problem?').boardCommands)
         .toEqual([{ action: 'clear' }]);
     });
+
+    it('extracts a graph with fn only', () => {
+      const input = '<BOARD action="graph" fn="x^2 - 4" />';
+      expect(parseBoardTags(input).boardCommands).toEqual([
+        { action: 'graph', fn: 'x^2 - 4' },
+      ]);
+    });
+
+    it('extracts a graph with fn and caption', () => {
+      const input = '<BOARD action="graph" fn="sin(x)" caption="One full period" />';
+      expect(parseBoardTags(input).boardCommands).toEqual([
+        { action: 'graph', fn: 'sin(x)', caption: 'One full period' },
+      ]);
+    });
+
+    it('drops a graph with no fn', () => {
+      expect(parseBoardTags('<BOARD action="graph" />').boardCommands).toEqual([]);
+    });
+
+    it('extracts an image with query only', () => {
+      const input = '<BOARD action="image" query="unit circle labeled" />';
+      expect(parseBoardTags(input).boardCommands).toEqual([
+        { action: 'image', query: 'unit circle labeled' },
+      ]);
+    });
+
+    it('extracts an image with query and caption', () => {
+      const input = '<BOARD action="image" query="zero product property" caption="Reference" />';
+      expect(parseBoardTags(input).boardCommands).toEqual([
+        { action: 'image', query: 'zero product property', caption: 'Reference' },
+      ]);
+    });
+
+    it('drops an image with no query', () => {
+      expect(parseBoardTags('<BOARD action="image" />').boardCommands).toEqual([]);
+    });
   });
 
   describe('open/close form', () => {

--- a/utils/boardCommandGuard.js
+++ b/utils/boardCommandGuard.js
@@ -242,6 +242,23 @@ function evaluate(command, ctx) {
         return { allowed: false, reason: 'clear_without_start_over_or_completed_problem' };
     }
 
+    // Tutor-emitted reference content: graph/image cards are teaching aids,
+    // not the student's worked steps. They can't reveal the solution, so
+    // the #1-rule guard doesn't apply — we only validate required attrs.
+    if (action === 'graph') {
+        if (!command.fn) {
+            return { allowed: false, reason: 'graph_missing_fn' };
+        }
+        return { allowed: true };
+    }
+
+    if (action === 'image') {
+        if (!command.query) {
+            return { allowed: false, reason: 'image_missing_query' };
+        }
+        return { allowed: true };
+    }
+
     return { allowed: false, reason: 'unknown_action' };
 }
 

--- a/utils/boardTagParser.js
+++ b/utils/boardTagParser.js
@@ -12,6 +12,8 @@
 //   <BOARD action="resolve" tex="2x = 16" />
 //   <BOARD action="verify"  tex="x = 8" check="2(8) + 4 = 20" />
 //   <BOARD action="clear" />
+//   <BOARD action="graph"   fn="x^2 - 4" caption="The parabola" />
+//   <BOARD action="image"   query="unit circle labeled" caption="Reference" />
 //
 // Both self-closing (<BOARD … />) and open/close (<BOARD …>…</BOARD>)
 // forms are accepted. Attributes accept both single and double quotes.
@@ -22,7 +24,7 @@
 
 'use strict';
 
-const VALID_ACTIONS = new Set(['pose', 'apply', 'resolve', 'verify', 'clear']);
+const VALID_ACTIONS = new Set(['pose', 'apply', 'resolve', 'verify', 'clear', 'graph', 'image']);
 
 // Matches a single <BOARD …/> or <BOARD …>…</BOARD> tag. The `g` flag
 // lets us iterate multiple occurrences in one response. The inner
@@ -73,6 +75,9 @@ function parseBoardTags(aiResponseText) {
         const texAttr = extractAttr(attrString, 'tex');
         const opAttr = extractAttr(attrString, 'op');
         const checkAttr = extractAttr(attrString, 'check');
+        const fnAttr = extractAttr(attrString, 'fn');
+        const queryAttr = extractAttr(attrString, 'query');
+        const captionAttr = extractAttr(attrString, 'caption');
         const innerTrim = innerBody ? innerBody.trim() : '';
 
         const command = { action };
@@ -88,6 +93,18 @@ function parseBoardTags(aiResponseText) {
         }
         if (action === 'verify' && checkAttr) {
             command.check = checkAttr;
+        }
+        if (action === 'graph') {
+            const fn = fnAttr || innerTrim || null;
+            if (!fn) continue;
+            command.fn = fn;
+            if (captionAttr) command.caption = captionAttr;
+        }
+        if (action === 'image') {
+            const query = queryAttr || innerTrim || null;
+            if (!query) continue;
+            command.query = query;
+            if (captionAttr) command.caption = captionAttr;
         }
         boardCommands.push(command);
     }

--- a/utils/promptCompact.js
+++ b/utils/promptCompact.js
@@ -55,14 +55,18 @@ SYNTAX (case-sensitive on action; quotes can be " or '):
 <BOARD action="resolve" tex="2x = 16" />
 <BOARD action="verify" tex="x = 8" check="2(8) + 4 = 20" />
 <BOARD action="clear" />
+<BOARD action="graph" fn="x^2 - 4" caption="Where it crosses zero" />
+<BOARD action="image" query="unit circle labeled" caption="Reference" />
 
-WHEN TO EMIT (the only six rules — follow them strictly):
+WHEN TO EMIT (rules — follow them strictly):
 1. POSE: when you first present a problem to the student. Emit once per problem at the moment the problem starts. Don't re-pose mid-conversation.
 2. APPLY: AFTER the student tells you the move they want to make ("I'd subtract 4 from both sides"). Never before. The op="..." must restate the student's stated move.
 3. RESOLVE: AFTER the student tells you the result of that move ("so 2x = 16"). The tex="..." must be what the student wrote.
 4. VERIFY: when the student verifies the solution (substitutes back, or you've confirmed the final answer). tex="..." is the student's solution; check="..." shows the substitution math (e.g., "2(8) + 4 = 20").
 5. CLEAR: ONLY when the student signals a new problem ("new one", "let's try another") OR right after a verify card lands. Never to "demonstrate a cleaner path" — that erases the student's work.
-6. NEVER emit a resolve or apply for a step the student hasn't said. The board mirrors the student's reasoning, not yours. A server-side guard drops any tag that doesn't trace back to the student's recent message — don't try to slip them past.
+6. GRAPH: drop a live plot into the board to illustrate a concept — e.g., showing where a quadratic crosses zero before factoring, or visualizing a function the student is analyzing. fn="..." is a function of x (e.g., "x^2 - 4"). Optional caption="..." is a short label. Reference content only: do not graph the student's exact problem expression if it would reveal the answer.
+7. IMAGE: drop a reference image (unit circle, geometric figure, axis labels, etc.). query="..." is what you'd search for on a textbook glossary; the system fetches from a safe educational whitelist. Optional caption="...". Use sparingly — verbal explanation is usually faster.
+8. NEVER emit a resolve or apply for a step the student hasn't said. The board mirrors the student's reasoning, not yours. A server-side guard drops any equation-step tag that doesn't trace back to the student's recent message — don't try to slip them past. (Graph/image tags are exempt from that guard since they're teaching aids, but you're still responsible for not previewing the answer.)
 
 WORKED EXAMPLE (the canonical dialog):
   Student: "I need help with 2x + 4 = 20"


### PR DESCRIPTION
## Summary

Extends the BOARD tag protocol so the WorkBoard timeline can host more than equation steps. Maya can now drop two new card types into the same vertical stack as `pose`/`apply`/`resolve`/`verify`:

```xml
<BOARD action="graph" fn="x^2 - 4" caption="Where it crosses zero" />
<BOARD action="image" query="unit circle labeled" caption="Reference" />
```

- **Graph cards** instantiate an inline `MathGraph` (compact: no info bar, no key-point overlay).
- **Image cards** hit the existing `/api/images/search` endpoint (educational whitelist + COPPA-safe sanitizer) and render the first whitelisted result.
- **Pedagogy guard** treats both as tutor-emitted reference content: always allowed if required attrs are present. They can't reveal the student's answer the way an equation step can, so the #1-rule trace-to-student check doesn't apply.
- **Prompt instructions** document when to reach for each — and warn against graphing the student's exact problem expression if it would preview the solution.

## Files touched (8)

- `utils/boardTagParser.js` — `graph`/`image` in `VALID_ACTIONS`; parse `fn`, `query`, `caption`
- `utils/boardCommandGuard.js` — always-allow for tutor-emitted reference content
- `utils/promptCompact.js` — instructions for when to graph vs. image
- `public/js/boardCommandHandler.js` — dispatch the two new actions (staggered)
- `public/js/workspace.js` — render branches for the two new step types; `boardGraph()` / `boardImage()` public API
- `public/css/workspace.css` — compact card styling for graph + image
- `tests/unit/boardTagParser.test.js` — 6 new parser cases
- `tests/unit/boardCommandGuard.test.js` — 4 new guard cases

## Test plan

- [x] Parser: 6 new tests pass (graph with fn only, graph with fn+caption, graph drops when fn missing; same three for image)
- [x] Guard: 4 new tests pass (graph/image always allowed with required attrs; dropped when required attr missing)
- [x] Full board+pipeline test suite passes (201 tests across `boardTagParser`, `boardCommandGuard`, `boardTagStreamFilter`, `pipeline`, `pipelineIntegration`)
- [ ] **Manual:** spin up the dev server, ask Maya for help with a quadratic, and see whether she reaches for `graph` naturally. If not, the prompt needs a stronger nudge.
- [ ] **Manual:** trigger an image card (e.g. ask about the unit circle) and confirm the API result renders inside the card.

## Out of scope (deferred)

- The "mockup is too busy" layout concern. This PR only extends the card vocabulary inside the existing board panel — it doesn't change the panel's overall layout or chrome. That's a separate iteration once we see the new card types live.

https://claude.ai/code/session_01RJiSDQ6fpqUJKS8gaUSJtp

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJiSDQ6fpqUJKS8gaUSJtp)_