### PR TITLE
Add scaffold board card — fill-in-the-blank hints on the WorkBoard

### DIFF
--- a/models/conversation.js
+++ b/models/conversation.js
@@ -150,7 +150,7 @@ const conversationSchema = new Schema({
     // commands have been emitted yet.
     lastBoardAction: {
         type: String,
-        enum: ['pose', 'apply', 'resolve', 'verify', 'clear', null],
+        enum: ['pose', 'apply', 'resolve', 'verify', 'clear', 'scaffold', null],
         default: null,
     },
     alerts: [{

--- a/public/css/workspace.css
+++ b/public/css/workspace.css
@@ -496,6 +496,38 @@
   }
 }
 
+/* Scaffold — a hint card: the next step's structure with empty \boxed{}
+   slots for the student to fill. Dashed amber presence + a "your turn"
+   eyebrow so it reads as an invitation, not a finished step. The blanks
+   reveal nothing, which is why this card is allowed on the student's own
+   problem (see utils/boardCommandGuard.js). */
+.cr-ws-board-card--scaffold {
+  border-style: dashed;
+  border-color: rgba(255, 184, 77, 0.55);
+  background: linear-gradient(180deg,
+    rgba(255, 184, 77, 0.07) 0%,
+    var(--cr-bg-panel) 100%);
+}
+.cr-ws-board-card--scaffold::before {
+  content: "YOUR TURN — FILL THE BLANKS";
+  position: absolute;
+  top: 8px;
+  left: 14px;
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.10em;
+  color: #E0962B;
+  opacity: 0.95;
+}
+/* The empty boxes themselves: dashed amber outline so they read as slots
+   waiting for input rather than rendered (filled) answers. */
+.cr-ws-board-card--scaffold .cr-ws-board-card-math .boxed,
+.cr-ws-board-card--scaffold .cr-ws-board-card-math .katex .boxpad {
+  border-color: rgba(224, 150, 43, 0.85) !important;
+  border-style: dashed !important;
+  background: rgba(255, 184, 77, 0.10);
+}
+
 /* Math display inside cards — KaTeX renders into here. */
 .cr-ws-board-card-math {
   padding-top: 14px;

--- a/public/js/boardCommandHandler.js
+++ b/public/js/boardCommandHandler.js
@@ -21,7 +21,7 @@
     'use strict';
 
     var STAGGER_MS = 250;
-    var STAGGER_ACTIONS = { apply: true, resolve: true, verify: true, graph: true, image: true };
+    var STAGGER_ACTIONS = { apply: true, resolve: true, verify: true, graph: true, image: true, scaffold: true };
 
     function getWorkspace() {
         return typeof window !== 'undefined' ? window.MathWorkspace : null;
@@ -43,6 +43,9 @@
                     break;
                 case 'resolve':
                     if (command.tex) W.boardResolve(command.tex);
+                    break;
+                case 'scaffold':
+                    if (command.tex) W.boardScaffold(command.tex);
                     break;
                 case 'verify':
                     if (command.tex) {

--- a/public/js/workspace.js
+++ b/public/js/workspace.js
@@ -54,6 +54,17 @@
     target.textContent = String(tex || '');
   }
 
+  // Give empty \boxed{} scaffold slots a visible width so they read as
+  // fill-in blanks rather than collapsing to a hairline box. Only widens
+  // boxes that are empty or contain nothing but LaTeX spacing macros.
+  function widenScaffoldBlanks(tex) {
+    if (!tex || typeof tex !== 'string') return tex || '';
+    return tex.replace(
+      /\\boxed\s*\{\s*(?:\\(?:[;,:! ]|quad|qquad)\s*)*\}/g,
+      '\\boxed{\\phantom{00}}'
+    );
+  }
+
   // ---- Launcher tools (open an existing floating surface) --------------
   // Board used to be a launcher into the floating whiteboard; it's now
   // the embedded home base (see renderBoard below). Tiles + Calc stay
@@ -228,6 +239,15 @@
         .catch(function () {
           imgHost.textContent = 'Image unavailable.';
         });
+    } else if (step.type === 'scaffold') {
+      // Hint card — shows the next step's structure with empty \boxed{}
+      // slots the student fills in. Distinct look + an eyebrow so it reads
+      // as "your move", not as a finished step. Blanks reveal nothing, so
+      // this is the one card allowed on the student's own problem.
+      card = el('div', 'cr-ws-board-card cr-ws-board-card--scaffold');
+      var sMath = el('div', 'cr-ws-board-card-math');
+      card.appendChild(sMath);
+      renderTex(sMath, widenScaffoldBlanks(step.tex));
     } else {
       // Equation card — pose / resolve / verify all share the same shape;
       // verify gets a badge + an expanded check line.
@@ -498,6 +518,22 @@
       tex = (tex == null ? '' : String(tex)).trim();
       if (!tex) return false;
       pushBoardStep({ type: 'resolve', tex: tex });
+      return true;
+    },
+
+    /**
+     * Post a scaffold hint — the next step's structure with empty \boxed{}
+     * slots for the student to fill. Unlike resolve, this is NOT a step the
+     * student has stated; the blanks are the teaching affordance.
+     * @param {string} tex  LaTeX with at least one \boxed{} blank, e.g.
+     *                      "x^2 + 4x + \\boxed{} = 12 + \\boxed{}"
+     */
+    boardScaffold: function (tex) {
+      tex = (tex == null ? '' : String(tex)).trim();
+      if (!tex) return false;
+      openWorkspace();
+      this.showTool('board');
+      pushBoardStep({ type: 'scaffold', tex: tex });
       return true;
     },
 

--- a/tests/unit/boardCommandGuard.test.js
+++ b/tests/unit/boardCommandGuard.test.js
@@ -3,6 +3,7 @@ const {
   texMatchesStudentText,
   opMatchesStudentText,
   hasStartOverIntent,
+  texHasBlank,
 } = require('../../utils/boardCommandGuard');
 
 describe('boardCommandGuard', () => {
@@ -188,6 +189,51 @@ describe('boardCommandGuard', () => {
     });
   });
 
+  describe('scaffold (fill-in-the-blank hint)', () => {
+    it('is allowed on the student\'s own problem when it carries a blank', () => {
+      // The scaffold sits on the student's OWN equation but reveals nothing —
+      // the boxes are empty. This is the case the #1 rule must permit.
+      const { allowed, dropped } = enforcePedagogyRule({
+        commands: [{ action: 'scaffold', tex: 'x^2 + 4x + \\boxed{} = 12 + \\boxed{}' }],
+        userMessage: "I'm stuck on completing the square",
+      });
+      expect(allowed).toHaveLength(1);
+      expect(allowed[0].action).toBe('scaffold');
+      expect(dropped).toHaveLength(0);
+    });
+
+    it('accepts spacing-only boxes and \\square blanks', () => {
+      const a = enforcePedagogyRule({
+        commands: [{ action: 'scaffold', tex: 'x^2 + 4x + \\boxed{\\;\\;} = 12 + \\boxed{\\;\\;}' }],
+        userMessage: 'help',
+      });
+      expect(a.allowed).toHaveLength(1);
+      const b = enforcePedagogyRule({
+        commands: [{ action: 'scaffold', tex: '2x = \\square' }],
+        userMessage: 'help',
+      });
+      expect(b.allowed).toHaveLength(1);
+    });
+
+    it('DROPS a scaffold with no blank — a filled-in scaffold is an answer dump', () => {
+      const { allowed, dropped } = enforcePedagogyRule({
+        commands: [{ action: 'scaffold', tex: 'x^2 + 4x + 4 = 12 + 4' }],
+        userMessage: 'what do I add to both sides',
+      });
+      expect(allowed).toHaveLength(0);
+      expect(dropped[0].reason).toBe('scaffold_has_no_blank');
+    });
+
+    it('is dropped when tex is missing', () => {
+      const { allowed, dropped } = enforcePedagogyRule({
+        commands: [{ action: 'scaffold' }],
+        userMessage: 'hint please',
+      });
+      expect(allowed).toHaveLength(0);
+      expect(dropped[0].reason).toBe('scaffold_missing_tex');
+    });
+  });
+
   describe('full drop scenario', () => {
     it('drops every move-tag when the student message is unrelated', () => {
       const { allowed, dropped } = enforcePedagogyRule({
@@ -234,6 +280,19 @@ describe('boardCommandGuard', () => {
       expect(hasStartOverIntent('start over')).toBe(true);
       expect(hasStartOverIntent("let's try another")).toBe(true);
       expect(hasStartOverIntent('I want to continue this one')).toBe(false);
+    });
+
+    it('texHasBlank recognizes empty boxes, squares, and underscores', () => {
+      expect(texHasBlank('x + \\boxed{}')).toBe(true);
+      expect(texHasBlank('x + \\boxed{\\;\\;}')).toBe(true);
+      expect(texHasBlank('x + \\boxed{\\quad}')).toBe(true);
+      expect(texHasBlank('2x = \\square')).toBe(true);
+      expect(texHasBlank('x + _____')).toBe(true);
+      // A fully-filled expression has no blank — must be false.
+      expect(texHasBlank('x^2 + 4x + 4 = 16')).toBe(false);
+      expect(texHasBlank('\\boxed{4}')).toBe(false); // a filled box is not a blank
+      expect(texHasBlank('')).toBe(false);
+      expect(texHasBlank(null)).toBe(false);
     });
   });
 });

--- a/tests/unit/boardResponseSchema.test.js
+++ b/tests/unit/boardResponseSchema.test.js
@@ -76,6 +76,18 @@ describe('boardResponseSchema — normalizeBoardCommand', () => {
     });
   });
 
+  test('keeps tex on a scaffold command', () => {
+    expect(normalizeBoardCommand({
+      action: 'scaffold',
+      tex: 'x^2 + 4x + \\boxed{} = 12 + \\boxed{}',
+      op: null,
+      check: null,
+      fn: null,
+      query: null,
+      caption: null,
+    })).toEqual({ action: 'scaffold', tex: 'x^2 + 4x + \\boxed{} = 12 + \\boxed{}' });
+  });
+
   test('empty-string field is treated as null and dropped', () => {
     expect(normalizeBoardCommand({
       action: 'apply',
@@ -270,9 +282,9 @@ describe('boardResponseSchema — schema shape (OpenAI strict mode)', () => {
   // the API will reject the schema at call time; better to fail
   // loudly here than in production.
 
-  test('BOARD_ACTIONS lists the seven supported actions', () => {
+  test('BOARD_ACTIONS lists the eight supported actions', () => {
     expect(BOARD_ACTIONS).toEqual([
-      'pose', 'apply', 'resolve', 'verify', 'clear', 'graph', 'image',
+      'pose', 'apply', 'resolve', 'verify', 'clear', 'graph', 'image', 'scaffold',
     ]);
   });
 

--- a/tests/unit/boardTagParser.test.js
+++ b/tests/unit/boardTagParser.test.js
@@ -38,6 +38,19 @@ describe('boardTagParser', () => {
         .toEqual([{ action: 'clear' }]);
     });
 
+    it('extracts a scaffold with tex carrying boxed blanks', () => {
+      const input = 'Try this. <BOARD action="scaffold" tex="x^2 + 4x + \\boxed{} = 12 + \\boxed{}" /> What goes in the boxes?';
+      const { cleanedText, boardCommands } = parseBoardTags(input);
+      expect(boardCommands).toEqual([
+        { action: 'scaffold', tex: 'x^2 + 4x + \\boxed{} = 12 + \\boxed{}' },
+      ]);
+      expect(cleanedText).toBe('Try this. What goes in the boxes?');
+    });
+
+    it('drops a scaffold tag with no tex', () => {
+      expect(parseBoardTags('<BOARD action="scaffold" />').boardCommands).toEqual([]);
+    });
+
     it('extracts a graph with fn only', () => {
       const input = '<BOARD action="graph" fn="x^2 - 4" />';
       expect(parseBoardTags(input).boardCommands).toEqual([

--- a/utils/boardCommandGuard.js
+++ b/utils/boardCommandGuard.js
@@ -131,6 +131,27 @@ function hasStartOverIntent(text) {
 }
 
 /**
+ * True if a scaffold's tex contains at least one *empty* slot for the
+ * student to fill. This is the anti-cheat property for scaffold cards:
+ * scaffolding shows structure with holes; a "scaffold" with every term
+ * filled in is just an answer dump on the student's own problem and must
+ * be rejected. Recognized blanks:
+ *   - an empty (or whitespace/spacing-only) \boxed{...}  e.g. \boxed{}, \boxed{\;\;}
+ *   - \square                                            the open-box glyph
+ *   - a run of 3+ underscores                            e.g. _____ or \_\_\_
+ */
+function texHasBlank(tex) {
+    if (!tex || typeof tex !== 'string') return false;
+    // \boxed{...} whose contents are only LaTeX spacing macros / whitespace.
+    const EMPTY_BOXED = /\\boxed\s*\{\s*(?:\\(?:[;,:!\s]|quad|qquad|phantom\s*\{[^}]*\}|hspace\s*\{[^}]*\}|,|;)\s*)*\}/;
+    if (EMPTY_BOXED.test(tex)) return true;
+    if (/\\square\b/.test(tex)) return true;
+    if (/_{3,}/.test(tex)) return true;          // raw underscores
+    if (/(?:\\_){3,}/.test(tex)) return true;    // escaped underscores
+    return false;
+}
+
+/**
  * Enforce the #1-rule guard on a parsed list of board commands.
  *
  * @param {Object}   input
@@ -251,6 +272,22 @@ function evaluate(command, ctx) {
         return { allowed: false, reason: 'clear_without_start_over_or_completed_problem' };
     }
 
+    // Scaffold: the tutor shows the next step's STRUCTURE with empty slots
+    // for the student to fill (e.g. "x^2 + 4x + \boxed{} = 12 + \boxed{}").
+    // A blank reveals nothing, so this does not violate the #1 rule even on
+    // the student's own problem — it's a hint, not the answer. But we DO
+    // require a real blank: a "scaffold" with everything filled in is an
+    // answer dump wearing the wrong label, so reject it.
+    if (action === 'scaffold') {
+        if (!command.tex) {
+            return { allowed: false, reason: 'scaffold_missing_tex' };
+        }
+        if (!texHasBlank(command.tex)) {
+            return { allowed: false, reason: 'scaffold_has_no_blank' };
+        }
+        return { allowed: true };
+    }
+
     // Tutor-emitted reference content: graph/image cards are teaching aids,
     // not the student's worked steps. They can't reveal the solution, so
     // the #1-rule guard doesn't apply — we only validate required attrs.
@@ -278,4 +315,5 @@ module.exports = {
     texMatchesStudentText,
     opMatchesStudentText,
     hasStartOverIntent,
+    texHasBlank,
 };

--- a/utils/boardResponseSchema.js
+++ b/utils/boardResponseSchema.js
@@ -41,7 +41,7 @@
 
 'use strict';
 
-const BOARD_ACTIONS = ['pose', 'apply', 'resolve', 'verify', 'clear', 'graph', 'image'];
+const BOARD_ACTIONS = ['pose', 'apply', 'resolve', 'verify', 'clear', 'graph', 'image', 'scaffold'];
 
 // The kind of turn Maya is serving. The model self-declares this
 // on every structured response. Server-side audit (utils/turnTypeAudit.js)
@@ -76,7 +76,7 @@ const BOARD_COMMAND_SCHEMA = {
     },
     tex: {
       type: ['string', 'null'],
-      description: 'LaTeX expression. Required for pose, resolve, verify. Null for apply, clear, graph, image.',
+      description: 'LaTeX expression. Required for pose, resolve, verify, and scaffold. For scaffold it MUST contain at least one empty slot the student fills, written as \\boxed{} (e.g. "x^2 + 4x + \\boxed{} = 12 + \\boxed{}"). Null for apply, clear, graph, image.',
     },
     op: {
       type: ['string', 'null'],
@@ -242,7 +242,7 @@ Your reply is a structured object, not free text. You fill three fields:
   • verification — the student stated a final answer. board_commands SHOULD include a verify card.
   • concept_reference — the student asked about a concept and you're showing reference content. board_commands SHOULD include an image or graph card.
   • feedback — praise or correction that does NOT advance the work. board_commands SHOULD be empty (an image/graph reference aid is fine; a pose/apply/resolve/verify here usually means you mislabeled the turn).
-  • scaffold — you lowered difficulty, hinted, or broke the problem into a sub-question. Usually no work-advancing cards.
+  • scaffold — you lowered difficulty, hinted, or broke the problem into a sub-question. Pair it with a scaffold card when a visual hint helps (see below); never an apply/resolve/verify that does the step for them.
   • redirect — steering an off-topic student back to math. Usually no cards.
   • small_talk — greeting, closing, or off-task chitchat. board_commands empty.
 
@@ -254,6 +254,7 @@ CARD SHAPE (fields not used for an action are null):
 - clear:   { action: "clear" }                                            — only on a new problem or right after a verify lands.
 - graph:   { action: "graph", fn: "x^2 - 4", caption: "Where it crosses zero" } — reference plot in the board timeline.
 - image:   { action: "image", query: "unit circle labeled", caption: "Reference" } — reference diagram from the safe whitelist.
+- scaffold:{ action: "scaffold", tex: "x^2 + 4x + \\boxed{} = 12 + \\boxed{}" } — show the NEXT step's structure on the student's own problem with the new terms left as empty \\boxed{} slots for THEM to fill. This is the one card you may put on the student's own problem without them stating it first, BECAUSE the blanks reveal nothing — they're a hint, not the answer. Every scaffold MUST contain at least one \\boxed{} blank; never fill the boxes in yourself (that would be handing over the answer). Use it when a student is stuck and a partially-drawn step would unstick them.
 
 If the student references the board ("show me on the board", "draw it", "use the board"), you MUST include a relevant card (pose for an equation, graph for a function, image for a geometry concept). An empty board while a problem is on screen is the worst-case defect.`;
 }

--- a/utils/boardTagParser.js
+++ b/utils/boardTagParser.js
@@ -14,6 +14,7 @@
 //   <BOARD action="clear" />
 //   <BOARD action="graph"   fn="x^2 - 4" caption="The parabola" />
 //   <BOARD action="image"   query="unit circle labeled" caption="Reference" />
+//   <BOARD action="scaffold" tex="x^2 + 4x + \boxed{\;\;} = 12 + \boxed{\;\;}" />
 //
 // Both self-closing (<BOARD … />) and open/close (<BOARD …>…</BOARD>)
 // forms are accepted. Attributes accept both single and double quotes.
@@ -24,7 +25,7 @@
 
 'use strict';
 
-const VALID_ACTIONS = new Set(['pose', 'apply', 'resolve', 'verify', 'clear', 'graph', 'image']);
+const VALID_ACTIONS = new Set(['pose', 'apply', 'resolve', 'verify', 'clear', 'graph', 'image', 'scaffold']);
 
 // Matches a single <BOARD …/> or <BOARD …>…</BOARD> tag. The `g` flag
 // lets us iterate multiple occurrences in one response. The inner
@@ -81,7 +82,7 @@ function parseBoardTags(aiResponseText) {
         const innerTrim = innerBody ? innerBody.trim() : '';
 
         const command = { action };
-        if (action === 'pose' || action === 'resolve' || action === 'verify') {
+        if (action === 'pose' || action === 'resolve' || action === 'verify' || action === 'scaffold') {
             const tex = texAttr || innerTrim || null;
             if (!tex) continue; // require tex for these actions
             command.tex = tex;

--- a/utils/pipeline/boardSynthesizer.js
+++ b/utils/pipeline/boardSynthesizer.js
@@ -599,7 +599,7 @@ function mergeWithLlmCommands(llmCommands, synthesized) {
   // Order by canonical sequence — the frontend renders in array
   // order, so pose-first / verify-last produces the cleanest
   // animation when both LLM and synthesizer fire in the same turn.
-  const ORDER = { clear: 0, pose: 1, apply: 2, resolve: 3, verify: 4, graph: 5, image: 6 };
+  const ORDER = { clear: 0, pose: 1, scaffold: 2, apply: 3, resolve: 4, verify: 5, graph: 6, image: 7 };
   const all = [...llm, ...added].sort((a, b) => {
     const ai = ORDER[a.action] ?? 99;
     const bi = ORDER[b.action] ?? 99;


### PR DESCRIPTION
Introduces a new "scaffold" board action: the tutor shows the next step's STRUCTURE on the student's own problem with empty \boxed{} slots for the student to fill, e.g. "x^2 + 4x + \boxed{} = 12 + \boxed{}". A blank reveals nothing, so this is the one card allowed on the student's own problem without them stating it first — it is a hint, not the answer.

Anti-cheat: the pedagogy guard requires every scaffold to contain a real blank (empty \boxed{}, \square, or a run of underscores). A "scaffold" with everything filled in is an answer dump wearing the wrong label and is dropped (scaffold_has_no_blank).

- boardTagParser + boardResponseSchema: accept scaffold (tex-required) on both the legacy tag path and the structured-output path; prompt guidance teaches Maya when/how to use it and to never fill the boxes.
- boardCommandGuard: scaffold allowed iff tex present AND contains a blank (new texHasBlank helper).
- boardSynthesizer merge order + conversation.lastBoardAction enum.
- Frontend: boardScaffold() + a dashed amber "YOUR TURN" card that widens empty boxes to visible fill-in slots.