### PR TITLE
Stamp instance hostname + uptime on structured-metrics dashboard

### DIFF
--- a/public/admin-structured-metrics.html
+++ b/public/admin-structured-metrics.html
@@ -77,6 +77,7 @@
     <a href="/admin-dashboard.html" class="back"><i class="fas fa-arrow-left"></i> Admin</a>
     <h1>Structured Tutor Metrics</h1>
     <div class="controls">
+      <span id="instance" title="Counters are per-process and in-memory. If this hostname changes between refreshes, the app is running more than one instance and each holds its own slice."></span>
       <span class="refresh-dot" id="refresh-dot"></span>
       <span id="last-updated">never</span>
       <label><input type="checkbox" id="auto-refresh" checked /> auto-refresh</label>
@@ -126,10 +127,20 @@
       Watch <strong>hard mismatch rate</strong> (model misclassified the turn) and <strong>backfill pose-success</strong>
       (Stage 5c.1 rescued a forgotten pose) to decide whether the flag is safe to ramp.
       Source: <code>/api/admin/structured-tutor-metrics</code> (admin-only, in-memory ring buffer of last 1000 turns, resets on restart).
+      Counters are <strong>per-process</strong> — the <code>inst</code> tag in the header names the instance serving these numbers.
+      If that hostname changes between refreshes, the app is running more than one instance and each holds its own slice.
     </p>
   </main>
   <script>
     const fmtPct = (n) => n == null ? '—' : `${(n * 100).toFixed(1)}%`;
+    const fmtUptime = (s) => {
+      if (s == null) return '';
+      if (s < 60) return `${s}s`;
+      if (s < 3600) return `${Math.floor(s / 60)}m`;
+      if (s < 86400) return `${Math.floor(s / 3600)}h`;
+      return `${Math.floor(s / 86400)}d`;
+    };
+    const shortHost = (h) => h ? String(h).slice(0, 12) : '?';
     const escapeHtml = (s) => String(s ?? '').replace(/[&<>"']/g, c => ({
       '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'
     })[c]);
@@ -281,6 +292,9 @@
         }
         const data = await res.json();
         const agg = data.aggregate || {};
+        const inst = data.instance || {};
+        document.getElementById('instance').textContent =
+          inst.hostname ? `inst ${shortHost(inst.hostname)} · up ${fmtUptime(inst.uptimeSeconds)}` : '';
         renderFlag(!!data.flagEnabled);
         renderStats(agg);
         renderTurnTypes(agg.turn_type || {});

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1428,10 +1428,21 @@ router.get('/health-check', isAdmin, (req, res) => {
  * @access  Private (Admin)
  */
 router.get('/structured-tutor-metrics', isAdmin, (req, res) => {
+  const os = require('os');
   const structuredMetrics = require('../utils/structuredTutorMetrics');
   const { isStructuredModeEnabled } = require('../utils/boardResponseSchema');
   res.json({
     flagEnabled: isStructuredModeEnabled(),
+    // The counters are per-process and in-memory. The app is single-instance
+    // today, so this is the whole picture — but if it's ever scaled
+    // (numInstances > 1), each instance keeps its own ring and a plain HTTP
+    // refresh will bounce between them. Stamping the instance + uptime makes
+    // that self-evident on the page instead of looking like jittering data.
+    instance: {
+      hostname: os.hostname(),
+      pid: process.pid,
+      uptimeSeconds: Math.round(process.uptime()),
+    },
     aggregate: structuredMetrics.aggregate(),
     recent: structuredMetrics.snapshot(50),
   });


### PR DESCRIPTION
## Instance stamp on the structured-metrics dashboard

Closes the #4 caveat from the metrics self-review — the per-process, in-memory observability trap.

### The finding (from checking the deploy config)
- `render.yaml` declares **one** web service, no `numInstances`, no autoscaling → Render defaults to **1 instance**.
- Start command is `node server.js` — no `cluster` / `pm2` → **one process**.
- So the dashboard is accurate today; **no architecture change is warranted.**

### The latent risk
Sessions already live in Mongo via `connect-mongo`, so the app is **architecturally ready to scale horizontally** — `numInstances: 2` is a one-field change on the Render dashboard. The moment that happens, the metrics endpoint (plain HTTP, non-sticky) would bounce between instances on each 5s refresh, and the counters would jitter **with no indication why**.

### The fix (cheap insurance, not architecture)
- Endpoint now returns `instance: { hostname, pid, uptimeSeconds }`.
- Dashboard header shows `inst <host> · up <n>` with a tooltip, plus a footer note: *"Counters are per-process… if this hostname changes between refreshes, the app is running more than one instance."*

If the app is ever scaled, the jitter becomes **self-evident and self-documenting** instead of looking like a bug. No Redis, no shared store — correct as-is on a single instance, honest if that ever changes.

Full suite 2705/2705 green; route syntax + lint clean.

https://claude.ai/code/session_012qvEV3nBqGGBEu4UfvL5rJ

---
_Generated by [Claude Code](https://claude.ai/code/session_012qvEV3nBqGGBEu4UfvL5rJ)_