### PR TITLE
fix(guard): worked-example leak backstop — makes WORKED_EXAMPLE_BOARD…

### DIFF
--- a/tests/unit/workedExampleBackstop.test.js
+++ b/tests/unit/workedExampleBackstop.test.js
@@ -1,0 +1,80 @@
+const { enforcePedagogyRule } = require('../../utils/boardCommandGuard');
+
+// The worked-example relaxation lets the tutor demonstrate full steps on a
+// PARALLEL problem. The backstop guarantees that even then, a step that reveals
+// the student's OWN pinned problem or answer is dropped — so WORKED_EXAMPLE_BOARD
+// is leak-safe even if the model slips and works the graded problem.
+describe('worked-example leak backstop', () => {
+  const pinnedProblemTex = '3x^2 + 4x - 7 = 0';
+  const pinnedAnswer = 'x = -7/3 or x = 1';
+  const base = {
+    userMessage: 'show me an example',
+    workedExample: true,
+    pinnedProblemTex,
+    pinnedAnswer,
+    lastBoardActionInConversation: 'pose',
+  };
+
+  it('ALLOWS a genuine parallel-problem step (different numbers)', () => {
+    const { allowed, dropped } = enforcePedagogyRule({
+      ...base,
+      commands: [
+        { action: 'resolve', tex: 'x^2 - 5x + 6 = 0' },
+        { action: 'resolve', tex: '(x-2)(x-3)' },
+        { action: 'verify', tex: 'x = 2 or x = 3' },
+      ],
+    });
+    expect(allowed).toHaveLength(3);
+    expect(dropped).toEqual([]);
+  });
+
+  it('BLOCKS a worked-example step that IS the student\'s pinned problem', () => {
+    const { allowed, dropped } = enforcePedagogyRule({
+      ...base,
+      commands: [{ action: 'resolve', tex: '3x^2 + 4x - 7 = 0' }],
+    });
+    expect(allowed).toEqual([]);
+    expect(dropped[0].reason).toBe('worked_example_reveals_active_problem');
+  });
+
+  it('BLOCKS a worked-example verify that reveals the student\'s answer', () => {
+    const { allowed, dropped } = enforcePedagogyRule({
+      ...base,
+      commands: [{ action: 'verify', tex: 'x = -7/3 or x = 1' }],
+    });
+    expect(allowed).toEqual([]);
+    expect(dropped[0].reason).toBe('worked_example_reveals_active_problem');
+  });
+
+  it('BLOCKS an apply op that names the student\'s pinned expression', () => {
+    const { allowed, dropped } = enforcePedagogyRule({
+      ...base,
+      commands: [{ action: 'apply', op: 'factor 3x^2 + 4x - 7' }],
+    });
+    expect(allowed).toEqual([]);
+    expect(dropped[0].reason).toBe('worked_example_reveals_active_problem');
+  });
+
+  it('without pinned context, worked-example steps still pass (backstop is opt-in)', () => {
+    const { allowed } = enforcePedagogyRule({
+      userMessage: 'example',
+      workedExample: true,
+      lastBoardActionInConversation: 'pose',
+      commands: [{ action: 'resolve', tex: '3x^2 + 4x - 7 = 0' }],
+    });
+    expect(allowed).toHaveLength(1);
+  });
+
+  it('does not affect non-worked-example turns (strict rule still governs)', () => {
+    // Student stated their own step — allowed as normal, pinned context present.
+    const { allowed } = enforcePedagogyRule({
+      commands: [{ action: 'resolve', tex: '(x-1)(3x+7)' }],
+      userMessage: 'i got (x-1)(3x+7)',
+      workedExample: false,
+      pinnedProblemTex,
+      pinnedAnswer,
+      lastBoardActionInConversation: 'pose',
+    });
+    expect(allowed).toHaveLength(1);
+  });
+});

--- a/utils/boardCommandGuard.js
+++ b/utils/boardCommandGuard.js
@@ -168,12 +168,40 @@ function texHasBlank(tex) {
  *
  * @returns {{ allowed: Array, dropped: Array<{command, reason}> }}
  */
+// Symmetric tex match — does either string contain the other (normalized)?
+function texMatchesEither(a, b) {
+    return texMatchesStudentText(a, b) || texMatchesStudentText(b, a);
+}
+
+// WORKED-EXAMPLE LEAK BACKSTOP.
+// The worked-example relaxation trusts the model to demonstrate on a PARALLEL
+// problem, never the student's own. This is the deterministic safety net for
+// when it doesn't: a worked-example step that matches the student's pinned
+// problem expression OR its known answer is the model solving the graded
+// problem under cover of "example" — block it regardless of the relaxation, so
+// WORKED_EXAMPLE_BOARD is safe to enable even if the model occasionally slips.
+function revealsPinnedProblem(text, ctx) {
+    if (!text) return false;
+    if (ctx.pinnedProblemTex) {
+        if (texMatchesEither(text, ctx.pinnedProblemTex)) return true;
+        // Also match the bare expression (the pinned problem minus a trailing
+        // "= 0"), so a step/op that names the student's expression is caught
+        // even when it omits the "= 0" — e.g. op "factor 3x^2 + 4x - 7".
+        const expr = String(ctx.pinnedProblemTex).replace(/\s*=\s*0\s*$/, '');
+        if (expr !== ctx.pinnedProblemTex && texMatchesEither(text, expr)) return true;
+    }
+    if (ctx.pinnedAnswer && texMatchesEither(text, ctx.pinnedAnswer)) return true;
+    return false;
+}
+
 function enforcePedagogyRule({
     commands,
     userMessage,
     recentUserMessages = [],
     lastBoardActionInConversation = null,
     workedExample = false,
+    pinnedProblemTex = null,
+    pinnedAnswer = null,
 } = {}) {
     const allowed = [];
     const dropped = [];
@@ -207,6 +235,8 @@ function enforcePedagogyRule({
             runningLastAction,
             nextAction,
             workedExample,
+            pinnedProblemTex,
+            pinnedAnswer,
         });
 
         if (decision.allowed) {
@@ -244,6 +274,9 @@ function evaluate(command, ctx) {
             return { allowed: false, reason: 'apply_missing_op' };
         }
         if (ctx.workedExample) {
+            if (revealsPinnedProblem(command.op, ctx)) {
+                return { allowed: false, reason: 'worked_example_reveals_active_problem' };
+            }
             return { allowed: true, reason: 'worked_example_step' };
         }
         if (opMatchesStudentText(command.op, ctx.combinedText)) {
@@ -257,6 +290,9 @@ function evaluate(command, ctx) {
             return { allowed: false, reason: 'resolve_missing_tex' };
         }
         if (ctx.workedExample) {
+            if (revealsPinnedProblem(command.tex, ctx)) {
+                return { allowed: false, reason: 'worked_example_reveals_active_problem' };
+            }
             return { allowed: true, reason: 'worked_example_step' };
         }
         if (texMatchesStudentText(command.tex, ctx.combinedText)) {
@@ -270,6 +306,9 @@ function evaluate(command, ctx) {
             return { allowed: false, reason: 'verify_missing_tex' };
         }
         if (ctx.workedExample) {
+            if (revealsPinnedProblem(command.tex, ctx)) {
+                return { allowed: false, reason: 'worked_example_reveals_active_problem' };
+            }
             return { allowed: true, reason: 'worked_example_step' };
         }
         if (texMatchesStudentText(command.tex, ctx.combinedText)) {

--- a/utils/pipeline/index.js
+++ b/utils/pipeline/index.js
@@ -443,6 +443,11 @@ async function runPipeline(message, ctx) {
       recentUserMessages: recentUserMessagesForBoard,
       lastBoardActionInConversation: ctx.conversation?.lastBoardAction || null,
       workedExample: workedExampleBoard,
+      // Backstop: even in worked-example mode, never let a step that reveals the
+      // student's OWN pinned problem / answer through (model "demonstrating" on
+      // the graded problem instead of a parallel one).
+      pinnedProblemTex: ctx.conversation?.boardProblem?.tex || null,
+      pinnedAnswer: diagnosis.correctAnswer || null,
     });
     llmBoardCommands = guardResult.allowed;
     if (guardResult.dropped.length > 0) {


### PR DESCRIPTION
… safe to enable

The worked-example relaxation trusts the model to demonstrate on a PARALLEL problem, never the student's own. This is the deterministic safety net for when it slips: even in worked-example mode, drop any apply/resolve/verify step that reveals the student's pinned problem expression OR its known answer — that's the model solving the graded problem under cover of "example", i.e. a leak.

enforcePedagogyRule now takes pinnedProblemTex + pinnedAnswer; the pipeline passes conversation.boardProblem.tex + diagnosis.correctAnswer. Matching is symmetric and also checks the bare expression (problem minus a trailing "= 0") so an op like "factor 3x^2 + 4x - 7" is caught against pinned "3x^2+4x-7=0". Genuine parallel-problem steps (different numbers) still pass.

This converts WORKED_EXAMPLE_BOARD from "needs a flawless live check before enabling" to "leak-safe even if the model occasionally works the wrong problem" — so it can be turned on with confidence. 7 new tests; 241 board/guard green.