### PR TITLE
Add structured-tutor-response Phase 6 (observability)

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1419,6 +1419,25 @@ router.get('/health-check', isAdmin, (req, res) => {
 });
 
 /**
+ * @route   GET /api/admin/structured-tutor-metrics
+ * @desc    Observability for the structured-tutor-response path
+ *          (STRUCTURED_TUTOR_RESPONSE). Returns aggregate turn_type
+ *          distribution, hard/soft audit mismatch rates, and Stage 5c.1
+ *          pose-backfill outcomes — the signal for deciding whether the
+ *          flag is safe to flip on. In-memory, resets on restart.
+ * @access  Private (Admin)
+ */
+router.get('/structured-tutor-metrics', isAdmin, (req, res) => {
+  const structuredMetrics = require('../utils/structuredTutorMetrics');
+  const { isStructuredModeEnabled } = require('../utils/boardResponseSchema');
+  res.json({
+    flagEnabled: isStructuredModeEnabled(),
+    aggregate: structuredMetrics.aggregate(),
+    recent: structuredMetrics.snapshot(50),
+  });
+});
+
+/**
  * @route   POST /api/admin/seed-skills
  * @desc    Seed the skills database with Ready for Algebra 1 skills.
  * @access  Private (Admin)

--- a/tests/unit/pipelineIntegration.test.js
+++ b/tests/unit/pipelineIntegration.test.js
@@ -399,6 +399,28 @@ describe('Pipeline Integration: runPipeline', () => {
       expect(poses[0].tex).toContain('How many boxes');
     });
 
+    test('records the structured turn + backfill into metrics (Phase 6)', async () => {
+      process.env.STRUCTURED_TUTOR_RESPONSE = 'true';
+      const structuredMetrics = require('../../utils/structuredTutorMetrics');
+      structuredMetrics.reset();
+      callLLMStructured.mockResolvedValue({
+        turn_type: 'problem_introduction',
+        chat_message:
+          "Here's one for you. A baker has 24 cookies and packs them into boxes of 6. How many boxes does she fill?",
+        board_commands: [],
+      });
+
+      const user = mockUser();
+      const conversation = mockConversation([]);
+      await runPipeline('give me a word problem', buildCtx(user, conversation));
+
+      const agg = structuredMetrics.aggregate();
+      expect(agg.turns).toBe(1);
+      expect(agg.turn_type.problem_introduction).toBe(1);
+      expect(agg.mismatch.hard.problem_introduction_missing_pose).toBe(1);
+      expect(agg.backfill.posed).toBe(1);
+    });
+
     test('flag off → no structured turn_type, no backfill', async () => {
       delete process.env.STRUCTURED_TUTOR_RESPONSE;
       // Legacy path: free-text reply with no board tags.

--- a/tests/unit/structuredTutorMetrics.test.js
+++ b/tests/unit/structuredTutorMetrics.test.js
@@ -1,0 +1,149 @@
+/**
+ * structuredTutorMetrics — Phase 6 observability for the
+ * structured-tutor-response path.
+ *
+ * Verifies the recorder turns scattered per-turn audit/backfill signals
+ * into the cumulative rates the rollout decision depends on:
+ *   - turn_type distribution
+ *   - hard / soft mismatch counts (by kind) and per-turn rates
+ *   - Stage 5c.1 backfill outcomes + pose-success rate
+ */
+
+const metrics = require('../../utils/structuredTutorMetrics');
+
+describe('structuredTutorMetrics', () => {
+  beforeEach(() => metrics.reset());
+
+  describe('empty state', () => {
+    test('aggregate with no turns reports zeros and null rates', () => {
+      const a = metrics.aggregate();
+      expect(a.turns).toBe(0);
+      expect(a.turn_type._total).toBe(0);
+      expect(a.mismatch.hard._total).toBe(0);
+      expect(a.mismatch.hard_turn_rate).toBeNull();
+      expect(a.backfill.attempted).toBe(0);
+      expect(a.backfill.pose_success_rate).toBeNull();
+      expect(a.backfill.attempt_rate).toBeNull();
+    });
+
+    test('snapshot is empty', () => {
+      expect(metrics.snapshot()).toEqual([]);
+    });
+  });
+
+  describe('turn_type distribution', () => {
+    test('counts each declared turn_type', () => {
+      metrics.recordStructuredTurn({ turnType: 'problem_introduction' });
+      metrics.recordStructuredTurn({ turnType: 'verification' });
+      metrics.recordStructuredTurn({ turnType: 'problem_introduction' });
+      const a = metrics.aggregate();
+      expect(a.turns).toBe(3);
+      expect(a.turn_type._total).toBe(3);
+      expect(a.turn_type.problem_introduction).toBe(2);
+      expect(a.turn_type.verification).toBe(1);
+    });
+
+    test('null turn_type is bucketed under "null"', () => {
+      metrics.recordStructuredTurn({ turnType: null });
+      expect(metrics.aggregate().turn_type.null).toBe(1);
+    });
+  });
+
+  describe('mismatch accounting', () => {
+    test('splits hard vs soft by kind and tracks per-turn rates', () => {
+      // 1 clean, 1 hard, 1 soft, 1 both
+      metrics.recordStructuredTurn({ turnType: 'feedback', mismatches: [] });
+      metrics.recordStructuredTurn({
+        turnType: 'problem_introduction',
+        mismatches: [{ severity: 'hard', kind: 'problem_introduction_missing_pose' }],
+      });
+      metrics.recordStructuredTurn({
+        turnType: 'verification',
+        mismatches: [{ severity: 'soft', kind: 'verification_missing_verify' }],
+      });
+      metrics.recordStructuredTurn({
+        turnType: 'problem_introduction',
+        mismatches: [
+          { severity: 'hard', kind: 'problem_introduction_missing_pose' },
+          { severity: 'soft', kind: 'non_advancing_turn_with_board_action' },
+        ],
+      });
+
+      const a = metrics.aggregate();
+      expect(a.mismatch.hard.problem_introduction_missing_pose).toBe(2);
+      expect(a.mismatch.hard._total).toBe(2);
+      expect(a.mismatch.soft.verification_missing_verify).toBe(1);
+      expect(a.mismatch.soft.non_advancing_turn_with_board_action).toBe(1);
+      expect(a.mismatch.soft._total).toBe(2);
+      // 2 of 4 turns carried a hard mismatch; 2 of 4 a soft; 1 of 4 clean.
+      expect(a.mismatch.hard_turn_rate).toBe(0.5);
+      expect(a.mismatch.soft_turn_rate).toBe(0.5);
+      expect(a.mismatch.clean_turn_rate).toBe(0.25);
+    });
+  });
+
+  describe('backfill outcomes', () => {
+    test('counts attempts, outcomes, and pose-success rate', () => {
+      metrics.recordStructuredTurn({ turnType: 'problem_introduction', backfill: 'posed' });
+      metrics.recordStructuredTurn({ turnType: 'problem_introduction', backfill: 'posed' });
+      metrics.recordStructuredTurn({ turnType: 'problem_introduction', backfill: 'no_posable_problem' });
+      metrics.recordStructuredTurn({ turnType: 'problem_introduction', backfill: 'guard_dropped' });
+      // A turn that needed no backfill must not inflate attempts.
+      metrics.recordStructuredTurn({ turnType: 'feedback', backfill: null });
+
+      const a = metrics.aggregate();
+      expect(a.backfill.attempted).toBe(4);
+      expect(a.backfill.posed).toBe(2);
+      expect(a.backfill.no_posable_problem).toBe(1);
+      expect(a.backfill.guard_dropped).toBe(1);
+      expect(a.backfill.pose_success_rate).toBe(0.5); // 2/4
+      expect(a.backfill.attempt_rate).toBe(4 / 5);
+    });
+
+    test('an unknown backfill string counts the attempt but no outcome bucket', () => {
+      metrics.recordStructuredTurn({ turnType: 'problem_introduction', backfill: 'bogus' });
+      const a = metrics.aggregate();
+      expect(a.backfill.attempted).toBe(1);
+      expect(a.backfill.posed).toBe(0);
+      expect(a.backfill.no_posable_problem).toBe(0);
+      expect(a.backfill.guard_dropped).toBe(0);
+    });
+  });
+
+  describe('snapshot', () => {
+    test('returns records newest-first with the recorded fields', () => {
+      metrics.recordStructuredTurn({ turnType: 'feedback', llmBoardCount: 0 });
+      metrics.recordStructuredTurn({
+        turnType: 'problem_introduction',
+        llmBoardCount: 1,
+        mismatches: [{ severity: 'hard', kind: 'problem_introduction_missing_pose' }],
+        backfill: 'posed',
+      });
+
+      const recent = metrics.snapshot(10);
+      expect(recent).toHaveLength(2);
+      // Newest first
+      expect(recent[0].turnType).toBe('problem_introduction');
+      expect(recent[0].hard).toEqual(['problem_introduction_missing_pose']);
+      expect(recent[0].backfill).toBe('posed');
+      expect(recent[0].llmBoardCount).toBe(1);
+      expect(recent[1].turnType).toBe('feedback');
+    });
+
+    test('respects the limit argument', () => {
+      for (let i = 0; i < 5; i++) metrics.recordStructuredTurn({ turnType: 'feedback' });
+      expect(metrics.snapshot(3)).toHaveLength(3);
+    });
+  });
+
+  describe('robustness', () => {
+    test('tolerates missing / malformed input without throwing', () => {
+      expect(() => metrics.recordStructuredTurn()).not.toThrow();
+      expect(() => metrics.recordStructuredTurn({})).not.toThrow();
+      expect(() => metrics.recordStructuredTurn({ turnType: 'feedback', mismatches: null })).not.toThrow();
+      expect(() => metrics.recordStructuredTurn({ turnType: 'feedback', mismatches: [null, {}] })).not.toThrow();
+      // Two recorded turns above plus the defensive calls all count.
+      expect(metrics.aggregate().turns).toBe(4);
+    });
+  });
+});

--- a/utils/pipeline/index.js
+++ b/utils/pipeline/index.js
@@ -47,6 +47,7 @@ const { parseXpTags } = require('../xpTagParser');
 const { parseVisualTabTags } = require('../visualTabTagParser');
 const { synthesizeBoardCommands, mergeWithLlmCommands, synthesizeFallbackPose } = require('./boardSynthesizer');
 const { auditTurn } = require('../turnTypeAudit');
+const structuredMetrics = require('../structuredTutorMetrics');
 const log = require('../logger');
 const boardLogger = log.child({ service: 'board-tag-protocol' });
 const turnTypeLogger = log.child({ service: 'turn-type-audit' });
@@ -448,15 +449,18 @@ async function runPipeline(message, ctx) {
   // downstream in Stage 5c.1 (Phase 5), which runs after synthesis so
   // it only fires when no pose survives the merge. Soft mismatches stay
   // observe-only. The audit is a no-op under the legacy free-text path
-  // because there is no turn_type to audit.
+  // because there is no turn_type to audit. Phase 6 records the
+  // mismatches into structuredTutorMetrics (after Stage 5c.1, so the
+  // backfill outcome lands in the same record).
+  let auditMismatches = [];
   if (generatedResult.structuredTurnType) {
-    const mismatches = auditTurn({
+    auditMismatches = auditTurn({
       turnType: generatedResult.structuredTurnType,
       boardCommands: Array.isArray(generatedResult.structuredBoardCommands)
         ? generatedResult.structuredBoardCommands
         : [],
     });
-    for (const m of mismatches) {
+    for (const m of auditMismatches) {
       if (m.severity === 'hard') {
         turnTypeLogger.warn('turn_type mismatch (hard)', m);
       } else {
@@ -536,6 +540,7 @@ async function runPipeline(message, ctx) {
   // see, so we backfill a verbatim pose. Naturally dark-flagged:
   // structuredTurnType is only populated when STRUCTURED_TUTOR_RESPONSE
   // is on, so flag-off traffic never reaches this branch.
+  let backfillOutcome = null;
   if (generatedResult.structuredTurnType === 'problem_introduction'
       && !verified.boardCommands.some(c => c.action === 'pose')) {
     const fallbackPose = synthesizeFallbackPose({
@@ -554,20 +559,43 @@ async function runPipeline(message, ctx) {
         // Re-merge so canonical ordering (pose first) is preserved.
         const backfilled = mergeWithLlmCommands(verified.boardCommands, backfillGuard.allowed);
         verified.boardCommands = backfilled.all;
+        backfillOutcome = 'posed';
         boardLogger.info('Turn-type backfill posed problem (Phase 5)', {
           turnType: generatedResult.structuredTurnType,
           tex: fallbackPose.tex,
         });
       } else if (backfillGuard.dropped.length > 0) {
+        backfillOutcome = 'guard_dropped';
         boardLogger.warn('Pedagogy guard dropped turn-type backfill pose', {
           reason: backfillGuard.dropped[0].reason,
           tex: fallbackPose.tex,
         });
       }
     } else {
+      backfillOutcome = 'no_posable_problem';
       turnTypeLogger.warn('turn_type=problem_introduction with no posable problem; board left empty', {
         turnType: generatedResult.structuredTurnType,
       });
+    }
+  }
+
+  // ── Stage 5c.2: STRUCTURED-PATH METRICS (Phase 6) ──
+  // One passive record per structured turn — turn_type, audit mismatches,
+  // and the Stage 5c.1 backfill outcome — so the flag-on misclassification
+  // and backfill rates are observable in aggregate (scraped via
+  // GET /api/admin/structured-tutor-metrics). Same dark gate as the audit:
+  // structuredTurnType is only set when STRUCTURED_TUTOR_RESPONSE is on.
+  if (generatedResult.structuredTurnType) {
+    try {
+      structuredMetrics.recordStructuredTurn({
+        turnType: generatedResult.structuredTurnType,
+        llmBoardCount: llmBoardCommands.length,
+        mismatches: auditMismatches,
+        backfill: backfillOutcome,
+      });
+    } catch (metricsErr) {
+      // Metrics must never break a response.
+      turnTypeLogger.warn('structured metrics record failed (non-fatal)', { error: metricsErr.message });
     }
   }
 

--- a/utils/structuredTutorMetrics.js
+++ b/utils/structuredTutorMetrics.js
@@ -1,0 +1,182 @@
+// utils/structuredTutorMetrics.js
+// Per-turn observability for the structured-tutor-response path
+// (STRUCTURED_TUTOR_RESPONSE). In-memory ring buffer + cumulative
+// counters — no Mongo, no new infra. Reset on process restart; scraped
+// via GET /api/admin/structured-tutor-metrics.
+//
+// Why this exists
+// ---------------
+// The turn_type audit (turnTypeAudit.js) logs each mismatch one line at a
+// time, and Stage 5c.1's pose backfill is silent. With the flag still
+// dark there is no aggregated view of the two numbers that decide whether
+// STRUCTURED_TUTOR_RESPONSE is safe to flip on:
+//
+//   1. How often does the model misclassify the turn? (mismatch rates,
+//      split hard vs. soft, broken out by kind)
+//   2. How often must Stage 5c.1 backfill a pose the model forgot, and
+//      does the backfill succeed? (backfill rate + outcome)
+//
+// This module turns those scattered logs into rates. It is a passive
+// recorder: it never touches board_commands or the response.
+
+'use strict';
+
+const logger = require('./logger').child({ module: 'structuredTutorMetrics' });
+
+const RING_SIZE = 1000;
+let ring = new Array(RING_SIZE);
+let cursor = 0;
+
+// Cumulative since process start. The ring is for recent inspection;
+// these counters drive the rollout decision.
+let counters = freshCounters();
+
+function freshCounters() {
+  return {
+    turns: 0, // structured turns recorded (one per flag-on tutor turn)
+    turn_type: { _total: 0 }, // keyed by declared turn_type
+    mismatch_hard: { _total: 0 }, // keyed by mismatch kind
+    mismatch_soft: { _total: 0 }, // keyed by mismatch kind
+    turns_with_hard: 0, // turns carrying >= 1 hard mismatch
+    turns_with_soft: 0, // turns carrying >= 1 soft mismatch
+    clean_turns: 0, // turns with zero mismatches
+    // Stage 5c.1 outcomes. `attempted` counts turns that entered the
+    // backfill branch (problem_introduction with no surviving pose).
+    backfill: {
+      attempted: 0,
+      posed: 0, // a verbatim pose was synthesized + survived the guard
+      no_posable_problem: 0, // nothing posable in student/tutor text
+      guard_dropped: 0, // synthesized pose, but pedagogy guard dropped it
+    },
+  };
+}
+
+/**
+ * Record one structured tutor turn. Called once per turn from the
+ * pipeline when generate() returned a structured turn_type.
+ *
+ * @param {object} input
+ * @param {string|null} input.turnType - The model's declared turn_type.
+ * @param {number} [input.llmBoardCount] - Board commands the LLM emitted
+ *   (pre-synthesis), for context on how empty the model left the board.
+ * @param {Array<{severity:string, kind:string}>} [input.mismatches] -
+ *   Output of auditTurn().
+ * @param {('posed'|'no_posable_problem'|'guard_dropped'|null)} [input.backfill]
+ *   - Stage 5c.1 outcome, or null if the backfill branch didn't fire.
+ * @returns {object} The stored record.
+ */
+function recordStructuredTurn({ turnType, llmBoardCount = 0, mismatches = [], backfill = null } = {}) {
+  counters.turns++;
+
+  const typeKey = turnType == null ? 'null' : String(turnType);
+  counters.turn_type[typeKey] = (counters.turn_type[typeKey] || 0) + 1;
+  counters.turn_type._total++;
+
+  const hard = [];
+  const soft = [];
+  for (const m of Array.isArray(mismatches) ? mismatches : []) {
+    if (!m || !m.kind) continue;
+    if (m.severity === 'hard') {
+      hard.push(m.kind);
+      counters.mismatch_hard[m.kind] = (counters.mismatch_hard[m.kind] || 0) + 1;
+      counters.mismatch_hard._total++;
+    } else {
+      soft.push(m.kind);
+      counters.mismatch_soft[m.kind] = (counters.mismatch_soft[m.kind] || 0) + 1;
+      counters.mismatch_soft._total++;
+    }
+  }
+  if (hard.length) counters.turns_with_hard++;
+  if (soft.length) counters.turns_with_soft++;
+  if (!hard.length && !soft.length) counters.clean_turns++;
+
+  if (backfill) {
+    counters.backfill.attempted++;
+    if (Object.prototype.hasOwnProperty.call(counters.backfill, backfill)
+        && backfill !== 'attempted') {
+      counters.backfill[backfill]++;
+    }
+  }
+
+  const rec = {
+    ts: Date.now(),
+    turnType: typeKey,
+    llmBoardCount,
+    hard,
+    soft,
+    backfill: backfill || null,
+  };
+  ring[cursor] = rec;
+  cursor = (cursor + 1) % RING_SIZE;
+
+  // Sample 1-of-25 to logs so a flag-on session leaves a breadcrumb trail
+  // without flooding; always log a turn that needed a hard backfill.
+  if (backfill === 'posed' || backfill === 'guard_dropped' || counters.turns % 25 === 0) {
+    logger.info('structured_turn', {
+      turnType: rec.turnType,
+      hard: hard.length,
+      soft: soft.length,
+      backfill: rec.backfill,
+    });
+  }
+
+  return rec;
+}
+
+/**
+ * Most-recent records, newest first. For ad-hoc inspection in the admin
+ * endpoint; the rates in aggregate() are what drive decisions.
+ */
+function snapshot(limit = 100) {
+  const out = [];
+  const n = Math.min(limit, RING_SIZE);
+  for (let i = 0; i < n; i++) {
+    const idx = (cursor - 1 - i + RING_SIZE) % RING_SIZE;
+    if (ring[idx]) out.push(ring[idx]);
+  }
+  return out;
+}
+
+/**
+ * Cumulative counters with computed rates. This is the rollout dashboard.
+ */
+function aggregate() {
+  const n = counters.turns;
+  const rate = (x) => (n > 0 ? x / n : null);
+  return {
+    turns: n,
+    turn_type: { ...counters.turn_type },
+    mismatch: {
+      hard: { ...counters.mismatch_hard },
+      soft: { ...counters.mismatch_soft },
+      hard_turn_rate: rate(counters.turns_with_hard),
+      soft_turn_rate: rate(counters.turns_with_soft),
+      clean_turn_rate: rate(counters.clean_turns),
+    },
+    backfill: {
+      ...counters.backfill,
+      // Of the turns that entered the backfill branch, the share that
+      // produced a usable pose. The headline "did Phase 5 save the board"
+      // number.
+      pose_success_rate: counters.backfill.attempted > 0
+        ? counters.backfill.posed / counters.backfill.attempted
+        : null,
+      // Backfill branch entries as a share of all structured turns.
+      attempt_rate: rate(counters.backfill.attempted),
+    },
+  };
+}
+
+/** Test-only: wipe ring + counters. */
+function reset() {
+  ring = new Array(RING_SIZE);
+  cursor = 0;
+  counters = freshCounters();
+}
+
+module.exports = {
+  recordStructuredTurn,
+  snapshot,
+  aggregate,
+  reset,
+};


### PR DESCRIPTION
## Phase 6 — observability

Phases 1–5 built the structured-tutor path end-to-end; it's still **dark** behind `STRUCTURED_TUTOR_RESPONSE`. Before the flag can flip on safely we need the two numbers that decide whether the model classifies turns well enough:

1. **How often does it misclassify?** — audit mismatch rates, split hard vs. soft, broken out by kind.
2. **How often must Stage 5c.1 backfill a pose the model forgot, and does it succeed?** — backfill attempt rate + pose-success rate.

Today the audit logs each mismatch one line at a time and the Phase 5 backfill is silent, so there's no aggregated view. This PR adds one.

### What lands
- **`utils/structuredTutorMetrics.js`** — in-memory ring buffer + cumulative counters, mirroring the house pattern in `voiceMetrics.js` (no Mongo, no new infra, resets on restart). `recordStructuredTurn()` captures the declared `turn_type`, the audit mismatches (split hard/soft by kind), and the Stage 5c.1 backfill outcome. `aggregate()` turns those into the rollout dashboard: turn_type distribution, hard/soft/clean per-turn rates, and backfill attempt/pose-success rates. Passive recorder — it never touches `board_commands` or the response.
- **`utils/pipeline/index.js`** — Stage 5b.1 keeps its mismatches in scope; Stage 5c.1 records its outcome (`posed` / `no_posable_problem` / `guard_dropped`); new **Stage 5c.2** writes one record per structured turn, wrapped so a metrics failure can never break a response. Same dark gate as the audit.
- **`routes/admin.js`** — `GET /api/admin/structured-tutor-metrics` (`isAdmin`), alongside the existing error-metrics endpoint. Returns the flag state, `aggregate()`, and the 50 most-recent turn records.

### Dark by default
`structuredTurnType` is only set when `STRUCTURED_TUTOR_RESPONSE` is on, so flag-off traffic records nothing and behaves identically.

### Tests
11 new, full suite **2700/2700 green**, lint 0 errors:
- 10 unit tests — empty state, turn_type distribution, hard/soft mismatch accounting by kind, backfill outcomes + pose-success rate, snapshot ordering/limit, malformed-input robustness.
- 1 `runPipeline` integration test — confirms a structured `problem_introduction` backfill lands in the metrics.

Builds on structured-tutor-response Phase 5 (#1025).

https://claude.ai/code/session_012qvEV3nBqGGBEu4UfvL5rJ

---
_Generated by [Claude Code](https://claude.ai/code/session_012qvEV3nBqGGBEu4UfvL5rJ)_