### PR TITLE
fix(tutor): gate answer-key guard to upload context, regenerate in voice

### DIFF
--- a/tests/unit/pipeline.test.js
+++ b/tests/unit/pipeline.test.js
@@ -22,7 +22,8 @@ const { observe, MESSAGE_TYPES, PATTERNS, extractAnswer, detectContextSignals } 
 const { estimateIndependence, diagnose } = require('../../utils/pipeline/diagnose');
 const { decide, ACTIONS } = require('../../utils/pipeline/decide');
 const { buildActionPrompt, buildVerificationContext, buildStreakWarning, assemblePrompt } = require('../../utils/pipeline/generate');
-const { extractSystemTags, normalizeLatex } = require('../../utils/pipeline/verify');
+const { extractSystemTags, normalizeLatex, verify } = require('../../utils/pipeline/verify');
+const { callLLM } = require('../../utils/llmGateway');
 const { buildSidecar, mergeLlmSignals, getSidecarInstruction, getSignalStats } = require('../../utils/pipeline/sidecar');
 const { buildSlimRules, CORE_RULES } = require('../../utils/pipeline/promptSlim');
 const { computeSessionMood, scoreMessage, buildMoodDirective, TRAJECTORIES, ENERGY_LEVELS } = require('../../utils/pipeline/sessionMood');
@@ -1203,5 +1204,81 @@ describe('Pipeline: normalizeLatex', () => {
       // Should have at least one proper \\) close
       expect(result).toContain('\\)');
     });
+  });
+});
+
+// ============================================================================
+// VERIFY STAGE — Answer-key guard (regression: Triangle Inequality misfire)
+// ============================================================================
+//
+// Origin: live transcript where Maya explained the Triangle Inequality
+// Theorem with 3 numbered conditions and the verify stage swapped her reply
+// for "I can see the problems — which one do you want to work through
+// first?" — a hardcoded worksheet line that made no sense in a
+// no-upload chat. The same trip wire then fired on every retry,
+// trapping the conversation in a loop.
+//
+// The fix: gate the loose answer-key detector behind upload context.
+// When it fires (only in upload context), regenerate in voice via
+// socraticRegenerate instead of swapping in canned worksheet text.
+describe('Pipeline: Verify Stage — Answer-key guard', () => {
+  // A response that LOOKS like an answer key under the strict detector:
+  // three numbered lines, sequential, each starting with a digit so the
+  // numbered-list-math pattern fires.
+  const numberedExplanation =
+    'The Triangle Inequality Theorem has three conditions:\n' +
+    '1. 3 + 4 > 5\n' +
+    '2. 4 + 5 > 3\n' +
+    '3. 3 + 5 > 4\n' +
+    'What do you notice?';
+
+  beforeEach(() => {
+    callLLM.mockReset();
+  });
+
+  test('non-upload context: 3 numbered lines pass through unchanged (no canned worksheet swap)', async () => {
+    const result = await verify(numberedExplanation, {
+      userId: 'u1',
+      hasRecentUpload: false,
+      isWorksheetFollowUp: false,
+    });
+    expect(result.text).toBe(numberedExplanation);
+    expect(result.flags).not.toContain('answer_key_blocked');
+    expect(result.flags).not.toContain('upload_answer_giveaway_regenerated');
+    expect(result.text).not.toMatch(/i can see the problems/i);
+    expect(callLLM).not.toHaveBeenCalled();
+  });
+
+  test('upload context: same response triggers Socratic regeneration in voice', async () => {
+    callLLM.mockResolvedValueOnce({
+      choices: [{ message: { content: 'Let\'s look at the first condition together — what do you think happens if 3 + 4 is bigger than 5?' } }],
+    });
+    const result = await verify(numberedExplanation, {
+      userId: 'u1',
+      hasRecentUpload: true,
+      isWorksheetFollowUp: false,
+    });
+    expect(callLLM).toHaveBeenCalledTimes(1);
+    expect(result.text).toMatch(/first condition/i);
+    expect(result.text).not.toMatch(/i can see the problems on your worksheet/i);
+    expect(result.flags).toContain('upload_answer_giveaway_regenerated');
+  });
+
+  test('upload context with regen failure: falls back to a non-worksheet-specific line', async () => {
+    callLLM.mockRejectedValueOnce(new Error('LLM unavailable'));
+    const result = await verify(numberedExplanation, {
+      userId: 'u1',
+      hasRecentUpload: true,
+    });
+    expect(result.text).not.toBe(numberedExplanation); // must NOT pass the original through
+    expect(result.flags).toContain('upload_answer_giveaway_fallback');
+  });
+
+  test('non-upload context: safe response passes through untouched', async () => {
+    const safe = 'What is the first step?';
+    const result = await verify(safe, { userId: 'u1' });
+    expect(result.text).toBe(safe);
+    expect(result.flags).toEqual([]);
+    expect(callLLM).not.toHaveBeenCalled();
   });
 });

--- a/utils/pipeline/verify.js
+++ b/utils/pipeline/verify.js
@@ -10,7 +10,7 @@
  * @module pipeline/verify
  */
 
-const { filterAnswerKeyResponse, detectAnswerKeyResponse, detectWorkedSolution, detectAnswerAnnouncement } = require('../worksheetGuard');
+const { detectAnswerKeyResponse, detectWorkedSolution, detectAnswerAnnouncement } = require('../worksheetGuard');
 const { checkReadingLevel, buildSimplificationPrompt } = require('../readability');
 const { enforceVisualTeaching } = require('../visualCommandEnforcer');
 const { parseVisualTeaching } = require('../visualTeachingParser');
@@ -20,6 +20,44 @@ const { ACTIONS } = require('./decide');
 const { MESSAGE_TYPES, detectBareProblemDrop } = require('./observe');
 
 const PRIMARY_CHAT_MODEL = 'gpt-4o-mini';
+
+/**
+ * Regenerate a tutor reply in voice when post-checks (answer-key pattern,
+ * full worked solution, etc.) caught the original response handing too
+ * much over. Replaces the older pattern of swapping in canned worksheet
+ * text — which sounded robotic, lied about a worksheet outside upload
+ * context, and created a feedback loop when retries kept tripping the
+ * same detector.
+ *
+ * Returns the rewritten text on success, or null if the LLM call fails
+ * or produces something too short to trust. Callers decide the fallback.
+ *
+ * @param {string} originalText - The response that tripped a guard
+ * @param {Object} context - verify() context (hasRecentUpload, etc.)
+ * @param {string} reason - Short phrase explaining what tripped — used
+ *   in the system prompt so the rewrite addresses the real issue
+ * @returns {Promise<string|null>}
+ */
+async function socraticRegenerate(originalText, context, reason) {
+  const inUploadContext = !!(context.hasRecentUpload || context.isWorksheetFollowUp);
+  const systemPrompt = inUploadContext
+    ? `You are a math tutor. The student uploaded a worksheet. Your previous response ${reason}, which violates tutoring rules — you MUST guide with Socratic questions and NEVER give away answers. Rewrite the response in your own warm tutor voice: acknowledge what they are working on, surface the FIRST step only, and invite the student to attempt that step. Do NOT show subsequent steps. Do NOT name the final answer. End with a single guiding question. Keep it short (2–3 sentences).`
+    : `You are a math tutor. Your previous response ${reason}, which is too much at once for a conversation. Rewrite it in your own warm tutor voice as a short, conversational reply that invites the student into the FIRST idea or step. No numbered breakdowns. Do NOT name a final answer. Keep it to 2–3 sentences. End with a single guiding question.`;
+  try {
+    const completion = await callLLM(PRIMARY_CHAT_MODEL,
+      [{ role: 'system', content: systemPrompt },
+       { role: 'assistant', content: originalText },
+       { role: 'user', content: 'Rewrite this response. One step, one question, in voice.' }],
+      { temperature: 0.55, max_tokens: 600 }
+    );
+    const rewritten = completion?.choices?.[0]?.message?.content?.trim();
+    if (rewritten && rewritten.length > 10) return rewritten;
+    return null;
+  } catch (err) {
+    console.error('[Verify] Socratic regenerate failed:', err.message);
+    return null;
+  }
+}
 
 // Tags the system uses internally — must be stripped before showing to student
 const SYSTEM_TAG_PATTERNS = [
@@ -160,31 +198,33 @@ async function verify(responseText, context = {}) {
   const { text: tagStrippedText, extracted } = extractSystemTags(text);
   text = tagStrippedText;
 
-  // ── 2. Anti-answer-key filter ──
-  const answerKeyCheck = filterAnswerKeyResponse(text, context.userId);
-  if (answerKeyCheck.wasFiltered) {
-    text = answerKeyCheck.text;
-    flags.push('answer_key_blocked');
-
-    if (context.isStreaming && context.res) {
-      try {
-        context.res.write(`data: ${JSON.stringify({ type: 'replacement', content: text })}\n\n`);
-      } catch (e) { /* client disconnected */ }
-    }
-  }
-
-  // ── 2a. Upload-context answer giveaway detection ──
-  // When a student has uploaded a worksheet, apply STRICTER answer detection.
-  // Standard filter needs 3+ problems; during uploads, catch even 2 problems.
-  // Also detect single-problem complete solutions (the AI solving the student's problem).
-  if ((context.hasRecentUpload || context.isWorksheetFollowUp) && !answerKeyCheck.wasFiltered) {
-    // Lower threshold: catch 2+ numbered solutions
+  // ── 2. Anti-answer-key filter (upload-gated) ──
+  //
+  // The "numbered list of solutions" detector is only meaningful when an
+  // upload is in play. Outside that context, a tutor explaining (say) the
+  // three conditions of the Triangle Inequality Theorem with 3 numbered
+  // lines is pedagogy, not an answer key — running the detector there
+  // misfires and used to swap the reply with a hardcoded worksheet line.
+  //
+  // Inside upload context: use the strict 2+ threshold and regenerate
+  // through the LLM so the tutor stays in voice. The complete-solution
+  // detector (one problem fully solved) also routes through the same
+  // helper, replacing the older copy-pasted regen block.
+  if (context.hasRecentUpload || context.isWorksheetFollowUp) {
     const strictCheck = detectAnswerKeyResponse(text, { minProblems: 2 });
-    if (strictCheck.isAnswerKey) {
-      console.warn(`[Verify] UPLOAD CONTEXT: Answer giveaway detected (${strictCheck.problemCount} problems). Blocking.`);
-      text = "I can see the problems on your worksheet! Which one do you want to tackle first? Pick one and let's work through it together.";
-      flags.push('upload_answer_giveaway_blocked');
 
+    if (strictCheck.isAnswerKey) {
+      console.warn(`[Verify] UPLOAD CONTEXT: Answer-key pattern detected (${strictCheck.problemCount} problems, ${strictCheck.matchedPattern}). Regenerating in voice.`);
+      const rewritten = await socraticRegenerate(text, context, 'looked like an answer key — multiple problems solved at once');
+      if (rewritten) {
+        text = rewritten;
+        flags.push('upload_answer_giveaway_regenerated');
+      } else {
+        // Regen failed — last-resort fallback. We can't safely emit the
+        // original, but we're guaranteed to be in upload context here.
+        text = `Let's not jump to all of them at once — pick one problem and we'll work through the first step together.`;
+        flags.push('upload_answer_giveaway_fallback');
+      }
       if (context.isStreaming && context.res) {
         try {
           context.res.write(`data: ${JSON.stringify({ type: 'replacement', content: text })}\n\n`);
@@ -196,37 +236,25 @@ async function verify(responseText, context = {}) {
       const worked = detectWorkedSolution(text);
       const hasCompleteSolution = worked.breakdown.hasCompleteSolution;
       const hasFullWorkedSolution = worked.isWorkedSolution;
-
-      // Also check: does the response NOT contain a question mark? (Socratic should ask questions)
       const hasQuestion = /\?\s*$|\?\s*\n/m.test(text);
 
       // Redirect when:
-      //   (a) clear answer phrase with no question at all (original behavior), OR
-      //   (b) full worked solution with multiple signals — even if it ends with a
-      //       "now you try" question, the work has already been handed over.
+      //   (a) clear answer phrase with no question at all, OR
+      //   (b) full worked solution with multiple signals — even if it ends
+      //       with a "now you try" question, the work has been handed over.
       if ((hasCompleteSolution && !hasQuestion) || hasFullWorkedSolution) {
         console.warn(`[Verify] UPLOAD CONTEXT: Complete solution detected (signals=${worked.signalCount}, breakdown=${JSON.stringify(worked.breakdown)}). Regenerating.`);
-        try {
-          const socraticRedirect = await callLLM(PRIMARY_CHAT_MODEL,
-            [{ role: 'system', content: 'You are a math tutor. The student uploaded a worksheet. You MUST guide them with Socratic questions — NEVER give away answers. Your previous response gave a complete solution, which violates tutoring rules. Rewrite it: acknowledge the problem, break it into the FIRST step only, and ask the STUDENT to attempt that step. Do NOT show any subsequent steps or the final answer. End with a guiding question.' },
-             { role: 'assistant', content: text },
-             { role: 'user', content: 'Rewrite this response to be Socratic. Only show the first step, ask the student to try it. Never reveal the answer.' }],
-            { temperature: 0.55, max_tokens: 800 }
-          );
-          const redirectedText = socraticRedirect.choices[0]?.message?.content?.trim();
-          if (redirectedText && redirectedText.length > 10) {
-            text = redirectedText;
-            flags.push('upload_solution_redirected');
-
-            if (context.isStreaming && context.res) {
-              try {
-                context.res.write(`data: ${JSON.stringify({ type: 'replacement', content: text })}\n\n`);
-              } catch (e) { /* client disconnected */ }
-            }
+        const rewritten = await socraticRegenerate(text, context, 'gave a complete solution');
+        if (rewritten) {
+          text = rewritten;
+          flags.push('upload_solution_redirected');
+          if (context.isStreaming && context.res) {
+            try {
+              context.res.write(`data: ${JSON.stringify({ type: 'replacement', content: text })}\n\n`);
+            } catch (e) { /* client disconnected */ }
           }
-        } catch (err) {
-          console.error('[Verify] Upload solution redirect failed:', err.message);
-          // Fallback: just add a question to the end
+        } else {
+          // Regen failed — append a guiding question rather than emit the full solution as-is.
           text += "\n\nWhat do you think the first step should be?";
           flags.push('upload_solution_redirect_fallback');
         }

--- a/utils/worksheetGuard.js
+++ b/utils/worksheetGuard.js
@@ -254,12 +254,11 @@ function detectAnswerKeyResponse(responseText, options = {}) {
 }
 
 /**
- * The safe redirect message sent to the student when an answer key is detected.
- * This replaces the AI's response entirely.
+ * Last-resort fallback used by filterAnswerKeyResponse when an answer key
+ * is detected. Pipeline callers (verify.js) regenerate through the LLM
+ * instead of using this canned line — see socraticRegenerate. This is
+ * retained only for legacy callers that don't have access to an LLM.
  */
-// When the AI generates an answer-key-like response (multiple numbered solutions),
-// we regenerate through the LLM instead of showing a canned message. This fallback
-// is only used if regeneration fails.
 const ANSWER_KEY_REDIRECT_FALLBACK = `I can see the problems — which one do you want to work through first?`;
 
 /**


### PR DESCRIPTION
## Why

From a live transcript:

> **Maya:** Awesome! Let's kick things off with triangle properties. … Do you remember what the Triangle Inequality Theorem states? If not, I can break it down for you!
> **Jason:** nope
> **Maya:** I can see the problems — which one do you want to work through first?
> **Jason:** ?
> **Maya:** I can see the problems — which one do you want to work through first?
> **Jason:** what are you talking about?
> **Maya:** I can see the problems — which one do you want to work through first?

When Maya tried to explain the Triangle Inequality Theorem with three numbered inequalities (`1. a + b > c`, `2. b + c > a`, `3. a + c > b` etc.), the verify stage's answer-key detector tripped on the "3+ numbered problems" regex in `worksheetGuard.js`. Every reply got swapped with a hardcoded worksheet-context line — even though no worksheet was ever uploaded. Each retry hit the same trip wire and the conversation looped.

Three issues stacked:

1. **`utils/pipeline/verify.js:164`** ran `filterAnswerKeyResponse` unconditionally — even in chat with no upload context, where numbered explanations are pedagogy, not answer keys.
2. **`utils/worksheetGuard.js:260-262`** comment claimed "we regenerate through the LLM instead of showing a canned message" — but the code just swapped to canned text. The promised regen was never implemented.
3. **The canned fallback** ("I can see the problems on your worksheet…") lied about a worksheet outside upload context, and felt scripted even inside it.

## What changed

- **`utils/pipeline/verify.js`** — Added `socraticRegenerate()` helper. Gated the entire answer-key block behind `context.hasRecentUpload || context.isWorksheetFollowUp`. When the strict 2-problem detector or the complete-solution detector fires inside upload context, both now route through `socraticRegenerate()` so the response stays in Maya's voice. Removed the unconditional `filterAnswerKeyResponse` call and dropped the unused import.
- **`utils/worksheetGuard.js`** — Updated the misleading comment on `ANSWER_KEY_REDIRECT_FALLBACK` to reflect actual behavior (last-resort fallback only; pipeline does Socratic regen first). The pure function is unchanged so existing callers keep working.
- **`tests/unit/pipeline.test.js`** — Added 4 regression tests:
  - non-upload context: 3-numbered explanation passes through (the Triangle Inequality misfire)
  - upload context: same content triggers Socratic regen and emits in voice
  - upload context with regen failure: falls back to a non-worksheet-specific line, doesn't pass the raw answer key through
  - non-upload context: safe responses untouched

## Relationship to #996

Same theme — canned phrases misfiring and overriding Maya's voice. #996 fixed the `ELICIT_FIRST` bare-problem-drop path. This fixes the verify-stage answer-key path. Different code path, same underlying pattern: deterministic guards swapping in hardcoded text without context awareness.

## Test plan

- [x] `npx jest tests/unit/` — all 2255 tests pass
- [ ] Manual: in a fresh chat (no upload), ask Maya to explain a multi-condition theorem (Triangle Inequality, Pythagorean Theorem cases, etc.) → response comes through unchanged, no canned "I can see the problems" swap
- [ ] Manual: upload a worksheet, then ask Maya to "solve all of them" → she pivots to the first one in voice (Socratic regen), no answer key dump
- [ ] Manual: upload + ask Maya for a single complete solution → existing complete-solution redirect still works in voice

https://claude.ai/code/session_011aXhF1fhZ6pWFbiPLVmihn

---
_Generated by [Claude Code](https://claude.ai/code/session_011aXhF1fhZ6pWFbiPLVmihn)_