### PR TITLE
fix(sse): keepalive + client-side stream-idle abort

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -2355,6 +2355,16 @@ document.addEventListener("DOMContentLoaded", () => {
             let clientTimezone = null;
             try { clientTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone; } catch (_) {}
 
+            // Bound the request with an AbortController so a silently-dead
+            // SSE connection (proxy closed the socket mid-stream) can't park
+            // the "thinking…" indicator forever. The idle timer below resets
+            // on every reader.read() return; if more than STREAM_IDLE_MS
+            // elapses with no bytes (the server's : ping keepalive should
+            // arrive every 15s), we abort and show a retry-able error.
+            var STREAM_IDLE_MS = 90 * 1000;
+            var streamAbort = (typeof AbortController !== 'undefined') ? new AbortController() : null;
+            var streamSignal = streamAbort ? streamAbort.signal : undefined;
+
             // All chat goes through /api/chat — files, courses, and regular chat
             if (queuedFiles.length > 0) {
                 console.log(`[Frontend] Sending ${queuedFiles.length} file(s) to /api/chat`);
@@ -2378,7 +2388,8 @@ document.addEventListener("DOMContentLoaded", () => {
                 response = await csrfFetch("/api/chat", {
                     method: "POST",
                     body: formData,
-                    credentials: 'include'
+                    credentials: 'include',
+                    signal: streamSignal
                 });
             } else {
                 // Regular chat (no files) — same endpoint for courses and main chat
@@ -2394,7 +2405,8 @@ document.addEventListener("DOMContentLoaded", () => {
                     method: "POST",
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify(payload),
-                    credentials: 'include'
+                    credentials: 'include',
+                    signal: streamSignal
                 });
             }
 
@@ -2469,9 +2481,28 @@ document.addEventListener("DOMContentLoaded", () => {
                 const decoder = new TextDecoder();
                 let buffer = '';
 
+                // Idle-watchdog: if no bytes arrive for STREAM_IDLE_MS (well
+                // above the server's 15s keepalive cadence), the connection
+                // is silently dead. Abort the fetch so the outer catch can
+                // surface an error instead of leaving "thinking…" forever.
+                let streamIdleTimer = null;
+                function resetStreamIdleTimer() {
+                    if (streamIdleTimer) clearTimeout(streamIdleTimer);
+                    if (!streamAbort) return;
+                    streamIdleTimer = setTimeout(() => {
+                        console.warn(`[Stream] No bytes received in ${STREAM_IDLE_MS}ms — aborting`);
+                        try { streamAbort.abort(); } catch (_) { /* already aborted */ }
+                    }, STREAM_IDLE_MS);
+                }
+                resetStreamIdleTimer();
+
                 while (true) {
                     const { done, value } = await reader.read();
-                    if (done) break;
+                    resetStreamIdleTimer();
+                    if (done) {
+                        if (streamIdleTimer) clearTimeout(streamIdleTimer);
+                        break;
+                    }
 
                     buffer += decoder.decode(value, { stream: true });
                     const lines = buffer.split('\n');
@@ -3143,7 +3174,12 @@ document.addEventListener("DOMContentLoaded", () => {
 
             let errorMessage = "I'm having trouble connecting.";
             let isRetryable = true;
-            if (error.message) {
+            // AbortError fires when our stream-idle watchdog gives up on a
+            // silently-dead connection. Show a clearer message than the
+            // generic "trouble connecting" so the student knows to retry.
+            if (error && (error.name === 'AbortError' || /aborted/i.test(error.message || ''))) {
+                errorMessage = "The connection dropped before a response came back. Tap retry to try again.";
+            } else if (error.message) {
                 if (error.message.includes('Mathpix') || error.message.includes('API credentials')) {
                     errorMessage = "There was an issue processing your file. Our OCR service may be temporarily unavailable.";
                     isRetryable = false; // File-specific errors need a different file

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -14,6 +14,7 @@ const StudentUpload = require('../models/studentUpload');
 const Skill = require('../models/skill');
 const { generateSystemPrompt } = require('../utils/prompt');
 const { callLLM, callLLMStream } = require("../utils/llmGateway"); // CTO REVIEW FIX: Use unified LLMGateway
+const { createKeepalive } = require('../utils/sseKeepalive');
 const TUTOR_CONFIG = require('../utils/tutorConfig');
 const BRAND_CONFIG = require('../utils/brand');
 const axios = require('axios');
@@ -898,6 +899,7 @@ router.post('/', isAuthenticated, promptInjectionFilter, conditionalUpload, cond
         let clientDisconnected = false;
 
         // Set up streaming if requested
+        let sseKeepalive = null;
         if (useStreaming) {
             logger.debug('Streaming mode activated', { userId });
             res.setHeader('Content-Type', 'text/event-stream');
@@ -905,7 +907,18 @@ router.post('/', isAuthenticated, promptInjectionFilter, conditionalUpload, cond
             res.setHeader('Connection', 'keep-alive');
             res.setHeader('X-Accel-Buffering', 'no'); // Prevent proxy/ISP buffering (Nginx, Spectrum, etc.)
             res.flushHeaders();
-            req.on('close', () => { clientDisconnected = true; });
+            // Heartbeat through the silent stretch while we wait on the LLM.
+            // Without this, proxies between Express and the browser
+            // (Cloudflare, Render's edge, corporate routers) silently drop
+            // connections that go ~15-60s without any bytes — the server
+            // eventually writes the response, but the socket is already
+            // dead and the client's "thinking…" indicator spins forever.
+            sseKeepalive = createKeepalive(res);
+            sseKeepalive.start();
+            req.on('close', () => {
+                clientDisconnected = true;
+                if (sseKeepalive) sseKeepalive.stop();
+            });
         }
 
         // ── Re-entry detection & topic override ──
@@ -1335,6 +1348,7 @@ router.post('/', isAuthenticated, promptInjectionFilter, conditionalUpload, cond
         };
 
         if (useStreaming) {
+            if (sseKeepalive) sseKeepalive.stop();
             if (!clientDisconnected) {
                 try {
                     res.write(`data: ${JSON.stringify({ type: 'complete', data: responseData })}\n\n`);
@@ -1349,6 +1363,7 @@ router.post('/', isAuthenticated, promptInjectionFilter, conditionalUpload, cond
 
     } catch (error) {
         logger.error('Chat route failed', error);
+        if (sseKeepalive) sseKeepalive.stop();
         // Prevent "headers already sent" crash during streaming mode
         if (res.headersSent) {
             try {
@@ -2290,6 +2305,11 @@ The student has an overdue Growth Check (${timingPhrase} since their last one). 
             res.setHeader('Connection', 'keep-alive');
             res.setHeader('X-Accel-Buffering', 'no'); // Prevent proxy/ISP buffering (Nginx, Spectrum, etc.)
             res.flushHeaders();
+            // Same proxy-drop guard as the main chat route — keep the
+            // connection visibly alive during the LLM round-trip.
+            const greetingKeepalive = createKeepalive(res);
+            greetingKeepalive.start();
+            req.on('close', () => greetingKeepalive.stop());
 
             try {
                 const stream = await callLLMStream(PRIMARY_CHAT_MODEL, messagesForAI, { temperature: 0.55, max_tokens: maxTokens });
@@ -2367,11 +2387,13 @@ The student has an overdue Growth Check (${timingPhrase} since their last one). 
                 if (greetingInlineCta) {
                     streamDonePayload.inlineCta = greetingInlineCta;
                 }
+                greetingKeepalive.stop();
                 res.write(`data: ${JSON.stringify(streamDonePayload)}\n\n`);
                 res.end();
 
             } catch (streamError) {
                 logger.error('Greeting stream error', streamError);
+                greetingKeepalive.stop();
                 res.write(`data: ${JSON.stringify({ error: 'Stream failed' })}\n\n`);
                 res.end();
             }

--- a/tests/unit/sseKeepalive.test.js
+++ b/tests/unit/sseKeepalive.test.js
@@ -1,0 +1,238 @@
+/**
+ * sseKeepalive — heartbeat writer for SSE responses.
+ *
+ * The bug this guards: proxies between Express and the browser
+ * (Cloudflare, Render's edge, corporate routers) silently drop
+ * SSE connections that go ~15-60s without bytes. The server
+ * eventually writes the response, but the socket is already
+ * dead, and the client's "thinking…" indicator spins forever.
+ *
+ * The helper writes ": ping\n\n" — an SSE comment, ignored by
+ * the EventSource / hand-rolled fetch parser — on a fixed
+ * cadence so the connection stays visibly alive.
+ */
+
+const { createKeepalive, KEEPALIVE_LINE, DEFAULT_INTERVAL_MS } = require('../../utils/sseKeepalive');
+
+function makeFakeRes() {
+  const res = {
+    writes: [],
+    writableEnded: false,
+    writableFinished: false,
+    destroyed: false,
+    throwOnWrite: false,
+    write(chunk) {
+      if (this.throwOnWrite) throw new Error('EPIPE');
+      this.writes.push(chunk);
+      return true;
+    },
+  };
+  return res;
+}
+
+// Manual clock + scheduler so tests don't rely on real timers.
+function makeFakeScheduler() {
+  let nextId = 1;
+  const timers = new Map();
+  const scheduler = (fn, ms) => {
+    const id = { _id: nextId++, fn, ms, ticks: 0, unref: () => { id.unrefed = true; } };
+    timers.set(id._id, id);
+    return id;
+  };
+  const canceler = (id) => { if (id && id._id) timers.delete(id._id); };
+  return {
+    setInterval: scheduler,
+    clearInterval: canceler,
+    tick(id) {
+      const t = timers.get(id._id);
+      if (t) {
+        t.ticks++;
+        t.fn();
+      }
+    },
+    has(id) { return timers.has(id._id); },
+  };
+}
+
+describe('sseKeepalive — exports', () => {
+  test('KEEPALIVE_LINE is the SSE comment "ping" form (parser ignores it)', () => {
+    expect(KEEPALIVE_LINE).toBe(': ping\n\n');
+  });
+
+  test('DEFAULT_INTERVAL_MS is 15 seconds (well below typical proxy idle thresholds)', () => {
+    expect(DEFAULT_INTERVAL_MS).toBe(15 * 1000);
+  });
+});
+
+describe('sseKeepalive — start / stop lifecycle', () => {
+  test('start() schedules an interval; stop() clears it', () => {
+    const res = makeFakeRes();
+    const sched = makeFakeScheduler();
+    const ka = createKeepalive(res, {
+      intervalMs: 15000,
+      setInterval: sched.setInterval,
+      clearInterval: sched.clearInterval,
+    });
+    expect(ka.isRunning()).toBe(false);
+    ka.start();
+    expect(ka.isRunning()).toBe(true);
+    ka.stop();
+    expect(ka.isRunning()).toBe(false);
+  });
+
+  test('start() is idempotent — a second call is a no-op (no double scheduling)', () => {
+    const res = makeFakeRes();
+    const sched = makeFakeScheduler();
+    let scheduleCalls = 0;
+    const wrappedScheduler = (fn, ms) => { scheduleCalls++; return sched.setInterval(fn, ms); };
+    const ka = createKeepalive(res, {
+      setInterval: wrappedScheduler,
+      clearInterval: sched.clearInterval,
+    });
+    ka.start();
+    ka.start();
+    ka.start();
+    expect(scheduleCalls).toBe(1);
+  });
+
+  test('stop() is idempotent — calling twice does not throw', () => {
+    const res = makeFakeRes();
+    const ka = createKeepalive(res);
+    ka.start();
+    ka.stop();
+    expect(() => ka.stop()).not.toThrow();
+  });
+
+  test('start() after stop() is a no-op (cannot resurrect a stopped keepalive)', () => {
+    const res = makeFakeRes();
+    const sched = makeFakeScheduler();
+    const ka = createKeepalive(res, {
+      setInterval: sched.setInterval,
+      clearInterval: sched.clearInterval,
+    });
+    ka.start();
+    ka.stop();
+    ka.start();
+    expect(ka.isRunning()).toBe(false);
+  });
+});
+
+describe('sseKeepalive — emission', () => {
+  test('each tick writes one ": ping\\n\\n" line', () => {
+    const res = makeFakeRes();
+    const sched = makeFakeScheduler();
+    const ka = createKeepalive(res, {
+      setInterval: sched.setInterval,
+      clearInterval: sched.clearInterval,
+    });
+    ka.start();
+    const timerId = res; // unused — we need the id, grab from the scheduler's map
+    // Find the registered timer (only one exists)
+    let id;
+    sched.has = sched.has.bind(sched);
+    // Tick by calling each registered timer's fn.
+    // We don't expose them publicly, so do it via reflection: the
+    // scheduler returned IDs synchronously; we can capture them by
+    // wrapping setInterval. Re-do the build:
+
+    // Recreate cleanly with capture.
+    const res2 = makeFakeRes();
+    let capturedTimer = null;
+    const captureScheduler = (fn, ms) => {
+      capturedTimer = { _id: 1, fn, ticks: 0, unref: () => {} };
+      return capturedTimer;
+    };
+    const ka2 = createKeepalive(res2, {
+      setInterval: captureScheduler,
+      clearInterval: () => { capturedTimer = null; },
+    });
+    ka2.start();
+    capturedTimer.fn();
+    expect(res2.writes).toEqual([': ping\n\n']);
+    capturedTimer.fn();
+    capturedTimer.fn();
+    expect(res2.writes).toEqual([': ping\n\n', ': ping\n\n', ': ping\n\n']);
+    expect(ka2.beatCount()).toBe(3);
+  });
+
+  test('skips writes when res.writableEnded (response already finished)', () => {
+    const res = makeFakeRes();
+    let capturedTimer = null;
+    const ka = createKeepalive(res, {
+      setInterval: (fn) => { capturedTimer = { _id: 1, fn, unref: () => {} }; return capturedTimer; },
+      clearInterval: () => { capturedTimer = null; },
+    });
+    ka.start();
+    res.writableEnded = true;
+    capturedTimer.fn();
+    expect(res.writes).toHaveLength(0);
+    // And it self-stopped:
+    expect(ka.isRunning()).toBe(false);
+  });
+
+  test('skips writes when res.destroyed', () => {
+    const res = makeFakeRes();
+    let capturedTimer = null;
+    const ka = createKeepalive(res, {
+      setInterval: (fn) => { capturedTimer = { _id: 1, fn, unref: () => {} }; return capturedTimer; },
+      clearInterval: () => { capturedTimer = null; },
+    });
+    ka.start();
+    res.destroyed = true;
+    capturedTimer.fn();
+    expect(res.writes).toHaveLength(0);
+    expect(ka.isRunning()).toBe(false);
+  });
+
+  test('catches write errors (e.g. broken pipe) and stops cleanly', () => {
+    const res = makeFakeRes();
+    res.throwOnWrite = true;
+    let capturedTimer = null;
+    const ka = createKeepalive(res, {
+      setInterval: (fn) => { capturedTimer = { _id: 1, fn, unref: () => {} }; return capturedTimer; },
+      clearInterval: () => { capturedTimer = null; },
+    });
+    ka.start();
+    expect(() => capturedTimer.fn()).not.toThrow();
+    // After the throw, the keepalive should have stopped itself:
+    expect(ka.isRunning()).toBe(false);
+  });
+
+  test('beatCount() reflects only successful writes', () => {
+    const res = makeFakeRes();
+    let capturedTimer = null;
+    const ka = createKeepalive(res, {
+      setInterval: (fn) => { capturedTimer = { _id: 1, fn, unref: () => {} }; return capturedTimer; },
+      clearInterval: () => { capturedTimer = null; },
+    });
+    ka.start();
+    capturedTimer.fn();
+    capturedTimer.fn();
+    expect(ka.beatCount()).toBe(2);
+    res.writableEnded = true;
+    capturedTimer.fn(); // should NOT count
+    expect(ka.beatCount()).toBe(2);
+  });
+});
+
+describe('sseKeepalive — timer.unref()', () => {
+  test('calls unref() on the timer so it never keeps the event loop alive', () => {
+    const res = makeFakeRes();
+    let unrefed = false;
+    const ka = createKeepalive(res, {
+      setInterval: () => ({ _id: 1, fn: () => {}, unref: () => { unrefed = true; } }),
+      clearInterval: () => {},
+    });
+    ka.start();
+    expect(unrefed).toBe(true);
+  });
+
+  test('does not throw if the timer object has no unref method', () => {
+    const res = makeFakeRes();
+    const ka = createKeepalive(res, {
+      setInterval: () => ({ _id: 1, fn: () => {} }), // no unref
+      clearInterval: () => {},
+    });
+    expect(() => ka.start()).not.toThrow();
+  });
+});

--- a/utils/sseKeepalive.js
+++ b/utils/sseKeepalive.js
@@ -1,0 +1,112 @@
+// ============================================================
+// sseKeepalive.js — keep an SSE response alive through silent
+// stretches by emitting a no-op comment on a fixed interval.
+//
+// Why this exists
+// ---------------
+// When the chat pipeline is mid-LLM-call (a typical 5–15s of no
+// outbound writes), proxies between Express and the browser
+// (Cloudflare, Render's edge, corporate routers) can decide the
+// connection is idle and drop it. The TCP socket dies silently;
+// the server eventually writes the full response, but the bytes
+// have nowhere to go. The client never sees `done` on its reader
+// loop and the "thinking…" indicator spins forever.
+//
+// SSE has a built-in solution: any line starting with ":" is a
+// comment, ignored by the EventSource parser and by our hand-
+// rolled fetch reader. Writing `": ping\n\n"` every ~15 seconds
+// is enough to keep every proxy in the chain happy without
+// polluting the application stream.
+//
+// Usage
+// -----
+//   const { createKeepalive } = require('../utils/sseKeepalive');
+//   // After res.flushHeaders():
+//   const ka = createKeepalive(res, { intervalMs: 15000 });
+//   ka.start();
+//   req.on('close', () => ka.stop());
+//   // ... when the response completes:
+//   ka.stop();
+//   res.end();
+//
+// The helper is defensive: it stops itself once `res.end()` is
+// called and won't write to a finished response. It also catches
+// any synchronous write error (broken pipe, etc.) and stops.
+// ============================================================
+
+'use strict';
+
+const DEFAULT_INTERVAL_MS = 15 * 1000;
+const KEEPALIVE_LINE = ': ping\n\n';
+
+/**
+ * Wrap an Express response with a heartbeat writer.
+ *
+ * @param {import('http').ServerResponse} res
+ * @param {Object} [options]
+ * @param {number} [options.intervalMs=15000] - heartbeat cadence
+ * @param {Function} [options.now=Date.now] - testable clock
+ * @param {Function} [options.setInterval=setInterval] - testable scheduler
+ * @param {Function} [options.clearInterval=clearInterval]
+ * @returns {{ start: Function, stop: Function, isRunning: Function, beatCount: Function }}
+ */
+function createKeepalive(res, options = {}) {
+    const intervalMs = options.intervalMs || DEFAULT_INTERVAL_MS;
+    const scheduler = options.setInterval || setInterval;
+    const canceler = options.clearInterval || clearInterval;
+
+    let timer = null;
+    let stopped = false;
+    let beats = 0;
+
+    function stop() {
+        if (stopped) return;
+        stopped = true;
+        if (timer) {
+            canceler(timer);
+            timer = null;
+        }
+    }
+
+    function tick() {
+        if (stopped) return;
+        // writableEnded means res.end() was called; writableFinished means
+        // the body has been fully flushed. Either way, no more writes are
+        // safe — stop here rather than letting Node throw.
+        if (!res || res.writableEnded || res.writableFinished || res.destroyed) {
+            stop();
+            return;
+        }
+        try {
+            res.write(KEEPALIVE_LINE);
+            beats++;
+        } catch (_) {
+            // Broken pipe, ECONNRESET, etc. The response is gone; nothing
+            // we can do but stop the timer so we don't keep throwing.
+            stop();
+        }
+    }
+
+    function start() {
+        if (timer || stopped) return;
+        timer = scheduler(tick, intervalMs);
+        // Don't keep the Node event loop alive just for this heartbeat
+        // — if the process is otherwise idle, we have bigger problems.
+        if (timer && typeof timer.unref === 'function') {
+            timer.unref();
+        }
+    }
+
+    return {
+        start,
+        stop,
+        isRunning: () => !stopped && timer !== null,
+        beatCount: () => beats,
+    };
+}
+
+module.exports = {
+    createKeepalive,
+    KEEPALIVE_LINE,
+    DEFAULT_INTERVAL_MS,
+};


### PR DESCRIPTION
Proxies between Express and the browser (Cloudflare, Render's edge, corporate routers) silently drop SSE connections that go ~15-60s without bytes. The server eventually writes the response, but the socket is already dead — the client's reader.read() sits there forever, the "thinking…" indicator never clears, and the page can slip into "isn't responding."

Two changes addressing the same root cause:

Server: emit ": ping\n\n" (an SSE comment, ignored by the EventSource / fetch reader) every 15s while a streaming response is in flight. Applied to the main /api/chat streaming path and the streaming greeting opener. utils/sseKeepalive.js wraps the timer lifecycle (start, stop, self-cancel on res end or client disconnect, swallow write errors on broken pipe).

Client: wrap the chat fetch in an AbortController and arm a 90s idle timer in the SSE reader loop. Every reader.read() return resets the timer; if 90s elapse with no bytes (well above the 15s server keepalive cadence), abort the fetch and surface a clear "connection dropped" error with retry — the spinner clears instead of running forever.