### PR TITLE
chore(sw): bump CACHE_VERSION to v3 to invalidate stale student caches

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,5 +1,6 @@
 // Service Worker for MATHMATIX AI PWA
-const CACHE_VERSION = 'mathmatix-v2';
+// Bump CACHE_VERSION on every deploy so students get fresh CSS/JS/images.
+const CACHE_VERSION = 'mathmatix-v3';
 const STATIC_CACHE = `static-${CACHE_VERSION}`;
 const RUNTIME_CACHE = `runtime-${CACHE_VERSION}`;
 


### PR DESCRIPTION
Forces every returning browser to drop the v2 caches (static + runtime) and re-fetch CSS/JS/images on the next visit. Without a bump, the precached files listed in PRECACHE_URLS would never refresh, and stale-while-revalidate would keep serving one-deploy-behind JS/CSS on first paint.