### PR TITLE
Bump SW cache version v3->v4 so transparent tutor portraits propagate

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for MATHMATIX AI PWA
 // Bump CACHE_VERSION on every deploy so students get fresh CSS/JS/images.
-const CACHE_VERSION = 'mathmatix-v3';
+const CACHE_VERSION = 'mathmatix-v4';
 const STATIC_CACHE = `static-${CACHE_VERSION}`;
 const RUNTIME_CACHE = `runtime-${CACHE_VERSION}`;
 


### PR DESCRIPTION
The service worker caches images cache-first; replacing the Ms. Maria portrait PNGs without bumping CACHE_VERSION left students served the old checkerboard-baked copies on every normal navigation (only hard refresh, which bypasses the SW, showed the fix). Bumping the version purges the stale v3 caches on activate so the transparent assets take effect.