### PR TITLE
fix(mobile-chat): dock composer to keyboard, dismiss on send, clear greeting

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -923,7 +923,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         </button>
       </div>
       <div class="imessage-input-row">
-        <div id="user-input" contenteditable="true" data-placeholder="Ask a math question..." data-i18n-placeholder="chat.askQuestion" role="textbox" aria-multiline="true" autocomplete="off" autocapitalize="sentences" enterkeyhint="send" spellcheck="true"></div>
+        <div id="user-input" contenteditable="true" data-placeholder="Ask a math question..." data-i18n-placeholder="chat.askQuestion" role="textbox" aria-multiline="true" inputmode="text" autocomplete="off" autocorrect="off" autocapitalize="sentences" enterkeyhint="send" spellcheck="true" data-form-type="other" data-lpignore="true"></div>
         <!-- Math-field input (hidden until math mode activated) -->
         <div id="math-input-wrapper" class="math-input-wrapper" style="display:none;">
           <math-field id="math-keyboard-field" class="math-keyboard-field" virtual-keyboard-mode="off" math-virtual-keyboard-policy="manual"></math-field>

--- a/public/css/mobile-fixes.css
+++ b/public/css/mobile-fixes.css
@@ -1574,6 +1574,10 @@ a {
         flex-direction: column !important;
         height: 100vh !important;
         height: 100dvh !important;
+        /* --app-height is set by mobile-poster-chat.js from VisualViewport so the
+           composer docks to the on-screen keyboard instead of leaving a black
+           gap on iOS Safari. Falls back to 100dvh when the var is unset. */
+        height: var(--app-height, 100dvh) !important;
         overflow: hidden !important;
         margin: 0 !important;
         padding: 0 !important;

--- a/public/css/mobile-poster-chat.css
+++ b/public/css/mobile-poster-chat.css
@@ -226,7 +226,10 @@
     display: block;
     position: fixed;
     left: 0; right: 0;
-    bottom: 150px;
+    /* Clear the composer (toolbar row + input row + safe-area home indicator)
+       so the "I'll help you step by step." subtitle doesn't collide with the
+       √x / 📎 / 📷 / 🎤 toolbar icons. */
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 195px);
     z-index: 3;
     padding: 0 22px;
     pointer-events: none;

--- a/public/js/mobile-poster-chat.js
+++ b/public/js/mobile-poster-chat.js
@@ -204,6 +204,22 @@
     s.style.transform = '';
   }
 
+  /* ---- visual viewport tracker --------------------------------------- */
+  // iOS Safari leaves a gap between the composer and the on-screen keyboard
+  // because `100dvh` doesn't always recompute when the keyboard animates in.
+  // Mirror the actual visible height into --app-height so the body can dock
+  // to the keyboard. Falls back to 100dvh on browsers without VisualViewport.
+  function trackViewport() {
+    var vv = window.visualViewport;
+    if (!vv) return;
+    var update = function () {
+      document.documentElement.style.setProperty('--app-height', vv.height + 'px');
+    };
+    vv.addEventListener('resize', update);
+    vv.addEventListener('scroll', update);
+    update();
+  }
+
   /* ---- idle <-> conversation state ----------------------------------- */
   function watchMessages() {
     var box = document.getElementById('chat-messages-container');
@@ -223,6 +239,7 @@
     buildGreeting();
     buildSheet();
     watchMessages();
+    trackViewport();
     document.addEventListener('keydown', function (e) {
       if (e.key === 'Escape') closeSheet();
     });

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -2096,6 +2096,10 @@ document.addEventListener("DOMContentLoaded", () => {
         // Clear input immediately for responsive UX
         userInput.textContent = "";
         userInput.setAttribute('data-placeholder', "Ask a math question...");
+        // Dismiss the soft keyboard on mobile so the conversation is visible.
+        if (window.matchMedia && window.matchMedia('(max-width: 768px)').matches) {
+            userInput.blur();
+        }
 
         // Copy attached files and clear them from UI
         const filesToSend = attachedFiles.length > 0 ? [...attachedFiles] : [];


### PR DESCRIPTION
## Summary

Four mobile-chat UI bugs surfaced from screenshots of the live app on iOS Safari:

1. **Subtitle collides with the toolbar.** On the idle home screen, "I'll help you step by step." rendered on top of the √x / 📎 / 📷 / 🎤 toolbar row. The `#mpc-greeting` was anchored at `bottom: 150px`, which is roughly the composer's top edge on devices with a home indicator. Bumped to `calc(env(safe-area-inset-bottom, 0px) + 195px)` so the safe area is honored and the subtitle clears the composer on every phone size.

2. **Black gap between composer and iOS keyboard.** `100dvh` doesn't always recompute when the soft keyboard animates in on iOS Safari, so the body stayed at full viewport height and the composer floated mid-screen. Added a `VisualViewport` listener in `mobile-poster-chat.js` that mirrors the visible height into `--app-height`, and the mobile chat body now reads `height: var(--app-height, 100dvh)`. Falls back to `100dvh` where `VisualViewport` is unavailable.

3. **iOS autofill chips on the math input.** Added `inputmode="text"`, `autocorrect="off"`, `data-form-type="other"`, and `data-lpignore="true"` to `#user-input` to suppress QuickType / password-manager suggestions over a math chat field. Kept `autocapitalize="sentences"` and `spellcheck="true"` so natural-language tutoring messages still capitalize and spell-check.

4. **Keyboard stays up after send.** `sendMessage()` now calls `userInput.blur()` on `(max-width: 768px)` after clearing the input, so the soft keyboard collapses once a message goes out. Covers all three send paths (send button, Enter on text input, Enter on math field).

## Files changed

- `public/chat.html` — input attribute hardening
- `public/js/script.js` — blur on send (mobile only)
- `public/js/mobile-poster-chat.js` — VisualViewport → `--app-height`
- `public/css/mobile-fixes.css` — body uses `var(--app-height, 100dvh)`
- `public/css/mobile-poster-chat.css` — greeting bottom now safe-area aware

## Test plan

- [ ] iOS Safari, iPhone with home indicator: home screen subtitle clears toolbar
- [ ] iOS Safari: focus input → keyboard opens → composer docks (no black gap)
- [ ] iOS Safari: tap input → no QuickType password / card / location chips
- [ ] iOS Safari: send a message → keyboard collapses
- [ ] Android Chrome: same four checks
- [ ] Desktop: no regression on chat layout

https://claude.ai/code/session_01SZhKAMFygw3dnn7Ti3NDdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZhKAMFygw3dnn7Ti3NDdt)_