### PR TITLE
fix(test): de-flake streak suites — UTC-anchor daysAgo + freeze the c…

### DIFF
--- a/tests/unit/bumpDailyStreak.test.js
+++ b/tests/unit/bumpDailyStreak.test.js
@@ -15,11 +15,31 @@ jest.mock('../../utils/logger', () => ({
 const { bumpDailyStreak } = require('../../utils/gamificationEvents');
 
 function daysAgo(n) {
+    // UTC-anchored to match the production day-boundary diff (UTC fallback for
+    // users with no timezone). Local setDate/setHours would drift a day whenever
+    // the process TZ's calendar date differs from UTC.
     const d = new Date();
-    d.setDate(d.getDate() - n);
-    d.setHours(12, 0, 0, 0);
+    d.setUTCDate(d.getUTCDate() - n);
+    d.setUTCHours(12, 0, 0, 0);
     return d;
 }
+
+// Freeze "now" to a fixed instant so the suite is deterministic regardless of
+// when (wall-clock) it runs. Combined with the UTC-anchored daysAgo above, the
+// streak math is identical under any process timezone — previously this suite
+// failed nondeterministically under parallel runs when it landed in a worker
+// during the window where process-local date trailed UTC. super(FIXED_NOW)
+// (not a returned RealDate) keeps `new Date()` an instanceof Date.
+const RealDate = Date;
+const FIXED_NOW = RealDate.UTC(2026, 5, 17, 17, 0, 0); // Wed 2026-06-17 17:00 UTC
+class FixedDate extends RealDate {
+    constructor(...args) {
+        if (args.length === 0) { super(FIXED_NOW); } else { super(...args); }
+    }
+    static now() { return FIXED_NOW; }
+}
+beforeEach(() => { global.Date = FixedDate; });
+afterEach(() => { global.Date = RealDate; });
 
 describe('bumpDailyStreak', () => {
 

--- a/tests/unit/streakFreeze.test.js
+++ b/tests/unit/streakFreeze.test.js
@@ -31,11 +31,31 @@ function makeUser(overrides = {}) {
 }
 
 function daysAgo(n) {
+    // UTC-anchored on purpose: the production day-boundary diff uses UTC (the
+    // no-timezone fallback). Local setDate/setHours would land n+1 UTC-days back
+    // whenever the process TZ's calendar date differs from UTC, shifting every
+    // expectation by one — the bug below.
     const d = new Date();
-    d.setDate(d.getDate() - n);
-    d.setHours(12, 0, 0, 0); // Noon to avoid edge cases
+    d.setUTCDate(d.getUTCDate() - n);
+    d.setUTCHours(12, 0, 0, 0); // Noon UTC, far from any day boundary
     return d;
 }
+
+// Freeze "now" to a fixed instant so the suite is deterministic regardless of
+// when (wall-clock) it runs. Combined with the UTC-anchored daysAgo above, this
+// makes the streak math identical under any process timezone — previously these
+// date-based tests failed nondeterministically when the file happened to run in
+// a parallel worker during the window where process-local date trailed UTC.
+const RealDate = Date;
+const FIXED_NOW = RealDate.UTC(2026, 5, 17, 17, 0, 0); // Wed 2026-06-17 17:00 UTC
+class FixedDate extends RealDate {
+    constructor(...args) {
+        if (args.length === 0) { super(FIXED_NOW); } else { super(...args); }
+    }
+    static now() { return FIXED_NOW; }
+}
+beforeEach(() => { global.Date = FixedDate; });
+afterEach(() => { global.Date = RealDate; });
 
 describe('Streak Freeze Mechanic', () => {
 


### PR DESCRIPTION
…lock

The 5 intermittent failures in streakFreeze/bumpDailyStreak were a test-construction bug, not a logic bug. The suites built lastPracticeDate with process-LOCAL date math (daysAgo: setDate/setHours) while the production day-boundary diff uses UTC (the no-timezone fallback). Whenever the process timezone's calendar date trailed UTC (late evening in the Americas), daysAgo(n) landed n+1 UTC-days back and every streak expectation shifted by one. It looked "flaky" only because the file had to land in a parallel jest worker during that wall-clock window to trip — isolated, in-band, and most parallel runs passed.

A probe driving the real bumpDailyStreak across a month of hourly instants × timezones confirmed it: daysAgo(2) resets the streak ~6% of (now, tz) combos, never in production-realistic ones.

Fix: anchor daysAgo in UTC (setUTCDate/setUTCHours) to match the production diff, and freeze "now" to a fixed instant per test. Verified 20/20 across 8 timezones incl. UTC+14/-10, and the full 2817-test suite green under both Asia/Tokyo (the previously-failing window) and UTC. Production streak code untouched.