### PR TITLE
fix(screener): blacklist dead-end skills and seed growth checks from saved theta

### DIFF
--- a/models/screenerSession.js
+++ b/models/screenerSession.js
@@ -141,6 +141,14 @@ const screenerSessionSchema = new mongoose.Schema({
 
     // Skill coverage tracking
     testedSkills: [String],
+
+    // Skills blacklisted during this session because no usable problem was found.
+    // Prevents the selector from re-picking the same dead-end skill every question.
+    excludedSkills: {
+        type: [String],
+        default: []
+    },
+
     testedSkillCategories: {
         'number-operations': {
             type: Number,

--- a/routes/screener.js
+++ b/routes/screener.js
@@ -156,11 +156,20 @@ router.post('/start', isAuthenticated, async (req, res) => {
 
     // Determine starting theta based on mode
     let startingTheta;
+    let priorSD = null;
 
     if (isGrowthCheck) {
       // Growth Check: Start at user's current level (from previous assessment)
       startingTheta = user.learningProfile?.abilityEstimate?.theta || 0;
-      console.log(`[Screener Start] GROWTH CHECK - Starting at current level θ=${startingTheta.toFixed(2)}`);
+
+      // Anchor the Bayesian prior to the saved SE so MAP estimation trusts
+      // what we already know. Floor at 0.4 so the prior doesn't completely
+      // swamp new evidence; if we have no saved SE, use 0.6 (still tighter
+      // than the cold-start default of 1.25).
+      const savedSE = user.learningProfile?.abilityEstimate?.standardError;
+      priorSD = savedSE && savedSE > 0 ? Math.max(savedSE, 0.4) : 0.6;
+
+      console.log(`[Screener Start] GROWTH CHECK - Starting at current level θ=${startingTheta.toFixed(2)}, priorSD=${priorSD.toFixed(2)} (savedSE=${savedSE ?? 'none'})`);
     } else {
       // Starting Point: Start one grade below current to build confidence
       const currentGrade = parseInt(user.gradeLevel, 10);
@@ -183,6 +192,17 @@ router.post('/start', isAuthenticated, async (req, res) => {
       userId: user._id,
       sessionType: isGrowthCheck ? 'growth-check' : 'starting-point'
     });
+
+    // Growth checks are short progress checks, not full placement assessments.
+    // We already know roughly where the student stands, so we use a tighter
+    // question budget and a narrower prior to converge quickly.
+    if (isGrowthCheck) {
+      session.priorSD = priorSD;
+      session.minQuestions = 5;
+      session.targetQuestions = 6;
+      session.maxQuestions = 10;
+    }
+
     await session.save();
 
     res.json({
@@ -262,82 +282,82 @@ router.get('/next-problem', isAuthenticated, async (req, res) => {
     console.log(`[DEBUG] Tested skills so far: [${session.testedSkills.join(', ')}]`);
     console.log(`[DEBUG] Category counts:`, session.testedSkillCategories);
 
-    // Use the new modular skill selection system
-    // This replaces 300+ lines of inline skill scoring, clustering, and balancing logic
-    const selectionResult = selectSkill(filteredSkills, session, targetDifficulty, {
-      templateDifficultyMap: templateDifficulties,
-    });
-
-    const { selectedSkill, scoredCandidates, reason } = selectionResult;
-    const selectedSkillId = selectedSkill.skillId;
-
-    // Log selection results
-    if (reason === 'fallback') {
-      console.log(`[Screener Fallback] Using "${selectedSkillId}" - no optimal candidates found`);
-    } else {
-      console.log(`[Screener Q${session.questionCount + 1}] Target d=${targetDifficulty.toFixed(2)} → "${selectedSkillId}" (d=${selectedSkill.difficulty.toFixed(2)})`);
-      if (scoredCandidates.length > 0) {
-        console.log(`[DEBUG] Top candidates:`);
-        scoredCandidates.slice(0, 3).forEach((s, i) => {
-          console.log(`  ${i+1}. ${formatScoringLog(s)}`);
-        });
-      }
-    }
-
-    // SIMPLIFIED PROBLEM SELECTION
-    // Strategy: Prefer multiple-choice for screener reliability
+    // Compute LRU exclusion window once
     const recentProblemIds = session.responses
       .slice(-LRU_EXCLUSION_WINDOW)
       .map(r => r.problemId);
 
-    let problem = await Problem.findNearDifficulty(
-      selectedSkillId,
-      targetDifficulty,
-      recentProblemIds,
-      { preferMultipleChoice: true }  // Screener uses MC for clarity
-    );
+    // ADAPTIVE SKILL SELECTION with session blacklist retry.
+    // If the picked skill has no usable problem (e.g. position-words), we
+    // blacklist it on the session and re-run selection at the same target
+    // difficulty so we keep matching the student's level instead of falling
+    // back to whatever random easy problem Mongo returns first.
+    const MAX_SKILL_ATTEMPTS = 3;
+    let selectedSkillId = null;
+    let selectedSkill = null;
+    let problem = null;
+    let blacklistChanged = false;
 
-    // Fallback: Generate or find any problem
-    if (!problem) {
-      // Try generation first (templates are optimized for target difficulty)
-      try {
-        const generated = generateProblem(selectedSkillId, { difficulty: targetDifficulty });
-        problem = new Problem(generated);
-        await problem.save();
-      } catch {
-        // No template - find any existing problem for this skill
-        problem = await Problem.findOne({
-          skillId: selectedSkillId,
-          isActive: true,
-          answerType: 'multiple-choice'  // Prefer MC even in fallback
-        });
+    for (let attempt = 0; attempt < MAX_SKILL_ATTEMPTS; attempt++) {
+      const selectionResult = selectSkill(filteredSkills, session, targetDifficulty, {
+        templateDifficultyMap: templateDifficulties,
+        excludedSkillIds: session.excludedSkills || [],
+      });
 
-        // Last resort: any problem type
-        if (!problem) {
-          problem = await Problem.findOne({
-            skillId: selectedSkillId,
-            isActive: true
-          });
-        }
-      }
+      selectedSkill = selectionResult.selectedSkill;
+      selectedSkillId = selectedSkill.skillId;
+      const { scoredCandidates, reason } = selectionResult;
 
-      // If still no problem, try a different skill instead of crashing
-      if (!problem) {
-        console.warn(`[Screener] No problems for skill ${selectedSkillId}, selecting alternative`);
-        // Find any skill with available problems near target difficulty
-        const alternativeProblem = await Problem.findOne({
-          isActive: true,
-          answerType: 'multiple-choice',
-          problemId: { $nin: recentProblemIds }
-        });
-
-        if (alternativeProblem) {
-          problem = alternativeProblem;
-          console.log(`[Screener] Using alternative skill: ${problem.skillId}`);
+      if (attempt === 0) {
+        if (reason === 'fallback') {
+          console.log(`[Screener Fallback] Using "${selectedSkillId}" - no optimal candidates found`);
         } else {
-          throw new Error(`No problems available for screener`);
+          console.log(`[Screener Q${session.questionCount + 1}] Target d=${targetDifficulty.toFixed(2)} → "${selectedSkillId}" (d=${selectedSkill.difficulty.toFixed(2)})`);
+          if (scoredCandidates.length > 0) {
+            console.log(`[DEBUG] Top candidates:`);
+            scoredCandidates.slice(0, 3).forEach((s, i) => {
+              console.log(`  ${i+1}. ${formatScoringLog(s)}`);
+            });
+          }
+        }
+      } else {
+        console.log(`[Screener Retry ${attempt}] Target d=${targetDifficulty.toFixed(2)} → "${selectedSkillId}" (d=${selectedSkill.difficulty.toFixed(2)}), blacklist=${(session.excludedSkills || []).length}`);
+      }
+
+      // Try a real DB problem near target difficulty
+      problem = await Problem.findNearDifficulty(
+        selectedSkillId,
+        targetDifficulty,
+        recentProblemIds,
+        { preferMultipleChoice: true }
+      );
+
+      // Try template generation (templates are optimized for target difficulty)
+      if (!problem) {
+        try {
+          const generated = generateProblem(selectedSkillId, { difficulty: targetDifficulty });
+          problem = new Problem(generated);
+          await problem.save();
+        } catch {
+          // No template available for this skill
         }
       }
+
+      if (problem) break;
+
+      // Skill has no usable problem - blacklist it for the rest of the session.
+      console.warn(`[Screener] No problems for skill ${selectedSkillId}, blacklisting for session`);
+      session.excludedSkills = [...(session.excludedSkills || []), selectedSkillId];
+      blacklistChanged = true;
+    }
+
+    // Persist blacklist additions so subsequent /next-problem calls see them
+    if (blacklistChanged) {
+      await session.save();
+    }
+
+    if (!problem) {
+      throw new Error(`No problems available for screener after ${MAX_SKILL_ATTEMPTS} skill attempts`);
     }
 
     // Fix mismatched answer types

--- a/utils/skillSelector.js
+++ b/utils/skillSelector.js
@@ -275,7 +275,7 @@ function applyContentBalancing(candidates, testedCategories) {
  */
 function selectSkill(availableSkills, session, targetDifficulty, options = {}) {
   const { theta, testedSkills, testedSkillCategories } = session;
-  const { templateDifficultyMap = {} } = options;
+  const { templateDifficultyMap = {}, excludedSkillIds = [] } = options;
 
   // Build context for scoring
   const context = {
@@ -285,8 +285,12 @@ function selectSkill(availableSkills, session, targetDifficulty, options = {}) {
     testedCategories: testedSkillCategories || {},
   };
 
-  // Filter out excluded skills (conceptual/vague questions)
-  let eligibleSkills = availableSkills.filter(skill => !isScreenerExcluded(skill.skillId));
+  // Filter out skills that are conceptually excluded from the screener or have
+  // been blacklisted for this session (no usable problems found).
+  const sessionBlacklist = new Set(excludedSkillIds);
+  let eligibleSkills = availableSkills.filter(skill =>
+    !isScreenerExcluded(skill.skillId) && !sessionBlacklist.has(skill.skillId)
+  );
 
   // HARD DIFFICULTY FLOOR: Never select skills too far below current level
   // Prevents calculus students from getting skip counting questions


### PR DESCRIPTION
## Summary

A recent growth-check session burned all 30 questions without converging (SE stuck at 0.72 from Q17 onward). Logs showed three connected bugs:

1. **`position-words` won the selector every question** from Q16-Q30 but had zero usable problems. The fallback path stored the *substitute* skill in `testedSkills`, so `position-words` never accrued any recency/repetition penalty — it kept winning the score.
2. **The "alternative skill" fallback ignored target difficulty entirely** (`Problem.findOne({ isActive: true, answerType: 'multiple-choice' })` — no skill filter, no difficulty filter, no sort). A student at θ=1.3 got served `12-3=?`, `61+83=?`, `Order 37,41,25` — items with near-zero Fisher information at that ability, so θ couldn't move.
3. **Growth checks behaved like cold-start placement tests** — 30 questions, priorSD=1.25 — even though the student already has a saved θ and SE from the starting-point assessment.

## Changes

- **`models/screenerSession.js`**: new `excludedSkills: [String]` field — per-session blacklist for skills that fail to yield a problem.
- **`utils/skillSelector.js`**: `selectSkill` now accepts `excludedSkillIds` and filters them out alongside the existing conceptually-excluded skills.
- **`routes/screener.js` `/next-problem`**: retry loop (max 3 attempts). When the picked skill has no DB problem and no template, blacklist it on the session, persist, and re-run `selectSkill` at the *same* target difficulty. Replaces the broken "any MC problem" fallback.
- **`routes/screener.js` `/start`**: for growth checks, seed `priorSD` from `user.learningProfile.abilityEstimate.standardError` (floored at 0.4) so MAP estimation trusts the saved baseline, and tighten the question budget to 5/6/10.

## Test plan

- [ ] Unit tests pass (IRT suite green locally — 39/39)
- [ ] Manually trigger a growth check for a student with a completed starting-point assessment and confirm the session uses `priorSD≈saved SE` and ends within 5-10 questions
- [ ] Trigger /next-problem against a skill known to have no active problems (e.g. seed `position-words`-style empty skill) and confirm it gets added to `excludedSkills`, the retry picks a different skill, and the served problem is near target difficulty
- [ ] Verify existing starting-point assessments still run end-to-end (no regression — only growth-check branch sets the new question budget / priorSD)

https://claude.ai/code/session_01K1h5fwj9bEregyhcGVL7fz

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1h5fwj9bEregyhcGVL7fz)_