### PR TITLE
Mobile UX/UI polish (in progress)

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -2247,6 +2247,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <script src="/js/avatar-config-data.js"></script>
   <!-- Redesigned chat shell behavior (tutor swap, quick actions, header pills) -->
   <script defer src="/js/chat-redesign.js"></script>
+  <!-- Drive the "Live with <tutor>" pill bars from real TTS playback -->
+  <script type="module" src="/js/chat-voice-meter.js"></script>
   <script src="/js/voice-stream-client.js?v=3"></script>
   <script src="/js/voice-controller.js"></script>
   <!-- Voice as a layout mode of the chat stage -->

--- a/public/chat.html
+++ b/public/chat.html
@@ -931,9 +931,11 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         </div>
         <!-- Enter immersive voice tutor — plain anchor, no JS needed.
              The actual paywall fires when voice-tutor's WS upgrade is
-             attempted (utils/voiceUpgrade.js / PR #985). -->
+             attempted (utils/voiceUpgrade.js / PR #985). Icon is a
+             headset so it reads as "voice call with tutor" rather than
+             "another dictation mic" (the toolbar already has a mic). -->
         <a href="/voice-tutor.html" id="voice-mode-btn" class="imessage-voice-btn" title="Talk to your tutor" aria-label="Switch to voice tutor">
-          <i class="fas fa-microphone-lines"></i>
+          <i class="fas fa-headset"></i>
         </a>
         <button id="send-button" class="imessage-send-btn" title="Send" aria-label="Send message">
           <i class="fas fa-arrow-up"></i>

--- a/public/css/mobile-poster-chat.css
+++ b/public/css/mobile-poster-chat.css
@@ -90,11 +90,15 @@
       rgba(7,9,15,.97) 100%);
     transition: background .45s ease;
   }
+  /* Conversation state: darken the top of the gradient too. Idle keeps a
+     bright poster behind the greeting; once the student is reading lesson
+     cards, every part of the surface has to support text, including the
+     top band that sits in front of the tutor's face. */
   body.cr-mode.mpc-has-messages .mpc-scrim {
     background: linear-gradient(180deg,
-      rgba(7,9,15,.30) 0%,
-      rgba(7,9,15,.34) 24%,
-      rgba(7,9,15,.86) 52%,
+      rgba(7,9,15,.58) 0%,
+      rgba(7,9,15,.62) 22%,
+      rgba(7,9,15,.90) 52%,
       rgba(7,9,15,.98) 78%);
   }
 
@@ -311,7 +315,7 @@
   /* assistant = lesson card */
   body.cr-mode #chat-messages-container .message.ai {
     max-width: 88% !important;
-    background: rgba(22,27,46,.92) !important;
+    background: rgba(22,27,46,.96) !important;
     color: #E6E9F2 !important;
     border: 1px solid rgba(124,107,255,.30) !important;
     border-radius: 5px 18px 18px 18px !important;
@@ -323,6 +327,32 @@
     -webkit-backdrop-filter: blur(6px);
   }
   body.cr-mode #chat-messages-container .message.ai .message-text { color: #E6E9F2; }
+
+  /* KaTeX inside AI bubbles — the default .katex color inherits, but
+     the serif math glyphs are thinner than the surrounding sans text
+     and read as washed-out against the poster bleed. Force a brighter
+     stroke and a hair more weight so equations land with the same
+     visual weight as the prose around them. Targeting just .katex
+     keeps any future colored-math (\color{...}) intact via specificity. */
+  body.cr-mode #chat-messages-container .message.ai .katex {
+    color: #F4F6FB !important;
+    font-weight: 500;
+  }
+  /* Display math inside AI bubbles needs its own surface — without one,
+     the gradient card from math-style.css collapses into the bubble and
+     equations lose their "this is the thing" framing. Lift it onto a
+     slightly darker pad with a brighter accent rail. */
+  body.cr-mode #chat-messages-container .message.ai .katex-display {
+    margin: 10px 0;
+    padding: 12px 14px !important;
+    background: rgba(7, 9, 15, 0.55) !important;
+    border: 1px solid rgba(255, 255, 255, 0.08) !important;
+    border-left: 3px solid #8B7BFF !important;
+    border-radius: 10px !important;
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+
   body.cr-mode #chat-messages-container .message.system-error {
     background: rgba(255,78,78,.16) !important;
     border: 1px solid rgba(255,78,78,.4) !important;
@@ -330,8 +360,9 @@
   }
   body.cr-mode #chat-messages-container .message-timestamp {
     font-size: 11px;
-    color: #8a93a8;
+    color: #b6bfd2;
     margin-top: 4px;
+    text-shadow: 0 1px 4px rgba(0, 0, 0, 0.75);
   }
   /* Per-message TTS button: its base styling is light-theme (near-black
      icon on a faint dark wash) so it was invisible on the dark poster
@@ -343,12 +374,6 @@
   }
   body.cr-mode #chat-messages-container .play-audio-btn:active {
     background-color: rgba(124,107,255,.34) !important;
-  }
-  /* give rendered math room to breathe */
-  body.cr-mode #chat-messages-container .message.ai .katex-display {
-    margin: 10px 0;
-    overflow-x: auto;
-    overflow-y: hidden;
   }
   body.cr-mode #thinking-indicator {
     margin: 4px 16px 10px !important;

--- a/public/css/workspace.css
+++ b/public/css/workspace.css
@@ -186,6 +186,7 @@
 
 /* ---- Mobile / tablet: workspace becomes a slide-in drawer ---- */
 .cr-ws-fab { display: none; }
+.cr-ws-backdrop { display: none; }
 
 @media (max-width: 1200px) {
   .cr-workspace {
@@ -204,7 +205,44 @@
   }
   .cr-workspace.is-open { transform: none; }
   .cr-ws-close { display: block; }
-  .cr-ws-tabs { padding-right: 44px; }
+
+  /* Reserve room for the close X (top-right) and respect the device notch
+     so the first tab ("Board") isn't sliced when the drawer opens. */
+  .cr-ws-tabs {
+    padding-right: 44px;
+    padding-top: calc(env(safe-area-inset-top, 0px) + 6px);
+  }
+  .cr-ws-close {
+    top: calc(env(safe-area-inset-top, 0px) + 8px);
+  }
+
+  /* Dimmed backdrop. Acts as the tap-to-close target and visually anchors
+     the drawer as a modal surface over the chat poster. Lives at the body
+     level (see workspace.js) so it can sit above #mpc-topbar (z-index 30)
+     and clear the wrapper's mobile stacking context. */
+  .cr-ws-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(7, 9, 15, 0.55);
+    backdrop-filter: blur(2px);
+    -webkit-backdrop-filter: blur(2px);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity var(--cr-transition);
+    z-index: 1700;
+  }
+  .cr-ws-backdrop.is-open {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  /* When the drawer is open, hide the floating top chrome so it doesn't
+     paint over the drawer's own tab row (mpc-topbar is z-index:30 at body
+     level; the drawer is trapped inside #app-layout-wrapper's z-index:1
+     stacking context on mobile, so it can't beat the topbar from inside). */
+  body.cr-ws-drawer-open #mpc-topbar { display: none !important; }
+  body.cr-ws-drawer-open .cr-ws-fab { display: none; }
 
   .cr-ws-fab {
     display: inline-flex;
@@ -226,8 +264,21 @@
   }
 }
 
+/* Phones: drawer goes full-width so chat content doesn't leak through on
+   the left and read as "half-open". The body class also bumps the wrapper
+   above mpc-topbar in case the user has a tablet-width device where the
+   backdrop alone isn't enough. */
+@media (max-width: 768px) {
+  .cr-workspace {
+    width: 100vw;
+    border-radius: 0;
+  }
+  body.cr-ws-drawer-open #app-layout-wrapper { z-index: 50; }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .cr-workspace { transition: none; }
+  .cr-ws-backdrop { transition: none; }
 }
 
 /* ============================================================

--- a/public/css/workspace.css
+++ b/public/css/workspace.css
@@ -337,17 +337,48 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
+  /* Number resolve cards in document order so the student sees STEP 1,
+     STEP 2, ... without needing JS bookkeeping. Reset per board. */
+  counter-reset: cr-ws-step;
 }
 
 .cr-ws-board-empty {
   text-align: center;
-  padding: 28px 14px;
+  padding: 28px 18px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
   color: var(--cr-text-dim);
   font-size: 13px;
   line-height: 1.5;
   border: 1px dashed var(--cr-border);
   border-radius: var(--cr-radius-md);
   background: rgba(255, 255, 255, 0.02);
+}
+.cr-ws-board-empty-ico {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: var(--cr-pill-bg);
+  color: var(--cr-accent);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+}
+.cr-ws-board-empty-title {
+  margin: 4px 0 0;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--cr-text);
+}
+.cr-ws-board-empty-body {
+  margin: 0;
+  max-width: 260px;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--cr-text-dim);
 }
 
 /* Common card chrome */
@@ -385,6 +416,25 @@
   font-weight: 700;
   letter-spacing: 0.10em;
   color: var(--cr-accent);
+  opacity: 0.85;
+}
+
+/* Resolve — a step the student has taken. Numbered (STEP 1, STEP 2, ...)
+   so two cards with the same equation don't read as a duplicate. The
+   counter is incremented by the card itself and reset on the stack. */
+.cr-ws-board-card--resolve {
+  counter-increment: cr-ws-step;
+  border-color: rgba(139, 123, 255, 0.18);
+}
+.cr-ws-board-card--resolve::before {
+  content: "STEP " counter(cr-ws-step);
+  position: absolute;
+  top: 8px;
+  left: 14px;
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.10em;
+  color: var(--cr-text-dim);
   opacity: 0.85;
 }
 

--- a/public/css/workspace.css
+++ b/public/css/workspace.css
@@ -248,20 +248,25 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    gap: 7px;
     position: fixed;
-    right: 16px;
-    bottom: 84px;
-    width: 52px;
-    height: 52px;
-    border: 1px solid var(--cr-border);
-    border-radius: 50%;
+    right: 14px;
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 92px);
+    height: 38px;
+    padding: 0 14px 0 12px;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 999px;
     background: var(--cr-accent-grad);
     color: #fff;
-    font-size: 19px;
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 0.01em;
     box-shadow: var(--cr-shadow-md);
     cursor: pointer;
     z-index: 901;
   }
+  .cr-ws-fab i { font-size: 14px; }
+  .cr-ws-fab-label { line-height: 1; }
 }
 
 /* Phones: drawer goes full-width so chat content doesn't leak through on

--- a/public/js/chat-voice-meter.js
+++ b/public/js/chat-voice-meter.js
@@ -29,7 +29,15 @@ import { createStripMeter } from './modules/voice-meter.js';
   }
 
   function loop() {
-    if (!analyser) return;
+    // Self-terminate if the audio context was closed under us. stopAudio()
+    // in modules/audio.js closes the context without dispatching
+    // audioPlaybackEnded, so without this check the loop would keep polling
+    // a dead analyser and the bars would freeze at floor value instead of
+    // returning to the CSS keyframe pulse.
+    if (!analyser || (analyser.context && analyser.context.state === 'closed')) {
+      stop();
+      return;
+    }
     analyser.getByteFrequencyData(buf);
     meter.update(buf);
     raf = requestAnimationFrame(loop);

--- a/public/js/chat-voice-meter.js
+++ b/public/js/chat-voice-meter.js
@@ -1,0 +1,48 @@
+// chat-voice-meter.js
+// Wire the "Live with <tutor>" pill's waveform to the real TTS playback.
+//
+// The pill's bars used to be a pure CSS keyframe animation (six spans
+// with staggered heights). Now: when audio.js dispatches
+// audioPlaybackStarted, we drive the bars from frequency data on the
+// playback analyser. When playback ends, hand control back to the CSS
+// keyframes so the pill keeps a subtle idle pulse.
+
+import { createStripMeter } from './modules/voice-meter.js';
+
+(function () {
+  if (!document.body.classList.contains('cr-mode')) return;
+
+  const container = document.querySelector('.cr-waveform');
+  if (!container) return;
+
+  const meter = createStripMeter(container);
+  let raf = 0;
+  let analyser = null;
+  let buf = null;
+
+  function stop() {
+    if (raf) cancelAnimationFrame(raf);
+    raf = 0;
+    analyser = null;
+    buf = null;
+    meter.idle();
+  }
+
+  function loop() {
+    if (!analyser) return;
+    analyser.getByteFrequencyData(buf);
+    meter.update(buf);
+    raf = requestAnimationFrame(loop);
+  }
+
+  document.addEventListener('audioPlaybackStarted', (e) => {
+    const a = e && e.detail && e.detail.analyser;
+    if (!a) return;
+    analyser = a;
+    buf = new Uint8Array(analyser.frequencyBinCount);
+    if (raf) cancelAnimationFrame(raf);
+    loop();
+  });
+
+  document.addEventListener('audioPlaybackEnded', stop);
+})();

--- a/public/js/modules/audio.js
+++ b/public/js/modules/audio.js
@@ -6,6 +6,7 @@ export const audioState = {
     context: null,
     buffer: null,
     source: null,
+    analyser: null,
     startTime: 0,
     pausedAt: 0,
     isPaused: false,
@@ -123,7 +124,20 @@ function startAudioPlayback(offset = 0, playButton = null) {
     const source = audioState.context.createBufferSource();
     source.buffer = audioState.buffer;
     source.playbackRate.value = audioState.playbackRate;
-    source.connect(audioState.context.destination);
+
+    // Insert an AnalyserNode between the source and the destination so
+    // voice-reactive meters (chat pill, voice-tutor orb) can pull
+    // frequency data from a live playback chain. Reuses the analyser
+    // across playbacks within the same context so listeners stay
+    // attached across queue items.
+    if (!audioState.analyser || audioState.analyser.context !== audioState.context) {
+        const analyser = audioState.context.createAnalyser();
+        analyser.fftSize = 256;
+        analyser.smoothingTimeConstant = 0.8;
+        analyser.connect(audioState.context.destination);
+        audioState.analyser = analyser;
+    }
+    source.connect(audioState.analyser);
 
     audioState.source = source;
     _currentAudioSource = source;
@@ -136,6 +150,9 @@ function startAudioPlayback(offset = 0, playButton = null) {
     }
 
     source.start(0, offset);
+    document.dispatchEvent(new CustomEvent('audioPlaybackStarted', {
+        detail: { analyser: audioState.analyser }
+    }));
 
     source.onended = () => {
         if (audioState.isPlaying && !audioState.isPaused) {
@@ -250,6 +267,7 @@ export function resetAudioState() {
     audioState.context = null;
     audioState.buffer = null;
     audioState.source = null;
+    audioState.analyser = null;
     audioState.startTime = 0;
     audioState.pausedAt = 0;
     audioState.isPaused = false;

--- a/public/js/modules/audio.js
+++ b/public/js/modules/audio.js
@@ -127,9 +127,10 @@ function startAudioPlayback(offset = 0, playButton = null) {
 
     // Insert an AnalyserNode between the source and the destination so
     // voice-reactive meters (chat pill, voice-tutor orb) can pull
-    // frequency data from a live playback chain. Reuses the analyser
-    // across playbacks within the same context so listeners stay
-    // attached across queue items.
+    // frequency data from a live playback chain. Guarded null check is
+    // defensive — in current flow resetAudioState nulls audioState.analyser
+    // alongside the context so the second branch never trips, but we keep
+    // it in case the lifecycle changes.
     if (!audioState.analyser || audioState.analyser.context !== audioState.context) {
         const analyser = audioState.context.createAnalyser();
         analyser.fftSize = 256;

--- a/public/js/modules/voice-meter.js
+++ b/public/js/modules/voice-meter.js
@@ -1,0 +1,135 @@
+// modules/voice-meter.js
+// Audio-reactive meter renderers.
+//
+// Two shapes share one engine:
+//   - Orb meter:   48 radial bars on a canvas (voice-tutor presence)
+//   - Strip meter: N inline DOM bars whose heights track frequency bins
+//                  (chat's "Live with <tutor>" pill)
+//
+// Callers own the AnalyserNode + drive .update(buffer) per frame. This
+// module is pure rendering — no audio plumbing — so it can be reused
+// against any source (mic MediaStream, BufferSourceNode, MediaElement).
+
+const TEAL = { r: 18, g: 179, b: 179 };
+const INDIGO = { r: 102, g: 126, b: 234 };
+
+function rgba(c, a) {
+  return `rgba(${c.r}, ${c.g}, ${c.b}, ${a})`;
+}
+
+/**
+ * Draw a radial bar waveform to a 2D canvas.
+ *
+ * Lifted from voice-tutor-session.js so chat and voice-tutor can render
+ * from the same code. Tuning (bars, radius, color) is overridable.
+ *
+ * @param {HTMLCanvasElement} canvas
+ * @param {Uint8Array} freqData  result of analyser.getByteFrequencyData
+ * @param {{ color?: {r,g,b}, bars?: number, baseRadius?: number, maxHeight?: number, slice?: number }} [opts]
+ */
+export function drawRadialWaveform(canvas, freqData, opts = {}) {
+  if (!canvas || !freqData) return;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+
+  const w = canvas.width;
+  const h = canvas.height;
+  const cx = w / 2;
+  const cy = h / 2;
+
+  const color = opts.color || TEAL;
+  const bars = opts.bars || 48;
+  const baseRadius = opts.baseRadius != null ? opts.baseRadius : 25;
+  const maxHeight = opts.maxHeight != null ? opts.maxHeight : 35;
+  // Voice band ≈ bottom ~40-50% of the spectrum; trims out high noise that
+  // makes the viz look "jittery" without adding information.
+  const slice = opts.slice || 0.5;
+
+  ctx.clearRect(0, 0, w, h);
+
+  for (let i = 0; i < bars; i++) {
+    const angle = (i / bars) * Math.PI * 2 - Math.PI / 2;
+    const freqIndex = Math.floor((i / bars) * freqData.length * slice);
+    const value = (freqData[freqIndex] || 0) / 255;
+
+    const r1 = baseRadius;
+    const r2 = baseRadius + value * maxHeight;
+
+    const x1 = cx + Math.cos(angle) * r1;
+    const y1 = cy + Math.sin(angle) * r1;
+    const x2 = cx + Math.cos(angle) * r2;
+    const y2 = cy + Math.sin(angle) * r2;
+
+    ctx.beginPath();
+    ctx.moveTo(x1, y1);
+    ctx.lineTo(x2, y2);
+    ctx.strokeStyle = rgba(color, 0.3 + value * 0.7);
+    ctx.lineWidth = 2.5;
+    ctx.lineCap = 'round';
+    ctx.stroke();
+  }
+
+  const glow = ctx.createRadialGradient(cx, cy, 0, cx, cy, baseRadius);
+  glow.addColorStop(0, rgba(color, 0.12));
+  glow.addColorStop(1, 'transparent');
+  ctx.beginPath();
+  ctx.arc(cx, cy, baseRadius, 0, Math.PI * 2);
+  ctx.fillStyle = glow;
+  ctx.fill();
+}
+
+export const VOICE_METER_COLORS = { TEAL, INDIGO };
+
+/**
+ * Drive a row of inline DOM bars (the chat "Live" pill waveform) from
+ * frequency data. Each child <span> of the container becomes one bar;
+ * its height is animated via inline style. Falls back to a slow idle
+ * pulse when no audio is flowing.
+ *
+ * @param {HTMLElement} container
+ * @param {{ minHeight?: number, maxHeight?: number, slice?: number }} [opts]
+ * @returns {{ update: (freqData: Uint8Array) => void, idle: () => void, dispose: () => void }}
+ */
+export function createStripMeter(container, opts = {}) {
+  if (!container) return { update() {}, idle() {}, dispose() {} };
+
+  const bars = Array.from(container.children).filter(n => n.nodeType === 1);
+  const minHeight = opts.minHeight != null ? opts.minHeight : 20;
+  const maxHeight = opts.maxHeight != null ? opts.maxHeight : 100;
+  const slice = opts.slice || 0.5;
+
+  function update(freqData) {
+    if (!freqData) return;
+    const usable = Math.floor(freqData.length * slice);
+    const step = Math.max(1, Math.floor(usable / bars.length));
+    for (let i = 0; i < bars.length; i++) {
+      // Average a small bin window so adjacent bars don't twin from
+      // hitting the same exact frequency index.
+      let sum = 0;
+      const start = i * step;
+      const end = Math.min(usable, start + step);
+      for (let j = start; j < end; j++) sum += freqData[j] || 0;
+      const v = sum / Math.max(1, end - start) / 255;
+      const pct = minHeight + v * (maxHeight - minHeight);
+      // animation:'none' disables the CSS keyframe so inline height wins
+      // (a paused animation still locks the property in some browsers).
+      bars[i].style.animation = 'none';
+      bars[i].style.height = pct + '%';
+    }
+  }
+
+  function idle() {
+    // Hand control back to the CSS keyframe animation. Clearing inline
+    // styles lets the per-bar defaults from the stylesheet take over.
+    bars.forEach(b => {
+      b.style.animation = '';
+      b.style.height = '';
+    });
+  }
+
+  function dispose() {
+    idle();
+  }
+
+  return { update, idle, dispose };
+}

--- a/public/js/workspace.js
+++ b/public/js/workspace.js
@@ -124,7 +124,12 @@
     body.appendChild(stack);
 
     var empty = el('div', 'cr-ws-empty cr-ws-board-empty',
-      'Your working solution will appear here as you and your tutor reason through it together.');
+      '<div class="cr-ws-board-empty-ico" aria-hidden="true">' +
+        '<i class="fas fa-pen-ruler"></i></div>' +
+      '<h5 class="cr-ws-board-empty-title">Ready to work it out?</h5>' +
+      '<p class="cr-ws-board-empty-body">' +
+        'Your steps will land here as you and your tutor work through ' +
+        'the problem together.</p>');
     if (WS.board.steps.length === 0) stack.appendChild(empty);
 
     // Rebuild any persisted steps (e.g. when re-entering the tab).

--- a/public/js/workspace.js
+++ b/public/js/workspace.js
@@ -92,7 +92,7 @@
       btn.textContent = L.btn;
       btn.addEventListener('click', function () {
         // On the mobile drawer, get out of the way of the tool.
-        WS.el.classList.remove('is-open');
+        closeWorkspace();
         try { L.open(); } catch (e) { /* tool not ready yet */ }
       });
       card.appendChild(btn);
@@ -369,8 +369,31 @@
   }
 
   // ---- Drawer (mobile) --------------------------------------------------
-  function openWorkspace()  { if (WS.el) WS.el.classList.add('is-open'); }
-  function closeWorkspace() { if (WS.el) WS.el.classList.remove('is-open'); }
+  // The backdrop is a body-level sibling of the drawer so it can outrank
+  // #mpc-topbar — the drawer itself is trapped inside #app-layout-wrapper's
+  // mobile stacking context, so the backdrop is what actually wins the
+  // z-fight against the floating top chrome.
+  function ensureBackdrop() {
+    if (WS.backdrop) return WS.backdrop;
+    var b = el('div', 'cr-ws-backdrop');
+    b.setAttribute('aria-hidden', 'true');
+    b.addEventListener('click', closeWorkspace);
+    document.body.appendChild(b);
+    WS.backdrop = b;
+    return b;
+  }
+  function openWorkspace() {
+    if (!WS.el) return;
+    WS.el.classList.add('is-open');
+    ensureBackdrop().classList.add('is-open');
+    document.body.classList.add('cr-ws-drawer-open');
+  }
+  function closeWorkspace() {
+    if (!WS.el) return;
+    WS.el.classList.remove('is-open');
+    if (WS.backdrop) WS.backdrop.classList.remove('is-open');
+    document.body.classList.remove('cr-ws-drawer-open');
+  }
 
   function buildFab() {
     var fab = el('button', 'cr-ws-fab',
@@ -378,7 +401,8 @@
     fab.type = 'button';
     fab.setAttribute('aria-label', 'Toggle math workspace');
     fab.addEventListener('click', function () {
-      WS.el.classList.toggle('is-open');
+      if (WS.el.classList.contains('is-open')) closeWorkspace();
+      else openWorkspace();
     });
     document.body.appendChild(fab);
   }

--- a/public/js/workspace.js
+++ b/public/js/workspace.js
@@ -401,10 +401,13 @@
   }
 
   function buildFab() {
+    // Labeled pill, not a mystery circle. Students don't intuit a shapes
+    // icon as "math tools"; the explicit "Workspace" word does the work.
     var fab = el('button', 'cr-ws-fab',
-      '<i class="fas fa-shapes" aria-hidden="true"></i>');
+      '<i class="fas fa-shapes" aria-hidden="true"></i>' +
+      '<span class="cr-ws-fab-label">Workspace</span>');
     fab.type = 'button';
-    fab.setAttribute('aria-label', 'Toggle math workspace');
+    fab.setAttribute('aria-label', 'Open math workspace');
     fab.addEventListener('click', function () {
       if (WS.el.classList.contains('is-open')) closeWorkspace();
       else openWorkspace();


### PR DESCRIPTION
Working through mobile UX/UI issues raised against the live chat experience. Each pass lands as its own commit so you can roll any of them back independently.

## Summary

### Pass 1 — Workspace drawer header collision (this commit)

**Symptom:** On phones, opening the math workspace drawer left the "Live with Maya" pill + hamburger floating on top of the drawer's tab row, slicing off the "Board" tab. The drawer was also only 90vw with no backdrop, so the chat behind leaked through on the left edge and read as a half-open drawer.

**Root cause:** `#app-layout-wrapper { z-index: 1 }` on mobile creates a stacking context that traps the drawer's `z-index: 900` inside it. `#mpc-topbar` is appended to `<body>` with `z-index: 30`, so globally the topbar paints above the drawer.

**Fix:**
- New body-level `.cr-ws-backdrop` (z-index 1700) — tap to close, dims the page.
- `body.cr-ws-drawer-open` hides `#mpc-topbar` + FAB while drawer is up.
- Drawer is 100vw on phones (no leaking chat content underneath).
- Safety net: bump `#app-layout-wrapper` z-index while open.
- Safe-area-inset-top padding on tabs + close X so iOS notch doesn't slice them.
- Launcher's drawer-dismiss now routes through `closeWorkspace()` so the body class + backdrop clean up.

### Pass 2 — Coming next
- Workboard duplicate-card labeling + warmer empty state
- Math rendering contrast inside dark chat bubbles + avatar bleed-through
- Chat input zone density (collapse toolbar, remove duplicate mic, anchor the floating shapes button)

## Test plan
- [ ] iOS Safari — open chat, open workspace drawer via FAB → tabs visible, no pill overlap, backdrop dims chat, tap backdrop closes drawer
- [ ] iOS Safari — open drawer, hit the close X → drawer + body class + backdrop all clear
- [ ] iOS Safari — open drawer, tap a launcher (Tiles / Calc) → drawer closes cleanly, tool opens
- [ ] Android Chrome — same paths
- [ ] Desktop ≥1200px — workspace stays as inline grid column, no backdrop, no body class side-effects

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xnen5iy1SN3t45CYDqVPcw)_