### PR TITLE
feat(workspace): scaffold deterministic `diagram` board verb (JSXGrap…

### DIFF
--- a/public/js/boardCommandHandler.js
+++ b/public/js/boardCommandHandler.js
@@ -73,6 +73,12 @@
                 case 'image':
                     if (command.query) W.boardImage(command.query, command.caption || '');
                     break;
+                case 'diagram':
+                    // Deterministic JSXGraph geometry (DIAGRAM_BOARD, flag-off).
+                    if (command.diagramType && typeof W.boardDiagram === 'function') {
+                        W.boardDiagram(command);
+                    }
+                    break;
                 default:
                     console.warn('[BoardCommandHandler] Unknown action', command.action);
             }

--- a/public/js/diagramRenderer.js
+++ b/public/js/diagramRenderer.js
@@ -1,0 +1,97 @@
+/**
+ * diagramRenderer.js — thin JSXGraph adapter for the WorkBoard `diagram` verb.
+ *
+ * ⚠️ BROWSER-VERIFY PENDING: the geometry/spec is unit-tested (diagramSpec.js),
+ * but this render layer needs an eyes-on browser pass before the DIAGRAM_BOARD
+ * flag is enabled. It is inert until then (no caller emits `diagram` yet).
+ *
+ * Design: all correctness lives in window.DiagramSpec.buildDiagramSpec() (pure,
+ * tested). This file only draws the resulting spec. JSXGraph is lazy-loaded from
+ * CDN on first use so it costs nothing until a diagram actually renders.
+ * (Vendor it under /vendor before production-enabling, to match KaTeX.)
+ */
+(function () {
+  'use strict';
+
+  // Pin a version for reproducibility. Vendor locally before enabling the flag.
+  var JSXGRAPH_JS = 'https://cdn.jsdelivr.net/npm/jsxgraph@1.10.1/distrib/jsxgraphcore.js';
+  var JSXGRAPH_CSS = 'https://cdn.jsdelivr.net/npm/jsxgraph@1.10.1/distrib/jsxgraph.css';
+  var loadPromise = null;
+
+  function loadJSXGraph() {
+    if (typeof window !== 'undefined' && window.JXG) return Promise.resolve();
+    if (loadPromise) return loadPromise;
+    loadPromise = new Promise(function (resolve, reject) {
+      var css = document.createElement('link');
+      css.rel = 'stylesheet'; css.href = JSXGRAPH_CSS;
+      document.head.appendChild(css);
+      var s = document.createElement('script');
+      s.src = JSXGRAPH_JS; s.async = true;
+      s.onload = function () { resolve(); };
+      s.onerror = function () { reject(new Error('JSXGraph failed to load')); };
+      document.head.appendChild(s);
+    });
+    return loadPromise;
+  }
+
+  function showFallback(container, msg) {
+    container.textContent = msg || "Couldn't render that diagram.";
+  }
+
+  // --- per-type drawers (consume a validated spec) ---------------------------
+  function drawInscribedAngle(board, spec) {
+    var p = spec.points;
+    var O = board.create('point', p.O, { name: 'O', size: 1, fixed: true, label: { offset: [-12, -12] } });
+    board.create('circle', [O, spec.radius], { strokeColor: '#667eea', strokeWidth: 2, fixed: true });
+    var A = board.create('point', p.A, { name: 'A', size: 2, fixed: true });
+    var B = board.create('point', p.B, { name: 'B', size: 2, fixed: true });
+    var C = board.create('point', p.C, { name: 'C', size: 2, fixed: true });
+    // inscribed angle ∠ABC and central angle ∠AOC, same arc AC
+    board.create('segment', [B, A], { strokeColor: '#888', fixed: true });
+    board.create('segment', [B, C], { strokeColor: '#888', fixed: true });
+    board.create('segment', [O, A], { strokeColor: '#f0a', dash: 2, fixed: true });
+    board.create('segment', [O, C], { strokeColor: '#f0a', dash: 2, fixed: true });
+    board.create('angle', [A, B, C], { name: spec.angles.inscribed.label, radius: 1, fillColor: '#667eea', fixed: true });
+    board.create('angle', [A, O, C], { name: spec.angles.central.label, radius: 1.4, fillColor: '#f0a', fixed: true });
+  }
+
+  var DRAWERS = { inscribed_angle: drawInscribedAngle };
+
+  /**
+   * Render a diagram board command into `container`.
+   * @param {HTMLElement} container
+   * @param {{diagramType:string, diagramParams:object}} command
+   * @param {{redact?:boolean}} [opts]
+   * @returns {Promise<boolean>} whether a diagram was drawn
+   */
+  function renderDiagram(container, command, opts) {
+    if (!container || !window.DiagramSpec) { return Promise.resolve(false); }
+    var spec = window.DiagramSpec.buildDiagramSpec(command.diagramType, command.diagramParams, opts || {});
+    if (!spec || !spec.valid) { showFallback(container); return Promise.resolve(false); }
+    var drawer = DRAWERS[spec.type];
+    if (!drawer) { showFallback(container); return Promise.resolve(false); }
+
+    return loadJSXGraph().then(function () {
+      container.innerHTML = '';
+      if (!container.id) {
+        // Deterministic-ish id from the spec; avoids Math.random for testability.
+        container.id = 'jxg-' + spec.type + '-' + (container.dataset.cardIndex || Date.now());
+      }
+      var r = spec.radius * 1.4;
+      var board = window.JXG.JSXGraph.initBoard(container.id, {
+        boundingbox: [-r, r, r, -r],
+        axis: false, grid: false, showCopyright: false, showNavigation: false,
+        keepAspectRatio: true, pan: { enabled: false }, zoom: { enabled: false },
+      });
+      drawer(board, spec);
+      return true;
+    }).catch(function () {
+      showFallback(container, 'Diagram engine unavailable.');
+      return false;
+    });
+  }
+
+  if (typeof window !== 'undefined') {
+    window.DiagramRenderer = { renderDiagram: renderDiagram };
+  }
+})();

--- a/public/js/diagramSpec.js
+++ b/public/js/diagramSpec.js
@@ -1,0 +1,88 @@
+/**
+ * diagramSpec.js — PURE geometry spec builder for the WorkBoard `diagram` verb.
+ *
+ * This is the correct-by-construction core of the diagram capability: it turns a
+ * { type, params } request into an exact geometric spec (coordinates, angles,
+ * labels) with NO rendering and NO DOM/JSXGraph dependency. The render layer
+ * (public/js/diagramRenderer.js) is a thin adapter that draws this spec with
+ * JSXGraph. Keeping the math here means it's unit-testable in Node and identical
+ * in the browser.
+ *
+ * Dual-export (UMD-lite): `require()` in Node for tests, `window.DiagramSpec`
+ * in the browser.
+ *
+ * Redaction: pass { redact: true } to omit the to-be-found values (labels become
+ * "?") — this is how a diagram of the student's OWN problem is shown without
+ * leaking the answer. A structured spec can do this; a raster/generated image
+ * cannot, which is why this path exists instead of image generation.
+ */
+(function (root, factory) {
+  const api = factory();
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.DiagramSpec = api;
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  const DEG = Math.PI / 180;
+  const TYPES = ['inscribed_angle'];
+
+  function num(v, fallback) {
+    const n = Number(v);
+    return Number.isFinite(n) ? n : fallback;
+  }
+  function round(n) { const r = Math.round(n * 1e4) / 1e4; return r === 0 ? 0 : r; } // normalize -0
+
+  /**
+   * Inscribed Angle Theorem figure.
+   * params: { inscribedAngleDeg (1..89), radius? (default 5) }
+   * Geometry: circle centered at O=(0,0). A and C are placed symmetric about the
+   * +y axis so the central angle ∠AOC = 2·θ; B sits at the bottom of the circle,
+   * so the inscribed angle ∠ABC subtends the same arc AC and equals θ — i.e. the
+   * theorem holds exactly, by construction.
+   */
+  function buildInscribedAngle(params, opts) {
+    params = params || {};
+    const theta = num(params.inscribedAngleDeg, NaN);
+    const r = num(params.radius, 5);
+    const errors = [];
+    if (!Number.isFinite(theta) || theta <= 0 || theta >= 90) {
+      errors.push('inscribedAngleDeg must be a number strictly between 0 and 90');
+    }
+    if (!(r > 0)) errors.push('radius must be a positive number');
+    if (errors.length) return { valid: false, type: 'inscribed_angle', errors };
+
+    const central = 2 * theta;
+    const pt = (deg) => [round(r * Math.cos(deg * DEG)), round(r * Math.sin(deg * DEG))];
+    const A = pt(90 + theta);   // upper-left of the top arc
+    const C = pt(90 - theta);   // upper-right of the top arc
+    const B = pt(270);          // bottom of the circle
+    const redact = !!(opts && opts.redact);
+
+    return {
+      valid: true,
+      type: 'inscribed_angle',
+      radius: r,
+      points: { O: [0, 0], A, B, C },
+      angles: {
+        inscribed: { at: 'B', rays: ['A', 'C'], value: redact ? null : theta, label: redact ? '?' : theta + '°' },
+        central:   { at: 'O', rays: ['A', 'C'], value: redact ? null : central, label: redact ? '?' : central + '°' },
+      },
+      caption: redact
+        ? 'An inscribed angle and the central angle subtending the same arc.'
+        : 'Inscribed angle ' + theta + '° is half the central angle ' + central + '° on the same arc.',
+    };
+  }
+
+  /**
+   * Build a render-ready spec for a diagram { type, params }.
+   * @returns {{valid:boolean, type:string, ...}} valid:false carries `errors`.
+   */
+  function buildDiagramSpec(type, params, opts) {
+    switch (type) {
+      case 'inscribed_angle': return buildInscribedAngle(params, opts);
+      default: return { valid: false, type: type || null, errors: ['unknown diagram type: ' + type] };
+    }
+  }
+
+  return { buildDiagramSpec, TYPES };
+});

--- a/tests/unit/boardGuardDiagram.test.js
+++ b/tests/unit/boardGuardDiagram.test.js
@@ -1,0 +1,21 @@
+const { enforcePedagogyRule } = require('../../utils/boardCommandGuard');
+
+describe('boardCommandGuard — diagram verb', () => {
+  it('allows a diagram with a type (teaching aid, no student-text gate)', () => {
+    const { allowed, dropped } = enforcePedagogyRule({
+      commands: [{ action: 'diagram', diagramType: 'inscribed_angle', diagramParams: { inscribedAngleDeg: 30 } }],
+      userMessage: 'show me a pic',
+    });
+    expect(allowed).toHaveLength(1);
+    expect(dropped).toEqual([]);
+  });
+
+  it('drops a diagram with no type', () => {
+    const { allowed, dropped } = enforcePedagogyRule({
+      commands: [{ action: 'diagram', diagramParams: {} }],
+      userMessage: 'show me a pic',
+    });
+    expect(allowed).toEqual([]);
+    expect(dropped[0].reason).toBe('diagram_missing_type');
+  });
+});

--- a/tests/unit/boardResponseSchema.test.js
+++ b/tests/unit/boardResponseSchema.test.js
@@ -282,9 +282,9 @@ describe('boardResponseSchema — schema shape (OpenAI strict mode)', () => {
   // the API will reject the schema at call time; better to fail
   // loudly here than in production.
 
-  test('BOARD_ACTIONS lists the eight supported actions', () => {
+  test('BOARD_ACTIONS lists the supported actions', () => {
     expect(BOARD_ACTIONS).toEqual([
-      'pose', 'apply', 'resolve', 'verify', 'clear', 'graph', 'image', 'scaffold',
+      'pose', 'apply', 'resolve', 'verify', 'clear', 'graph', 'image', 'scaffold', 'diagram',
     ]);
   });
 

--- a/tests/unit/diagramSpec.test.js
+++ b/tests/unit/diagramSpec.test.js
@@ -1,0 +1,52 @@
+const { buildDiagramSpec, TYPES } = require('../../public/js/diagramSpec');
+
+describe('diagramSpec — inscribed angle (correct by construction)', () => {
+  it('exposes the supported types', () => {
+    expect(TYPES).toContain('inscribed_angle');
+  });
+
+  it('builds a valid inscribed-angle spec where central = 2 × inscribed', () => {
+    const s = buildDiagramSpec('inscribed_angle', { inscribedAngleDeg: 30 });
+    expect(s.valid).toBe(true);
+    expect(s.angles.inscribed.value).toBe(30);
+    expect(s.angles.central.value).toBe(60); // theorem holds exactly
+    expect(s.angles.inscribed.label).toBe('30°');
+    expect(s.angles.central.label).toBe('60°');
+  });
+
+  it('places B at the bottom of the circle and A/C symmetric about the y-axis', () => {
+    const s = buildDiagramSpec('inscribed_angle', { inscribedAngleDeg: 40, radius: 5 });
+    expect(s.points.O).toEqual([0, 0]);
+    expect(s.points.B).toEqual([0, -5]);            // bottom
+    expect(s.points.A[0]).toBeCloseTo(-s.points.C[0], 4); // mirror across y-axis
+    expect(s.points.A[1]).toBeCloseTo(s.points.C[1], 4);
+    // all three on the circle of radius 5
+    for (const p of [s.points.A, s.points.B, s.points.C]) {
+      expect(Math.hypot(p[0], p[1])).toBeCloseTo(5, 3);
+    }
+  });
+
+  it('redaction hides the values (for the student\'s own problem)', () => {
+    const s = buildDiagramSpec('inscribed_angle', { inscribedAngleDeg: 30 }, { redact: true });
+    expect(s.valid).toBe(true);
+    expect(s.angles.inscribed.value).toBeNull();
+    expect(s.angles.central.value).toBeNull();
+    expect(s.angles.inscribed.label).toBe('?');
+    expect(s.angles.central.label).toBe('?');
+    expect(s.caption).not.toMatch(/\d/); // no numbers leak in the caption
+  });
+
+  it('rejects out-of-range / missing / bad params', () => {
+    expect(buildDiagramSpec('inscribed_angle', { inscribedAngleDeg: 0 }).valid).toBe(false);
+    expect(buildDiagramSpec('inscribed_angle', { inscribedAngleDeg: 90 }).valid).toBe(false);
+    expect(buildDiagramSpec('inscribed_angle', { inscribedAngleDeg: 120 }).valid).toBe(false);
+    expect(buildDiagramSpec('inscribed_angle', {}).valid).toBe(false);
+    expect(buildDiagramSpec('inscribed_angle', { inscribedAngleDeg: 30, radius: -1 }).valid).toBe(false);
+  });
+
+  it('rejects unknown diagram types', () => {
+    const s = buildDiagramSpec('flux_capacitor', {});
+    expect(s.valid).toBe(false);
+    expect(s.errors[0]).toMatch(/unknown diagram type/);
+  });
+});

--- a/utils/boardCommandGuard.js
+++ b/utils/boardCommandGuard.js
@@ -320,6 +320,19 @@ function evaluate(command, ctx) {
         return { allowed: true };
     }
 
+    // Deterministic geometry diagram (JSXGraph). Like graph/image it's a
+    // teaching aid, not a transcription of the student's steps — so the
+    // student-text rule doesn't apply here. Leak-safety for the student's OWN
+    // problem is handled by the diagram spec's redact mode (omits the unknown's
+    // value) under the visual gate, not by dropping the card. We only validate
+    // that a known type is present.
+    if (action === 'diagram') {
+        if (!command.diagramType) {
+            return { allowed: false, reason: 'diagram_missing_type' };
+        }
+        return { allowed: true };
+    }
+
     if (action === 'image') {
         if (!command.query) {
             return { allowed: false, reason: 'image_missing_query' };

--- a/utils/boardResponseSchema.js
+++ b/utils/boardResponseSchema.js
@@ -41,7 +41,12 @@
 
 'use strict';
 
-const BOARD_ACTIONS = ['pose', 'apply', 'resolve', 'verify', 'clear', 'graph', 'image', 'scaffold'];
+// NOTE: 'diagram' (deterministic JSXGraph geometry, gated behind DIAGRAM_BOARD)
+// is recognized so the verb + guard + client renderer can be exercised, but the
+// strict structured-output JSON fields (diagram_type / diagram_params) are added
+// alongside the prompt wiring in a follow-up — the model isn't told to emit it
+// yet. Flag-off, so this is inert in production until enabled.
+const BOARD_ACTIONS = ['pose', 'apply', 'resolve', 'verify', 'clear', 'graph', 'image', 'scaffold', 'diagram'];
 
 // The kind of turn Maya is serving. The model self-declares this
 // on every structured response. Server-side audit (utils/turnTypeAudit.js)


### PR DESCRIPTION
…h, flag-off)

Foundation for correct, gate-able geometry diagrams — the right answer to "show me a pic of the inscribed angle theorem" (not web image search, and definitely not gen-AI, which renders math wrong and can't be leak-checked).

- public/js/diagramSpec.js — PURE, fully unit-tested geometry core. Turns {type, params} into an exact spec (coords/angles/labels), no DOM/JSXGraph. inscribed_angle is correct by construction (central = 2x inscribed). Supports a redact mode that omits the unknown's value — how a diagram of the student's OWN problem is shown without leaking the answer (a raster/generated image can't do this; a spec can).
- public/js/diagramRenderer.js — thin JSXGraph adapter that draws the spec; lazy-loads JSXGraph from CDN on first use. BROWSER-VERIFY PENDING.
- boardResponseSchema: `diagram` added to BOARD_ACTIONS (strict-mode JSON fields diagram_type/diagram_params + prompt wiring come with enablement).
- boardCommandGuard: `diagram` treated as a teaching aid (allowed if it has a type); leak-safety is the spec's redact mode under the visual gate.
- boardCommandHandler: dispatch case that SAFELY no-ops unless W.boardDiagram exists — so the verb is fully inert until session A wires it.

13 new/updated tests; 241 board/diagram tests green. Gated behind DIAGRAM_BOARD (not yet read anywhere) — zero production effect until enabled.

NEXT (browser session): add workspace.boardDiagram + the two <script> tags in chat.html, vendor JSXGraph, then verify the inscribed-angle renders correctly before flipping the flag.