### PR TITLE
Fix mobile workspace drawer dimmed by its own backdrop

### DIFF
--- a/public/css/workspace.css
+++ b/public/css/workspace.css
@@ -217,9 +217,11 @@
   }
 
   /* Dimmed backdrop. Acts as the tap-to-close target and visually anchors
-     the drawer as a modal surface over the chat poster. Lives at the body
-     level (see workspace.js) so it can sit above #mpc-topbar (z-index 30)
-     and clear the wrapper's mobile stacking context. */
+     the drawer as a modal surface over the chat poster. Inserted as the
+     drawer's sibling (see workspace.js) so it shares the drawer's stacking
+     context: it sits just BELOW the drawer (z-index 900) and above the chat
+     content behind it. The topbar is hidden via .cr-ws-drawer-open while the
+     drawer is open, so the backdrop no longer needs to outrank it. */
   .cr-ws-backdrop {
     display: block;
     position: fixed;
@@ -230,7 +232,7 @@
     opacity: 0;
     pointer-events: none;
     transition: opacity var(--cr-transition);
-    z-index: 1700;
+    z-index: 899;
   }
   .cr-ws-backdrop.is-open {
     opacity: 1;

--- a/public/js/workspace.js
+++ b/public/js/workspace.js
@@ -412,16 +412,23 @@
   }
 
   // ---- Drawer (mobile) --------------------------------------------------
-  // The backdrop is a body-level sibling of the drawer so it can outrank
-  // #mpc-topbar — the drawer itself is trapped inside #app-layout-wrapper's
-  // mobile stacking context, so the backdrop is what actually wins the
-  // z-fight against the floating top chrome.
+  // The backdrop is inserted as the drawer's immediate sibling so the two
+  // share a single stacking context: the backdrop dims the chat behind it
+  // and the drawer sits cleanly on top (see workspace.css z-index pairing).
+  //
+  // It used to live at the body level to outrank #mpc-topbar, but that put
+  // it ABOVE #app-layout-wrapper — which traps the drawer in its own mobile
+  // stacking context — so the backdrop ended up painting over the drawer it
+  // was meant to sit behind. The topbar is hidden via .cr-ws-drawer-open
+  // while the drawer is open, so the body-level placement is no longer needed.
   function ensureBackdrop() {
     if (WS.backdrop) return WS.backdrop;
     var b = el('div', 'cr-ws-backdrop');
     b.setAttribute('aria-hidden', 'true');
     b.addEventListener('click', closeWorkspace);
-    document.body.appendChild(b);
+    // Sibling of the drawer (same parent) so z-index ordering is direct.
+    var parent = (WS.el && WS.el.parentNode) || document.body;
+    parent.insertBefore(b, WS.el || null);
     WS.backdrop = b;
     return b;
   }


### PR DESCRIPTION
## Problem

On mobile, opening the math workspace drawer rendered the whole panel grayed out — the tabs, "Work Board" header, and "Ready to work it out?" empty state were all dimmed and the drawer was effectively unusable.

## Root cause — a z-index / stacking-context issue

The drawer's own backdrop was painting **on top of the drawer**:

- `.cr-ws-backdrop` was appended to `<body>` with `z-index: 1700` (`workspace.js`, `workspace.css`).
- The drawer `.cr-workspace` is trapped inside `#app-layout-wrapper`, which gets `position: relative; z-index: 1` on phones (`mobile-fixes.css`), bumped to `z-index: 50` when the drawer opens (`workspace.css`).

At the body level the paint order compares `#app-layout-wrapper` (50) against `.cr-ws-backdrop` (1700) — so the backdrop covers the *entire* wrapper, including the drawer inside it. Bumping the wrapper to 50 can never beat a body-level backdrop at 1700. It's actually structurally impossible to keep the backdrop *above* the chat content yet *below* a drawer that lives in the same wrapper as that content.

## Fix

Insert the backdrop as the drawer's **sibling** (same parent, `.cr-stage`) so both share a single stacking context, and order the backdrop (`z-index: 899`) just below the drawer (`900`). Now:

- backdrop dims the chat content behind it ✓
- drawer sits cleanly on top of the backdrop ✓ (no more gray panel)
- works on phones (full-width drawer) and tablets (partial drawer with the chat beside it still dimmed)

The original body-level rationale ("sit above `#mpc-topbar`") is moot: the topbar is already hidden via `body.cr-ws-drawer-open #mpc-topbar { display: none }` whenever the drawer is open.

## Testing

CSS/JS-only change. Verified the stacking math and checked that no chat-content element inside the wrapper carries a competing z-index ≥ 899 (the only high z-indexes — `#mpc-sheet-overlay`/`#mpc-sheet` at 3000/3001 — are separate body-level JS overlays, not part of the drawer-open state). Recommend a quick manual smoke test opening the workspace on a phone-width viewport.

https://claude.ai/code/session_012Qc56DtoUzYEh5aPjQ1fiD

---
_Generated by [Claude Code](https://claude.ai/code/session_012Qc56DtoUzYEh5aPjQ1fiD)_