### PR TITLE
Fix WorkBoard PROBLEM card drift with a canonical problem pin

### DIFF
--- a/models/conversation.js
+++ b/models/conversation.js
@@ -192,6 +192,16 @@ const conversationSchema = new Schema({
         type: Schema.Types.Mixed,
         default: null
     },
+    // Canonical problem currently pinned on the WorkBoard PROBLEM card.
+    // { tex, posedAt }. Set when a problem is posed, cleared on verify/clear.
+    // The board synthesizer reads this so it never re-parses an
+    // intermediate scratch line (or a stale earlier problem) as the
+    // PROBLEM — the pin is the single source of truth for "what's on the
+    // board". Null when the board has no active problem.
+    boardProblem: {
+        type: Schema.Types.Mixed,
+        default: null
+    },
     // Session summary: compact snapshot for cross-session pattern detection.
     // Written at periodic intervals (every 10 turns) by the pipeline.
     sessionSummary: {

--- a/tests/unit/boardSynthesizer.test.js
+++ b/tests/unit/boardSynthesizer.test.js
@@ -20,6 +20,7 @@ const {
   _detectFinalSolution,
   _detectSubstitutionCheck,
   _detectPosedProblem,
+  _looksLikeProblemStatement,
   _detectGeometryProblem,
   _extractProblemSentence,
   _extractPosableSentence,
@@ -118,6 +119,18 @@ describe('boardSynthesizer — detectors', () => {
       const r = _detectPosedProblem('Solve 4x+3=27');
       expect(r).not.toBeNull();
       expect(r.tex).toMatch(/4x.*3.*27/);
+    });
+
+    test('renders a quadratic equation (was null before the coeff-shape fix)', () => {
+      const r = _detectPosedProblem('solve 2x^2+4x-6=0');
+      expect(r).not.toBeNull();
+      expect(r.tex).toBe('2x^2 + 4x - 6 = 0');
+    });
+
+    test('renders a factoring task as the bare trinomial (no "= 0")', () => {
+      const r = _detectPosedProblem('factor x^2-7x+10');
+      expect(r).not.toBeNull();
+      expect(r.tex).toBe('x^2 - 7x + 10');
     });
   });
 
@@ -678,5 +691,112 @@ describe('boardSynthesizer — Phase 5 backfill', () => {
       expect(synthesizeFallbackPose({})).toBeNull();
       expect(synthesizeFallbackPose()).toBeNull();
     });
+  });
+});
+
+describe('boardSynthesizer — pinned problem anchor', () => {
+  // Regression coverage for the two WorkBoard PROBLEM bugs:
+  //   • Screenshot 1: an intermediate scratch line ("x(x+6)-2(x+6)=0")
+  //     overwrote the PROBLEM card.
+  //   • Screenshot 2: a stale earlier problem ("(x+3)(x+2)") stayed
+  //     pinned while the student worked a different one.
+  // The fix pins the canonical problem and passes it back in as
+  // `pinnedProblem`; pose decisions key on that, not on whatever
+  // equation happens to appear in the turn.
+
+  describe('_looksLikeProblemStatement', () => {
+    test('accepts a single fresh equation', () => {
+      expect(_looksLikeProblemStatement('2x^2+4x-6=0')).toBe(true);
+    });
+    test('accepts a command-prefixed problem', () => {
+      expect(_looksLikeProblemStatement('factor x^2-7x+10')).toBe(true);
+    });
+    test('rejects a stated solution "x=2 or -6"', () => {
+      expect(_looksLikeProblemStatement('x=2 or -6')).toBe(false);
+    });
+    test('rejects multi-line worked scratch (screenshot 1)', () => {
+      expect(_looksLikeProblemStatement(
+        'x^2 +6x-2x-12=0\nx(x+6)-2(x+6)=0\n(x-2)(x+6)=0\nx=2 or -6'
+      )).toBe(false);
+    });
+    test('does not misread "2x = 10" as an answer', () => {
+      expect(_looksLikeProblemStatement('solve 2x = 10')).toBe(true);
+    });
+  });
+
+  test('no pin + worked scratch dropped on a closed cycle → no pose (screenshot 1 closed-cycle guard)', () => {
+    const cards = synthesizeBoardCommands({
+      studentMessage: 'x^2 +6x-2x-12=0\nx(x+6)-2(x+6)=0\n(x-2)(x+6)=0\nx=2 or -6',
+      tutorResponse: "Let's double-check those factors together.",
+      diagnosis: { type: 'no_answer', isCorrect: null },
+      observation: { messageType: 'general_math' },
+      lastBoardAction: 'verify', // cycle closed
+      pinnedProblem: null,
+    });
+    expect(cards.some(c => c.action === 'pose')).toBe(false);
+  });
+
+  test('pinned problem holds while student posts intermediate work → no re-pose (screenshot 1)', () => {
+    const cards = synthesizeBoardCommands({
+      studentMessage: 'x(x+6)-2(x+6)=0',
+      tutorResponse: 'Good grouping! What comes next?',
+      diagnosis: { type: 'no_answer', isCorrect: null },
+      observation: { messageType: 'general_math' },
+      lastBoardAction: 'apply',
+      pinnedProblem: '2x^2 + 4x - 6 = 0',
+    });
+    expect(cards.some(c => c.action === 'pose')).toBe(false);
+    expect(cards.some(c => c.action === 'clear')).toBe(false);
+  });
+
+  test('pinned problem + intermediate equation "3x=21" → resolve, never a re-pose', () => {
+    const cards = synthesizeBoardCommands({
+      studentMessage: '3x=21',
+      tutorResponse: 'Great job! Now what?',
+      diagnosis: { type: 'no_answer', isCorrect: null },
+      observation: { messageType: 'general_math' },
+      lastBoardAction: 'apply',
+      pinnedProblem: '3x - 5 = 16',
+    });
+    expect(cards.some(c => c.action === 'pose')).toBe(false);
+    expect(cards).toEqual([{ action: 'resolve', tex: '3x = 21' }]);
+  });
+
+  test('student explicitly starts a DIFFERENT problem → clear + pose (auto-advance, fixes screenshot 2)', () => {
+    const cards = synthesizeBoardCommands({
+      studentMessage: 'factor x^2-7x+10',
+      tutorResponse: "Sure! Let's factor that one.",
+      diagnosis: { type: 'no_answer', isCorrect: null },
+      observation: { messageType: 'general_math' },
+      lastBoardAction: 'resolve',          // old cycle still open
+      pinnedProblem: '(x+3)(x+2)',          // stale pin from a prior problem
+    });
+    const actions = cards.map(c => c.action);
+    expect(actions).toContain('clear');
+    expect(actions).toContain('pose');
+    // clear must precede pose so the board resets before the new problem
+    expect(actions.indexOf('clear')).toBeLessThan(actions.indexOf('pose'));
+    const pose = cards.find(c => c.action === 'pose');
+    expect(pose.tex).toMatch(/7x.*10/);
+  });
+
+  test('re-stating the SAME pinned problem does not re-pose', () => {
+    const cards = synthesizeBoardCommands({
+      studentMessage: 'solve 3x-5=16',
+      tutorResponse: "We're already on it!",
+      diagnosis: { type: 'no_answer', isCorrect: null },
+      observation: { messageType: 'general_math' },
+      lastBoardAction: 'apply',
+      pinnedProblem: '3x - 5 = 16',
+    });
+    expect(cards.some(c => c.action === 'pose')).toBe(false);
+  });
+
+  test('merge keeps clear before pose for an auto-advance pair', () => {
+    const { all } = mergeWithLlmCommands([], [
+      { action: 'pose', tex: 'x^2 - 7x + 10' },
+      { action: 'clear' },
+    ]);
+    expect(all.map(c => c.action)).toEqual(['clear', 'pose']);
   });
 });

--- a/utils/boardCommandGuard.js
+++ b/utils/boardCommandGuard.js
@@ -176,11 +176,14 @@ function enforcePedagogyRule({
     // is judged against the student's message, not the in-batch pose.
     let runningLastAction = lastBoardActionInConversation;
 
-    for (const command of commands) {
+    for (let i = 0; i < commands.length; i++) {
+        const command = commands[i];
+        const nextAction = commands[i + 1] ? commands[i + 1].action : null;
         const decision = evaluate(command, {
             currentText,
             combinedText,
             runningLastAction,
+            nextAction,
         });
 
         if (decision.allowed) {
@@ -237,6 +240,12 @@ function evaluate(command, ctx) {
             return { allowed: true };
         }
         if (ctx.runningLastAction === 'verify') {
+            return { allowed: true };
+        }
+        // A clear immediately followed by a pose is a board reset for a
+        // new problem (auto-advance). The pose itself is always allowed,
+        // so the reset that precedes it is too.
+        if (ctx.nextAction === 'pose') {
             return { allowed: true };
         }
         return { allowed: false, reason: 'clear_without_start_over_or_completed_problem' };

--- a/utils/pipeline/boardSynthesizer.js
+++ b/utils/pipeline/boardSynthesizer.js
@@ -207,6 +207,31 @@ function tutorAffirms(tutorResponse) {
 // dependencies).
 // ---------------------------------------------------------------------------
 
+// Reconstruct a quadratic's tex from mathSolver's coefficient shape
+// { a, bSign, b, cSign, c }. Drops unit coefficients (1x² → x²,
+// 1x → x) and zero terms so the card reads the way a student writes it.
+function quadraticTex(p, withEquals) {
+  const a = p.a;
+  let head;
+  if (a === 1) head = 'x^2';
+  else if (a === -1) head = '-x^2';
+  else head = `${a}x^2`;
+
+  let mid = '';
+  if (p.b !== undefined && p.b !== 0) {
+    const coeff = p.b === 1 ? '' : `${p.b}`;
+    mid = ` ${p.bSign || '+'} ${coeff}x`;
+  }
+
+  let tail = '';
+  if (p.c !== undefined && p.c !== 0) {
+    tail = ` ${p.cSign || '+'} ${p.c}`;
+  }
+
+  const expr = `${head}${mid}${tail}`.trim();
+  return withEquals ? `${expr} = 0` : expr;
+}
+
 function canonicalProblemTex(problem) {
   if (!problem) return null;
   switch (problem.type) {
@@ -220,10 +245,16 @@ function canonicalProblemTex(problem) {
       }
       return problem.equation || problem.expression || null;
     case 'quadratic_equation':
+      // mathSolver returns { a, bSign, b, cSign, c } for quadratics —
+      // no `equation`/`expression` field — so reconstruct the trinomial.
+      if (problem.a !== undefined) return quadraticTex(problem, /*withEquals*/ true);
       return problem.equation || problem.expression || null;
     case 'expand_polynomial':
     case 'factor_quadratic':
     case 'factor_diff_of_squares':
+      // Same coefficient shape, but a factoring/expansion task shows the
+      // bare trinomial (no "= 0").
+      if (problem.a !== undefined) return quadraticTex(problem, /*withEquals*/ false);
       return problem.expression || null;
     case 'evaluation':
       // The evaluation type is mathSolver's catch-all when text like
@@ -270,6 +301,31 @@ function detectPosedProblem(text) {
   if (!tex) return null;
   return { tex, problem: result.problem, correctAnswer: String(result.solution.answer) };
 }
+
+// A fresh problem *statement* is a single ask — one equation/expression,
+// optionally prefixed with a command verb. A worked-solution message
+// (multiple equation lines, or a stated "x = …" answer) is the student's
+// scratch work, NOT a new problem to pin on the board. This guard is what
+// stops an intermediate derivation line from being posed as the PROBLEM.
+function looksLikeProblemStatement(text) {
+  if (!text || typeof text !== 'string') return false;
+  const t = text.trim();
+  // A stated solution ("x = 2 or -6", "y= -3") is the end of work, never
+  // a new problem. Require the variable isolated on one side so a real
+  // problem like "2x = 10" isn't misread as an answer.
+  if (/(^|[\s,(])[a-z]\s*=\s*-?\d/i.test(t)) return false;
+  // Two or more equation/expression lines = a derivation, not a fresh ask.
+  const eqLines = t.split(/\n+/).map(l => l.trim())
+    .filter(l => /=/.test(l) || /[+\-*/^]/.test(l));
+  if (eqLines.length >= 2) return false;
+  return true;
+}
+
+// Explicit "I'm starting a new problem" verbs. Required before we'll
+// REPLACE a problem already pinned on the board — an intermediate
+// equation like "3x = 21" carries no cue and must never be mistaken for
+// a new problem to re-pose.
+const NEW_PROBLEM_CUE = /\b(solve|factor|simplify|expand|evaluate|graph|compute|calculate|find|what\s+is|new\s+problem|next\s+problem|another\s+(?:one|problem))\b/i;
 
 // ---------------------------------------------------------------------------
 // Geometry pose fallback — when parseCleanProblem can't see a problem.
@@ -399,6 +455,7 @@ function synthesizeBoardCommands({
   diagnosis,
   observation,
   lastBoardAction = null,
+  pinnedProblem = null,
   recentAssistantMessages: _recentAssistantMessages = [], // eslint-disable-line no-unused-vars
 } = {}) {
   const cards = [];
@@ -408,16 +465,34 @@ function synthesizeBoardCommands({
     || lastBoardAction === 'clear';
 
   // ── 1. POSE ──
-  // A new problem can appear on either side of the turn:
-  //   - student bare-drops "solve 3x-5=16"
-  //   - tutor offers "Try 4x+3=27"
-  // The math engine is the source of truth: if it parses a problem
-  // out of the text AND there's no active problem on the board, emit
-  // pose.
-  if (cycleIsClosed) {
-    // Prefer the student's message — if they introduced the problem,
-    // the canonical text matches what they typed. Fall back to tutor.
+  // A problem reaches the board one of two ways:
+  //   • the board is empty → pose the problem the student bare-dropped
+  //     ("solve 3x-5=16") or the tutor offered ("Try 4x+3=27");
+  //   • a problem is already pinned but the student explicitly starts a
+  //     DIFFERENT one → clear the old board and pose the new one.
+  // `pinnedProblem` (conversation.boardProblem.tex) is the source of
+  // truth for "what's on the board". Without it the synthesizer used to
+  // re-parse whatever equation appeared in the turn and latch onto
+  // intermediate scratch work (or leave a stale problem pinned).
+  if (pinnedProblem) {
+    // Replace only on an explicit, different new problem statement. An
+    // intermediate equation ("3x = 21") carries no NEW_PROBLEM_CUE and
+    // must not be mistaken for a fresh problem; a clear+pose resets the
+    // board to the new one.
+    const fresh = detectPosedProblem(studentMessage);
+    if (fresh
+        && NEW_PROBLEM_CUE.test(studentMessage)
+        && looksLikeProblemStatement(studentMessage)
+        && normalizeForCompare(fresh.tex) !== normalizeForCompare(pinnedProblem)) {
+      cards.push({ action: 'clear' });
+      cards.push({ action: 'pose', tex: fresh.tex });
+    }
+  } else if (cycleIsClosed) {
+    // Empty board. Prefer the student's message — if they introduced
+    // the problem, the canonical text matches what they typed — but
+    // never pose from the student's own worked solution.
     let posed = detectPosedProblem(studentMessage);
+    if (posed && !looksLikeProblemStatement(studentMessage)) posed = null;
     if (!posed) posed = detectPosedProblem(tutorResponse);
     // Geometry word problems don't parse as algebra; quote the
     // tutor's question sentence verbatim so the board reflects the
@@ -524,7 +599,7 @@ function mergeWithLlmCommands(llmCommands, synthesized) {
   // Order by canonical sequence — the frontend renders in array
   // order, so pose-first / verify-last produces the cleanest
   // animation when both LLM and synthesizer fire in the same turn.
-  const ORDER = { pose: 0, apply: 1, resolve: 2, verify: 3, clear: 4, graph: 5, image: 6 };
+  const ORDER = { clear: 0, pose: 1, apply: 2, resolve: 3, verify: 4, graph: 5, image: 6 };
   const all = [...llm, ...added].sort((a, b) => {
     const ai = ORDER[a.action] ?? 99;
     const bi = ORDER[b.action] ?? 99;
@@ -630,6 +705,7 @@ module.exports = {
   _detectFinalSolution: detectFinalSolution,
   _detectSubstitutionCheck: detectSubstitutionCheck,
   _detectPosedProblem: detectPosedProblem,
+  _looksLikeProblemStatement: looksLikeProblemStatement,
   _detectGeometryProblem: detectGeometryProblem,
   _extractProblemSentence: extractProblemSentence,
   _extractPosableSentence: extractPosableSentence,

--- a/utils/pipeline/index.js
+++ b/utils/pipeline/index.js
@@ -494,6 +494,7 @@ async function runPipeline(message, ctx) {
       diagnosis,
       observation,
       lastBoardAction: ctx.conversation?.lastBoardAction || null,
+      pinnedProblem: ctx.conversation?.boardProblem?.tex || null,
       recentAssistantMessages,
     });
   } catch (synthErr) {
@@ -613,6 +614,20 @@ async function runPipeline(message, ctx) {
   if (verified.boardCommands.length > 0 && ctx.conversation) {
     const lastEmitted = verified.boardCommands[verified.boardCommands.length - 1].action;
     ctx.conversation.lastBoardAction = lastEmitted;
+
+    // Pin / unpin the canonical board problem so future turns anchor to
+    // it instead of re-parsing intermediate scratch work (or leaving a
+    // stale problem on the board). A pose — including an auto-advance
+    // clear+pose or a turn-type backfill — sets the pin; a verify/clear
+    // that ends the cycle drops it.
+    const poseCard = [...verified.boardCommands].reverse().find(c => c.action === 'pose');
+    if (poseCard && poseCard.tex) {
+      ctx.conversation.boardProblem = { tex: poseCard.tex, posedAt: new Date() };
+      ctx.conversation.markModified?.('boardProblem');
+    } else if (lastEmitted === 'verify' || lastEmitted === 'clear') {
+      ctx.conversation.boardProblem = null;
+      ctx.conversation.markModified?.('boardProblem');
+    }
   }
 
   // ── Stage 5d: XP CEREMONY TAGS (Phase C) ──


### PR DESCRIPTION
The board's PROBLEM panel was sourcing its equation by re-parsing chat text each turn, so it latched onto intermediate scratch work or a stale earlier problem instead of the canonical starting problem. Quadratics were never posed at all: canonicalProblemTex only handled .equation/.expression shapes, but the solver returns quadratics as {a,bSign,b,cSign,c}.

- Add conversation.boardProblem pin as the single source of truth for what's on the board; set on pose, clear on verify/clear.
- Render quadratics via quadraticTex() and wire it into the quadratic/factor/expand cases (the core "no quadratic could ever pose" bug behind both reported screenshots).
- Anchor synthesis on the pin: hold while the student posts intermediate work; auto-advance (clear + pose) only when the student explicitly states a different problem.
- Allow a clear immediately followed by a pose in the pedagogy guard (auto-advance board reset) and order clear before pose.