### PR TITLE
feat(billing): free AI quota resets monthly (30 min/mo), decoupled fr…

### DIFF
--- a/middleware/usageGate.js
+++ b/middleware/usageGate.js
@@ -2,7 +2,7 @@
 //
 // OPTION D — School License Model:
 //   Teachers: always free unlimited (drives adoption)
-//   Students: 30 free AI-minutes per week
+//   Students: 30 free AI-minutes per month
 //   Students with school license: unlimited (school purchased access)
 //   Unlimited individual subscribers: always pass
 //   Parents/admins: always pass (free unlimited)
@@ -16,7 +16,10 @@ const User = require('../models/user');
 const SchoolLicense = require('../models/schoolLicense');
 
 const BILLING_ENABLED = process.env.BILLING_ENABLED === 'true';
-const FREE_WEEKLY_SECONDS = 30 * 60; // 30 minutes per week for ALL students
+// NOTE: constant/field names keep the "weekly" prefix for backward compatibility
+// (no DB migration), but the free AI quota now resets MONTHLY (see FREE_QUOTA_RESET_DAYS).
+const FREE_WEEKLY_SECONDS = 30 * 60; // 30 free AI minutes per RESET PERIOD (now monthly) for ALL students
+const FREE_QUOTA_RESET_DAYS = 30;    // free-AI-minute quota window (was 7 / weekly)
 
 // Freemium taste limits — free users get a sample before upgrade prompt
 const FREE_UPLOAD_LIMIT  = 1;    // 1 free upload, then Mathmatix+ required
@@ -66,7 +69,7 @@ async function isLicenseValid(licenseId) {
  * - Teachers, parents, admins: always pass (free unlimited)
  * - Students with active school license: always pass (school purchased access)
  * - Unlimited individual subscribers: always pass
- * - Any student with free weekly minutes remaining: pass (free minutes first)
+ * - Any student with free monthly minutes remaining: pass (free minutes first)
  * - Otherwise: 402 Payment Required
  */
 async function usageGate(req, res, next) {
@@ -115,21 +118,35 @@ async function usageGate(req, res, next) {
       if (subscribedParent) return next();
     }
 
-    // --- Weekly reset check (applies to all students) ---
-    let weeklyAIUsed = user.weeklyAISeconds || 0;
     const now = new Date();
-    const lastReset = user.lastWeeklyReset ? new Date(user.lastWeeklyReset) : new Date(0);
-    if ((now - lastReset) / (1000 * 60 * 60 * 24) >= 7) {
-      weeklyAIUsed = 0;
+
+    // --- WEEKLY engagement-metric reset (every 7 days) ---
+    // weeklyActive* feed the teacher/parent "min/wk" dashboards and the
+    // struggling heuristic, so they stay weekly even though the free-AI quota
+    // below is monthly. (Decoupled from the quota anchor on purpose.)
+    const lastWeeklyReset = user.lastWeeklyReset ? new Date(user.lastWeeklyReset) : new Date(0);
+    if ((now - lastWeeklyReset) / (1000 * 60 * 60 * 24) >= 7) {
       // Atomic reset: only resets if lastWeeklyReset hasn't changed (prevents race condition)
       await User.findOneAndUpdate(
         { _id: user._id, lastWeeklyReset: user.lastWeeklyReset },
-        { $set: { weeklyAISeconds: 0, weeklyActiveSeconds: 0, weeklyActiveTutoringMinutes: 0, lastWeeklyReset: now } }
+        { $set: { weeklyActiveSeconds: 0, weeklyActiveTutoringMinutes: 0, lastWeeklyReset: now } }
       );
     }
 
-    // --- Free weekly minutes (every student gets these first) ---
-    const freeRemaining = FREE_WEEKLY_SECONDS - weeklyAIUsed;
+    // --- MONTHLY free-AI-minute quota reset (rolling 30-day window) ---
+    let aiUsed = user.weeklyAISeconds || 0;
+    const lastQuotaReset = user.lastAIQuotaReset ? new Date(user.lastAIQuotaReset) : new Date(0);
+    if ((now - lastQuotaReset) / (1000 * 60 * 60 * 24) >= FREE_QUOTA_RESET_DAYS) {
+      aiUsed = 0;
+      // Atomic reset: only resets if lastAIQuotaReset hasn't changed (prevents race condition)
+      await User.findOneAndUpdate(
+        { _id: user._id, lastAIQuotaReset: user.lastAIQuotaReset },
+        { $set: { weeklyAISeconds: 0, lastAIQuotaReset: now } }
+      );
+    }
+
+    // --- Free monthly minutes (every student gets these first) ---
+    const freeRemaining = FREE_WEEKLY_SECONDS - aiUsed;
 
     if (freeRemaining > 0) {
       // Still have free minutes — let them through regardless of tier
@@ -142,15 +159,15 @@ async function usageGate(req, res, next) {
     }
 
     // --- Free minutes exhausted — calculate when they reset ---
-    const resetDate = new Date(lastReset.getTime() + 7 * 24 * 60 * 60 * 1000);
+    const resetDate = new Date(lastQuotaReset.getTime() + FREE_QUOTA_RESET_DAYS * 24 * 60 * 60 * 1000);
     const msUntilReset = resetDate - now;
     const daysUntilReset = Math.max(0, Math.ceil(msUntilReset / (1000 * 60 * 60 * 24)));
 
     return res.status(402).json({
-      message: `You've used your 30 free minutes this week. Your minutes reset in ${daysUntilReset} day${daysUntilReset !== 1 ? 's' : ''}. Upgrade to Unlimited for non-stop tutoring, or ask your teacher about a school license!`,
+      message: `You've used your 30 free minutes this month. Your minutes reset in ${daysUntilReset} day${daysUntilReset !== 1 ? 's' : ''}. Upgrade to Unlimited for non-stop tutoring, or ask your teacher about a school license!`,
       usageLimitReached: true,
       tier: 'free',
-      freeMinutesUsed: Math.floor(weeklyAIUsed / 60),
+      freeMinutesUsed: Math.floor(aiUsed / 60),
       freeMinutesTotal: 30,
       freeSecondsRemaining: 0,
       nextResetAt: resetDate.toISOString(),

--- a/models/user.js
+++ b/models/user.js
@@ -630,7 +630,8 @@ const userSchema = new Schema({
   // Only counts time while AI is generating a response - not reading/thinking/idle time
   totalAISeconds:  { type: Number, default: 0 },
   weeklyAISeconds: { type: Number, default: 0 },
-  lastWeeklyReset: { type: Date, default: Date.now },
+  lastWeeklyReset: { type: Date, default: Date.now },   // anchors WEEKLY engagement-metric reset (weeklyActive*)
+  lastAIQuotaReset: { type: Date, default: Date.now },  // anchors MONTHLY free-AI-minute quota reset (weeklyAISeconds)
 
   /* Conversations */
   activeConversationId: { type: Schema.Types.ObjectId, ref: 'Conversation' },

--- a/public/index.html
+++ b/public/index.html
@@ -825,7 +825,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               <i class="fas fa-chevron-down"></i>
             </button>
             <div class="lp-faq-answer">
-              <p>Every student gets 30 free AI minutes per week &mdash; that&rsquo;s roughly 2&ndash;3 hours of real homework help. No credit card required. For unlimited access plus voice tutoring, homework uploads, and courses, Mathmatix+ is $9.95/mo. <a href="/pricing.html" style="color:var(--clr-primary-teal);font-weight:600;">See plans &rarr;</a></p>
+              <p>Every student gets 30 free AI minutes per month &mdash; that&rsquo;s roughly 2&ndash;3 hours of real homework help. No credit card required. For unlimited access plus voice tutoring, homework uploads, and courses, Mathmatix+ is $9.95/mo. <a href="/pricing.html" style="color:var(--clr-primary-teal);font-weight:600;">See plans &rarr;</a></p>
             </div>
           </div>
         </div>
@@ -836,7 +836,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <section class="lp-final-cta lp-reveal">
       <div class="lp-inner">
         <h2>Your child deserves a math tutor who never gives up on them.</h2>
-        <p>30 free AI minutes every week &mdash; no credit card, no commitment. Mathmatix+ unlocks everything for $9.95/mo. <a href="/pricing.html" style="color:#fff;font-weight:600;text-decoration:underline;">See plans &rarr;</a></p>
+        <p>30 free AI minutes every month &mdash; no credit card, no commitment. Mathmatix+ unlocks everything for $9.95/mo. <a href="/pricing.html" style="color:#fff;font-weight:600;text-decoration:underline;">See plans &rarr;</a></p>
         <a href="/signup.html" class="btn btn-primary btn-lg lp-final-cta-btn">Start Free Now</a>
         <p class="lp-cta-note">Free for every student. Upgrade to Mathmatix+ anytime.</p>
       </div>

--- a/public/login.html
+++ b/public/login.html
@@ -636,7 +636,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             No account needed. Explore as a teacher, parent, or student.
           </p>
           <p class="lp-post-launch login-demo-post-launch">
-            <a href="/signup.html">Sign up free</a> — get 30 minutes of AI tutoring every week.
+            <a href="/signup.html">Sign up free</a> — get 30 minutes of AI tutoring every month.
           </p>
         </div>
       </div>

--- a/public/mastery-chat.html
+++ b/public/mastery-chat.html
@@ -909,7 +909,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                     // Handle usage limit (402) — show friendly message
                     if (response.status === 402) {
                         const errorData = await response.json().catch(() => ({}));
-                        aiMessageDiv.textContent = errorData.message || "You've used your 30 free AI minutes this week. Come back next week!";
+                        aiMessageDiv.textContent = errorData.message || "You've used your 30 free AI minutes this month. Come back next month!";
                         aiMessageDiv.style.color = '#ff6b6b';
                         return;
                     }

--- a/public/pricing.html
+++ b/public/pricing.html
@@ -11,7 +11,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Pricing | Mathmatix AI - Free AI Math Tutoring + Mathmatix+</title>
-  <meta name="description" content="Mathmatix AI: Free math tutoring (30 AI min/week, ~2+ hours of real help). Mathmatix+ for $9.95/mo unlocks unlimited tutoring, voice chat, homework uploads, and courses." />
+  <meta name="description" content="Mathmatix AI: Free math tutoring (30 AI min/month, ~2+ hours of real help). Mathmatix+ for $9.95/mo unlocks unlimited tutoring, voice chat, homework uploads, and courses." />
   <meta name="robots" content="index, follow" />
   <link rel="canonical" href="https://mathmatix.ai/pricing.html" />
   <meta property="og:type" content="website" />
@@ -73,9 +73,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         <h2 class="card-plan-name">Free</h2>
         <div class="card-price">$0</div>
         <div class="card-period">forever &mdash; no credit card needed</div>
-        <div class="card-realtime-note"><i class="fas fa-clock"></i> 30 AI min/week &asymp; 2&ndash;3 hours of real homework help</div>
+        <div class="card-realtime-note"><i class="fas fa-clock"></i> 30 AI min/month &asymp; 2&ndash;3 hours of real homework help</div>
         <ul class="card-features">
-          <li><i class="fas fa-check"></i> 30 min/week AI chat tutoring</li>
+          <li><i class="fas fa-check"></i> 30 min/month AI chat tutoring</li>
           <li><i class="fas fa-check"></i> Starting point screener</li>
           <li><i class="fas fa-check"></i> Text-to-speech read-aloud</li>
           <li><i class="fas fa-check"></i> Mastery Mode &amp; Fact Fluency</li>
@@ -165,7 +165,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       var skipLink = document.querySelector('.pricing-skip-link');
       if (skipLink) {
         skipLink.href = '/signup.html';
-        skipLink.textContent = 'Sign up free \u2014 30 minutes every week';
+        skipLink.textContent = 'Sign up free \u2014 30 minutes every month';
       }
       return;
     }
@@ -331,7 +331,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         } else if (sub.cancelAtPeriodEnd) {
           panel.innerHTML = `
             <h3 style="margin:0 0 12px;font-size:18px;"><i class="fas fa-exclamation-triangle" style="color:#ff6b6b;"></i> Cancellation Scheduled</h3>
-            <p style="color:#aaa;margin:0 0 16px;font-size:14px;line-height:1.5;">Your Mathmatix+ access ends on <strong style="color:#fff;">${periodEndStr}</strong>. After that, you'll revert to the free plan (30 min/week).</p>
+            <p style="color:#aaa;margin:0 0 16px;font-size:14px;line-height:1.5;">Your Mathmatix+ access ends on <strong style="color:#fff;">${periodEndStr}</strong>. After that, you'll revert to the free plan (30 min/month).</p>
             <button id="pricing-reactivate-btn" style="background:linear-gradient(135deg,#00d4ff,#7b2ff7);color:#fff;border:none;padding:12px 24px;border-radius:10px;font-size:14px;font-weight:600;cursor:pointer;"><i class="fas fa-undo"></i> Keep My Subscription</button>
             ${supportLine}`;
         } else {

--- a/routes/billing.js
+++ b/routes/billing.js
@@ -1,7 +1,7 @@
-// routes/billing.js — Stripe billing: Free (30 min/week) + Mathmatix+ ($9.95/mo unlimited)
+// routes/billing.js — Stripe billing: Free (30 min/month) + Mathmatix+ ($9.95/mo unlimited)
 //
 // Plans:
-//   Free      — 30 AI min/week (~2-3 hours real help), no credit card
+//   Free      — 30 AI min/month (~2-3 hours real help), no credit card
 //   Mathmatix+ — $9.95/mo recurring, unlimited everything, cancel anytime
 //
 // Legacy minute packs (pack_60, pack_120) are retained in webhook processing
@@ -29,7 +29,8 @@ const logger = require('../utils/logger').child({ route: 'billing' });
 
 // ---- Configuration ----
 const BILLING_ENABLED = process.env.BILLING_ENABLED === 'true';
-const FREE_WEEKLY_SECONDS = 30 * 60; // 30 free AI minutes per week for all students
+const FREE_WEEKLY_SECONDS = 30 * 60; // 30 free AI minutes per reset period (now monthly) for all students
+const FREE_QUOTA_RESET_DAYS = 30;    // free-AI-minute quota window — keep in sync with middleware/usageGate.js
 
 // Active plan — Mathmatix+ is the only paid tier for new purchases
 const PACKS = {
@@ -652,15 +653,15 @@ router.get('/status', isAuthenticated, async (req, res) => {
       });
     }
 
-    // Legacy pack users — check free weekly allowance + pack balance
+    // Legacy pack users — check free monthly allowance + pack balance
     if (tier === 'pack_60' || tier === 'pack_120') {
       const expired = user.packExpiresAt && now > user.packExpiresAt;
       const packRemaining = expired ? 0 : (user.packSecondsRemaining || 0);
 
-      // Pack users also get 30 free minutes/week before pack is used
+      // Pack users also get 30 free minutes/month before pack is used
       let weeklyAIUsedPack = user.weeklyAISeconds || 0;
-      const lastResetPack = user.lastWeeklyReset ? new Date(user.lastWeeklyReset) : new Date(0);
-      if ((now - lastResetPack) / (1000 * 60 * 60 * 24) >= 7) {
+      const lastResetPack = user.lastAIQuotaReset ? new Date(user.lastAIQuotaReset) : new Date(0);
+      if ((now - lastResetPack) / (1000 * 60 * 60 * 24) >= FREE_QUOTA_RESET_DAYS) {
         weeklyAIUsedPack = 0;
       }
       const freeRemainingPack = Math.max(0, FREE_WEEKLY_SECONDS - weeklyAIUsedPack);
@@ -713,8 +714,8 @@ router.get('/status', isAuthenticated, async (req, res) => {
       }
     }
 
-    // Free users — calculate remaining free weekly AI minutes
-    // Teachers, parents, admins get unlimited; students get 30 free AI minutes/week
+    // Free users — calculate remaining free monthly AI minutes
+    // Teachers, parents, admins get unlimited; students get 30 free AI minutes/month
     if (user.role === 'teacher' || user.role === 'parent' || user.role === 'admin') {
       return res.json({
         success: true,
@@ -725,21 +726,21 @@ router.get('/status', isAuthenticated, async (req, res) => {
       });
     }
 
-    // Students: check weekly AI seconds used vs free allowance
+    // Students: check monthly AI seconds used vs free allowance
     let weeklyAIUsed = user.weeklyAISeconds || 0;
-    const lastReset = user.lastWeeklyReset ? new Date(user.lastWeeklyReset) : new Date(0);
-    if ((now - lastReset) / (1000 * 60 * 60 * 24) >= 7) {
+    const lastReset = user.lastAIQuotaReset ? new Date(user.lastAIQuotaReset) : new Date(0);
+    if ((now - lastReset) / (1000 * 60 * 60 * 24) >= FREE_QUOTA_RESET_DAYS) {
       // Reset is pending — they effectively have full free minutes
       weeklyAIUsed = 0;
     }
     const freeRemaining = Math.max(0, FREE_WEEKLY_SECONDS - weeklyAIUsed);
     const limitReached = freeRemaining <= 0;
 
-    // Calculate when free minutes reset (7 days from lastWeeklyReset)
-    const lastResetDate = weeklyAIUsed === 0 && (now - lastReset) / (1000 * 60 * 60 * 24) >= 7
-      ? now  // Reset just happened, next reset is 7 days from now
+    // Calculate when free minutes reset (FREE_QUOTA_RESET_DAYS from lastAIQuotaReset)
+    const lastResetDate = weeklyAIUsed === 0 && (now - lastReset) / (1000 * 60 * 60 * 24) >= FREE_QUOTA_RESET_DAYS
+      ? now  // Reset just happened, next reset is FREE_QUOTA_RESET_DAYS from now
       : lastReset;
-    const nextReset = new Date(lastResetDate.getTime() + 7 * 24 * 60 * 60 * 1000);
+    const nextReset = new Date(lastResetDate.getTime() + FREE_QUOTA_RESET_DAYS * 24 * 60 * 60 * 1000);
 
     res.json({
       success: true,

--- a/tests/unit/usageGate.test.js
+++ b/tests/unit/usageGate.test.js
@@ -27,6 +27,7 @@ describe('Feature Gating Middleware', () => {
         subscriptionTier: 'free',
         weeklyAISeconds: 0,
         lastWeeklyReset: new Date(),
+        lastAIQuotaReset: new Date(),
         freeUploadsUsed: 0,
         freeGradesUsed: 0,
         freeCoursesUsed: 0,
@@ -210,13 +211,22 @@ describe('Feature Gating Middleware', () => {
       expect(warningCalls.length).toBe(0);
     });
 
-    // --- Weekly reset ---
-    test('should reset weekly usage when 7+ days have passed', async () => {
+    // --- Monthly AI quota reset (decoupled from weekly engagement reset) ---
+    test('should reset AI quota when 30+ days have passed', async () => {
       req.user.weeklyAISeconds = FREE_WEEKLY_SECONDS + 100;
-      req.user.lastWeeklyReset = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000); // 8 days ago
+      req.user.lastAIQuotaReset = new Date(Date.now() - 31 * 24 * 60 * 60 * 1000); // 31 days ago
       await usageGate(req, res, next);
       expect(User.findOneAndUpdate).toHaveBeenCalled();
       expect(next).toHaveBeenCalled(); // After reset, free minutes are available
+    });
+
+    test('should NOT reset AI quota before 30 days, even after the weekly engagement reset', async () => {
+      req.user.weeklyAISeconds = FREE_WEEKLY_SECONDS + 100;
+      req.user.lastAIQuotaReset = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000); // 8 days — quota NOT due
+      req.user.lastWeeklyReset = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000);  // 8 days — engagement reset due
+      await usageGate(req, res, next);
+      expect(res.status).toHaveBeenCalledWith(402); // quota still exhausted
+      expect(next).not.toHaveBeenCalled();
     });
 
     // --- Free minutes exhausted, free tier ---

--- a/utils/emailService.js
+++ b/utils/emailService.js
@@ -1522,7 +1522,7 @@ function getCancellationConfirmationTemplate(firstName, accessUntilDate, baseUrl
       </div>
 
       <p style="margin: 0 0 15px 0; color: #555; font-size: 16px; line-height: 1.6;">
-        After ${accessUntilDate}, the account will switch to our free plan (30 AI minutes per week).
+        After ${accessUntilDate}, the account will switch to our free plan (30 AI minutes per month).
       </p>
 
       <h3 style="margin: 25px 0 12px 0; color: #2c3e50; font-size: 18px;">Changed your mind?</h3>


### PR DESCRIPTION
…om weekly dashboards

Change the free-tier AI allowance from 30 min/week to 30 min/month.

The free quota and the weekly engagement metrics previously shared one reset anchor (lastWeeklyReset). Naively flipping 7→30 days would have silently turned every "min/wk" / "this week" teacher/parent/admin dashboard into a monthly total and broken the <10 min/wk struggling heuristic. So the two are now decoupled:

- weeklyActiveSeconds / weeklyActiveTutoringMinutes  -> still reset every 7 days (lastWeeklyReset) — dashboards unchanged.
- weeklyAISeconds (the free quota)                   -> resets every 30 days
  (new lastAIQuotaReset anchor, FREE_QUOTA_RESET_DAYS).

Field/constant names keep the "weekly" prefix for back-compat (no DB migration); existing users get one fresh monthly window at first request.

- models/user.js: add lastAIQuotaReset
- middleware/usageGate.js: split reset; monthly quota + copy
- routes/billing.js: /status mirrors monthly quota math (free + pack paths)
- tests/unit/usageGate.test.js: monthly-reset + decoupling tests (52 pass)
- public/*, utils/emailService.js: "per week" -> "per month" copy