### PR TITLE
fix(graph): keep graph title/caption math in sync with fn

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -2264,6 +2264,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- returningUserModal.js removed — no longer used -->
   <script src="/js/graphTool.js"></script>
   <script src="/js/diagram-display.js"></script>
+  <script src="/js/graphTitleSync.js"></script>
   <script src="/js/inlineChatVisuals.js"></script>
   <link rel="stylesheet" href="/css/algebra-tiles.css">
   <script src="/js/algebra-tiles.js"></script>

--- a/public/js/graphTitleSync.js
+++ b/public/js/graphTitleSync.js
@@ -1,0 +1,131 @@
+/* ============================================================
+   graphTitleSync.js — keep a graph card's title/caption math
+   in sync with its fn.
+
+   Why this exists
+   ---------------
+   The tutor sometimes emits a graph tag where the fn is a
+   simplification ("x^2") and the title spells out a fuller
+   expression ("Graph of y=x^2 + 4x - 12"). Each surface is
+   trusted independently, so the rendered parabola disagrees with
+   its own label.
+
+   This helper runs at render time: if a title contains a math
+   expression on the right of "y =" / "f(x) =" that doesn't match
+   the fn the renderer is about to plot, the title is replaced
+   with the canonical "Graph of y = ${fn}". Titles that are pure
+   descriptions ("Quadratic crossing zero") pass through —
+   they're not claims about the math.
+
+   UMD wrapper so the same source backs both the browser (loaded
+   via <script src="...">) and Node-side unit tests.
+   ============================================================ */
+
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    root.MathmatixGraphTitleSync = factory();
+  }
+}(typeof self !== 'undefined' ? self : (typeof globalThis !== 'undefined' ? globalThis : this), function () {
+  'use strict';
+
+  // Pulls the right-hand math out of a title like "Graph of y = x^2 + 4x - 12"
+  // or "f(x) = sin(x)". Returns the matched expression or null when the
+  // title is purely descriptive.
+  function extractMathFromTitle(title) {
+    if (!title || typeof title !== 'string') return null;
+    // Match "y = expr" or "y=expr" or "f(x) = expr" or "f(x)=expr".
+    // Capture lazily, stop at the first comma/semicolon/period that
+    // isn't inside a number (so "y = x + 1.5" still captures fully).
+    const m = title.match(/(?:y|f\s*\(\s*x\s*\))\s*=\s*([^,;]+?)\s*$/i);
+    if (!m) return null;
+    return m[1].trim();
+  }
+
+  // Normalize a math expression for comparison: lowercase, strip
+  // whitespace, fold common Unicode operators and "**" → "^".
+  function normalizeMath(s) {
+    if (!s || typeof s !== 'string') return '';
+    return s.toLowerCase()
+      .replace(/\s+/g, '')
+      .replace(/\*\*/g, '^')
+      .replace(/[−–—]/g, '-')  // U+2212 minus, en/em dash
+      .replace(/[×⋅]/g, '*')        // × and ⋅
+      .replace(/[÷]/g, '/')              // ÷
+      .replace(/[²]/g, '^2')             // ²
+      .replace(/[³]/g, '^3');            // ³
+  }
+
+  // Decide what title to actually render. Defaults to the canonical
+  // "Graph of y = ${fn}" when the LLM provided no title; passes
+  // through descriptive titles unchanged; overrides math-bearing
+  // titles whose math doesn't match fn.
+  function syncGraphTitle(title, fn) {
+    const safeFn = (fn || '').toString().trim();
+    if (!safeFn) {
+      // No fn to anchor against — fall back to whatever the caller
+      // supplied (or empty).
+      return title || '';
+    }
+
+    const canonical = `Graph of y = ${safeFn}`;
+
+    if (!title || typeof title !== 'string' || title.trim() === '') {
+      return canonical;
+    }
+
+    const titleMath = extractMathFromTitle(title);
+    if (!titleMath) {
+      // Pure description — keep as-is. Titles like "Quadratic Function"
+      // or "Position, Velocity & Acceleration" are not claims about
+      // the math.
+      return title;
+    }
+
+    if (normalizeMath(titleMath) === normalizeMath(safeFn)) {
+      return title;
+    }
+
+    // Mismatch — replace with canonical and log so we can track how
+    // often this triggers in real sessions.
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn(
+        `[graphTitleSync] Title math doesn't match fn — overriding. ` +
+        `title="${title}" extracted="${titleMath}" fn="${safeFn}"`
+      );
+    }
+    return canonical;
+  }
+
+  // Same logic for the BOARD graph card's caption. Captions on the
+  // board are usually short hints ("Where it crosses zero") — pure
+  // description. But when a caption embeds y=expr math, we apply the
+  // same sync rule. When the caption is replaced, we return null so
+  // the caller can render WITHOUT a caption rather than re-showing
+  // the same equation that's already visible elsewhere.
+  function syncGraphCaption(caption, fn) {
+    const safeFn = (fn || '').toString().trim();
+    if (!safeFn || !caption || typeof caption !== 'string' || caption.trim() === '') {
+      return caption || null;
+    }
+    const captionMath = extractMathFromTitle(caption);
+    if (!captionMath) return caption;
+    if (normalizeMath(captionMath) === normalizeMath(safeFn)) return caption;
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn(
+        `[graphTitleSync] Caption math doesn't match fn — dropping. ` +
+        `caption="${caption}" extracted="${captionMath}" fn="${safeFn}"`
+      );
+    }
+    return null;
+  }
+
+  return {
+    syncGraphTitle,
+    syncGraphCaption,
+    // Exposed for tests
+    _extractMathFromTitle: extractMathFromTitle,
+    _normalizeMath: normalizeMath,
+  };
+}));

--- a/public/js/inlineChatVisuals.js
+++ b/public/js/inlineChatVisuals.js
@@ -417,6 +417,13 @@ class InlineChatVisuals {
             // Pure numeric/symbol title — almost certainly garbage (e.g. "1783").
             title = defaultTitle;
         }
+        // Final sync: if the title carries math that doesn't match fn
+        // (e.g. fn="x^2" but title="Graph of y=x^2 + 4x - 12"), override
+        // with the canonical "Graph of y = ${fn}". Without this, the
+        // rendered curve and the label disagree on screen.
+        if (window.MathmatixGraphTitleSync) {
+            title = window.MathmatixGraphTitleSync.syncGraphTitle(title, fn);
+        }
         const color = params.color || '#667eea';
 
         // Store graph config for later rendering
@@ -4366,7 +4373,10 @@ class InlineChatVisuals {
         const fn = params.fn || params.function || 'x^3-3*x^2+2*x';
         const xMin = params.xMin ?? params.xmin ?? -5;
         const xMax = params.xMax ?? params.xmax ?? 5;
-        const title = params.title || `f(x) and f′(x)`;
+        let title = params.title || `f(x) and f′(x)`;
+        if (window.MathmatixGraphTitleSync) {
+            title = window.MathmatixGraphTitleSync.syncGraphTitle(title, fn);
+        }
 
         const graphConfig = JSON.stringify({
             type: 'derivative', fn, xMin, xMax
@@ -4401,7 +4411,10 @@ class InlineChatVisuals {
         const fn = params.fn || params.function || '(x^2-1)/(x-1)';
         const xMin = params.xMin ?? params.xmin ?? -8;
         const xMax = params.xMax ?? params.xmax ?? 8;
-        const title = params.title || `Rational Function`;
+        let title = params.title || `Rational Function`;
+        if (window.MathmatixGraphTitleSync) {
+            title = window.MathmatixGraphTitleSync.syncGraphTitle(title, fn);
+        }
 
         const graphConfig = JSON.stringify({
             type: 'rational', fn, xMin, xMax
@@ -4436,7 +4449,10 @@ class InlineChatVisuals {
         const fn = params.fn || params.function || '4*x^3-6*x^2+2*x';
         const xMin = params.xMin ?? params.xmin ?? 0;
         const xMax = params.xMax ?? params.xmax ?? 4;
-        const title = params.title || `Position, Velocity & Acceleration`;
+        let title = params.title || `Position, Velocity & Acceleration`;
+        if (window.MathmatixGraphTitleSync) {
+            title = window.MathmatixGraphTitleSync.syncGraphTitle(title, fn);
+        }
 
         const graphConfig = JSON.stringify({
             type: 'velocity', fn, xMin, xMax

--- a/public/js/workspace.js
+++ b/public/js/workspace.js
@@ -162,9 +162,16 @@
       card = el('div', 'cr-ws-board-card cr-ws-board-card--graph');
       var graphHost = el('div', 'cr-ws-board-card-graph');
       card.appendChild(graphHost);
-      if (step.caption) {
+      // Drop a caption whose embedded "y = X" math doesn't match the fn
+      // we're about to plot — otherwise the curve and its own label
+      // disagree on screen.
+      var syncedCaption = step.caption || null;
+      if (window.MathmatixGraphTitleSync) {
+        syncedCaption = window.MathmatixGraphTitleSync.syncGraphCaption(step.caption, step.fn);
+      }
+      if (syncedCaption) {
         var graphCap = el('div', 'cr-ws-board-card-caption');
-        graphCap.textContent = step.caption;
+        graphCap.textContent = syncedCaption;
         card.appendChild(graphCap);
       }
       // Defer instantiation until the card is attached; MathGraph reads

--- a/tests/unit/graphTitleSync.test.js
+++ b/tests/unit/graphTitleSync.test.js
@@ -1,0 +1,133 @@
+/**
+ * graphTitleSync — keep graph card titles/captions in sync with fn.
+ *
+ * The bug this guards against: a [FUNCTION_GRAPH:fn=x^2,title="Graph
+ * of y=x^2 + 4x - 12"] tag renders a y=x^2 parabola with the label
+ * "Graph of y=x^2 + 4x - 12" — curve and label disagree on screen.
+ *
+ * The helper compares the math embedded in the title against fn and
+ * replaces mismatches with the canonical "Graph of y = ${fn}".
+ */
+
+const {
+  syncGraphTitle,
+  syncGraphCaption,
+  _extractMathFromTitle,
+  _normalizeMath,
+} = require('../../public/js/graphTitleSync');
+
+describe('graphTitleSync — extractMathFromTitle', () => {
+  test('pulls "x^2 + 4x - 12" out of "Graph of y=x^2 + 4x - 12"', () => {
+    expect(_extractMathFromTitle('Graph of y=x^2 + 4x - 12')).toBe('x^2 + 4x - 12');
+  });
+
+  test('pulls expression with spaces around =', () => {
+    expect(_extractMathFromTitle('Graph of y = x^2 - 4')).toBe('x^2 - 4');
+  });
+
+  test('handles f(x) = form', () => {
+    expect(_extractMathFromTitle('Plot of f(x) = sin(x)')).toBe('sin(x)');
+  });
+
+  test('returns null for a purely descriptive title', () => {
+    expect(_extractMathFromTitle('Quadratic Function')).toBeNull();
+    expect(_extractMathFromTitle('Where it crosses zero')).toBeNull();
+    expect(_extractMathFromTitle('Position, Velocity & Acceleration')).toBeNull();
+  });
+
+  test('returns null for empty / non-string input', () => {
+    expect(_extractMathFromTitle('')).toBeNull();
+    expect(_extractMathFromTitle(null)).toBeNull();
+    expect(_extractMathFromTitle(undefined)).toBeNull();
+    expect(_extractMathFromTitle(42)).toBeNull();
+  });
+});
+
+describe('graphTitleSync — normalizeMath', () => {
+  test('strips whitespace and lowercases', () => {
+    expect(_normalizeMath('X^2 + 4X - 12')).toBe('x^2+4x-12');
+  });
+
+  test('folds ** to ^', () => {
+    expect(_normalizeMath('x**2 + 4*x - 12')).toBe('x^2+4*x-12');
+  });
+
+  test('folds Unicode minus to ASCII -', () => {
+    expect(_normalizeMath('x − 4')).toBe('x-4');     // U+2212
+    expect(_normalizeMath('x – 4')).toBe('x-4');     // en dash
+  });
+
+  test('folds × and ⋅ to *', () => {
+    expect(_normalizeMath('2×x')).toBe('2*x');
+    expect(_normalizeMath('2⋅x')).toBe('2*x');
+  });
+
+  test('folds ² and ³ to ^2 and ^3', () => {
+    expect(_normalizeMath('x²')).toBe('x^2');
+    expect(_normalizeMath('x³')).toBe('x^3');
+  });
+
+  test('empty / non-string returns empty', () => {
+    expect(_normalizeMath('')).toBe('');
+    expect(_normalizeMath(null)).toBe('');
+    expect(_normalizeMath(undefined)).toBe('');
+  });
+});
+
+describe('graphTitleSync — syncGraphTitle (the bug)', () => {
+  test('the failing case: fn="x^2" + title="Graph of y=x^2 + 4x - 12" → canonical override', () => {
+    expect(syncGraphTitle('Graph of y=x^2 + 4x - 12', 'x^2')).toBe('Graph of y = x^2');
+  });
+
+  test('matching title passes through verbatim (no normalization on output)', () => {
+    expect(syncGraphTitle('Graph of y = x^2', 'x^2')).toBe('Graph of y = x^2');
+  });
+
+  test('match through whitespace/case differences passes through', () => {
+    expect(syncGraphTitle('Graph of Y=X^2', 'x^2')).toBe('Graph of Y=X^2');
+  });
+
+  test('descriptive-only title passes through unchanged', () => {
+    expect(syncGraphTitle('Quadratic crossing zero', 'x^2 - 4')).toBe('Quadratic crossing zero');
+    expect(syncGraphTitle('Position, Velocity & Acceleration', '4*x^3-6*x^2+2*x')).toBe('Position, Velocity & Acceleration');
+  });
+
+  test('missing title falls back to canonical', () => {
+    expect(syncGraphTitle('', 'x^2 + 4x - 12')).toBe('Graph of y = x^2 + 4x - 12');
+    expect(syncGraphTitle(null, 'x^2 + 4x - 12')).toBe('Graph of y = x^2 + 4x - 12');
+    expect(syncGraphTitle(undefined, 'x^2 + 4x - 12')).toBe('Graph of y = x^2 + 4x - 12');
+  });
+
+  test('Unicode-equivalent forms match', () => {
+    // Title uses ² unicode, fn uses ^2 — same math, should pass through.
+    expect(syncGraphTitle('Graph of y = x²', 'x^2')).toBe('Graph of y = x²');
+  });
+
+  test('missing fn returns title unchanged (no anchor)', () => {
+    expect(syncGraphTitle('Some title', '')).toBe('Some title');
+    expect(syncGraphTitle('Some title', null)).toBe('Some title');
+  });
+});
+
+describe('graphTitleSync — syncGraphCaption', () => {
+  test('drops a mismatched caption (returns null)', () => {
+    expect(syncGraphCaption('y = x^2 + 4x - 12', 'x^2')).toBeNull();
+  });
+
+  test('keeps a matching caption', () => {
+    expect(syncGraphCaption('y = x^2 - 4', 'x^2 - 4')).toBe('y = x^2 - 4');
+  });
+
+  test('keeps a descriptive caption', () => {
+    expect(syncGraphCaption('Where it crosses zero', 'x^2 - 4')).toBe('Where it crosses zero');
+  });
+
+  test('missing caption returns null', () => {
+    expect(syncGraphCaption('', 'x^2')).toBeNull();
+    expect(syncGraphCaption(null, 'x^2')).toBeNull();
+  });
+
+  test('missing fn returns caption unchanged', () => {
+    expect(syncGraphCaption('y = x^2', '')).toBe('y = x^2');
+  });
+});


### PR DESCRIPTION
The tutor sometimes emits a graph tag where the fn is a simplification ("x^2") and the title spells out a fuller expression ("Graph of y=x^2 + 4x - 12"). Each surface is trusted independently, so the rendered parabola disagrees with its own label.

Add graphTitleSync (UMD-wrapped so the same source backs the browser and Node tests): if a title contains "y = X" or "f(x) = X" math that doesn't normalize-equal the fn, replace the title with the canonical "Graph of y = ${fn}". Pure-description titles ("Quadratic crossing zero") pass through untouched. Same logic applied to BOARD graph card captions — mismatched captions are dropped rather than shown alongside a contradicting curve.

Wired into createFunctionGraph, createDerivativeGraph, createRationalGraph, createVelocityGraph (legacy [FUNCTION_GRAPH:…] modal path) and the new <BOARD action="graph"/> card in workspace.js. Warns on every override so we can track frequency.