### PR TITLE
fix(tutor): drop canned ELICIT_FIRST template, make bare-drop detector context-aware

### DIFF
--- a/tests/unit/bareProblemDrop.test.js
+++ b/tests/unit/bareProblemDrop.test.js
@@ -11,9 +11,12 @@
  *
  * The two fixes tested here:
  *   1. observe.detectBareProblemDrop flags bare equation drops.
- *      decide routes them to ACTIONS.ELICIT_FIRST with a deterministic
- *      response (no LLM). The response cannot leak an answer because no
- *      LLM is involved in producing it.
+ *      decide routes them to ACTIONS.ELICIT_FIRST and attaches strong
+ *      anti-leak directives. The LLM still generates the reply in tutor
+ *      voice — no canned templates — but is barred from naming a value.
+ *      The detector also skips when the tutor's prior turn asked the
+ *      student to perform a step (mid-conversation, the student's math
+ *      reply is an answer, not a fresh drop).
  *   2. decide checks modeTransition before applying plan-based mode. When
  *      the transition detector reports exploratory_tangent / homework /
  *      prerequisite_surface / course_topic_overlap at ≥0.6 confidence, the
@@ -102,6 +105,35 @@ describe('detectBareProblemDrop', () => {
     expect(detectBareProblemDrop('hello', MESSAGE_TYPES.GREETING, noAnswer)).toBe(false);
     expect(detectBareProblemDrop('tell me about derivatives', MESSAGE_TYPES.QUESTION, noAnswer)).toBe(false);
   });
+
+  // ── Conversation-context guard: math replies to step prompts are NOT drops ──
+
+  test('does NOT flag math reply when tutor just asked "what\'s the first step?"', () => {
+    const recent = [{ content: "What's the first step you think we should take to set this up?" }];
+    expect(detectBareProblemDrop('1/3x^3', typeGeneralMath, noAnswer, recent)).toBe(false);
+  });
+
+  test('does NOT flag math reply when tutor just asked "what do you think we should do?"', () => {
+    const recent = [{ content: 'What do you think we should do with 1/3x^3 at those points?' }];
+    expect(detectBareProblemDrop('9- 1/3 = 26/3', typeGeneralMath, noAnswer, recent)).toBe(false);
+  });
+
+  test('does NOT flag math reply when tutor asked "can you evaluate that?"', () => {
+    const recent = [{ content: 'Can you evaluate that at x=3 and x=1?' }];
+    expect(detectBareProblemDrop('27-1=26', typeGeneralMath, noAnswer, recent)).toBe(false);
+  });
+
+  test('STILL flags a fresh problem drop after a generic invite ("what do you want to work on?")', () => {
+    const recent = [{ content: 'What do you want to work on today? Anything specific on your mind?' }];
+    // "want" isn't a step-progression verb — the tutor is opening the floor,
+    // not asking the student to perform a step. A fresh equation is a drop.
+    expect(detectBareProblemDrop('4x-5=22', typeGeneralMath, noAnswer, recent)).toBe(true);
+  });
+
+  test('STILL flags a fresh drop when there are no prior tutor messages', () => {
+    expect(detectBareProblemDrop('4x-5=22', typeGeneralMath, noAnswer, [])).toBe(true);
+    expect(detectBareProblemDrop('4x-5=22', typeGeneralMath, noAnswer, undefined)).toBe(true);
+  });
 });
 
 // ============================================================================
@@ -127,7 +159,7 @@ describe('observe() — isBareProblemDrop flag', () => {
 });
 
 // ============================================================================
-// decide() — bare-drop routes to ELICIT_FIRST with a deterministic response
+// decide() — bare-drop routes to ELICIT_FIRST with anti-leak directives
 // ============================================================================
 
 describe('decide() — ELICIT_FIRST for bare problem drops', () => {
@@ -147,28 +179,23 @@ describe('decide() — ELICIT_FIRST for bare problem drops', () => {
 
   const noAnswerDiagnosis = { type: 'no_answer', isCorrect: null, answer: null, correctAnswer: null };
 
-  test('routes to ELICIT_FIRST and attaches a deterministic response', () => {
+  test('routes to ELICIT_FIRST with anti-leak directives, no canned response', () => {
     const decision = decide(baseObservation, noAnswerDiagnosis, {
       phaseState: null,
       hasRecentUpload: false,
     });
 
     expect(decision.action).toBe(ACTIONS.ELICIT_FIRST);
-    expect(typeof decision.deterministicResponse).toBe('string');
-    expect(decision.deterministicResponse.length).toBeGreaterThan(20);
-    // Response must not contain a solved answer
-    expect(decision.deterministicResponse).not.toMatch(/x\s*=\s*-?\d/);
-    // Response must invite the student to show work or request an example
-    expect(decision.deterministicResponse).toMatch(/tried|tripping|stuck|example/i);
-  });
+    // The LLM generates the turn — no deterministic short-circuit anymore.
+    expect(decision.deterministicResponse).toBeUndefined();
+    expect(Array.isArray(decision.directives)).toBe(true);
+    expect(decision.directives.length).toBeGreaterThan(0);
 
-  test('uses student first name when available', () => {
-    const decision = decide(baseObservation, noAnswerDiagnosis, {
-      phaseState: null,
-      hasRecentUpload: false,
-      user: { firstName: 'Jason' },
-    });
-    expect(decision.deterministicResponse).toContain('Jason');
+    const joined = decision.directives.join('\n').toLowerCase();
+    // Must instruct the LLM not to solve / not to name an answer.
+    expect(joined).toMatch(/do not solve|do not name the answer|do not show steps/);
+    // Must explicitly forbid the old canned phrases (scripted-voice fix).
+    expect(joined).toMatch(/show me what you tried|tripping you up|canned/);
   });
 
   test('does NOT route to ELICIT_FIRST when hasRecentUpload (worksheet guards own this flow)', () => {

--- a/tests/unit/tutorValidation.test.js
+++ b/tests/unit/tutorValidation.test.js
@@ -703,14 +703,13 @@ describe('Tutor Validation: Answer Leak Prevention', () => {
   // ────────────────────────────────────────────────────────────────────────
 
   // ────────────────────────────────────────────────────────────────────────
-  // These bare-equation drops are now caught earlier by the ELICIT_FIRST
-  // gate (decide.js) — the pipeline returns a deterministic response that
-  // never reaches the LLM, so there is no leak surface. The old behavior
-  // (continue_conversation + Socratic directives) was a prompt-level
-  // mitigation; the new behavior is a structural guarantee.
+  // These bare-equation drops are caught by the ELICIT_FIRST gate
+  // (decide.js). The pipeline routes the action and attaches strong
+  // anti-leak directives, but the LLM still generates the reply so the
+  // tutor speaks in voice — no canned templates.
   // ────────────────────────────────────────────────────────────────────────
 
-  test('ANSWER LEAK BUG: "4x-15=21" routes to ELICIT_FIRST with deterministic response', async () => {
+  test('ANSWER LEAK BUG: "4x-15=21" routes to ELICIT_FIRST with anti-leak directives', async () => {
     const { observation, diagnosis, decision } = await runDeterministicStages(
       '4x-15=21',
       [] // no prior tutor messages — student is posing a new problem
@@ -724,12 +723,13 @@ describe('Tutor Validation: Answer Leak Prevention', () => {
     expect(diagnosis.type).toBe('no_answer');
     expect(diagnosis.isCorrect).toBeNull();
 
-    // Structural guarantee: bare drop → deterministic template, no LLM call.
+    // Bare drop → ELICIT_FIRST + directives, no deterministic template.
     expect(observation.isBareProblemDrop).toBe(true);
     expect(decision.action).toBe('elicit_first');
-    expect(typeof decision.deterministicResponse).toBe('string');
-    // The template must not reveal a solved answer.
-    expect(decision.deterministicResponse).not.toMatch(/x\s*=\s*-?\d/);
+    expect(decision.deterministicResponse).toBeUndefined();
+
+    const joined = decision.directives.join('\n').toLowerCase();
+    expect(joined).toMatch(/do not solve|do not show steps|do not name the answer/);
   });
 
   test('ANSWER LEAK BUG: "3^(x+1) = 81" routes to ELICIT_FIRST', async () => {
@@ -743,6 +743,7 @@ describe('Tutor Validation: Answer Leak Prevention', () => {
     expect(diagnosis.type).toBe('no_answer');
     expect(observation.isBareProblemDrop).toBe(true);
     expect(decision.action).toBe('elicit_first');
+    expect(decision.deterministicResponse).toBeUndefined();
   });
 
   test('ANSWER LEAK BUG: "3(3^x + 3^(x+1)) = 108" routes to ELICIT_FIRST', async () => {
@@ -756,6 +757,7 @@ describe('Tutor Validation: Answer Leak Prevention', () => {
     expect(diagnosis.type).toBe('no_answer');
     expect(observation.isBareProblemDrop).toBe(true);
     expect(decision.action).toBe('elicit_first');
+    expect(decision.deterministicResponse).toBeUndefined();
   });
 
   test('ANSWER LEAK BUG: "solve 2x + 5 = 13" routes to ELICIT_FIRST', async () => {
@@ -769,6 +771,24 @@ describe('Tutor Validation: Answer Leak Prevention', () => {
     expect(observation.answer).toBeNull();
     expect(observation.isBareProblemDrop).toBe(true);
     expect(decision.action).toBe('elicit_first');
+    expect(decision.deterministicResponse).toBeUndefined();
+  });
+
+  // Regression: the misfire from the production transcript. Maya asked
+  // "what's the first step?" and the student answered with the antiderivative.
+  // The detector was treating that math reply as a fresh problem drop and
+  // hijacking the conversation with a canned template.
+  test('REGRESSION: math reply to tutor\'s step prompt is NOT a bare drop', async () => {
+    const { observation, decision } = await runDeterministicStages(
+      '1/3x^3',
+      [
+        'Let\'s find the definite integral of f(x)=x² from x=1 to x=3.',
+        'What\'s the first step you think we should take to set this up?',
+      ]
+    );
+    expect(observation.isBareProblemDrop).toBe(false);
+    expect(decision.action).not.toBe('elicit_first');
+    expect(decision.deterministicResponse).toBeUndefined();
   });
 
   // ────────────────────────────────────────────────────────────────────────

--- a/utils/pipeline/decide.js
+++ b/utils/pipeline/decide.js
@@ -118,30 +118,31 @@ function decideCore(observation, diagnosis, context) {
     directives: [], // Additional instructions for the generate stage
   };
 
-  // ── Bare problem drop — deterministic elicit-first gate ──
+  // ── Bare problem drop — elicit-first gate ──
   //
   // Student handed over a new math problem (e.g. "4x-5=22", "x²=49") with
   // no attempt, no stuck-point, no reasoning. This is the single highest-
-  // risk moment for answer leaks — GPT's helpfulness training wins the
-  // fight against every prompt directive. So we take the LLM out of the
-  // loop entirely: return a deterministic response asking for the student's
-  // work or offering a parallel example.
+  // risk moment for answer leaks — the LLM's helpfulness training pushes
+  // it to solve the problem outright. The decide stage marks the action
+  // so generate can attach strong anti-leak directives; the tutor still
+  // responds in voice, like a human would.
   //
   // Gate conditions:
   //   - observation flagged isBareProblemDrop (structural signals)
   //   - no recent upload (worksheet flow has its own guards)
   //   - no active mastery/lesson phase (those are structured contexts with
   //     their own appropriate pedagogical path, e.g. I-DO phase teaches)
-  //
-  // When this fires, the LLM does not generate the turn — the deterministic
-  // template in decision.deterministicResponse is returned verbatim.
   if (observation.isBareProblemDrop
       && !context.hasRecentUpload
       && !phaseState?.currentPhase) {
     decision.action = ACTIONS.ELICIT_FIRST;
-    decision.deterministicResponse = buildElicitFirstResponse(observation.raw, context);
     decision.directives.push(
-      'BARE PROBLEM DROP: student handed over a new problem with no attempt or question. This turn is deterministic — no LLM generation, no leak surface.'
+      'BARE PROBLEM DROP: the student handed you a new problem with no attempt, no stuck-point, no reasoning. Respond like a human tutor — in your own voice, not a template.',
+      'DO NOT solve. DO NOT show steps. DO NOT name the answer or any intermediate value. DO NOT walk through the method.',
+      'DO show interest in the problem and invite them in: ask where they want to start, what they already see, or which part feels unclear. One short, natural opener — not a checklist.',
+      'If they truly have nothing, offer to work a similar problem (different numbers) first, then hand the original back to them.',
+      'NEVER use canned phrasing like "show me what you tried" or "what step is tripping you up" — say it the way YOU would say it, fitted to this student and this problem.',
+      'Keep it short. 1–3 sentences. End with a single concrete invitation, not a wall of questions.'
     );
     return decision;
   }
@@ -545,30 +546,6 @@ function decideCore(observation, diagnosis, context) {
     'Do NOT repeat information already confirmed or covered.'
   );
   return decision;
-}
-
-/**
- * Build the deterministic response for a bare problem drop.
- *
- * This text is returned to the student VERBATIM — it never passes through
- * an LLM, so it cannot leak an answer regardless of model behavior. Voice
- * is kept neutral-warm; tutor-specific personality layering happens in
- * follow-up turns once the student engages.
- *
- * @param {string} problem - The student's raw message (treated as the problem)
- * @param {Object} context - Pipeline context (for user firstName, if available)
- * @returns {string}
- */
-function buildElicitFirstResponse(problem, context) {
-  const cleaned = (problem || '').trim().replace(/\s+/g, ' ').slice(0, 100);
-  const firstName = context?.user?.firstName;
-  const opener = firstName ? `Got it, ${firstName}` : 'Got it';
-  const problemEcho = cleaned ? ` — ${cleaned}.` : '.';
-  return (
-    `${opener}${problemEcho}\n\n` +
-    `Before I help, show me what you've tried so far — even if it's a guess — or tell me which step is tripping you up.\n\n` +
-    `If you're truly starting from zero, say **"show me an example"** and I'll walk through a similar problem, then you try yours.`
-  );
 }
 
 // Transitions that indicate the student's message is off the plan target.

--- a/utils/pipeline/generate.js
+++ b/utils/pipeline/generate.js
@@ -125,6 +125,15 @@ function buildActionPrompt(decision) {
       parts.push('Brief, not preachy. One sentence redirect, then offer a problem.');
       break;
 
+    case ACTIONS.ELICIT_FIRST:
+      parts.push('The student dropped a fresh problem with no work attached. You are NOT solving it. Read the room first.');
+      parts.push('Respond in your tutor voice — warm, brief, curious about THEIR thinking. Sound like a person, not a form.');
+      parts.push('Do not echo the problem back verbatim, do not announce a procedure, do not list steps, do not state any value that could be part of the answer.');
+      parts.push('Pick ONE natural opener that invites them in — e.g. wonder where they want to start, ask what they notice, or offer to work a parallel problem if they\'re cold.');
+      parts.push('No canned phrasing. Avoid the literal strings "show me what you tried", "what step is tripping you up", "say show me an example".');
+      parts.push('1–3 sentences. End with a single concrete invitation, not a barrage of questions.');
+      break;
+
     case ACTIONS.PRESENT_PROBLEM:
       parts.push('Present the next problem for the student to work on.');
       parts.push('ANSWER-DUMP GUARD: Do NOT state, hint at, or embed the answer in the problem presentation.');

--- a/utils/pipeline/observe.js
+++ b/utils/pipeline/observe.js
@@ -297,6 +297,45 @@ function detectStreaks(recentUserMessages) {
 }
 
 /**
+ * Did the tutor's last message ask the student to perform or describe the
+ * next math step? If yes, any math-shaped reply is an answer attempt to that
+ * step — not a fresh problem drop. Without this guard, the bare-drop gate
+ * fires mid-conversation and clobbers the student's work with a canned
+ * "show me what you tried" message.
+ *
+ * Matches "what's the first step", "what do you think we should do",
+ * "what's next", "now what", "try it", "can you evaluate", etc.
+ *
+ * Returns false when there is no last assistant message or it doesn't
+ * read as a step-guidance question.
+ */
+function lastTutorAskedForNextStep(recentAssistantMessages) {
+  if (!recentAssistantMessages || recentAssistantMessages.length === 0) return false;
+  const last = recentAssistantMessages[recentAssistantMessages.length - 1];
+  const text = (last?.content || '').toLowerCase();
+  if (!text) return false;
+  if (!/\?/.test(text)) return false;
+
+  const stepGuidance = [
+    /\bwhat'?s\s+the\s+(?:next|first|second|third|last|final)\s+step\b/,
+    /\bwhat\s+(?:do|should|would|could)\s+(?:we|you)\s+(?:do|try|use|think|get|notice|see|need|start|begin)\b/,
+    /\bwhat\s+(?:do|did)\s+you\s+(?:think|get|notice|see|find|come\s+up\s+with)\b/,
+    /\bwhat'?s\s+(?:next|the\s+(?:answer|result|value|next\s+step))\b/,
+    /\bnow\s+what\b/,
+    /\bany\s+ideas?\b/,
+    /\bcan\s+you\s+(?:tell|show|try|evaluate|simplify|factor|solve|find|compute|integrate|differentiate|plug|substitute)\b/,
+    /\b(?:give\s+it\s+a\s+(?:try|shot)|take\s+a\s+(?:try|shot|stab)|try\s+(?:it|that|this|one))\b/,
+    /\bwhat\s+about\s+(?:the\s+)?(?:next|second|first|other|remaining)\s+(?:step|part|piece)\b/,
+    /\bplug(?:\s+(?:that|those|it|in))\b/,
+    /\bevaluate\s+(?:at|that|this|it)\b/,
+    /\bhow\s+(?:do|would|should)\s+(?:we|you)\s+(?:start|begin|approach|set\s+up|tackle)\b/,
+    /\bwhat\s+(?:goes?|happens?)\s+(?:there|next|in\s+the\s+blank)\b/,
+  ];
+
+  return stepGuidance.some(pat => pat.test(text));
+}
+
+/**
  * Detect a "bare problem drop" — the student handed over a new math problem
  * (equation, expression, worked-problem prompt) without an attempt, without
  * a specific stuck point, and without reasoning language.
@@ -312,16 +351,22 @@ function detectStreaks(recentUserMessages) {
  *   "I'm stuck on step 2 of 4x-5=22"             (stuck indicator)
  *   "after I factor, what do I do next?"          (reasoning indicator)
  *   "the square root of 49 is 7"                  (statement, not a new problem)
+ *   ANY math reply right after the tutor asked "what's the next step?"
  *
- * When this fires, the pipeline must respond deterministically — ask what
- * the student tried or offer a parallel example. Never solve.
+ * When this fires, the decide stage steers the LLM to ask for the student's
+ * work or offer a parallel example. Never solve.
  *
  * @returns {boolean}
  */
-function detectBareProblemDrop(text, messageType, hasAnswer) {
+function detectBareProblemDrop(text, messageType, hasAnswer, recentAssistantMessages) {
   if (!text || typeof text !== 'string') return false;
   const t = text.trim();
   if (t.length === 0 || t.length > 140) return false;
+
+  // Conversation guard: if the tutor just asked the student to perform or
+  // describe a step, the student's math reply is an answer to that step, not
+  // a fresh problem. Suppress the bare-drop flag.
+  if (lastTutorAskedForNextStep(recentAssistantMessages)) return false;
 
   // Message types that encode student intent already — don't override.
   const NON_DROP_TYPES = new Set([
@@ -468,9 +513,13 @@ function observe(message, context = {}) {
 
   // Detect a bare problem drop — student handed over a new problem with no
   // attempt and no specific question. This is the #1 leak vector: LLM
-  // defaults to helpfulness and solves it. The pipeline must respond
-  // deterministically when this fires (see decide.js ELICIT_FIRST action).
-  const isBareProblemDrop = detectBareProblemDrop(text, messageType, !!answer);
+  // defaults to helpfulness and solves it. The pipeline steers the LLM with
+  // anti-leak directives when this fires (see decide.js ELICIT_FIRST action).
+  // We pass recent tutor turns so a math reply to "what's the next step?"
+  // doesn't get misread as a fresh drop.
+  const isBareProblemDrop = detectBareProblemDrop(
+    text, messageType, !!answer, context.recentAssistantMessages
+  );
 
   return {
     messageType,
@@ -502,6 +551,7 @@ module.exports = {
   detectParroting,
   detectEvasiveAffirmative,
   detectBareProblemDrop,
+  lastTutorAskedForNextStep,
   MESSAGE_TYPES,
   CONTEXT_SIGNALS,
   PATTERNS,


### PR DESCRIPTION
## Why

From a live transcript:

> **Maya:** What's the first step you think we should take to set this up? ✨
> **Jason:** `1/3x^3`
> **Maya:** Got it, Jason — 1/3x^3.
>
> Before I help, show me what you've tried so far — even if it's a guess — or tell me which step is tripping you up.
>
> If you're truly starting from zero, say **"show me an example"** and I'll walk through a similar problem, then you try yours.

Two problems:

1. **Scripted voice.** The reply is a verbatim template baked into the code (`utils/pipeline/decide.js`). Maya's personality, the conversational thread, even the student's name handling — all overwritten by the same canned paragraph every time.
2. **Misfires mid-conversation.** The bare-problem-drop detector doesn't look at context. When Maya just asked "what's the next step?" any math-shaped reply gets misread as a brand-new problem drop, hijacking the conversation and clobbering the student's actual work (the antiderivative they correctly produced).

## What changed

- **`utils/pipeline/observe.js`** — `detectBareProblemDrop` now accepts `recentAssistantMessages`. A new helper `lastTutorAskedForNextStep` skips the bare-drop flag when the tutor's previous turn ended in `?` and contains a step-guidance phrase ("what's the first step", "what do you think we should do", "can you evaluate", "now what", etc.). Fresh drops with no prior tutor turn still flag, and generic invites like "what do you want to work on?" still let a real drop through.
- **`utils/pipeline/decide.js`** — `ELICIT_FIRST` no longer attaches a `deterministicResponse`. The LLM generates the turn under strong directives: don't solve, don't show steps, don't name any value, and explicitly don't use the old canned phrasing. The `buildElicitFirstResponse` helper is removed.
- **`utils/pipeline/generate.js`** — Added an `ELICIT_FIRST` case in `buildActionPrompt` that gives the LLM in-voice tactical guidance (1–3 sentences, one natural opener, offer a parallel problem if the student is cold).
- **Tests** — Updated `bareProblemDrop.test.js` and `tutorValidation.test.js` to assert the new directive-based behavior; added regression tests for the misfire (math reply to a step prompt) and for the false-trigger case (fresh drop after a generic invite still flags).

## Trade-off

The deterministic template existed as a "structural guarantee" against LLM answer-leaks on cold drops — no LLM, no leak. We're trading that hard guarantee for in-voice replies plus explicit anti-leak directives in the system prompt. Per @jnappier7's call (selected "Both: context-aware + LLM voice").

## Test plan

- [x] `npx jest tests/unit/` — all 2159 tests pass
- [ ] Manual: open a fresh chat, drop a bare problem ("4x-5=22") → Maya responds in her voice, no canned phrasing, doesn't leak the answer
- [ ] Manual: ask Maya to set up an integral, answer her "first step" prompt with raw math → conversation continues normally, no canned interruption
- [ ] Manual: upload a worksheet → behavior unchanged (worksheet path still owns its own guards)

https://claude.ai/code/session_011aXhF1fhZ6pWFbiPLVmihn

---
_Generated by [Claude Code](https://claude.ai/code/session_011aXhF1fhZ6pWFbiPLVmihn)_