### PR TITLE
Add structured-tutor-response Phase 4 (prompt rewrite)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,15 @@ GOOGLE_SEARCH_ENGINE_ID=your_search_engine_id
 # — turning it on changes live AI behavior.
 ENABLE_VISUAL_TOOLS=false
 
+# STRUCTURED_TUTOR_RESPONSE — when 'true', the tutor's reply is generated as a
+# schema-enforced JSON object (chat_message + board_commands + turn_type) instead
+# of free text with inline <BOARD/> tags. The OpenAI API guarantees the board
+# signal is present at the wire boundary, fixing the unreliable-tag failure mode.
+# Covers both streaming and non-streaming paths; falls back to the legacy
+# free-text path on any error. Leave 'false' until verified on a deploy —
+# turning it on changes how live AI responses are produced.
+STRUCTURED_TUTOR_RESPONSE=false
+
 # --- STRIPE BILLING ---
 # MASTER SWITCH: Set to 'true' to activate billing, usage limits, and paywall.
 # When false (or missing), all users get unlimited free access (pre-launch mode).

--- a/tests/unit/assemblePromptStructured.test.js
+++ b/tests/unit/assemblePromptStructured.test.js
@@ -1,0 +1,95 @@
+/**
+ * assemblePrompt() — structured-mode prompt injection (Phase 4)
+ *
+ * Phase 4 owns the prompt rewrite: when STRUCTURED_TUTOR_RESPONSE is
+ * on, assemblePrompt appends buildStructuredResponseInstructions() to
+ * the system prompt so the model drives the WorkBoard through the
+ * board_commands JSON array (and classifies turn_type) instead of the
+ * legacy <BOARD/> tag protocol. Flag off → the prompt is unchanged.
+ *
+ * assemblePrompt is pure (no LLM calls), so these tests need no
+ * gateway mock — but generate.js requires llmGateway at module load,
+ * so we stub it to keep the import side-effect-free.
+ */
+
+jest.mock('../../utils/llmGateway', () => ({
+  callLLM: jest.fn(),
+  callLLMStream: jest.fn(),
+  callLLMStructured: jest.fn(),
+}));
+
+const { assemblePrompt } = require('../../utils/pipeline/generate');
+const { ACTIONS } = require('../../utils/pipeline/decide');
+
+function buildDecision(overrides = {}) {
+  return {
+    action: ACTIONS.CONTINUE_CONVERSATION,
+    diagnosis: { type: 'no_answer' },
+    observation: { streaks: null },
+    directives: [],
+    ...overrides,
+  };
+}
+
+function buildPromptContext(overrides = {}) {
+  return {
+    // useSlimRules defaults to on; give a base prompt with no SECURITY
+    // marker so the slim-rules surgery is skipped and we test the raw
+    // append behavior deterministically.
+    systemPrompt: '--- IDENTITY ---\nYou are Maya.',
+    messages: [{ role: 'user', content: 'help with 2x + 4 = 20' }],
+    useSlimRules: false,
+    ...overrides,
+  };
+}
+
+function systemContentOf(assembled) {
+  const sys = assembled.messages.find((m) => m.role === 'system');
+  return sys ? sys.content : '';
+}
+
+describe('assemblePrompt() — structured-mode injection', () => {
+  const ORIGINAL_FLAG = process.env.STRUCTURED_TUTOR_RESPONSE;
+
+  afterEach(() => {
+    if (ORIGINAL_FLAG === undefined) {
+      delete process.env.STRUCTURED_TUTOR_RESPONSE;
+    } else {
+      process.env.STRUCTURED_TUTOR_RESPONSE = ORIGINAL_FLAG;
+    }
+  });
+
+  test('flag off → no structured instructions appended', () => {
+    delete process.env.STRUCTURED_TUTOR_RESPONSE;
+    const assembled = assemblePrompt(buildDecision(), buildPromptContext());
+    expect(systemContentOf(assembled)).not.toMatch(/STRUCTURED RESPONSE MODE/);
+  });
+
+  test('flag on → structured instructions appended to the system prompt', () => {
+    process.env.STRUCTURED_TUTOR_RESPONSE = 'true';
+    const assembled = assemblePrompt(buildDecision(), buildPromptContext());
+    const sys = systemContentOf(assembled);
+    expect(sys).toMatch(/STRUCTURED RESPONSE MODE/);
+    expect(sys).toMatch(/OVERRIDES THE WORKBOARD TAG PROTOCOL/);
+    // The base prompt is preserved, override is appended after it.
+    expect(sys.indexOf('You are Maya.'))
+      .toBeLessThan(sys.indexOf('STRUCTURED RESPONSE MODE'));
+  });
+
+  test("env='1' also enables injection", () => {
+    process.env.STRUCTURED_TUTOR_RESPONSE = '1';
+    const assembled = assemblePrompt(buildDecision(), buildPromptContext());
+    expect(systemContentOf(assembled)).toMatch(/STRUCTURED RESPONSE MODE/);
+  });
+
+  test('deterministic-response short-circuit is unaffected by the flag', () => {
+    process.env.STRUCTURED_TUTOR_RESPONSE = 'true';
+    const assembled = assemblePrompt(
+      buildDecision({ deterministicResponse: 'canned reply' }),
+      buildPromptContext(),
+    );
+    // No system message is built on the deterministic path.
+    expect(assembled.deterministicResponse).toBe('canned reply');
+    expect(assembled.messages).toEqual([]);
+  });
+});

--- a/tests/unit/boardResponseSchema.test.js
+++ b/tests/unit/boardResponseSchema.test.js
@@ -20,6 +20,7 @@ const {
   normalizeBoardCommand,
   normalizeStructuredResponse,
   isStructuredModeEnabled,
+  buildStructuredResponseInstructions,
 } = require('../../utils/boardResponseSchema');
 
 describe('boardResponseSchema — normalizeBoardCommand', () => {
@@ -223,6 +224,44 @@ describe('boardResponseSchema — isStructuredModeEnabled', () => {
   test('env=anything-else is OFF', () => {
     process.env.STRUCTURED_TUTOR_RESPONSE = 'maybe';
     expect(isStructuredModeEnabled()).toBe(false);
+  });
+});
+
+describe('boardResponseSchema — buildStructuredResponseInstructions (Phase 4)', () => {
+  const instructions = buildStructuredResponseInstructions();
+
+  test('returns a non-trivial system-prompt block', () => {
+    expect(typeof instructions).toBe('string');
+    expect(instructions.length).toBeGreaterThan(200);
+  });
+
+  test('is deterministic — no per-request data leaks in (stays cacheable)', () => {
+    expect(buildStructuredResponseInstructions()).toBe(instructions);
+  });
+
+  test('announces itself as overriding the legacy WorkBoard tag protocol', () => {
+    expect(instructions).toMatch(/OVERRIDES THE WORKBOARD TAG PROTOCOL/);
+  });
+
+  test('tells the model NOT to write <BOARD/> tags in chat_message', () => {
+    expect(instructions).toMatch(/Do NOT write <BOARD/);
+  });
+
+  test('names every turn_type so the model can classify', () => {
+    for (const tt of TURN_TYPES) {
+      expect(instructions).toContain(tt);
+    }
+  });
+
+  test('states the hard rule the audit enforces: problem_introduction MUST pose', () => {
+    // Mirrors turnTypeAudit.js problem_introduction_missing_pose.
+    expect(instructions).toMatch(/problem_introduction[\s\S]*MUST include a pose/);
+  });
+
+  test('documents each board action shape', () => {
+    for (const action of BOARD_ACTIONS) {
+      expect(instructions).toContain(action);
+    }
   });
 });
 

--- a/utils/boardResponseSchema.js
+++ b/utils/boardResponseSchema.js
@@ -113,7 +113,7 @@ const BOARD_RESPONSE_SCHEMA = {
     },
     chat_message: {
       type: 'string',
-      description: 'The natural-language reply the student sees in the chat bubble. Keep it conversational, in voice — do NOT include any <BOARD>, <XP>, or other system tags; structured fields carry that signal.',
+      description: 'The natural-language reply the student sees in the chat bubble. Keep it conversational, in voice. Do NOT include any <BOARD .../> tags here — the board_commands array carries the WorkBoard signal now. You MAY still use the other inline tags exactly as instructed elsewhere in the prompt (<XP/> ceremonies, <GRAPH/>/<TILES/> tab switches, and the silent signal tags like <CORE_BEHAVIOR_XP>, <SAFETY_CONCERN>, <LEARNING_INSIGHT>, <PROBLEM_RESULT>); only the board protocol has moved to structured output.',
     },
     board_commands: {
       type: 'array',
@@ -206,6 +206,58 @@ function isStructuredModeEnabled() {
   return v === 'true' || v === '1';
 }
 
+/**
+ * Phase 4: the prompt rewrite. When structured mode is on, the
+ * model fills `board_commands` (a JSON array) and self-declares a
+ * `turn_type` instead of weaving `<BOARD .../>` tags through its
+ * prose. The legacy WORKBOARD TAG PROTOCOL block in the static
+ * prompt is now actively wrong for this path — it tells the model
+ * to emit tags that the structured generate stage neither reads
+ * nor strips. This block overrides it.
+ *
+ * The guidance intentionally mirrors utils/turnTypeAudit.js: the
+ * audit logs a mismatch whenever the declared turn_type and the
+ * emitted board disagree (e.g. problem_introduction with no pose).
+ * Teaching the model the same MUST/SHOULD rules the audit checks
+ * is how we move that mismatch rate toward zero — the schema
+ * guarantees the field exists and is in-enum, but only the prompt
+ * can teach the model to pick the right value and pair it with the
+ * right card.
+ *
+ * Appended to the system prompt by assemblePrompt() only when
+ * isStructuredModeEnabled() is true, so flag-off traffic sees the
+ * exact prompt it sees today.
+ *
+ * @returns {string} A system-prompt section. Stable across calls
+ *   (no per-request data) so it stays inside the cacheable prefix.
+ */
+function buildStructuredResponseInstructions() {
+  return `--- STRUCTURED RESPONSE MODE (OVERRIDES THE WORKBOARD TAG PROTOCOL) ---
+Your reply is a structured object, not free text. You fill three fields:
+- chat_message: what the student reads in the chat bubble. Talk like a tutor, in your voice. Do NOT write <BOARD .../> tags anywhere — the board is driven by the board_commands array below, not by tags in your prose. (The other inline tags still work normally: <XP/>, <GRAPH/>, <TILES/>, and the silent signal tags.)
+- board_commands: an array of cards for the WorkBoard beside the chat, in the order they should appear. Same actions as before — pose, apply, resolve, verify, clear, graph, image — now as JSON objects instead of tags. The board mirrors the STUDENT's reasoning: never emit a resolve/apply for a step the student hasn't said, and never pose the answer.
+- turn_type: classify this turn so the board matches the pedagogy. Pick the single best fit:
+  • problem_introduction — you put a NEW problem in front of the student. board_commands MUST include a pose card. This is the rule we most often miss: if you're giving them something to work on, the pose card is mandatory, every time.
+  • step_acknowledgment — you're reacting to a step the student took in an open problem. apply/resolve cards are common; any combination is fine.
+  • verification — the student stated a final answer. board_commands SHOULD include a verify card.
+  • concept_reference — the student asked about a concept and you're showing reference content. board_commands SHOULD include an image or graph card.
+  • feedback — praise or correction that does NOT advance the work. board_commands SHOULD be empty (an image/graph reference aid is fine; a pose/apply/resolve/verify here usually means you mislabeled the turn).
+  • scaffold — you lowered difficulty, hinted, or broke the problem into a sub-question. Usually no work-advancing cards.
+  • redirect — steering an off-topic student back to math. Usually no cards.
+  • small_talk — greeting, closing, or off-task chitchat. board_commands empty.
+
+CARD SHAPE (fields not used for an action are null):
+- pose:    { action: "pose", tex: "2x + 4 = 20" }                         — at the moment a problem starts, once per problem.
+- apply:   { action: "apply", op: "subtract 4 from both sides" }          — AFTER the student names the move; op restates THEIR move.
+- resolve: { action: "resolve", tex: "2x = 16" }                          — AFTER the student states the result; tex is what THEY wrote.
+- verify:  { action: "verify", tex: "x = 8", check: "2(8) + 4 = 20" }     — when the solution is checked.
+- clear:   { action: "clear" }                                            — only on a new problem or right after a verify lands.
+- graph:   { action: "graph", fn: "x^2 - 4", caption: "Where it crosses zero" } — reference plot in the board timeline.
+- image:   { action: "image", query: "unit circle labeled", caption: "Reference" } — reference diagram from the safe whitelist.
+
+If the student references the board ("show me on the board", "draw it", "use the board"), you MUST include a relevant card (pose for an equation, graph for a function, image for a geometry concept). An empty board while a problem is on screen is the worst-case defect.`;
+}
+
 module.exports = {
   BOARD_ACTIONS,
   TURN_TYPES,
@@ -215,4 +267,5 @@ module.exports = {
   normalizeBoardCommand,
   normalizeStructuredResponse,
   isStructuredModeEnabled,
+  buildStructuredResponseInstructions,
 };

--- a/utils/pipeline/generate.js
+++ b/utils/pipeline/generate.js
@@ -24,6 +24,7 @@ const {
   OPENAI_RESPONSE_FORMAT,
   normalizeStructuredResponse,
   isStructuredModeEnabled,
+  buildStructuredResponseInstructions,
 } = require('../boardResponseSchema');
 
 // Strip <BOARD …/> tags from a one-shot text chunk (deterministic /
@@ -342,6 +343,17 @@ function assemblePrompt(decision, promptContext) {
     // Fallback: slim rules not used, but Socratic suppression is active.
     // Swap Rule 1 in the full static rules using the named constants.
     fullSystemPrompt = fullSystemPrompt.replace(RULE_1_SOCRATIC, RULE_1_TEACHING);
+  }
+
+  // ── Structured-response mode (Phase 4) ──
+  // When the dark flag is on, the generate stage asks the LLM for the
+  // schema-enforced JSON object and the board comes from board_commands,
+  // not <BOARD/> tags. The static prompt still teaches the legacy tag
+  // protocol; append the override block so the model drives the board
+  // through structured output and classifies its turn_type correctly.
+  // Flag off → this is a no-op and the prompt is byte-for-byte today's.
+  if (isStructuredModeEnabled()) {
+    fullSystemPrompt += '\n\n' + buildStructuredResponseInstructions();
   }
 
   // Inject phase-specific prompt if available


### PR DESCRIPTION
## Phase 4: the prompt rewrite

Resumes the structured-tutor-response arc. Phases 1–3 (all merged) built the schema, streaming adapter, and turn_type audit, but deliberately left the prompt untouched — the Phase 3 commit states *"Phase 4 owns the prompt rewrite."* This PR is that rewrite.

### The gap this closes

Under the `STRUCTURED_TUTOR_RESPONSE` dark flag, two things were wrong:

1. **The prompt still taught the legacy `<BOARD/>` tag protocol** — which the structured generate stage neither reads nor strips. The model got zero positive guidance on how to populate `board_commands` or classify `turn_type`, so it was flying blind on the exact fields the schema requires.
2. **A live contradiction in the schema** — `chat_message`'s description forbade `<XP>`, `<GRAPH>`, `<TILES>` and other tags that the pipeline *still parses downstream* (Stage 5d/5e in `pipeline/index.js`). The model was told to suppress signals the pipeline depends on.

### What lands

- **`utils/boardResponseSchema.js`**
  - `buildStructuredResponseInstructions()` — a stable, cacheable system-prompt block that overrides the WorkBoard tag protocol for the structured path. Teaches `board_commands` as JSON, documents every action's card shape, and walks the full `turn_type` taxonomy with the **same MUST/SHOULD rules `turnTypeAudit.js` checks** (`problem_introduction` MUST pose, `verification` SHOULD verify, `concept_reference` SHOULD show a visual, non-advancing turns stay empty). Teaching the model the audit's own rules is how we drive the observed mismatch rate down.
  - Fixed the `chat_message` description: forbids only `<BOARD/>` now, and explicitly permits the inline tags the pipeline reads.
- **`utils/pipeline/generate.js`** — `assemblePrompt()` appends the override block only when `isStructuredModeEnabled()`. Single chokepoint covering slim + full prompt paths and streaming + non-streaming. Placed in the stable prefix region for prompt-cache friendliness.
- **`.env.example`** — documents `STRUCTURED_TUTOR_RESPONSE`.

### Safety

**Dark by default.** With the flag off, the assembled prompt is byte-for-byte identical to today's — the injection is a single guarded `if`.

### Tests

11 new tests, full suite **2676/2676 green**, lint clean (0 errors):
- 7 guidance-generator unit tests — every turn type named, the hard pose rule present, every action shape documented, output is deterministic (cacheable).
- 4 `assemblePrompt` injection tests — flag off (no injection), flag on, `env='1'`, and the deterministic short-circuit is unaffected.

### Follow-ups (per the arc's roadmap)
- **Phase 5**: wire hard turn_type mismatches (e.g. `problem_introduction` with no pose) to the deterministic board synthesizer for backfill — now that Phase 4 gives the model the guidance, Phase 5 catches what slips through.
- Enable the flag on a deploy and watch the `turn-type-audit` logger to confirm the mismatch rate drops before considering it the default.


---
_Generated by [Claude Code](https://claude.ai/code/session_012qvEV3nBqGGBEu4UfvL5rJ)_