### PR TITLE
hotfix(inline-visuals): stop infinite loop freezing the page on "=" i…

### DIFF
--- a/public/js/inlineChatVisuals.js
+++ b/public/js/inlineChatVisuals.js
@@ -2842,6 +2842,12 @@ class InlineChatVisuals {
         let match;
 
         while ((match = termRegex.exec(expr)) !== null) {
+            // Guard against zero-width matches. termRegex's groups are ALL
+            // optional, so it matches the empty string at any position it can't
+            // consume (e.g. the "=" in "2x^2-5x=7"). On a zero-width match
+            // lastIndex doesn't advance, so a bare `continue` spins forever and
+            // freezes the page. Bump lastIndex past it before continuing.
+            if (match.index === termRegex.lastIndex) { termRegex.lastIndex++; }
             if (!match[0]) continue;
             const sign = match[1] === '-' ? -1 : 1;
             const coeffStr = match[2];


### PR DESCRIPTION
…n expressions

expressionToTiles used `while ((match = termRegex.exec(expr)) !== null)` with termRegex = /([+-]?)(\d*)(x\^2|x²|x|y|xy)?/g — every group optional, so it matches the EMPTY string at any char it can't consume (e.g. the "=" in "2x^2-5x=7"). On a zero-width match lastIndex doesn't advance, and the existing `if (!match[0]) continue;` then spins forever → "This page isn't responding".

Surfaced live when STRUCTURED_TUTOR_RESPONSE=true started routing the raw equation (with "=") into this parser; the board never rendered and the tab froze. Latent pre-existing bug — this is the only empty-matchable regex of the ~12 while(exec) loops audited across inlineChatVisuals/algebra-tiles/diagram- display (all others require a non-empty atom).

Fix: bump lastIndex past zero-width matches (the canonical guard) before the continue. Verified the loop terminates and parses correctly on "2x^2-5x=7", "x²+2x+1", "= ( ) { }", "", "y-x=0", and others.