### PR TITLE
fix(streak): bump on every chat turn, not just on graded problem answers

### DIFF
--- a/tests/unit/bumpDailyStreak.test.js
+++ b/tests/unit/bumpDailyStreak.test.js
@@ -1,0 +1,109 @@
+// tests/unit/bumpDailyStreak.test.js
+// Tests for the bumpDailyStreak helper. Streak updates must NOT depend on
+// problem classification — reaching this code means the student engaged in
+// a substantive session turn. Prior bug: streak was gated behind a flaky
+// turn-classifier and stuck at 2 days for months of active use.
+
+jest.mock('../../utils/logger', () => ({
+    child: () => ({
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    }),
+}));
+
+const { bumpDailyStreak } = require('../../utils/gamificationEvents');
+
+function daysAgo(n) {
+    const d = new Date();
+    d.setDate(d.getDate() - n);
+    d.setHours(12, 0, 0, 0);
+    return d;
+}
+
+describe('bumpDailyStreak', () => {
+
+    test('initializes dailyQuests when missing', () => {
+        const user = {};
+        bumpDailyStreak(user);
+        expect(user.dailyQuests).toBeDefined();
+        expect(user.dailyQuests.currentStreak).toBe(1);
+        expect(user.dailyQuests.lastPracticeDate).toBeInstanceOf(Date);
+    });
+
+    test('first-ever practice starts streak at 1', () => {
+        const user = { dailyQuests: { currentStreak: 0, longestStreak: 0, lastPracticeDate: null } };
+        bumpDailyStreak(user);
+        expect(user.dailyQuests.currentStreak).toBe(1);
+        expect(user.dailyQuests.longestStreak).toBe(1);
+    });
+
+    test('same-day repeat does not change streak', () => {
+        const user = { dailyQuests: { currentStreak: 7, longestStreak: 10, lastPracticeDate: new Date() } };
+        bumpDailyStreak(user);
+        expect(user.dailyQuests.currentStreak).toBe(7);
+    });
+
+    test('consecutive day increments streak', () => {
+        const user = { dailyQuests: { currentStreak: 4, longestStreak: 4, lastPracticeDate: daysAgo(1) } };
+        bumpDailyStreak(user);
+        expect(user.dailyQuests.currentStreak).toBe(5);
+        expect(user.dailyQuests.longestStreak).toBe(5);
+    });
+
+    test('one missed day consumes weekly freeze and increments', () => {
+        const user = { dailyQuests: { currentStreak: 6, longestStreak: 6, lastPracticeDate: daysAgo(2), streakFreezeUsedAt: null } };
+        const result = bumpDailyStreak(user);
+        expect(user.dailyQuests.currentStreak).toBe(7);
+        expect(result.streakFreezeUsed).toBe(true);
+        expect(user.dailyQuests.streakFreezeUsedAt).toBeInstanceOf(Date);
+    });
+
+    test('one missed day with freeze already used this week resets streak', () => {
+        const now = new Date();
+        const weekStartMs = Date.UTC(
+            now.getUTCFullYear(),
+            now.getUTCMonth(),
+            now.getUTCDate() - now.getUTCDay()
+        );
+        const recentFreezeTime = new Date(Math.max(
+            weekStartMs + 1000,
+            Date.now() - 60 * 60 * 1000
+        ));
+        const user = { dailyQuests: { currentStreak: 9, longestStreak: 9, lastPracticeDate: daysAgo(2), streakFreezeUsedAt: recentFreezeTime } };
+        const result = bumpDailyStreak(user);
+        expect(user.dailyQuests.currentStreak).toBe(1);
+        expect(result.streakLost).toBe(9);
+        expect(result.streakFreezeUsed).toBeUndefined();
+    });
+
+    test('two-plus missed days always resets streak', () => {
+        const user = { dailyQuests: { currentStreak: 20, longestStreak: 25, lastPracticeDate: daysAgo(3), streakFreezeUsedAt: null } };
+        const result = bumpDailyStreak(user);
+        expect(user.dailyQuests.currentStreak).toBe(1);
+        expect(result.streakLost).toBe(20);
+        expect(user.dailyQuests.longestStreak).toBe(25);
+    });
+
+    test('updates lastPracticeDate to now on every call', () => {
+        const old = daysAgo(1);
+        const user = { dailyQuests: { currentStreak: 3, lastPracticeDate: old } };
+        bumpDailyStreak(user);
+        expect(user.dailyQuests.lastPracticeDate.getTime()).toBeGreaterThan(old.getTime());
+    });
+
+    test('does not require a problem classification or quest data', () => {
+        // Regression: prior bug gated streak on problemAnswered + quests.length > 0.
+        // This helper must work on a bare engagement signal.
+        const user = { dailyQuests: { currentStreak: 2, lastPracticeDate: daysAgo(1) } };
+        bumpDailyStreak(user);
+        expect(user.dailyQuests.currentStreak).toBe(3);
+    });
+
+    test('longestStreak only updates when surpassed', () => {
+        const user = { dailyQuests: { currentStreak: 4, longestStreak: 50, lastPracticeDate: daysAgo(1) } };
+        bumpDailyStreak(user);
+        expect(user.dailyQuests.currentStreak).toBe(5);
+        expect(user.dailyQuests.longestStreak).toBe(50);
+    });
+});

--- a/utils/gamificationEvents.js
+++ b/utils/gamificationEvents.js
@@ -85,12 +85,9 @@ function emitGamificationEvent(user, eventType, data = {}) {
 }
 
 /**
- * Update daily quests based on an event.
- * Mirrors the logic in routes/dailyQuests.js POST handler but runs in-process.
+ * Initialize user.dailyQuests in place if missing. Idempotent.
  */
-function updateDailyQuests(user, eventType, data) {
-  const result = { completed: [], xpAwarded: 0 };
-
+function ensureDailyQuestsInit(user) {
   if (!user.dailyQuests) {
     user.dailyQuests = {
       quests: [],
@@ -102,10 +99,27 @@ function updateDailyQuests(user, eventType, data) {
       todayProgress: {},
     };
   }
+}
 
-  // Always update streak on any activity — even if quests need refresh.
-  // Streak tracking is independent of quest generation.
-  //
+/**
+ * Bump the daily streak based on session activity. Called once per substantive
+ * student turn — NOT gated on problem classification, since the streak measures
+ * "did the student show up and engage today," not "did they answer a graded
+ * problem correctly." See [[mathmatix-streak-design]] for the rationale.
+ *
+ * Preserves:
+ *  - same-day repeat → no change
+ *  - consecutive day → +1
+ *  - exactly 1 missed day with freeze available → +1 + consume weekly freeze
+ *  - 2+ missed days OR freeze exhausted → reset to 1
+ *
+ * @param {Object} user - Mongoose user document (mutated in place; caller saves)
+ * @returns {{ streakFreezeUsed?: true, streakLost?: number }}
+ */
+function bumpDailyStreak(user) {
+  ensureDailyQuestsInit(user);
+  const result = {};
+
   // Day boundaries are computed in the user's IANA timezone (user.timezone),
   // falling back to UTC when missing. Server-local setHours(0,0,0,0) breaks
   // for students whose local-day boundary doesn't line up with the server.
@@ -123,7 +137,6 @@ function updateDailyQuests(user, eventType, data) {
     if (daysDiff === 1) {
       user.dailyQuests.currentStreak = (user.dailyQuests.currentStreak || 0) + 1;
     } else if (daysDiff === 2 && canUseStreakFreeze(user)) {
-      // Missed exactly 1 day — auto-apply weekly streak freeze
       user.dailyQuests.currentStreak = (user.dailyQuests.currentStreak || 0) + 1;
       user.dailyQuests.streakFreezeUsedAt = now;
       result.streakFreezeUsed = true;
@@ -131,7 +144,7 @@ function updateDailyQuests(user, eventType, data) {
       result.streakLost = user.dailyQuests.currentStreak || 0;
       user.dailyQuests.currentStreak = 1;
     }
-    // daysDiff === 0 means same day — keep current streak
+    // daysDiff === 0 → same day, keep streak
   } else {
     user.dailyQuests.currentStreak = 1;
   }
@@ -141,6 +154,22 @@ function updateDailyQuests(user, eventType, data) {
   if ((user.dailyQuests.currentStreak || 0) > (user.dailyQuests.longestStreak || 0)) {
     user.dailyQuests.longestStreak = user.dailyQuests.currentStreak;
   }
+
+  return result;
+}
+
+/**
+ * Update daily quests based on an event.
+ * Mirrors the logic in routes/dailyQuests.js POST handler but runs in-process.
+ */
+function updateDailyQuests(user, eventType, data) {
+  const result = { completed: [], xpAwarded: 0 };
+
+  ensureDailyQuestsInit(user);
+
+  const streakResult = bumpDailyStreak(user);
+  if (streakResult.streakFreezeUsed) result.streakFreezeUsed = true;
+  if (streakResult.streakLost) result.streakLost = streakResult.streakLost;
 
   // Check if quests need refresh (new day)
   if (shouldRefreshDailyQuests(user.dailyQuests.lastRefreshDate)) {
@@ -433,4 +462,4 @@ function getWeekStart(date = new Date()) {
   return d;
 }
 
-module.exports = { emitGamificationEvent };
+module.exports = { emitGamificationEvent, bumpDailyStreak };

--- a/utils/pipeline/persist.js
+++ b/utils/pipeline/persist.js
@@ -19,7 +19,7 @@ const { sendSafetyConcernAlert } = require('../emailService');
 const { recordMisconception } = require('../misconceptionDetector');
 const { processMathMessage } = require('../mathSolver');
 const { computeXpBreakdown, applyXpToUser } = require('./xpEngine');
-const { emitGamificationEvent } = require('../gamificationEvents');
+const { emitGamificationEvent, bumpDailyStreak } = require('../gamificationEvents');
 const { canonicalProblemId, contentHash, recordShownProblem } = require('../problemTracking');
 const { getNextActions } = require('../nextActionSuggestions');
 const { checkForInterventionAlert } = require('../interventionAlerts');
@@ -332,6 +332,20 @@ async function persist(params) {
       results.badgeAwarded = masteryResult.badgeAwarded;
     }
   }
+
+  // ── 8a-streak. Daily streak ──
+  // Bump unconditionally on any persist call — reaching this stage means the
+  // student sent a substantive message and received a reply. Decoupled from
+  // problemAnswered because the turn-classifier is imperfect; gating the
+  // streak on it left long-running users stuck at 2 days for months.
+  const streakResult = bumpDailyStreak(user);
+  results.streak = {
+    current: user.dailyQuests?.currentStreak || 0,
+    longest: user.dailyQuests?.longestStreak || 0,
+    freezeUsed: streakResult.streakFreezeUsed || false,
+    lost: streakResult.streakLost || 0,
+  };
+  user.markModified('dailyQuests');
 
   // ── 8b. Gamification events (daily quests, weekly challenges) ──
   if (results.problemAnswered) {


### PR DESCRIPTION
The daily streak was gated behind two flaky signals:
  - persist.js only emitted gamification events when results.problemAnswered was true (i.e. the turn-classifier flagged a graded answer)
  - routes/chat.js's updateQuestProgress further gated streak updates on user.dailyQuests.quests.length > 0

In practice this meant long-running, actively-engaged students could sit at a 2-day streak for months — every other day the classifier failed to fire and lastPracticeDate would drift, causing the next successful classification to read daysDiff > 1 and reset to 1.

Streaks measure session engagement, not answer correctness. This change:

  - Extracts bumpDailyStreak() out of updateDailyQuests as a pure helper over user.dailyQuests (same freeze/reset semantics, no event coupling)
  - Calls bumpDailyStreak() unconditionally from utils/pipeline/persist.js on every persist invocation — reaching that stage means the student sent a substantive message and received a reply
  - Removes the duplicate, gated streak math from routes/chat.js's updateQuestProgress (which still updates quest progress, just no longer touches the streak)
  - Adds tests/unit/bumpDailyStreak.test.js covering the helper directly, including the regression case that the streak must not depend on problem classification or quest data

Existing tests/unit/streakFreeze.test.js continues to pass unchanged — the underlying freeze/reset semantics are preserved.