### PR TITLE
style(landing): shift tutor card avatars 6px left

### DIFF
--- a/public/css/landing-page.css
+++ b/public/css/landing-page.css
@@ -1825,6 +1825,7 @@
   object-position: top;
   border: 3px solid #f0f2f5;
   margin-bottom: 1rem;
+  transform: translateX(-6px);
   transition: border-color 0.3s ease, box-shadow 0.3s ease;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
 }


### PR DESCRIPTION
Avatars looked slightly right-of-center against the card text. Add transform: translateX(-6px) to .lp-tutor-card-img so the circle sits visually centered without changing layout flow.