### PR TITLE
Add structured-tutor-response Phase 5 (turn-type backfill)

### DIFF
--- a/tests/unit/boardSynthesizer.test.js
+++ b/tests/unit/boardSynthesizer.test.js
@@ -14,6 +14,7 @@
 const {
   synthesizeBoardCommands,
   mergeWithLlmCommands,
+  synthesizeFallbackPose,
   _detectAppliedOperation,
   _detectIntermediateEquation,
   _detectFinalSolution,
@@ -21,6 +22,7 @@ const {
   _detectPosedProblem,
   _detectGeometryProblem,
   _extractProblemSentence,
+  _extractPosableSentence,
   _sentenceToTex,
   _tutorAffirms,
   _commandsOverlap,
@@ -576,5 +578,80 @@ describe('boardSynthesizer — merge with LLM commands', () => {
       { action: 'pose', tex: '3x - 5 = 16' },
       { action: 'pose', tex: '3x-5=16' }
     )).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 5 — turn-type backfill pose
+// ---------------------------------------------------------------------------
+
+describe('boardSynthesizer — Phase 5 backfill', () => {
+  describe('_extractPosableSentence', () => {
+    test('quotes the question sentence plus up to two setup sentences', () => {
+      const text = 'A train leaves at noon. It travels 60 mph. How far does it go in 3 hours?';
+      expect(_extractPosableSentence(text)).toBe(text);
+    });
+
+    test('falls back to the first sentence carrying a number when no question', () => {
+      const text = 'Sure, let me set this up. A rectangle has length 8 and width 5. Find its area.';
+      // No "?" — quote the first numeric sentence, skipping the greeting.
+      expect(_extractPosableSentence(text)).toBe('A rectangle has length 8 and width 5.');
+    });
+
+    test('returns null when there is no question and no numbers', () => {
+      expect(_extractPosableSentence('Great work today. You really get this.')).toBeNull();
+    });
+
+    test('rejects an over-long chunk', () => {
+      const long = `${'x'.repeat(400)}?`;
+      expect(_extractPosableSentence(long)).toBeNull();
+    });
+
+    test('returns null on empty / non-string input', () => {
+      expect(_extractPosableSentence('')).toBeNull();
+      expect(_extractPosableSentence(null)).toBeNull();
+      expect(_extractPosableSentence(undefined)).toBeNull();
+    });
+  });
+
+  describe('synthesizeFallbackPose', () => {
+    test('prefers exact algebra tex from the student message', () => {
+      const pose = synthesizeFallbackPose({
+        tutorResponse: "Let's give this a shot together!",
+        studentMessage: 'solve 3x - 5 = 16',
+      });
+      expect(pose).toMatchObject({ action: 'pose' });
+      expect(_commandsOverlap(pose, { action: 'pose', tex: '3x-5=16' })).toBe(true);
+    });
+
+    test('uses exact algebra tex from the tutor when the student has none', () => {
+      const pose = synthesizeFallbackPose({
+        tutorResponse: 'Okay, try this one: 4x + 3 = 27.',
+        studentMessage: 'ok ready',
+      });
+      expect(pose).toMatchObject({ action: 'pose' });
+      expect(_commandsOverlap(pose, { action: 'pose', tex: '4x+3=27' })).toBe(true);
+    });
+
+    test('falls back to a verbatim \\text pose for an unparseable word problem', () => {
+      const tutor = "Here's one for you. A baker has 24 cookies and packs them into boxes of 6. How many boxes does she fill?";
+      const pose = synthesizeFallbackPose({ tutorResponse: tutor, studentMessage: 'next please' });
+      expect(pose.action).toBe('pose');
+      expect(pose.tex).toMatch(/^\\text\{/);
+      expect(pose.tex).toContain('How many boxes');
+    });
+
+    test('returns null when there is no posable problem anywhere', () => {
+      const pose = synthesizeFallbackPose({
+        tutorResponse: 'Nice — you nailed that. Proud of you.',
+        studentMessage: 'thanks!',
+      });
+      expect(pose).toBeNull();
+    });
+
+    test('returns null on empty input', () => {
+      expect(synthesizeFallbackPose({})).toBeNull();
+      expect(synthesizeFallbackPose()).toBeNull();
+    });
   });
 });

--- a/tests/unit/pipelineIntegration.test.js
+++ b/tests/unit/pipelineIntegration.test.js
@@ -17,6 +17,7 @@
 jest.mock('../../utils/llmGateway', () => ({
   callLLM: jest.fn(),
   callLLMStream: jest.fn(),
+  callLLMStructured: jest.fn(),
 }));
 
 jest.mock('../../utils/openaiClient', () => ({
@@ -80,7 +81,7 @@ jest.mock('../../utils/promptCompressor', () => ({
   buildSystemPrompt: jest.fn(() => 'system prompt'),
 }));
 
-const { callLLM } = require('../../utils/llmGateway');
+const { callLLM, callLLMStructured } = require('../../utils/llmGateway');
 const { runPipeline } = require('../../utils/pipeline');
 
 // ── Helpers ──
@@ -361,5 +362,71 @@ describe('Pipeline Integration: runPipeline', () => {
 
     expect(result.text).not.toMatch(/\n\s*\?/);
     expect(result.text).toMatch(/answer\??/); // ? should be right after "answer"
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Phase 5 — turn-type backfill (Stage 5c.1)
+  //
+  // When the structured path returns turn_type=problem_introduction but no
+  // board_commands, and the deterministic synthesizer also can't derive a
+  // pose (mathSolver is mocked to see no math here), the pipeline must
+  // backfill a verbatim pose so the board never sits empty on the turn the
+  // model itself declared a problem. Dark-flagged behind
+  // STRUCTURED_TUTOR_RESPONSE.
+  // ──────────────────────────────────────────────────────────────────────
+  describe('Phase 5: turn-type backfill', () => {
+    const ORIGINAL_FLAG = process.env.STRUCTURED_TUTOR_RESPONSE;
+    afterEach(() => {
+      if (ORIGINAL_FLAG === undefined) delete process.env.STRUCTURED_TUTOR_RESPONSE;
+      else process.env.STRUCTURED_TUTOR_RESPONSE = ORIGINAL_FLAG;
+    });
+
+    test('problem_introduction with no pose backfills a verbatim pose', async () => {
+      process.env.STRUCTURED_TUTOR_RESPONSE = 'true';
+      callLLMStructured.mockResolvedValue({
+        turn_type: 'problem_introduction',
+        chat_message:
+          "Here's one for you. A baker has 24 cookies and packs them into boxes of 6. How many boxes does she fill?",
+        board_commands: [], // model forgot the pose
+      });
+
+      const user = mockUser();
+      const conversation = mockConversation([]);
+      const result = await runPipeline('give me a word problem', buildCtx(user, conversation));
+
+      const poses = result.boardCommands.filter(c => c.action === 'pose');
+      expect(poses).toHaveLength(1);
+      expect(poses[0].tex).toContain('How many boxes');
+    });
+
+    test('flag off → no structured turn_type, no backfill', async () => {
+      delete process.env.STRUCTURED_TUTOR_RESPONSE;
+      // Legacy path: free-text reply with no board tags.
+      mockLLMResponse(
+        "Here's one for you. A baker has 24 cookies and packs them into boxes of 6. How many boxes does she fill?"
+      );
+
+      const user = mockUser();
+      const conversation = mockConversation([]);
+      const result = await runPipeline('give me a word problem', buildCtx(user, conversation));
+
+      expect(result.boardCommands.some(c => c.action === 'pose')).toBe(false);
+      expect(callLLMStructured).not.toHaveBeenCalled();
+    });
+
+    test('does not double-pose when the model already emitted one', async () => {
+      process.env.STRUCTURED_TUTOR_RESPONSE = 'true';
+      callLLMStructured.mockResolvedValue({
+        turn_type: 'problem_introduction',
+        chat_message: 'Try this one!',
+        board_commands: [{ action: 'pose', tex: '\\text{A baker has 24 cookies...}' }],
+      });
+
+      const user = mockUser();
+      const conversation = mockConversation([]);
+      const result = await runPipeline('give me a word problem', buildCtx(user, conversation));
+
+      expect(result.boardCommands.filter(c => c.action === 'pose')).toHaveLength(1);
+    });
   });
 });

--- a/utils/pipeline/boardSynthesizer.js
+++ b/utils/pipeline/boardSynthesizer.js
@@ -527,9 +527,94 @@ function mergeWithLlmCommands(llmCommands, synthesized) {
   return { added, kept: llm, all };
 }
 
+// ---------------------------------------------------------------------------
+// Phase 5 — turn-type backfill pose
+//
+// synthesizeBoardCommands derives a pose from pipeline ground truth, but
+// only for parseable algebra / recognized geometry AND only when the prior
+// cycle was closed. When the model self-declares turn_type=problem_intro-
+// duction yet no pose survives (the text parses as neither algebra nor
+// geometry, or the main synth skipped pose on a stale-but-open cycle), the
+// board sits empty on the exact turn the model said a problem is on the
+// table. The turn_type is the missing ground-truth signal; this turns it
+// into a card.
+// ---------------------------------------------------------------------------
+
+/**
+ * Relaxed problem-sentence extractor for the backfill fallback. Unlike
+ * extractProblemSentence it does NOT require geometry vocab — by the time
+ * we reach it the model has already declared a problem_introduction, so the
+ * only job is to quote what the tutor put on the table. Verbatim quotation
+ * is ground truth (it's literally the tutor's own words), so there is no
+ * guessing about what the problem means.
+ *
+ * Prefers the question sentence (plus up to two setup sentences carrying
+ * the parameters). With no explicit question, falls back to the first
+ * sentence that carries a concrete number — problems almost always do, and
+ * it skips greeting / transition prose.
+ *
+ * @returns {string|null}
+ */
+function extractPosableSentence(text) {
+  if (!text || typeof text !== 'string') return null;
+  const sample = text.slice(0, 800).trim();
+  if (!sample) return null;
+
+  const sentences = sample.split(/(?<=[.!?])\s+/).map(s => s.trim()).filter(Boolean);
+  if (sentences.length === 0) return null;
+
+  const qIdx = sentences.findIndex(s => /\?\s*$/.test(s));
+  let chunk;
+  if (qIdx !== -1) {
+    chunk = sentences.slice(Math.max(0, qIdx - 2), qIdx + 1).join(' ').trim();
+  } else {
+    const numIdx = sentences.findIndex(s => /\d/.test(s));
+    if (numIdx === -1) return null;
+    chunk = sentences[numIdx];
+  }
+
+  if (chunk.length < 8 || chunk.length > 320) return null;
+  return chunk;
+}
+
+/**
+ * Last-resort pose synthesis for the Phase 5 turn-type backfill. Called
+ * only when turn_type=problem_introduction yet no pose card survived from
+ * either the LLM or the main synthesizer.
+ *
+ * Resolution order, best tex first:
+ *   1. detectPosedProblem(student) / detectPosedProblem(tutor) — exact
+ *      algebra tex when either side carries a parseable equation. (The
+ *      main synth may have skipped this purely because the prior cycle
+ *      wasn't closed; here the model's turn_type overrides that.)
+ *   2. detectGeometryProblem(tutor) — verbatim geometry question.
+ *   3. extractPosableSentence(tutor) — verbatim tutor sentence, the
+ *      universal fallback so the board never sits empty on a declared
+ *      problem_introduction.
+ *
+ * @param {object} params
+ * @param {string} params.tutorResponse  tutor's reply (post-tag-strip)
+ * @param {string} params.studentMessage incoming student text
+ * @returns {{action:'pose', tex:string}|null}
+ */
+function synthesizeFallbackPose({ tutorResponse, studentMessage } = {}) {
+  let posed = detectPosedProblem(studentMessage);
+  if (!posed) posed = detectPosedProblem(tutorResponse);
+  if (posed) return { action: 'pose', tex: posed.tex };
+
+  const geo = detectGeometryProblem(tutorResponse);
+  if (geo) return { action: 'pose', tex: geo.tex };
+
+  const sentence = extractPosableSentence(tutorResponse);
+  if (sentence) return { action: 'pose', tex: sentenceToTex(sentence) };
+
+  return null;
+}
+
 module.exports = {
   synthesizeBoardCommands,
   mergeWithLlmCommands,
+  synthesizeFallbackPose,
   // Exposed for tests
   _detectAppliedOperation: detectAppliedOperation,
   _detectIntermediateEquation: detectIntermediateEquation,
@@ -538,6 +623,7 @@ module.exports = {
   _detectPosedProblem: detectPosedProblem,
   _detectGeometryProblem: detectGeometryProblem,
   _extractProblemSentence: extractProblemSentence,
+  _extractPosableSentence: extractPosableSentence,
   _sentenceToTex: sentenceToTex,
   _tutorAffirms: tutorAffirms,
   _commandsOverlap: commandsOverlap,

--- a/utils/pipeline/index.js
+++ b/utils/pipeline/index.js
@@ -45,7 +45,7 @@ const { parseBoardTags } = require('../boardTagParser');
 const { enforcePedagogyRule } = require('../boardCommandGuard');
 const { parseXpTags } = require('../xpTagParser');
 const { parseVisualTabTags } = require('../visualTabTagParser');
-const { synthesizeBoardCommands, mergeWithLlmCommands } = require('./boardSynthesizer');
+const { synthesizeBoardCommands, mergeWithLlmCommands, synthesizeFallbackPose } = require('./boardSynthesizer');
 const { auditTurn } = require('../turnTypeAudit');
 const log = require('../logger');
 const boardLogger = log.child({ service: 'board-tag-protocol' });
@@ -442,12 +442,13 @@ async function runPipeline(message, ctx) {
   }
 
   // ── Stage 5b.1: TURN-TYPE AUDIT (Phase 3) ──
-  // Observe-only. Phase 3 lights up the signal so we can measure
-  // how often the model's declared turn_type contradicts the board
-  // it emitted. Phase 5 will wire hard mismatches (e.g., a
-  // problem_introduction with no pose) to the deterministic
-  // synthesizer for backfill. The audit is a no-op under the legacy
-  // free-text path because there is no turn_type to audit.
+  // Lights up the signal so we can measure how often the model's
+  // declared turn_type contradicts the board it emitted. The one hard
+  // bug it detects — problem_introduction with no pose — is acted on
+  // downstream in Stage 5c.1 (Phase 5), which runs after synthesis so
+  // it only fires when no pose survives the merge. Soft mismatches stay
+  // observe-only. The audit is a no-op under the legacy free-text path
+  // because there is no turn_type to audit.
   if (generatedResult.structuredTurnType) {
     const mismatches = auditTurn({
       turnType: generatedResult.structuredTurnType,
@@ -522,6 +523,52 @@ async function runPipeline(message, ctx) {
       actions: merged.added.map(c => c.action),
       llmEmitted: llmBoardCommands.length,
     });
+  }
+
+  // ── Stage 5c.1: TURN-TYPE BACKFILL (Phase 5) ──
+  // Phase 3 lit the audit signal; Phase 5 acts on the one hard bug it
+  // detects. When the model self-declared turn_type=problem_introduction
+  // yet no pose survived the merge — neither LLM-emitted nor synthesized
+  // (the problem parses as neither algebra nor recognized geometry, or
+  // the main synth skipped pose on a stale-but-open cycle) — the board
+  // would sit empty on the exact turn the model said a problem is on the
+  // table. The turn_type is ground truth the synthesizer can't otherwise
+  // see, so we backfill a verbatim pose. Naturally dark-flagged:
+  // structuredTurnType is only populated when STRUCTURED_TUTOR_RESPONSE
+  // is on, so flag-off traffic never reaches this branch.
+  if (generatedResult.structuredTurnType === 'problem_introduction'
+      && !verified.boardCommands.some(c => c.action === 'pose')) {
+    const fallbackPose = synthesizeFallbackPose({
+      tutorResponse: verified.text,
+      studentMessage: message,
+    });
+    if (fallbackPose) {
+      // Defense in depth — same guard every other board path runs.
+      const backfillGuard = enforcePedagogyRule({
+        commands: [fallbackPose],
+        userMessage: message,
+        recentUserMessages: recentUserMessagesForBoard,
+        lastBoardActionInConversation: ctx.conversation?.lastBoardAction || null,
+      });
+      if (backfillGuard.allowed.length > 0) {
+        // Re-merge so canonical ordering (pose first) is preserved.
+        const backfilled = mergeWithLlmCommands(verified.boardCommands, backfillGuard.allowed);
+        verified.boardCommands = backfilled.all;
+        boardLogger.info('Turn-type backfill posed problem (Phase 5)', {
+          turnType: generatedResult.structuredTurnType,
+          tex: fallbackPose.tex,
+        });
+      } else if (backfillGuard.dropped.length > 0) {
+        boardLogger.warn('Pedagogy guard dropped turn-type backfill pose', {
+          reason: backfillGuard.dropped[0].reason,
+          tex: fallbackPose.tex,
+        });
+      }
+    } else {
+      turnTypeLogger.warn('turn_type=problem_introduction with no posable problem; board left empty', {
+        turnType: generatedResult.structuredTurnType,
+      });
+    }
   }
 
   if (verified.boardCommands.length > 0 && ctx.conversation) {

--- a/utils/turnTypeAudit.js
+++ b/utils/turnTypeAudit.js
@@ -21,11 +21,13 @@
    Phase 3 policy: observe, don't act
    ----------------------------------
    The audit returns structured mismatches that the pipeline logs.
-   It does NOT mutate board_commands. We need a few sessions of
-   real data to know which mismatch patterns are bugs vs. legitimate
-   tutor judgment, so Phase 3 only lights up the signal. Phase 5
-   wires the audit to the deterministic synthesizer where a hard
-   bug ("problem_introduction with no pose") gets backfilled.
+   It does NOT mutate board_commands itself — it is pure observation.
+   Phase 5 acts on the one hard bug it detects ("problem_introduction
+   with no pose"): the pipeline's Stage 5c.1 backfills a verbatim pose
+   via the deterministic synthesizer when no pose survives the merge.
+   Soft mismatches stay observe-only — a few sessions of real data are
+   needed to know which patterns are bugs vs. legitimate tutor
+   judgment.
    ============================================================ */
 
 'use strict';
@@ -34,7 +36,8 @@ const { TURN_TYPES } = require('./boardResponseSchema');
 
 const SEVERITY = {
   HARD: 'hard',   // schema-allowed but pedagogically wrong; the
-                  // synthesizer should backfill (Phase 5 wires this).
+                  // synthesizer backfills it (wired in pipeline
+                  // Stage 5c.1, Phase 5).
   SOFT: 'soft',   // unusual combination; log for analysis but the
                   // tutor's judgment may be legitimate.
 };


### PR DESCRIPTION
## Phase 5 — turn-type backfill

Phases 1–4 built the schema, streaming adapter, `turn_type` audit, and prompt rewrite. Phase 3 lit the audit signal but kept it **observe-only**, with an explicit note that Phase 5 would wire the one hard bug it detects — `problem_introduction` with no pose — into the deterministic synthesizer for backfill. This PR closes that loop.

### The failure mode
The model self-declares `turn_type=problem_introduction` yet emits no pose card, **and** the deterministic synthesizer also can't derive one (the problem parses as neither algebra nor recognized geometry, or the main synth skipped pose because the prior cycle wasn't closed). The board then sits empty on the exact turn the model said a problem is on the table. The `turn_type` is ground truth the synthesizer can't otherwise see — Phase 5 turns it into a card.

### What lands
- **`utils/pipeline/boardSynthesizer.js`** — `synthesizeFallbackPose()`, a last-resort pose synthesizer. Best tex first: exact algebra (student → tutor) → verbatim geometry question → relaxed verbatim tutor sentence via `extractPosableSentence()` (question sentence + up to two setup sentences, else the first sentence carrying a number). Verbatim quotation is ground truth, so there's no guessing about the problem.
- **`utils/pipeline/index.js`** — new **Stage 5c.1**, placed *after* the synth merge so it only fires when no pose survived from either the LLM or the synthesizer. Gated on `structuredTurnType === 'problem_introduction' && no pose present`. The backfilled pose runs through `enforcePedagogyRule` (the same guard every board path uses) and re-merges so canonical pose-first ordering holds. Logs the backfill, or warns when no posable problem exists.
- **`utils/turnTypeAudit.js`** / **Stage 5b.1 comments** — updated from "Phase 5 will wire this" to reflect that it's now wired; soft mismatches stay observe-only.

### Dark by default
Naturally gated: `structuredTurnType` is only populated when `STRUCTURED_TUTOR_RESPONSE` is on, so flag-off traffic never reaches the backfill branch and behavior is byte-for-byte unchanged.

### Tests
13 new, full suite **2689/2689 green**, lint 0 errors:
- 10 synthesizer unit tests — resolution order, the relaxed sentence extractor, null cases.
- 3 `runPipeline` integration tests — backfill-on, flag-off no-op (no structured call), and no double-pose when the model already posed.

Builds on structured-tutor-response Phase 4 (#1024).

https://claude.ai/code/session_012qvEV3nBqGGBEu4UfvL5rJ

---
_Generated by [Claude Code](https://claude.ai/code/session_012qvEV3nBqGGBEu4UfvL5rJ)_