### PR TITLE
fix(chat): legible header pills, theme-aware math, equal column heights

### DIFF
--- a/public/css/chat-redesign.css
+++ b/public/css/chat-redesign.css
@@ -26,6 +26,19 @@ body.cr-mode .landing-header {
   border-bottom: 1px solid var(--cr-border);
 }
 
+/* The header is always painted dark navy regardless of theme, so its
+   contents must use a light foreground. Without this, light-theme
+   pages inherit --cr-text: #18202B (near-black) and the streak/Progress
+   pills go invisible against the navy backdrop. */
+body.cr-mode .landing-header,
+body.cr-mode .landing-header .cr-streak-pill,
+body.cr-mode .landing-header .cr-progress-btn {
+  --cr-text: #E6E9F2;
+  --cr-border: rgba(255, 255, 255, 0.18);
+  --cr-pill-bg: rgba(255, 255, 255, 0.08);
+  --cr-pill-bg-hover: rgba(255, 255, 255, 0.14);
+}
+
 body.cr-mode .landing-header .main-logo-hero {
   /* Flip the colored mark to a clean white silhouette so it reads on
      the dark header. Brand identity here is the SHAPE (glasses +
@@ -241,6 +254,12 @@ body.cr-mode #app-layout-wrapper { background: var(--cr-bg-0); }
   background: linear-gradient(180deg, #1A1F35 0%, #0E1322 100%);
   border: 1px solid var(--cr-border);
   min-height: 520px;
+  /* Cap + margin-bottom match #chat-container and .cr-workspace so the
+     three stage columns end at the same vertical line above the fixed
+     footer. Without this the hero stretched the full grid row while the
+     other two were capped, leaving the middle short. */
+  max-height: calc(100vh - 124px);
+  margin-bottom: 60px;
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
@@ -411,15 +430,12 @@ body.cr-mode #chat-container {
   border-radius: 22px;
   padding: 8px 0 0 !important;
   margin-bottom: 60px !important;
-  /* Cap the container's height so its bottom — and the composer's input
-     row inside it — cannot extend past the visible viewport, regardless of
-     how the stage's min-height adds up. The fixed footer occupies ~52px
-     at the bottom; 200px leaves room for the footer + a typical header +
-     padding. Inside the container, #chat-messages-container is flex:1
-     overflow:auto so it shrinks; the composer (flex-shrink:0) keeps its
-     full height and stays visible. The previous margin-bottom-only lift
-     was too fragile across header sizes. */
-  max-height: calc(100vh - 200px);
+  /* Cap matches .cr-workspace so the three stage columns end at the same
+     vertical line. The fixed footer occupies ~52px; this leaves room for
+     the header + footer + a small breathing gap. Inside the container,
+     #chat-messages-container is flex:1 overflow:auto so it shrinks; the
+     composer (flex-shrink:0) keeps its full height and stays visible. */
+  max-height: calc(100vh - 124px);
   overflow: hidden;
   display: flex;
   flex-direction: column;

--- a/public/css/math-style.css
+++ b/public/css/math-style.css
@@ -36,5 +36,5 @@ body.cr-mode #chat-messages-container .katex-display::-webkit-scrollbar-thumb {
 
 /* ---- Inline math: a subtle lift so it reads as math, not prose ---- */
 body.cr-mode #chat-messages-container .katex {
-  color: #F2F3F8;
+  color: var(--cr-text);
 }


### PR DESCRIPTION
- Override --cr-text / --cr-border / --cr-pill-bg on the dark header so light-theme pages render the streak and Progress pills with light text on the navy backdrop instead of inheriting near-black --cr-text.
- Inline KaTeX now uses var(--cr-text) instead of a hardcoded #F2F3F8, so equations are readable on light-theme bubbles/cards.
- Cap #chat-container and .cr-tutor-hero at calc(100vh - 124px) with a 60px margin-bottom to match .cr-workspace, so all three stage columns end at the same vertical line above the fixed footer.