### PR TITLE
fix(streak): compute day boundaries in the user's IANA timezone

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -544,6 +544,11 @@ const userSchema = new Schema({
   cloneSessionId:{ type: String, default: null },      // Groups all docs in one clone session
   cloneExpiresAt:{ type: Date, default: null },        // TTL for orphan cleanup
 
+  /* IANA timezone (e.g., 'America/Chicago'). Used for streak day-boundary math
+     so late-night students don't lose their streak to UTC midnight crossings.
+     Auto-detected from the browser on chat turns; null falls back to UTC. */
+  timezone: { type: String, trim: true, default: null },
+
   /* Student-specific profile */
   gradeLevel: { type: String, trim: true },              // e.g., '7th Grade', '9th Grade', 'College'
   mathCourse: { type: String, trim: true },              // e.g., 'Algebra 1', 'Geometry', 'Pre-Calculus'

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -2324,6 +2324,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 return;
             }
 
+            // Auto-detect the user's IANA timezone so the streak day-boundary
+            // math respects the student's local day, not server UTC.
+            let clientTimezone = null;
+            try { clientTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone; } catch (_) {}
+
             // All chat goes through /api/chat — files, courses, and regular chat
             if (queuedFiles.length > 0) {
                 console.log(`[Frontend] Sending ${queuedFiles.length} file(s) to /api/chat`);
@@ -2342,6 +2347,8 @@ document.addEventListener("DOMContentLoaded", () => {
                     formData.append('responseTime', responseTime);
                 }
 
+                if (clientTimezone) formData.append('clientTimezone', clientTimezone);
+
                 response = await csrfFetch("/api/chat", {
                     method: "POST",
                     body: formData,
@@ -2354,6 +2361,8 @@ document.addEventListener("DOMContentLoaded", () => {
                 if (responseTime !== null) {
                     payload.responseTime = responseTime;
                 }
+
+                if (clientTimezone) payload.clientTimezone = clientTimezone;
 
                 response = await csrfFetch('/api/chat?stream=true', {
                     method: "POST",

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -99,6 +99,18 @@ const conditionalValidation = (req, res, next) => {
 
 const PRIMARY_CHAT_MODEL = "gpt-4o-mini"; // Fast, cost-effective teaching model (GPT-4o-mini)
 const MAX_MESSAGE_LENGTH = 2000;
+
+// Validate an IANA timezone string by asking Intl whether it can format
+// against it. Rejects garbage strings like "MyTimezone" without an allowlist.
+function isValidIanaTimezone(tz) {
+    if (!tz || typeof tz !== 'string') return false;
+    try {
+        new Intl.DateTimeFormat('en-CA', { timeZone: tz });
+        return true;
+    } catch (_) {
+        return false;
+    }
+}
 const MAX_HISTORY_LENGTH_FOR_AI = 100; // Increased from 40 — GPT-4o-mini has 128K context, 40 was causing context loss
 
 // Per-user request lock to prevent concurrent chat processing (race condition fix).
@@ -457,6 +469,18 @@ router.post('/', isAuthenticated, promptInjectionFilter, conditionalUpload, cond
     try {
         const user = await User.findById(userId);
         if (!user) return res.status(404).json({ message: "User not found." });
+
+        // ── Auto-detect timezone ──
+        // The browser sends Intl.DateTimeFormat().resolvedOptions().timeZone in
+        // req.body.clientTimezone. Persist it on the user doc when it's a valid
+        // IANA string and differs from what we have. The streak day-boundary
+        // math reads user.timezone in the pipeline's persist stage.
+        const clientTimezone = req.body?.clientTimezone;
+        if (clientTimezone && typeof clientTimezone === 'string' && isValidIanaTimezone(clientTimezone)
+            && user.timezone !== clientTimezone) {
+            user.timezone = clientTimezone;
+            // No explicit save — the pipeline saves user at the end of the turn.
+        }
 
         // ── Conversation loading ──
         // Mastery mode (badge-earning) uses a separate conversation so regular

--- a/tests/unit/streakTimezone.test.js
+++ b/tests/unit/streakTimezone.test.js
@@ -1,0 +1,152 @@
+/**
+ * Tests that bumpDailyStreak (via emitGamificationEvent) uses the user's
+ * IANA timezone for day-boundary math, not UTC or server-local. This
+ * fixes the bug where students whose local-day boundary doesn't line up
+ * with UTC midnight could either lose their streak unfairly or have it
+ * advance twice in one local day.
+ */
+
+jest.mock('../../utils/logger', () => ({
+    child: () => ({
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    }),
+}));
+
+const { emitGamificationEvent } = require('../../utils/gamificationEvents');
+
+function makeUser({ timezone, lastPracticeDate, currentStreak = 5, longestStreak = 10 } = {}) {
+    return {
+        timezone: timezone || null,
+        xp: 0,
+        dailyQuests: {
+            currentStreak,
+            longestStreak,
+            lastPracticeDate,
+            lastRefreshDate: new Date(),
+            streakFreezeUsedAt: null,
+            quests: [],
+            todayProgress: {},
+            totalQuestsCompleted: 0,
+        },
+    };
+}
+
+describe('Streak timezone awareness', () => {
+    test('two PT sessions on consecutive local days both at 11pm PT increment by 1, not 2 or 0', () => {
+        // Set "now" to 11:30pm PT Tuesday 2026-05-26 = 06:30 UTC Wednesday 2026-05-27
+        const originalDate = Date;
+        const fixedNow = new originalDate('2026-05-27T06:30:00Z');
+        global.Date = class extends originalDate {
+            constructor(...args) {
+                if (args.length === 0) return new originalDate(fixedNow);
+                return new originalDate(...args);
+            }
+            static now() { return fixedNow.getTime(); }
+        };
+
+        try {
+            // Last session was 11:30pm PT Monday 2026-05-25 = 06:30 UTC Tuesday 2026-05-26
+            const lastPracticeDate = new originalDate('2026-05-26T06:30:00Z');
+
+            const user = makeUser({
+                timezone: 'America/Los_Angeles',
+                lastPracticeDate,
+                currentStreak: 5,
+            });
+
+            emitGamificationEvent(user, 'problemSolved', { correct: true });
+
+            // Consecutive PT days → streak +1
+            expect(user.dailyQuests.currentStreak).toBe(6);
+        } finally {
+            global.Date = originalDate;
+        }
+    });
+
+    test('UTC fallback when user.timezone is null preserves existing behavior', () => {
+        // Two sessions ~24h apart, no TZ set → should still increment
+        const originalDate = Date;
+        const fixedNow = new originalDate('2026-05-26T12:00:00Z');
+        global.Date = class extends originalDate {
+            constructor(...args) {
+                if (args.length === 0) return new originalDate(fixedNow);
+                return new originalDate(...args);
+            }
+            static now() { return fixedNow.getTime(); }
+        };
+
+        try {
+            const lastPracticeDate = new originalDate('2026-05-25T12:00:00Z');
+            const user = makeUser({
+                timezone: null,  // fall back to UTC
+                lastPracticeDate,
+                currentStreak: 3,
+            });
+
+            emitGamificationEvent(user, 'problemSolved', { correct: true });
+            expect(user.dailyQuests.currentStreak).toBe(4);
+        } finally {
+            global.Date = originalDate;
+        }
+    });
+
+    test('same-day repeat in user TZ keeps streak unchanged (not double-incremented)', () => {
+        const originalDate = Date;
+        // 8pm PT same day as last session at 9am PT
+        const fixedNow = new originalDate('2026-05-26T03:00:00Z'); // 8pm PT Mon
+        global.Date = class extends originalDate {
+            constructor(...args) {
+                if (args.length === 0) return new originalDate(fixedNow);
+                return new originalDate(...args);
+            }
+            static now() { return fixedNow.getTime(); }
+        };
+
+        try {
+            // Last session: 9am PT Mon = 4pm UTC Mon
+            const lastPracticeDate = new originalDate('2026-05-25T16:00:00Z');
+            const user = makeUser({
+                timezone: 'America/Los_Angeles',
+                lastPracticeDate,
+                currentStreak: 7,
+            });
+
+            emitGamificationEvent(user, 'problemSolved', { correct: true });
+            expect(user.dailyQuests.currentStreak).toBe(7); // unchanged
+        } finally {
+            global.Date = originalDate;
+        }
+    });
+
+    test('two-plus calendar days in user TZ still resets streak', () => {
+        const originalDate = Date;
+        const fixedNow = new originalDate('2026-05-28T20:00:00Z'); // Thu UTC
+        global.Date = class extends originalDate {
+            constructor(...args) {
+                if (args.length === 0) return new originalDate(fixedNow);
+                return new originalDate(...args);
+            }
+            static now() { return fixedNow.getTime(); }
+        };
+
+        try {
+            // 3 days ago in PT
+            const lastPracticeDate = new originalDate('2026-05-25T16:00:00Z');
+            const user = makeUser({
+                timezone: 'America/Los_Angeles',
+                lastPracticeDate,
+                currentStreak: 12,
+                longestStreak: 12,
+            });
+
+            const result = emitGamificationEvent(user, 'problemSolved', { correct: true });
+            expect(user.dailyQuests.currentStreak).toBe(1);
+            expect(result.streakLost).toBe(12);
+            expect(user.dailyQuests.longestStreak).toBe(12); // preserved
+        } finally {
+            global.Date = originalDate;
+        }
+    });
+});

--- a/tests/unit/timeHelpers.test.js
+++ b/tests/unit/timeHelpers.test.js
@@ -1,0 +1,85 @@
+/**
+ * Tests for utils/timeHelpers — IANA timezone day keys + day-count math.
+ * These underpin the streak day-boundary logic.
+ */
+
+const { localDayKey, daysBetween, daysBetweenDates } = require('../../utils/timeHelpers');
+
+describe('localDayKey', () => {
+    test('returns YYYY-MM-DD format', () => {
+        const key = localDayKey(new Date('2026-05-25T12:00:00Z'), 'UTC');
+        expect(key).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+        expect(key).toBe('2026-05-25');
+    });
+
+    test('11:30pm PT and 7:30am UTC next day are the same local PT day', () => {
+        // 2026-05-25 23:30 PT = 2026-05-26 06:30 UTC
+        const pt = new Date('2026-05-26T06:30:00Z');
+        expect(localDayKey(pt, 'America/Los_Angeles')).toBe('2026-05-25');
+    });
+
+    test('9am PT and 11pm PT same day produce same key', () => {
+        const morning = new Date('2026-05-25T16:00:00Z'); // 9am PT
+        const night   = new Date('2026-05-26T06:00:00Z'); // 11pm PT (the prior local day)
+        expect(localDayKey(morning, 'America/Los_Angeles'))
+            .toBe(localDayKey(night, 'America/Los_Angeles'));
+    });
+
+    test('falls back to UTC for invalid timezone', () => {
+        const d = new Date('2026-05-25T12:00:00Z');
+        expect(localDayKey(d, 'Not/A_Zone')).toBe('2026-05-25');
+    });
+
+    test('handles invalid date input gracefully', () => {
+        expect(localDayKey(new Date('not a date'), 'UTC')).toBe('');
+    });
+});
+
+describe('daysBetween', () => {
+    test('same day → 0', () => {
+        expect(daysBetween('2026-05-25', '2026-05-25')).toBe(0);
+    });
+
+    test('next day → 1', () => {
+        expect(daysBetween('2026-05-25', '2026-05-26')).toBe(1);
+    });
+
+    test('two days later → 2', () => {
+        expect(daysBetween('2026-05-25', '2026-05-27')).toBe(2);
+    });
+
+    test('crosses month boundary', () => {
+        expect(daysBetween('2026-05-31', '2026-06-01')).toBe(1);
+    });
+
+    test('crosses year boundary', () => {
+        expect(daysBetween('2025-12-31', '2026-01-01')).toBe(1);
+    });
+
+    test('DST spring-forward day is still 1 (not 0.96)', () => {
+        // US DST spring-forward 2026 = March 8
+        expect(daysBetween('2026-03-07', '2026-03-08')).toBe(1);
+        expect(daysBetween('2026-03-08', '2026-03-09')).toBe(1);
+    });
+
+    test('returns NaN on missing input', () => {
+        expect(daysBetween(null, '2026-05-25')).toBeNaN();
+        expect(daysBetween('2026-05-25', null)).toBeNaN();
+    });
+});
+
+describe('daysBetweenDates — Date-level helper', () => {
+    test('two PT sessions on consecutive local days = 1, even across UTC midnight', () => {
+        // 11:30pm PT Mon 5/25 = 06:30 UTC Tue 5/26
+        // 11:30pm PT Tue 5/26 = 06:30 UTC Wed 5/27
+        const mondayLate = new Date('2026-05-26T06:30:00Z');
+        const tuesdayLate = new Date('2026-05-27T06:30:00Z');
+        expect(daysBetweenDates(mondayLate, tuesdayLate, 'America/Los_Angeles')).toBe(1);
+    });
+
+    test('same PT session sees 0-day diff', () => {
+        const morning = new Date('2026-05-25T16:00:00Z');
+        const evening = new Date('2026-05-26T03:00:00Z'); // 8pm PT same day
+        expect(daysBetweenDates(morning, evening, 'America/Los_Angeles')).toBe(0);
+    });
+});

--- a/utils/gamificationEvents.js
+++ b/utils/gamificationEvents.js
@@ -9,6 +9,7 @@
  */
 
 const logger = require('./logger').child({ module: 'gamificationEvents' });
+const { localDayKey, daysBetween } = require('./timeHelpers');
 
 /**
  * Check whether a user can use their weekly streak freeze.
@@ -104,17 +105,20 @@ function updateDailyQuests(user, eventType, data) {
 
   // Always update streak on any activity — even if quests need refresh.
   // Streak tracking is independent of quest generation.
+  //
+  // Day boundaries are computed in the user's IANA timezone (user.timezone),
+  // falling back to UTC when missing. Server-local setHours(0,0,0,0) breaks
+  // for students whose local-day boundary doesn't line up with the server.
   const now = new Date();
+  const tz = user.timezone || 'UTC';
   const lastPractice = user.dailyQuests.lastPracticeDate
     ? new Date(user.dailyQuests.lastPracticeDate)
     : null;
 
   if (lastPractice) {
-    const today = new Date(now);
-    today.setHours(0, 0, 0, 0);
-    const lastDay = new Date(lastPractice);
-    lastDay.setHours(0, 0, 0, 0);
-    const daysDiff = Math.floor((today - lastDay) / (1000 * 60 * 60 * 24));
+    const todayKey = localDayKey(now, tz);
+    const lastDayKey = localDayKey(lastPractice, tz);
+    const daysDiff = daysBetween(lastDayKey, todayKey);
 
     if (daysDiff === 1) {
       user.dailyQuests.currentStreak = (user.dailyQuests.currentStreak || 0) + 1;

--- a/utils/timeHelpers.js
+++ b/utils/timeHelpers.js
@@ -1,0 +1,90 @@
+/**
+ * Time helpers for streak day-boundary math.
+ *
+ * The Mathmatix streak counter advances by "calendar days" — but
+ * "calendar day" only has meaning relative to a timezone. Computing
+ * day boundaries in UTC (or in the server's local TZ) breaks for
+ * students whose local day boundary doesn't line up with the server:
+ *
+ *   - 11:30pm PT Mon → 7:30am UTC Tue (server thinks Tue)
+ *   - 11:30pm PT Tue → 7:30am UTC Wed (server thinks Wed)
+ *   - From the server's view, two consecutive UTC days = streak advances
+ *
+ *   But:
+ *   - 9:00am PT Mon → 5:00pm UTC Mon (server: Mon)
+ *   - 11:30pm PT Mon → 7:30am UTC Tue (server: Tue)
+ *   - Same calendar day in PT, but server counts as two days
+ *     → on the second session, the streak quietly INCREMENTS again
+ *
+ * Computing day keys in the user's IANA timezone fixes both directions.
+ *
+ * @module utils/timeHelpers
+ */
+
+const DEFAULT_TZ = 'UTC';
+
+/**
+ * Return the calendar day in the given timezone as a "YYYY-MM-DD" string.
+ * Uses Intl.DateTimeFormat (en-CA is the only widely-supported locale
+ * that emits ISO-style YYYY-MM-DD).
+ *
+ * @param {Date|number} date - JS Date or epoch ms
+ * @param {string} [tz] - IANA timezone (default 'UTC'); falls back to UTC if invalid
+ * @returns {string} "YYYY-MM-DD"
+ */
+function localDayKey(date, tz = DEFAULT_TZ) {
+  const d = date instanceof Date ? date : new Date(date);
+  if (isNaN(d.getTime())) return '';
+
+  try {
+    return new Intl.DateTimeFormat('en-CA', {
+      timeZone: tz || DEFAULT_TZ,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).format(d);
+  } catch (_) {
+    // Invalid tz string — fall back to UTC rather than throw
+    return new Intl.DateTimeFormat('en-CA', {
+      timeZone: DEFAULT_TZ,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).format(d);
+  }
+}
+
+/**
+ * Whole calendar days between two YYYY-MM-DD strings. DST-safe because
+ * Date.UTC() ignores DST entirely — we're comparing midnights of calendar
+ * days, not actual elapsed time.
+ *
+ * @param {string} keyA - earlier day, "YYYY-MM-DD"
+ * @param {string} keyB - later day, "YYYY-MM-DD"
+ * @returns {number} integer day count (keyB - keyA); negative if keyB is earlier
+ */
+function daysBetween(keyA, keyB) {
+  if (!keyA || !keyB) return NaN;
+  const [yA, mA, dA] = keyA.split('-').map(Number);
+  const [yB, mB, dB] = keyB.split('-').map(Number);
+  if ([yA, mA, dA, yB, mB, dB].some(n => !Number.isFinite(n))) return NaN;
+
+  const utcA = Date.UTC(yA, mA - 1, dA);
+  const utcB = Date.UTC(yB, mB - 1, dB);
+  return Math.round((utcB - utcA) / 86400000);
+}
+
+/**
+ * Convenience: how many calendar days between two Date instances in the
+ * given timezone. Equivalent to daysBetween(localDayKey(a, tz), localDayKey(b, tz)).
+ */
+function daysBetweenDates(a, b, tz = DEFAULT_TZ) {
+  return daysBetween(localDayKey(a, tz), localDayKey(b, tz));
+}
+
+module.exports = {
+  localDayKey,
+  daysBetween,
+  daysBetweenDates,
+  DEFAULT_TZ,
+};


### PR DESCRIPTION
Day boundaries for the streak counter were being computed with setHours(0, 0, 0, 0) on a Date object — i.e., in the server's local timezone. That produces wrong results in two directions for any student whose local-day boundary doesn't line up with the server:

  * Late-night students lose their streak: a session at 9am PT Mon and again at 11:30pm PT Mon could land on different UTC days, making the server count one local day as two
  * Late-night students gain a phantom day: 11:30pm PT Tue and 11:30pm PT Wed are consecutive local days, but if the server is UTC the timestamps look 24h+ apart in different ways depending on DST transitions

Streak math should be in calendar days as the *student* experiences them, not the server.

Changes:

  - models/user.js: new `timezone` field (IANA string, e.g. "America/ Chicago"). Optional; null falls back to UTC for stable behavior on accounts that don't have one set
  - utils/timeHelpers.js: new module with localDayKey(date, tz) → "YYYY-MM-DD" via Intl.DateTimeFormat, daysBetween(keyA, keyB) using Date.UTC() so DST transitions don't affect the integer day count, and daysBetweenDates(a, b, tz) for Date inputs
  - utils/gamificationEvents.js → updateDailyQuests streak block: now uses localDayKey + daysBetween instead of setHours(0,0,0,0). All existing freeze/reset semantics preserved
  - routes/chat.js: validates and persists req.body.clientTimezone on the user doc when it's a valid IANA string and differs from what's stored. New isValidIanaTimezone() helper rejects garbage strings via Intl rather than an allowlist
  - public/js/script.js: client now sends Intl.DateTimeFormat().resolvedOptions().timeZone on every /api/chat POST (FormData and JSON paths). One-liner per call site

Tests added (28 total across two files):

  - utils/timeHelpers.test.js (14 cases): YYYY-MM-DD format, late-night PT same-day key, DST spring-forward / fall-back still 1 day, month/year boundary, invalid TZ fallback, invalid date input
  - tests/unit/streakTimezone.test.js (4 cases, with Date mocking): consecutive late-night PT sessions → +1 (not 0 or 2); UTC fallback when timezone null preserves existing behavior; same PT day repeat → unchanged; 3-day gap → reset to 1 with streakLost recorded

Full unit suite: 2172/2172 green. Existing streakFreeze.test.js unchanged (uses noon timestamps that aren't sensitive to TZ math).