### PR TITLE
fix(tutor): plug answer-leak on tutor-posed problems; gate parallel-example badge on actual text

### DIFF
--- a/tests/unit/pipeline.test.js
+++ b/tests/unit/pipeline.test.js
@@ -1282,3 +1282,94 @@ describe('Pipeline: Verify Stage — Answer-key guard', () => {
     expect(callLLM).not.toHaveBeenCalled();
   });
 });
+
+// ============================================================================
+// VERIFY STAGE — Answer-leak guard on tutor-posed problems
+// ============================================================================
+//
+// Origin: transcript where the tutor asked the student to compute -b/(2a)
+// for a vertex problem. After two wrong attempts the LLM caved and wrote
+// "t = -(-8)/(2·2) = 8/4 = 2. So the x-coordinate of the vertex is 2."
+// The 2a guard above only fires for student-posed problems, so an answer
+// leak on a tutor-posed problem had no defense in depth. This guard fills
+// that gap.
+describe('Pipeline: Verify Stage — Answer-leak guard on tutor-posed problems', () => {
+  // The real transcript shape: tutor solves the arithmetic and names the
+  // answer ("so the x-coordinate of the vertex is 2") after a wrong attempt.
+  const leakedAnswer =
+    'Almost there! When you calculate t = -(-8)/(2·2) = 8/4 = 2. ' +
+    'So the x-coordinate of the vertex is 2. Now substitute that back in.';
+
+  // Variant: same leak but with the simpler "so the vertex is 2" phrasing
+  // that hits the original explicit-answer-1 pattern.
+  const leakedAnswerSimple =
+    'Almost there! When you calculate t = -(-8)/(2·2) = 8/4 = 2. ' +
+    'So the vertex is 2.';
+
+  beforeEach(() => {
+    callLLM.mockReset();
+  });
+
+  test('GUIDE_INCORRECT + answer announcement → regenerates in voice', async () => {
+    callLLM.mockResolvedValueOnce({
+      choices: [{ message: { content: 'Take another look at the sign on that numerator — what should the negative of -8 be?' } }],
+    });
+    const result = await verify(leakedAnswer, {
+      userId: 'u1',
+      action: ACTIONS.GUIDE_INCORRECT,
+      messageType: MESSAGE_TYPES.ANSWER_ATTEMPT,
+    });
+    expect(callLLM).toHaveBeenCalledTimes(1);
+    expect(result.flags).toContain('answer_leak_on_tutor_posed_detected');
+    expect(result.flags).toContain('answer_leak_on_tutor_posed_regenerated');
+    expect(result.text).toMatch(/sign|negative/i);
+    expect(result.text).not.toMatch(/x-coordinate of the vertex is 2/i);
+  });
+
+  test('RETEACH_MISCONCEPTION + answer announcement → regenerates in voice', async () => {
+    callLLM.mockResolvedValueOnce({
+      choices: [{ message: { content: 'Try plugging your value back into the original equation — does it balance?' } }],
+    });
+    const result = await verify(leakedAnswer, {
+      userId: 'u1',
+      action: ACTIONS.RETEACH_MISCONCEPTION,
+      messageType: MESSAGE_TYPES.ANSWER_ATTEMPT,
+    });
+    expect(callLLM).toHaveBeenCalledTimes(1);
+    expect(result.flags).toContain('answer_leak_on_tutor_posed_regenerated');
+  });
+
+  test('GUIDE_INCORRECT + Socratic question only (no leak) → passes through', async () => {
+    const clean = 'Almost there! What sign should the numerator have when you take the negative of -8?';
+    const result = await verify(clean, {
+      userId: 'u1',
+      action: ACTIONS.GUIDE_INCORRECT,
+      messageType: MESSAGE_TYPES.ANSWER_ATTEMPT,
+    });
+    expect(result.text).toBe(clean);
+    expect(result.flags).not.toContain('answer_leak_on_tutor_posed_detected');
+    expect(callLLM).not.toHaveBeenCalled();
+  });
+
+  test('action is CONFIRM_CORRECT (not a wrong-answer turn) → guard does not fire', async () => {
+    const result = await verify(leakedAnswer, {
+      userId: 'u1',
+      action: ACTIONS.CONFIRM_CORRECT,
+      messageType: MESSAGE_TYPES.ANSWER_ATTEMPT,
+    });
+    expect(result.flags).not.toContain('answer_leak_on_tutor_posed_detected');
+    expect(callLLM).not.toHaveBeenCalled();
+  });
+
+  test('regen failure → leaves leak flag but does not crash', async () => {
+    callLLM.mockRejectedValueOnce(new Error('LLM unavailable'));
+    const result = await verify(leakedAnswer, {
+      userId: 'u1',
+      action: ACTIONS.GUIDE_INCORRECT,
+      messageType: MESSAGE_TYPES.ANSWER_ATTEMPT,
+    });
+    expect(result.flags).toContain('answer_leak_on_tutor_posed_detected');
+    expect(result.flags).toContain('answer_leak_on_tutor_posed_regeneration_failed');
+    expect(result.flags).not.toContain('answer_leak_on_tutor_posed_regenerated');
+  });
+});

--- a/tests/unit/tutorValidation.test.js
+++ b/tests/unit/tutorValidation.test.js
@@ -40,6 +40,10 @@ jest.mock('../../utils/misconceptionDetector', () => ({
 
 jest.mock('../../utils/worksheetGuard', () => ({
   filterAnswerKeyResponse: jest.fn((text) => ({ text, wasFiltered: false })),
+  detectAnswerKeyResponse: jest.fn(() => ({ isAnswerKey: false, problemCount: 0, matchedPattern: null, problemNumbers: [] })),
+  detectAnswerAnnouncement: jest.fn(() => ({ detected: false, pattern: null })),
+  detectWorkedSolution: jest.fn(() => ({ isWorkedSolution: false, signalCount: 0, breakdown: {} })),
+  detectParallelExampleIntroduction: jest.fn(() => false),
 }));
 
 jest.mock('../../utils/readability', () => ({

--- a/tests/unit/worksheetGuard.test.js
+++ b/tests/unit/worksheetGuard.test.js
@@ -23,6 +23,7 @@ const {
   stripCorrectAnswers,
   detectAnswerKeyResponse,
   filterAnswerKeyResponse,
+  detectParallelExampleIntroduction,
 } = require('../../utils/worksheetGuard');
 
 describe('detectAnswerAnnouncement', () => {
@@ -283,5 +284,64 @@ describe('filterAnswerKeyResponse', () => {
     const r = filterAnswerKeyResponse(safe, 'u1');
     expect(r.wasFiltered).toBe(false);
     expect(r.text).toBe(safe);
+  });
+});
+
+describe('detectParallelExampleIntroduction', () => {
+  // Positive: response actually introduces a parallel example.
+  test('flags "let me show you a similar problem"', () => {
+    expect(detectParallelExampleIntroduction(
+      'Let me show you a similar problem with different numbers.'
+    )).toBe(true);
+  });
+
+  test('flags "let\'s try one together"', () => {
+    expect(detectParallelExampleIntroduction(
+      'Let\'s try one together: 2x + 3 = 7.'
+    )).toBe(true);
+  });
+
+  test('flags "here\'s a similar example"', () => {
+    expect(detectParallelExampleIntroduction(
+      'Here\'s a similar example we can work through first.'
+    )).toBe(true);
+  });
+
+  test('flags "different numbers"', () => {
+    expect(detectParallelExampleIntroduction(
+      'Let me walk through this with different numbers so you can see the pattern.'
+    )).toBe(true);
+  });
+
+  test('flags "worked example"', () => {
+    expect(detectParallelExampleIntroduction(
+      'Here is a worked example.'
+    )).toBe(true);
+  });
+
+  // Negative: tutor continuing the same problem, no parallel pivot.
+  test('does NOT flag a normal Socratic continuation', () => {
+    expect(detectParallelExampleIntroduction(
+      'You\'re right that -8(2) = -16. Now combine 8 - 16 + 6. What do you get?'
+    )).toBe(false);
+  });
+
+  test('does NOT flag a hint', () => {
+    expect(detectParallelExampleIntroduction(
+      'Remember to include the sign — what would -(-8) be?'
+    )).toBe(false);
+  });
+
+  test('does NOT flag confirmation', () => {
+    expect(detectParallelExampleIntroduction(
+      'Yes! That\'s right. The next step is to combine like terms.'
+    )).toBe(false);
+  });
+
+  test('handles empty / non-string input', () => {
+    expect(detectParallelExampleIntroduction(null)).toBe(false);
+    expect(detectParallelExampleIntroduction('')).toBe(false);
+    expect(detectParallelExampleIntroduction(undefined)).toBe(false);
+    expect(detectParallelExampleIntroduction(123)).toBe(false);
   });
 });

--- a/utils/pipeline/index.js
+++ b/utils/pipeline/index.js
@@ -21,6 +21,7 @@ const { diagnose } = require('./diagnose');
 const { decide, ACTIONS } = require('./decide');
 const { generate, assemblePrompt } = require('./generate');
 const { verify } = require('./verify');
+const { detectParallelExampleIntroduction } = require('../worksheetGuard');
 const { persist } = require('./persist');
 const { llmVerifyAnswer, pickProblemContext } = require('./llmVerifier');
 const { buildSidecar, mergeLlmSignals, getSignalStats } = require('./sidecar');
@@ -893,8 +894,15 @@ async function runPipeline(message, ctx) {
     problemResult: persistResults.problemAnswered
       ? (persistResults.wasCorrect ? 'correct' : 'incorrect')
       : null,
-    // Parallel worked example flag — frontend can render a distinct "similar problem" label
-    isParallelExample: decision.action === ACTIONS.WORKED_EXAMPLE || decision.action === ACTIONS.EXIT_RAMP,
+    // Parallel worked example flag — drives the "🔄 Similar problem" UI badge.
+    // Gated on BOTH the decision (intent) AND the verified response text
+    // (actual behavior). The decide stage sometimes routes to WORKED_EXAMPLE
+    // / EXIT_RAMP from cumulative wrong-counts that include misdiagnosed
+    // turns, so action alone is unreliable — we confirm the tutor's reply
+    // actually introduces a parallel example before tagging the turn.
+    isParallelExample:
+      (decision.action === ACTIONS.WORKED_EXAMPLE || decision.action === ACTIONS.EXIT_RAMP)
+      && detectParallelExampleIntroduction(verified.text),
     // Error annotation: misconception label for frontend display (no answer revealed)
     errorAnnotation: (diagnosis.isCorrect === false && diagnosis.misconception) ? {
       name: diagnosis.misconception.name,

--- a/utils/pipeline/verify.js
+++ b/utils/pipeline/verify.js
@@ -425,6 +425,46 @@ async function verify(responseText, context = {}) {
     }
   }
 
+  // ── 2c-leak. Answer-announcement guard on tutor-posed problems ──
+  //
+  // When the tutor posed the problem (action is GUIDE_INCORRECT or
+  // RETEACH_MISCONCEPTION) and the student gave a wrong answer, the LLM
+  // is supposed to guide them to find the fix — NOT solve the problem
+  // and name the answer. The 2a guard above only fires for student-posed
+  // problems (it gates on isStudentPosed), so this fills the gap.
+  //
+  // Trigger: detectAnswerAnnouncement matches (multi-root reveal,
+  // pluralized conclusion, transitional reveal, explicit "answer is"),
+  // OR a trailing bare assignment like "x = 2." on its own line.
+  // Action: regenerate through the LLM so the reply stays in voice and
+  // doesn't leak the answer. Reuses socraticRegenerate for consistency.
+  if (!regeneratedThisPass &&
+      (context.action === ACTIONS.GUIDE_INCORRECT || context.action === ACTIONS.RETEACH_MISCONCEPTION)) {
+    const announcement = detectAnswerAnnouncement(text);
+    const trailingAssignment = /[a-z]\s*=\s*-?\d+\.?\d*\s*(?:[.!)\]]?\s*)$/m;
+    if (announcement.detected || trailingAssignment.test(text)) {
+      console.warn(`[Verify] ANSWER LEAK on tutor-posed problem (action=${context.action}, pattern=${announcement.pattern || 'trailing-assignment'}). Regenerating in voice.`);
+      flags.push('answer_leak_on_tutor_posed_detected');
+      const rewritten = await socraticRegenerate(
+        text,
+        context,
+        'named the correct answer or solved the problem for the student after they got it wrong'
+      );
+      if (rewritten) {
+        text = rewritten;
+        flags.push('answer_leak_on_tutor_posed_regenerated');
+        regeneratedThisPass = true;
+        if (context.isStreaming && context.res) {
+          try {
+            context.res.write(`data: ${JSON.stringify({ type: 'replacement', content: text })}\n\n`);
+          } catch (e) { /* client disconnected */ }
+        }
+      } else {
+        flags.push('answer_leak_on_tutor_posed_regeneration_failed');
+      }
+    }
+  }
+
   // ── 2d. False-rejection guard (CRITICAL — protects correct answers) ──
   // When the pipeline has VERIFIED the student's answer is correct
   // (action === CONFIRM_CORRECT) but the LLM's response implies the
@@ -756,7 +796,18 @@ async function verify(responseText, context = {}) {
   // ── 7. LaTeX normalization ──
   // gpt-4o-mini sometimes uses plain parentheses for math instead of \( \)
   // or omits delimiters entirely. Normalize common patterns.
+  //
+  // TEMP DEBUG (remove once LaTeX mangled-fraction bug is diagnosed):
+  // when LATEX_DEBUG=1, log pre- and post-normalize text for any response
+  // that contains plausible math markup, so we can compare what the LLM
+  // emits vs. what the frontend receives.
+  if (process.env.LATEX_DEBUG === '1' && /\\frac|\$|\bfrac\{|\\sqrt|\\\(|\\\[/.test(text)) {
+    console.log('[LATEX_DEBUG] pre-normalize:', JSON.stringify(text));
+  }
   text = normalizeLatex(text);
+  if (process.env.LATEX_DEBUG === '1' && /\\frac|\$|\bfrac\{|\\sqrt|\\\(|\\\[/.test(text)) {
+    console.log('[LATEX_DEBUG] post-normalize:', JSON.stringify(text));
+  }
 
   // ── 8. Final cleanup: strip any remaining system tags ──
   for (const pattern of SYSTEM_TAG_PATTERNS) {

--- a/utils/worksheetGuard.js
+++ b/utils/worksheetGuard.js
@@ -343,6 +343,12 @@ function detectAnswerAnnouncement(text) {
         /(?:therefore|so|thus|hence)\s*,?\s*(?:the\s+)?(?:factored\s+form|factors?|answers?|solutions?|results?|sum|difference|product|quotient|vertex|y-?intercept|x-?intercept|axis\s+of\s+symmetry|roots?|zeros?|maximum|minimum|slope|derivative|domain|range|equation)\s+(?:is|=|are)\s*[:=]?\s*(?:\\[(\[])?\s*[-\d(x]/i,
         /(?:=\s*\\[(\[])\s*\(.*?\)\s*\(.*?\)\s*(?:\\[\])])/,
         /(?:final\s+answer|boxed|result)\s*[:=]\s*/i,
+        // Coordinate-form leak: "so the x-coordinate of the vertex is 2",
+        // "so the y-coordinate is 5", "thus the y-value of the maximum is 12".
+        // Real transcripts from a vertex-of-parabola lesson hit this exact
+        // shape, which the prior patterns missed because a noun phrase
+        // ("x-coordinate of the vertex") sits between "the" and the verb.
+        /(?:therefore|so|thus|hence)\s*,?\s*(?:the\s+)?(?:[xyz]\s*-?\s*(?:coordinate|value|intercept))\s+(?:of\s+(?:the\s+)?[^,.\n]{1,40})?\s*(?:is|=|equals|are)\s*[:=]?\s*(?:\\[(\[])?\s*[-\d(x]/i,
     ];
     for (let i = 0; i < explicitAnswer.length; i++) {
         if (explicitAnswer[i].test(text)) {
@@ -431,6 +437,41 @@ function detectWorkedSolution(text) {
     };
 }
 
+/**
+ * Detect whether the tutor's response actually introduces a parallel /
+ * worked example (e.g. "let me show you a similar problem with different
+ * numbers"). This decouples the "🔄 Similar problem" UI badge from the
+ * decide stage's action name — when the decision engine miscounts wrong
+ * answers and routes to WORKED_EXAMPLE on a turn where the tutor doesn't
+ * actually pivot to a parallel problem, the badge would misfire. Using
+ * the actual response text as the source of truth fixes that.
+ *
+ * Requires explicit phrasing — "different numbers", "similar problem",
+ * "let's try one together", "let me work through an example", etc. The
+ * standard tutor reply that just keeps guiding the same problem will
+ * NOT match.
+ *
+ * @param {string} text - The verified AI response text
+ * @returns {boolean}
+ */
+function detectParallelExampleIntroduction(text) {
+    if (!text || typeof text !== 'string') return false;
+    const PARALLEL_INTRO_PATTERNS = [
+        /\bsimilar\s+(?:problem|example|one|equation|question)\b/i,
+        /\b(?:different|new|fresh|other)\s+numbers\b/i,
+        /\blet'?s\s+try\s+(?:a\s+)?(?:similar|another|one\s+together|different)\b/i,
+        /\blet\s+me\s+(?:show|walk)\s+you\s+(?:through\s+)?(?:a|an|another)\s+(?:example|similar|problem)\b/i,
+        /\blet\s+me\s+(?:work\s+through|do)\s+(?:a|an|another|one)\s+(?:example|similar|problem|first)\b/i,
+        /\bhere'?s\s+(?:a|an|another)\s+(?:similar|example|practice)\s+(?:problem|one|example)?\b/i,
+        /\bworked?\s+example\b/i,
+        /\bparallel\s+(?:problem|example)\b/i,
+        /\btry\s+(?:this|one)\s+(?:first|together|instead)[:,.]/i,
+        /\bsay\s+we\s+had\s+(?:the\s+)?(?:problem|equation|expression)\b/i,
+        /\bsuppose\s+(?:we|you)\s+(?:had|were\s+given|see)\s+(?:the\s+)?(?:problem|equation)\b/i,
+    ];
+    return PARALLEL_INTRO_PATTERNS.some(pat => pat.test(text));
+}
+
 module.exports = {
     WORKSHEET_GUARD_INSTRUCTION,
     applyWorksheetGuard,
@@ -441,5 +482,6 @@ module.exports = {
     filterAnswerKeyResponse,
     detectAnswerAnnouncement,
     detectWorkedSolution,
+    detectParallelExampleIntroduction,
     ANSWER_KEY_REDIRECT_FALLBACK
 };


### PR DESCRIPTION
## Why

From a live transcript on a vertex-of-parabola lesson:

> **Maya:** Find the vertex of h = 2x² − 8x + 6. Use t = −b/(2a).
> **Jason:** -4
> **Maya:** Not quite, but close! What are a and b? What's −b/(2a)?
> **Jason:** 8/2 = 4
> **Maya:** You're on the right track but remember the sign! Now since a=2 and b=−8, calculate t = −(−8)/(2·2)
> **Jason:** -4?
> **Maya:** Almost there! When you calculate t = −(−8)/(2·2) = 8/4 = 2. **So, the x-coordinate of the vertex is 2.**

Two distinct bugs:

1. **Maya leaked the answer** after two wrong attempts. The verify stage has an answer-giveaway guard (`verify.js:297`), but it's gated on `isStudentPosed` — when the *tutor* posed the problem and the student got it wrong, the guard never runs. Defense-in-depth gap.

2. **The "🔄 Similar problem" badge fired mid-conversation** on a turn where the tutor was correctly continuing the same problem. Tied to `decision.action === WORKED_EXAMPLE || EXIT_RAMP` (`pipeline/index.js:880`). Cumulative `recentWrongCount` (inflated by an earlier misdiagnosed turn) pushed decide into WORKED_EXAMPLE even though the tutor's reply never introduced a parallel example.

## What changed

### Bug 1 — answer leak on tutor-posed problems
- **`utils/pipeline/verify.js`** — New guard `2c-leak`. When `action === GUIDE_INCORRECT || RETEACH_MISCONCEPTION` and the response trips `detectAnswerAnnouncement` or a trailing-assignment regex, regenerate through `socraticRegenerate` (the helper from #1005). Reuses the existing pattern, no new infrastructure.
- **`utils/worksheetGuard.js`** — Extended `detectAnswerAnnouncement` with a coordinate-form pattern (`/(?:therefore|so|thus|hence)\s*,?\s*(?:the\s+)?(?:[xyz]\s*-?\s*(?:coordinate|value|intercept))\s+(?:of\s+(?:the\s+)?[^,.\n]{1,40})?\s*(?:is|=|equals|are)\s*[:=]?\s*\.\.\./`). Catches the exact transcript shape — "so the x-coordinate of the vertex is 2" — which the original patterns missed because a noun phrase intervenes between `so` and the keyword.

### Bug 2 — parallel-example badge misfire
- **`utils/worksheetGuard.js`** — New `detectParallelExampleIntroduction(text)` helper. Returns true only when the response actually introduces a parallel/worked example ("similar problem", "different numbers", "let me show you a similar example", "worked example", etc.).
- **`utils/pipeline/index.js`** — `isParallelExample` now requires BOTH the decision (intent) AND the text detection (actual behavior). Decouples the badge from the (sometimes wrong) decision engine. The badge now reflects what the tutor said, not what the engine intended.

### Diagnostics for the separate LaTeX-mangling bug
- **`utils/pipeline/verify.js`** — Added `LATEX_DEBUG=1` env-gated logging around `normalizeLatex` that prints the pre- and post-normalize text for any response containing plausible math markup. No-op when the env var is unset. Will be removed once the mangled-fractions bug is diagnosed and fixed in a follow-up.

### Tests
- **`tests/unit/worksheetGuard.test.js`** — 9 tests for `detectParallelExampleIntroduction` (positive + negative cases).
- **`tests/unit/pipeline.test.js`** — 5 regression tests for the new `2c-leak` guard.
- **`tests/unit/tutorValidation.test.js`** — Completed the `worksheetGuard` mock so the new detector destructuring doesn't return undefined.

## Test plan

- [x] `npx jest tests/unit/` — all 2307 tests pass
- [ ] Manual: ask Maya for a vertex problem, give wrong answers twice → she should re-guide (rephrase, lower scaffold), not solve and name the answer
- [ ] Manual: rack up several wrong answers, then give a correct one → no "🔄 Similar problem" badge unless the tutor actually pivots to a parallel example
- [ ] Manual: ask Maya for a worked example explicitly → "🔄" badge fires (detector matches)
- [ ] Run a problem session with `LATEX_DEBUG=1` and capture a mangled-fraction turn — informs the LaTeX follow-up PR

## Out of scope (deferred)
- **Bug 3** (tutor invalidates correct early guess) — needs separate work to add overall-problem-context to `problemInfo` or a cross-turn answer cross-check
- **Bug 4** (LaTeX mangled fractions) — needs the raw output captured by the new debug log to know which regex to add

https://claude.ai/code/session_011aXhF1fhZ6pWFbiPLVmihn

---
_Generated by [Claude Code](https://claude.ai/code/session_011aXhF1fhZ6pWFbiPLVmihn)_