### PR TITLE
fix(openai): bound chat-completion calls with a 90s timeout

### DIFF
--- a/tests/unit/openaiClient.test.js
+++ b/tests/unit/openaiClient.test.js
@@ -82,18 +82,14 @@ describe('callLLM', () => {
   test('passes max_completion_tokens for gpt-4o models', async () => {
     mockChatCreate.mockResolvedValue({ choices: [{ message: { content: 'hi' } }] });
     await callLLM('gpt-4o', [{ role: 'user', content: 'hello' }], { max_tokens: 200 });
-    expect(mockChatCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ max_completion_tokens: 200 })
-    );
+    expect(mockChatCreate.mock.calls[0][0]).toMatchObject({ max_completion_tokens: 200 });
     expect(mockChatCreate.mock.calls[0][0].max_tokens).toBeUndefined();
   });
 
   test('uses legacy max_tokens for older models', async () => {
     mockChatCreate.mockResolvedValue({ choices: [{ message: { content: 'hi' } }] });
     await callLLM('gpt-3.5-turbo', [{ role: 'user', content: 'x' }], { max_tokens: 100 });
-    expect(mockChatCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ max_tokens: 100 })
-    );
+    expect(mockChatCreate.mock.calls[0][0]).toMatchObject({ max_tokens: 100 });
     expect(mockChatCreate.mock.calls[0][0].max_completion_tokens).toBeUndefined();
   });
 

--- a/tests/unit/openaiClientTimeout.test.js
+++ b/tests/unit/openaiClientTimeout.test.js
@@ -1,0 +1,120 @@
+/**
+ * openaiClient — request timeouts on chat completions.
+ *
+ * Bug this guards: the OpenAI SDK defaulted to a 10-minute timeout on
+ * chat.completions.create() with no override in our client. If the
+ * upstream API stalled (no first token, mid-stream stall), the SSE
+ * response never completed and the student's "thinking…" indicator
+ * spun indefinitely. The fix: pass a 90s timeout (overridable via
+ * options.timeoutMs) and disable the SDK's built-in retries so a true
+ * hang fails fast through to our own fallback path.
+ */
+
+// Mock the OpenAI SDK BEFORE requiring the client so the mock is in
+// place when the singleton client is constructed.
+const mockCreate = jest.fn();
+jest.mock('openai', () => {
+  return jest.fn().mockImplementation(() => ({
+    chat: { completions: { create: mockCreate } },
+  }));
+});
+
+const { callLLM, callLLMStream, DEFAULT_CHAT_TIMEOUT_MS } = require('../../utils/openaiClient');
+
+describe('openaiClient — DEFAULT_CHAT_TIMEOUT_MS', () => {
+  test('is 90 seconds (well below SDK default of 10 minutes)', () => {
+    expect(DEFAULT_CHAT_TIMEOUT_MS).toBe(90 * 1000);
+  });
+});
+
+describe('callLLM — request timeout passed to SDK', () => {
+  beforeEach(() => {
+    mockCreate.mockReset();
+    mockCreate.mockResolvedValue({
+      choices: [{ message: { content: 'ok' } }],
+    });
+  });
+
+  test('passes the default timeout to openai.chat.completions.create', async () => {
+    await callLLM('gpt-4o-mini', [{ role: 'user', content: 'hi' }]);
+    const args = mockCreate.mock.calls[0];
+    expect(args[1]).toBeDefined();
+    expect(args[1].timeout).toBe(DEFAULT_CHAT_TIMEOUT_MS);
+  });
+
+  test('disables SDK-level retries (maxRetries: 0)', async () => {
+    await callLLM('gpt-4o-mini', [{ role: 'user', content: 'hi' }]);
+    const args = mockCreate.mock.calls[0];
+    expect(args[1].maxRetries).toBe(0);
+  });
+
+  test('honors a caller-provided timeoutMs override', async () => {
+    await callLLM('gpt-4o-mini', [{ role: 'user', content: 'hi' }], { timeoutMs: 5000 });
+    const args = mockCreate.mock.calls[0];
+    expect(args[1].timeout).toBe(5000);
+  });
+
+  test('still passes signal when provided', async () => {
+    const controller = new AbortController();
+    await callLLM('gpt-4o-mini', [{ role: 'user', content: 'hi' }], { signal: controller.signal });
+    const args = mockCreate.mock.calls[0];
+    expect(args[1].signal).toBe(controller.signal);
+    expect(args[1].timeout).toBe(DEFAULT_CHAT_TIMEOUT_MS);
+  });
+
+  test('propagates an APIConnectionTimeoutError instead of retrying it', async () => {
+    // Our retryWithExponentialBackoff retries only 429/5xx. Timeouts
+    // have undefined status, so they should fail fast.
+    const timeoutErr = Object.assign(new Error('Request timed out.'), { status: undefined });
+    mockCreate.mockRejectedValue(timeoutErr);
+
+    await expect(
+      callLLM('gpt-4o-mini', [{ role: 'user', content: 'hi' }])
+    ).rejects.toThrow('Request timed out.');
+
+    // Only one attempt — no transient-error retry on a timeout.
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('callLLMStream — request timeout passed to SDK', () => {
+  beforeEach(() => {
+    mockCreate.mockReset();
+    // Return a no-op async iterable so the call resolves.
+    mockCreate.mockResolvedValue((async function* noop() {})());
+  });
+
+  test('passes the default timeout to openai.chat.completions.create', async () => {
+    await callLLMStream('gpt-4o-mini', [{ role: 'user', content: 'hi' }]);
+    const args = mockCreate.mock.calls[0];
+    expect(args[1]).toBeDefined();
+    expect(args[1].timeout).toBe(DEFAULT_CHAT_TIMEOUT_MS);
+  });
+
+  test('disables SDK-level retries (maxRetries: 0)', async () => {
+    await callLLMStream('gpt-4o-mini', [{ role: 'user', content: 'hi' }]);
+    const args = mockCreate.mock.calls[0];
+    expect(args[1].maxRetries).toBe(0);
+  });
+
+  test('honors a caller-provided timeoutMs override', async () => {
+    await callLLMStream('gpt-4o-mini', [{ role: 'user', content: 'hi' }], { timeoutMs: 10000 });
+    const args = mockCreate.mock.calls[0];
+    expect(args[1].timeout).toBe(10000);
+  });
+
+  test('always sets stream: true on the request body', async () => {
+    await callLLMStream('gpt-4o-mini', [{ role: 'user', content: 'hi' }]);
+    const args = mockCreate.mock.calls[0];
+    expect(args[0].stream).toBe(true);
+  });
+
+  test('propagates a timeout error rather than hanging forever', async () => {
+    const timeoutErr = Object.assign(new Error('Request timed out.'), { status: undefined });
+    mockCreate.mockRejectedValue(timeoutErr);
+    await expect(
+      callLLMStream('gpt-4o-mini', [{ role: 'user', content: 'hi' }])
+    ).rejects.toThrow('Request timed out.');
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/utils/openaiClient.js
+++ b/utils/openaiClient.js
@@ -15,6 +15,14 @@ if (process.env.OPENAI_API_KEY) {
 }
 
 
+// Default request timeout for chat completions. The OpenAI SDK defaults
+// to 10 minutes, which is far longer than any tutor reply should take —
+// long enough that an upstream hang freezes the SSE response and leaves
+// the student's "thinking…" indicator spinning indefinitely. 90 seconds
+// covers the slowest reasonable completion; callers needing more can
+// pass options.timeoutMs.
+const DEFAULT_CHAT_TIMEOUT_MS = 90 * 1000;
+
 // Utility for exponential backoff and retry
 async function retryWithExponentialBackoff(fn, retries = 5, delay = 1000) {
     let attempts = 0;
@@ -92,14 +100,22 @@ async function callLLM(model, messages, options = {}) {
             ...(options.response_format ? { response_format: options.response_format } : {}),
         };
 
-        // Only pass the SDK's request-options arg when we actually have a
-        // signal. Passing `undefined` as a second arg changes the call
-        // shape (always 2 args) and breaks unit tests that use
-        // toHaveBeenCalledWith strict-arity matching.
+        // Build the request-options arg. Always include a timeout so
+        // an upstream hang can't freeze the SSE response indefinitely.
+        // (See DEFAULT_CHAT_TIMEOUT_MS comment above for why.)
+        //
+        // maxRetries: 0 disables the SDK's built-in 2x retry — we have
+        // our own retryWithExponentialBackoff layer wrapped around this
+        // call, and stacking the two would multiply worst-case wait
+        // times by 3x with no added robustness.
+        const requestOptions = {
+            timeout: options.timeoutMs || DEFAULT_CHAT_TIMEOUT_MS,
+            maxRetries: 0,
+        };
+        if (options.signal) requestOptions.signal = options.signal;
+
         const completion = await retryWithExponentialBackoff(() =>
-            options.signal
-                ? openai.chat.completions.create(requestBody, { signal: options.signal })
-                : openai.chat.completions.create(requestBody)
+            openai.chat.completions.create(requestBody, requestOptions)
         );
         return completion;
     } catch (openAiError) {
@@ -140,6 +156,14 @@ async function callLLMStream(model, messages, options = {}) {
             }
         }
 
+        // Streaming responses can take longer than a one-shot completion,
+        // but they still need a bound. An upstream hang here blocks the
+        // SSE response from completing, so the student's "thinking…"
+        // indicator never clears. Caller can override via options.timeoutMs.
+        //
+        // maxRetries: 0 because there is no retry wrapper around the
+        // streaming call — and the streaming caller (generate.js) has
+        // its own non-stream fallback that handles transient failures.
         const stream = await openai.chat.completions.create({
             model: model,
             messages: messages,
@@ -147,6 +171,10 @@ async function callLLMStream(model, messages, options = {}) {
             ...tokenParam,
             ...toolParams,
             stream: true,
+        }, {
+            timeout: options.timeoutMs || DEFAULT_CHAT_TIMEOUT_MS,
+            maxRetries: 0,
+            ...(options.signal ? { signal: options.signal } : {}),
         });
         return stream;
     } catch (openAiError) {
@@ -256,6 +284,7 @@ async function moderateImage(image, mimetype = 'image/png') {
 module.exports = {
     openai,
     retryWithExponentialBackoff,
+    DEFAULT_CHAT_TIMEOUT_MS,
     callLLM,
     callLLMStream,
     generateEmbedding,


### PR DESCRIPTION
openai.chat.completions.create() inherits the SDK's 10-minute default timeout when called without a request-options arg. If the upstream API accepts the connection but never streams a first token (or stalls mid-stream), the SSE response stays open and the student's "thinking…" indicator spins indefinitely — observed for over an hour on a single message before manual abort.

Pass an explicit 90s timeout (callers can override via options.timeoutMs) and set maxRetries: 0 so the SDK doesn't multiply the worst-case wait by 3x. retryWithExponentialBackoff still wraps the non-streaming path for 429/5xx; timeouts fail fast since they have no status code and shouldn't trigger that retry layer. The streaming path has its own non-stream fallback in generate.js that takes over on any error.

Worst-case wait on a true upstream hang: ~180s (stream timeout + fallback timeout) instead of unbounded. Far enough below human patience that the SSE error path fires while the user is still looking at the screen.