### PR TITLE
Mockup: mobile voice mode layout

### DIFF
--- a/public/voice-mode-mockup.html
+++ b/public/voice-mode-mockup.html
@@ -1,0 +1,512 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
+  <title>Voice Mode — Mockup</title>
+
+  <!-- Tokens + math card chrome reused from production so the prototype
+       reads in the same visual language as the rest of the app. -->
+  <link rel="stylesheet" href="/css/design-system.css" />
+  <link rel="stylesheet" href="/css/workspace.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" />
+  <link rel="stylesheet" href="/vendor/katex/katex.min.css" />
+  <script defer src="/vendor/katex/katex.min.js"></script>
+  <script defer src="/vendor/katex/contrib/auto-render.min.js"></script>
+
+  <style>
+    /* ----- VOICE MODE — STATIC MOCKUP -----
+       Geometry only. No real audio. The waveform is a CSS keyframe
+       and the caption is hard-coded — both are placeholders for the
+       chat-voice-meter wiring and the live transcript stream. */
+
+    :root {
+      --vm-bg: #0B0F1A;
+      --vm-tutor-h: 42vh;            /* docked tutor zone height */
+      --vm-tutor-fade: 56px;         /* soft top fade over which cards dissolve */
+      --vm-caption-bg: rgba(7, 9, 15, 0.78);
+      --vm-accent-listen: 18, 179, 179;     /* teal */
+      --vm-accent-speak: 102, 126, 234;     /* indigo */
+    }
+
+    * { box-sizing: border-box; }
+    html, body {
+      margin: 0;
+      height: 100%;
+      background: var(--vm-bg);
+      color: var(--cr-text);
+      font-family: -apple-system, BlinkMacSystemFont, "Inter", "Helvetica Neue", sans-serif;
+      overflow: hidden;
+    }
+
+    /* Phone-frame so the mock reads at a phone aspect ratio on desktop.
+       On a real phone, body fills the viewport directly. */
+    .vm-frame {
+      position: relative;
+      width: 100vw;
+      height: 100dvh;
+      max-width: 430px;
+      max-height: 932px;
+      margin: 0 auto;
+      background: var(--vm-bg);
+      overflow: hidden;
+    }
+    @media (min-width: 480px) {
+      body { display: flex; align-items: center; justify-content: center; background: #06080F; }
+      .vm-frame { border-radius: 36px; box-shadow: 0 30px 80px rgba(0,0,0,.6); }
+    }
+
+    /* ---- TOP CHROME — minimal: just back + status ------------------- */
+    .vm-topbar {
+      position: absolute;
+      top: 0; left: 0; right: 0;
+      z-index: 30;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: calc(env(safe-area-inset-top, 0px) + 10px) 16px 10px;
+      pointer-events: none;
+    }
+    .vm-topbar > * { pointer-events: auto; }
+    .vm-back {
+      width: 36px; height: 36px;
+      border: 1px solid rgba(255,255,255,.14);
+      border-radius: 50%;
+      background: rgba(13,17,28,.6);
+      backdrop-filter: blur(10px);
+      -webkit-backdrop-filter: blur(10px);
+      color: #fff; font-size: 14px;
+      display: flex; align-items: center; justify-content: center;
+      cursor: pointer;
+    }
+    .vm-state-pill {
+      display: inline-flex; align-items: center; gap: 8px;
+      padding: 7px 13px;
+      border-radius: 999px;
+      background: rgba(13,17,28,.6);
+      border: 1px solid rgba(255,255,255,.13);
+      backdrop-filter: blur(10px);
+      -webkit-backdrop-filter: blur(10px);
+      color: #fff;
+      font-size: 12.5px; font-weight: 600;
+    }
+    .vm-state-dot {
+      width: 7px; height: 7px; border-radius: 50%;
+      background: rgb(var(--vm-accent-listen));
+      box-shadow: 0 0 7px rgba(var(--vm-accent-listen), .85);
+      animation: vmDot 1.6s ease-in-out infinite;
+    }
+    body[data-state="speaking"] .vm-state-dot {
+      background: rgb(var(--vm-accent-speak));
+      box-shadow: 0 0 7px rgba(var(--vm-accent-speak), .85);
+    }
+    @keyframes vmDot { 0%,100% { opacity:1; transform: scale(1) } 50% { opacity:.55; transform: scale(.8) } }
+
+    /* ---- WORK BOARD — scrolls behind the tutor ---------------------- */
+    .vm-board-scroll {
+      position: absolute;
+      top: 0; left: 0; right: 0;
+      bottom: 0;
+      overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
+      /* Bottom padding clears the tutor + waveform + caption + controls.
+         scroll-margin on each card ensures auto-scroll lands cards
+         ABOVE the tutor, not under him. */
+      padding: calc(env(safe-area-inset-top, 0px) + 64px) 16px var(--vm-tutor-h);
+    }
+    .vm-board-scroll::-webkit-scrollbar { display: none; }
+
+    .vm-board-title {
+      margin: 0 0 12px;
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: 0.12em;
+      color: rgba(255,255,255,.55);
+      text-transform: uppercase;
+      display: inline-flex; align-items: center; gap: 8px;
+    }
+    .vm-board-title i { color: var(--cr-accent); font-size: 11px; }
+
+    .vm-stack { display: flex; flex-direction: column; gap: 10px; counter-reset: vm-step; }
+    .vm-stack > * { scroll-margin-bottom: calc(var(--vm-tutor-h) + 12px); }
+
+    /* Reuse the production card chrome via class names that match
+       workspace.css so this prototype's cards look like real cards. */
+    .vm-card {
+      position: relative;
+      padding: 18px 18px 16px;
+      background: var(--cr-bg-panel);
+      border: 1px solid var(--cr-border);
+      border-radius: var(--cr-radius-md);
+      box-shadow: var(--cr-shadow-sm);
+      animation: vmCardIn .35s var(--cr-ease) both;
+    }
+    @keyframes vmCardIn { from { opacity: 0; transform: translateY(8px) } to { opacity: 1; transform: none } }
+
+    .vm-card--pose {
+      border-color: rgba(139, 123, 255, 0.30);
+      background: linear-gradient(180deg, rgba(139,123,255,.06), var(--cr-bg-panel));
+    }
+    .vm-card--pose::before {
+      content: "PROBLEM";
+      position: absolute; top: 8px; left: 14px;
+      font-size: 9.5px; font-weight: 700; letter-spacing: 0.10em;
+      color: var(--cr-accent); opacity: .85;
+    }
+
+    .vm-card--resolve { counter-increment: vm-step; border-color: rgba(139,123,255,.18); }
+    .vm-card--resolve::before {
+      content: "STEP " counter(vm-step);
+      position: absolute; top: 8px; left: 14px;
+      font-size: 9.5px; font-weight: 700; letter-spacing: 0.10em;
+      color: var(--cr-text-dim); opacity: .85;
+    }
+
+    .vm-card--verify {
+      border-color: rgba(46,204,113,.35);
+      background: linear-gradient(180deg, rgba(46,204,113,.08), var(--cr-bg-panel));
+    }
+    .vm-card--verify::before {
+      content: "SOLVED";
+      position: absolute; top: 8px; left: 14px;
+      font-size: 9.5px; font-weight: 700; letter-spacing: 0.10em;
+      color: #2ECC71; opacity: .9;
+    }
+
+    .vm-card-math { padding-top: 12px; font-size: 19px; color: var(--cr-text); text-align: center; }
+    .vm-card-math .katex { color: #F4F6FB; font-size: 1.15em; }
+
+    .vm-apply {
+      padding: 6px 14px;
+      display: flex; align-items: center; justify-content: center; gap: 10px;
+      border: 1px dashed var(--cr-border);
+      border-radius: var(--cr-radius-md);
+      background: transparent;
+      color: var(--cr-text-dim);
+      font-size: 12.5px; font-style: italic;
+    }
+    .vm-apply-arrow { color: var(--cr-accent); font-weight: 700; font-style: normal; }
+
+    /* ---- TUTOR DOCK ------------------------------------------------- */
+    /* Tutor sits absolutely at the bottom with a soft top fade so cards
+       passing behind dissolve into the dock rather than clipping. */
+    .vm-tutor-dock {
+      position: absolute;
+      left: 0; right: 0; bottom: 0;
+      height: var(--vm-tutor-h);
+      z-index: 5;
+      pointer-events: none;
+      -webkit-mask-image: linear-gradient(180deg, transparent 0, #000 var(--vm-tutor-fade), #000 100%);
+              mask-image: linear-gradient(180deg, transparent 0, #000 var(--vm-tutor-fade), #000 100%);
+    }
+    .vm-tutor-bg {
+      position: absolute; inset: 0;
+      background: linear-gradient(180deg, rgba(11,15,26,0) 0%, rgba(11,15,26,.55) 18%, var(--vm-bg) 60%);
+    }
+    .vm-tutor-img {
+      position: absolute;
+      left: 50%; bottom: 0;
+      transform: translateX(-50%);
+      height: 100%;
+      width: auto;
+      max-width: none;
+      object-fit: contain;
+      object-position: center bottom;
+      pointer-events: auto;
+      cursor: pointer;  /* tap to interrupt */
+    }
+    /* Faint listening ring around the portrait when it's the user's turn. */
+    .vm-tutor-ring {
+      position: absolute;
+      left: 50%; bottom: 12%;
+      transform: translateX(-50%);
+      width: 240px; height: 240px;
+      border-radius: 50%;
+      border: 2px solid rgba(var(--vm-accent-listen), .35);
+      animation: vmRing 2.2s ease-out infinite;
+      pointer-events: none;
+    }
+    body[data-state="speaking"] .vm-tutor-ring {
+      border-color: rgba(var(--vm-accent-speak), .35);
+    }
+    @keyframes vmRing {
+      0%   { transform: translateX(-50%) scale(.9); opacity: .55 }
+      80%  { opacity: 0 }
+      100% { transform: translateX(-50%) scale(1.3); opacity: 0 }
+    }
+
+    /* ---- WAVEFORM — painted on the tutor's chest -------------------- */
+    /* A horizontal band of bars, centered on the tutor's mid-section.
+       Color flips between teal (listening) and indigo (speaking) via
+       body[data-state]. Bars are CSS-animated here; in production this
+       canvas is driven by AnalyserNode.getByteFrequencyData via the
+       voice-meter module. */
+    .vm-wave {
+      position: absolute;
+      left: 0; right: 0;
+      bottom: calc(var(--vm-tutor-h) * 0.32);
+      height: 80px;
+      z-index: 6;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 3px;
+      padding: 0 12px;
+      pointer-events: none;
+    }
+    .vm-wave-bar {
+      flex: 1 1 0;
+      max-width: 5px;
+      height: 30%;
+      border-radius: 3px;
+      background: rgba(var(--vm-accent-listen), .85);
+      box-shadow: 0 0 10px rgba(var(--vm-accent-listen), .35);
+      animation: vmBar 1.1s ease-in-out infinite;
+    }
+    body[data-state="speaking"] .vm-wave-bar {
+      background: rgba(var(--vm-accent-speak), .85);
+      box-shadow: 0 0 10px rgba(var(--vm-accent-speak), .35);
+    }
+    @keyframes vmBar {
+      0%, 100% { transform: scaleY(.25) }
+      50%      { transform: scaleY(1) }
+    }
+
+    /* ---- LIVE CAPTION ----------------------------------------------- */
+    /* Sits ABOVE the waveform on its own dark plate so text stays
+       legible regardless of the bar colors below. */
+    .vm-caption {
+      position: absolute;
+      left: 14px; right: 14px;
+      bottom: calc(env(safe-area-inset-bottom, 0px) + 96px);
+      z-index: 10;
+      padding: 12px 16px;
+      background: var(--vm-caption-bg);
+      border: 1px solid rgba(255,255,255,.08);
+      border-radius: 14px;
+      color: #F4F6FB;
+      font-size: 16px;
+      line-height: 1.4;
+      text-align: center;
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
+      box-shadow: 0 8px 24px rgba(0,0,0,.45);
+    }
+    .vm-caption-attrib {
+      display: block;
+      margin-bottom: 4px;
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: rgba(var(--vm-accent-speak), 1);
+    }
+    body[data-state="listening"] .vm-caption-attrib { color: rgba(var(--vm-accent-listen), 1); }
+
+    /* ---- CONTROL ROW ------------------------------------------------ */
+    .vm-controls {
+      position: absolute;
+      left: 0; right: 0;
+      bottom: calc(env(safe-area-inset-bottom, 0px) + 14px);
+      z-index: 11;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 22px;
+      padding: 0 14px;
+    }
+    .vm-ctrl {
+      width: 56px; height: 56px;
+      border: 1px solid rgba(255,255,255,.12);
+      border-radius: 50%;
+      background: rgba(22,27,46,.92);
+      backdrop-filter: blur(10px);
+      -webkit-backdrop-filter: blur(10px);
+      color: #E6E9F2;
+      font-size: 20px;
+      display: flex; align-items: center; justify-content: center;
+      cursor: pointer;
+    }
+    .vm-ctrl--end {
+      background: linear-gradient(135deg, #ff5252, #e53935);
+      border: none;
+      color: #fff;
+      width: 64px; height: 64px;
+      box-shadow: 0 8px 22px rgba(229,57,53,.45);
+    }
+    .vm-ctrl:active { transform: scale(.94); }
+
+    /* ---- STATE TOGGLE (mockup affordance only) --------------------- */
+    .vm-demo-toggle {
+      position: absolute;
+      top: calc(env(safe-area-inset-top, 0px) + 60px);
+      right: 14px;
+      z-index: 40;
+      padding: 6px 10px;
+      font-size: 11px; font-weight: 700; letter-spacing: 0.04em;
+      background: rgba(255,255,255,.08);
+      color: #fff;
+      border: 1px solid rgba(255,255,255,.14);
+      border-radius: 8px;
+      cursor: pointer;
+      text-transform: uppercase;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .vm-wave-bar, .vm-tutor-ring, .vm-state-dot, .vm-card { animation: none }
+    }
+  </style>
+</head>
+
+<body data-state="speaking">
+  <div class="vm-frame">
+
+    <!-- Top: minimal chrome — back arrow + state pill -->
+    <nav class="vm-topbar" aria-label="Voice session controls">
+      <button class="vm-back" aria-label="Back to chat"><i class="fas fa-chevron-left"></i></button>
+      <div class="vm-state-pill">
+        <span class="vm-state-dot" aria-hidden="true"></span>
+        <span id="vm-state-text">Mr. Nappier is speaking</span>
+      </div>
+      <div style="width:36px"></div>
+    </nav>
+
+    <!-- Demo-only toggle to flip listening / speaking states -->
+    <button class="vm-demo-toggle" id="vm-demo-toggle">Speaking →</button>
+
+    <!-- Work board: scrolls inside this container, bottom padded so cards
+         can settle ABOVE the tutor dock. -->
+    <main class="vm-board-scroll">
+      <h2 class="vm-board-title"><i class="fas fa-pen"></i> Work Board</h2>
+      <div class="vm-stack">
+        <div class="vm-card vm-card--pose">
+          <div class="vm-card-math">\(2x + 6 = 12\)</div>
+        </div>
+
+        <div class="vm-apply">
+          <span class="vm-apply-arrow">↓</span>
+          <span>subtract 6 from both sides</span>
+        </div>
+
+        <div class="vm-card vm-card--resolve">
+          <div class="vm-card-math">\(2x = 6\)</div>
+        </div>
+
+        <div class="vm-apply">
+          <span class="vm-apply-arrow">↓</span>
+          <span>divide both sides by 2</span>
+        </div>
+
+        <div class="vm-card vm-card--resolve">
+          <div class="vm-card-math">\(x = 3\)</div>
+        </div>
+
+        <div class="vm-card vm-card--verify">
+          <div class="vm-card-math">\(2(3) + 6 = 12\) ✓</div>
+        </div>
+      </div>
+    </main>
+
+    <!-- Tutor dock: soft-masked from the top so cards fade into him.
+         Image is interactive (tap = interrupt). -->
+    <div class="vm-tutor-dock" aria-hidden="true">
+      <div class="vm-tutor-bg"></div>
+      <span class="vm-tutor-ring"></span>
+      <img class="vm-tutor-img" src="/images/tutor_avatars/mr-nappier-new2.png" alt="Tap Mr. Nappier to interrupt" />
+    </div>
+
+    <!-- Waveform: painted across the tutor's chest. Color flips with state. -->
+    <div class="vm-wave" aria-hidden="true">
+      <!-- 28 bars: enough to feel rich without being noisy -->
+      <span class="vm-wave-bar" style="animation-delay:0.00s"></span>
+      <span class="vm-wave-bar" style="animation-delay:0.04s"></span>
+      <span class="vm-wave-bar" style="animation-delay:0.08s"></span>
+      <span class="vm-wave-bar" style="animation-delay:0.12s"></span>
+      <span class="vm-wave-bar" style="animation-delay:0.16s"></span>
+      <span class="vm-wave-bar" style="animation-delay:0.20s"></span>
+      <span class="vm-wave-bar" style="animation-delay:0.24s"></span>
+      <span class="vm-wave-bar" style="animation-delay:0.28s"></span>
+      <span class="vm-wave-bar" style="animation-delay:0.32s"></span>
+      <span class="vm-wave-bar" style="animation-delay:0.36s"></span>
+      <span class="vm-wave-bar" style="animation-delay:0.40s"></span>
+      <span class="vm-wave-bar" style="animation-delay:0.44s"></span>
+      <span class="vm-wave-bar" style="animation-delay:0.48s"></span>
+      <span class="vm-wave-bar" style="animation-delay:0.44s"></span>
+      <span class="vm-wave-bar" style="animation-delay:0.40s"></span>
+      <span class="vm-wave-bar" style="animation-delay:0.36s"></span>
+      <span class="vm-wave-bar" style="animation-delay:0.32s"></span>
+      <span class="vm-wave-bar" style="animation-delay:0.28s"></span>
+      <span class="vm-wave-bar" style="animation-delay:0.24s"></span>
+      <span class="vm-wave-bar" style="animation-delay:0.20s"></span>
+      <span class="vm-wave-bar" style="animation-delay:0.16s"></span>
+      <span class="vm-wave-bar" style="animation-delay:0.12s"></span>
+      <span class="vm-wave-bar" style="animation-delay:0.08s"></span>
+      <span class="vm-wave-bar" style="animation-delay:0.04s"></span>
+      <span class="vm-wave-bar" style="animation-delay:0.00s"></span>
+      <span class="vm-wave-bar" style="animation-delay:0.10s"></span>
+      <span class="vm-wave-bar" style="animation-delay:0.20s"></span>
+      <span class="vm-wave-bar" style="animation-delay:0.30s"></span>
+    </div>
+
+    <!-- Live caption — ephemeral, last 1–2 lines only -->
+    <div class="vm-caption" id="vm-caption">
+      <span class="vm-caption-attrib" id="vm-caption-attrib">Mr. Nappier</span>
+      <span id="vm-caption-text">"That's perfect! You are definitely getting better."</span>
+    </div>
+
+    <!-- Control row: mute · end · transcript -->
+    <div class="vm-controls" role="toolbar" aria-label="Voice controls">
+      <button class="vm-ctrl" aria-label="Mute"><i class="fas fa-microphone-slash"></i></button>
+      <button class="vm-ctrl vm-ctrl--end" aria-label="End session"><i class="fas fa-phone-slash"></i></button>
+      <button class="vm-ctrl" aria-label="Show transcript"><i class="fas fa-comment-dots"></i></button>
+    </div>
+
+  </div>
+
+  <script>
+    // Auto-render the LaTeX in card bodies. Defer waits for KaTeX libs to
+    // finish loading — we kick this on DOMContentLoaded.
+    document.addEventListener('DOMContentLoaded', function () {
+      if (window.renderMathInElement) {
+        renderMathInElement(document.body, {
+          delimiters: [{ left: '\\(', right: '\\)', display: false }],
+          throwOnError: false
+        });
+      }
+    });
+
+    // Demo-only state flip so you can see both listening + speaking states
+    // without wiring real audio. Click the toggle to swap.
+    (function () {
+      var toggle = document.getElementById('vm-demo-toggle');
+      var stateText = document.getElementById('vm-state-text');
+      var captionAttrib = document.getElementById('vm-caption-attrib');
+      var captionText = document.getElementById('vm-caption-text');
+      var STATES = {
+        speaking: {
+          label: 'Speaking →',
+          pill: 'Mr. Nappier is speaking',
+          attrib: 'Mr. Nappier',
+          caption: '"That’s perfect! You are definitely getting better."'
+        },
+        listening: {
+          label: 'Listening →',
+          pill: 'Listening to you',
+          attrib: 'You',
+          caption: '"So x equals… three?"'
+        }
+      };
+      toggle.addEventListener('click', function () {
+        var current = document.body.dataset.state;
+        var next = current === 'speaking' ? 'listening' : 'speaking';
+        document.body.dataset.state = next;
+        var s = STATES[next === 'speaking' ? 'listening' : 'speaking'];
+        toggle.textContent = STATES[next].label;
+        stateText.textContent = STATES[next].pill;
+        captionAttrib.textContent = STATES[next].attrib;
+        captionText.textContent = STATES[next].caption;
+      });
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Static, self-contained HTML mockup of the mobile voice mode layout we sketched out. Open it on your phone (or via desktop devtools at phone aspect) to see the geometry breathe.

URL once deployed: `/voice-mode-mockup.html`

## What it shows
- **Workboard scrolls behind a docked tutor.** Tutor dock has a top mask gradient so cards passing behind him fade into the dock instead of clipping. `scroll-margin-bottom` on each card means a new STEP auto-scrolls ABOVE the tutor, not under him.
- **Waveform painted across the tutor's chest** — 28 bars, teal when listening, indigo when speaking. CSS keyframes for now; in production this is the `createStripMeter` call from `modules/voice-meter.js` driven by an AnalyserNode.
- **Ephemeral caption** on its own dark plate above the waveform (legible regardless of bar color).
- **Control row** — mute · end · transcript, sized for thumb reach, end-call in red.
- **Demo toggle** top-right lets you flip listening / speaking states to verify both feel right.

## Not in this PR
- No real audio engine; no wiring to voice-tutor's WebSocket. This is geometry validation only.
- voice-tutor.html and chat.html are untouched.
- Don't merge as-is — this is a mockup file for design review, not a production page.

## Test plan
- [ ] Open `/voice-mode-mockup.html` on iPhone Safari, screenshot in portrait
- [ ] Tap "Speaking →" / "Listening →" toggle, confirm waveform color flips + caption attribution swaps
- [ ] Scroll the workboard — confirm cards dissolve into the tutor at the fade edge instead of clipping
- [ ] Confirm KaTeX renders the equations (`2x + 6 = 12`, etc.) inside the cards

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xnen5iy1SN3t45CYDqVPcw)_