### PR TITLE
Seamless chat ↔ voice transitions (one continuous conversation)

### DIFF
--- a/routes/chat.js
+++ b/routes/chat.js
@@ -1944,6 +1944,48 @@ async function handleGreetingRequest(req, res, userId) {
             await user.save();
         }
 
+        // ── Continuation: returning to chat from the voice tutor ──
+        // The voice tutor's end-session writes a "[Voice session ... just ended]"
+        // continuity marker into this same conversation (see voiceTutor.js). When
+        // the student lands back on chat.html the greeting fires again — but this
+        // is a continuation of an in-progress session, not a new visit, so a fresh
+        // greeting would feel like "a new conversation began". Detect the marker
+        // and stay silent: the tutor already has the full session context, the
+        // student just keeps going.
+        if (activeConversation.messages && activeConversation.messages.length > 0) {
+            const lastMsg = activeConversation.messages[activeConversation.messages.length - 1];
+            const cameBackFromVoice = lastMsg
+                && lastMsg.role === 'assistant'
+                && typeof lastMsg.content === 'string'
+                && lastMsg.content.startsWith('[Voice session');
+
+            if (cameBackFromVoice) {
+                const contTutorKey = user.selectedTutorId && TUTOR_CONFIG[user.selectedTutorId] ? user.selectedTutorId : "default";
+                const contTutor = TUTOR_CONFIG[contTutorKey];
+                await Conversation.findByIdAndUpdate(activeConversation._id, { lastActivity: new Date() });
+
+                const useStreaming = req.query.stream === 'true';
+                if (useStreaming) {
+                    res.setHeader('Content-Type', 'text/event-stream');
+                    res.setHeader('Cache-Control', 'no-cache');
+                    res.setHeader('Connection', 'keep-alive');
+                    res.setHeader('X-Accel-Buffering', 'no');
+                    res.flushHeaders();
+                    res.write(`data: ${JSON.stringify({ done: true, voiceId: contTutor.voiceId, isGreeting: true, continued: true })}\n\n`);
+                    return res.end();
+                }
+                return res.json({
+                    text: '',
+                    continued: true,
+                    voiceId: contTutor.voiceId,
+                    isGreeting: true,
+                    userXp: user.xp || 0,
+                    userLevel: user.level || 1,
+                    xpNeeded: BRAND_CONFIG.xpRequiredForLevel(user.level || 1)
+                });
+            }
+        }
+
         // Replay the just-sent greeting on a quick page refresh so the same
         // greeting isn't generated and saved twice. Only replay when the last
         // message is still the greeting (no user reply yet) and was created

--- a/routes/voice.js
+++ b/routes/voice.js
@@ -5,13 +5,13 @@ const express = require('express');
 const router = express.Router();
 const { isAuthenticated } = require('../middleware/auth');
 const User = require('../models/user');
-const Conversation = require('../models/conversation');
 const { generateSystemPrompt } = require('../utils/prompt');
 const { callLLM } = require("../utils/llmGateway");
 const { verify: pipelineVerify } = require("../utils/pipeline");
 const { openai } = require('../utils/openaiClient');
 const { processAIResponse } = require('../utils/chatBoardParser');
 const { cleanTextForTTS } = require('../utils/mathTTS');
+const { loadActiveHistory, appendToActiveConversation } = require('../utils/activeConversation');
 
 const PRIMARY_CHAT_MODEL = "gpt-4o-mini"; // Fast, cost-effective model for voice responses
 
@@ -144,8 +144,11 @@ router.post('/process', isAuthenticated, async (req, res) => {
             'Vietnamese': 'vi', 'Arabic': 'ar', 'Somali': 'so', 'French': 'fr', 'German': 'de'
         };
 
-        // ── Run Whisper + full user data + conversation history in parallel ──
-        const [transcription, user, conversation] = await Promise.all([
+        // ── Run Whisper + full user data in parallel ──
+        // Conversation history is loaded after `user` resolves so it reads the
+        // SAME active conversation chat uses (user.activeConversationId) rather
+        // than "the most recent doc" — keeping chat <-> voice continuous.
+        const [transcription, user] = await Promise.all([
             openai.audio.transcriptions.create({
                 file: fs.createReadStream(tempAudioPath),
                 model: 'whisper-1',
@@ -154,10 +157,6 @@ router.post('/process', isAuthenticated, async (req, res) => {
                 if (fs.existsSync(tempAudioPath)) fs.unlinkSync(tempAudioPath);
             }),
             User.findById(userId).lean(),
-            Conversation.findOne({ userId })
-                .sort({ updatedAt: -1 })
-                .select({ messages: { $slice: -10 } })
-                .lean()
         ]);
 
         const step1Time = Date.now() - startTime;
@@ -187,12 +186,7 @@ router.post('/process', isAuthenticated, async (req, res) => {
         const selectedTutorId = user.selectedTutorId || 'default';
         const tutorProfile = TUTOR_CONFIG[selectedTutorId] || TUTOR_CONFIG['default'];
 
-        const conversationHistory = (conversation?.messages || [])
-            .filter(msg => msg.content && msg.content.trim().length > 0)
-            .map(msg => ({
-                role: msg.role === 'user' ? 'user' : 'assistant',
-                content: msg.content
-            }));
+        const conversationHistory = await loadActiveHistory(user, 10);
 
         // Add board context to system prompt if available
         let boardContextPrompt = '';
@@ -316,19 +310,12 @@ router.post('/process', isAuthenticated, async (req, res) => {
                     return null;
                 }
             })(),
-            // Save to conversation history
-            (async () => {
-                const messagesToPush = [];
-                if (userMessage) messagesToPush.push({ role: 'user', content: userMessage.trim(), timestamp: new Date() });
-                if (aiResponseText) messagesToPush.push({ role: 'assistant', content: aiResponseText.trim(), timestamp: new Date() });
-                if (messagesToPush.length > 0) {
-                    await Conversation.findOneAndUpdate(
-                        { userId },
-                        { $push: { messages: { $each: messagesToPush } }, $set: { updatedAt: new Date() } },
-                        { upsert: true }
-                    );
-                }
-            })()
+            // Save to conversation history — same active conversation chat uses,
+            // so the turn is visible when the student switches back to text.
+            appendToActiveConversation(user, [
+                { role: 'user', content: userMessage },
+                { role: 'assistant', content: aiResponseText },
+            ])
         ]);
 
         const totalTime = Date.now() - startTime;

--- a/routes/voiceTutor.js
+++ b/routes/voiceTutor.js
@@ -22,6 +22,7 @@ const { createVoiceSession } = require('../utils/voiceSession');
 const voiceMetrics = require('../utils/voiceMetrics');
 const orchestrator = require('../utils/orchestrator');
 const { loadOrCreatePlan, resolveCurrentTarget } = require('../utils/tutorPlanManager');
+const { loadActiveHistory, appendToActiveConversation } = require('../utils/activeConversation');
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
@@ -605,8 +606,10 @@ router.post('/process-text', isAuthenticated, conditionalVtUpload, conditionalVt
       }
     }
 
-    // Save the user-facing text (without giant base64 image blobs) to history
-    await saveToHistory(userId, combinedText, aiRaw);
+    // Save the user-facing text (without giant base64 image blobs) to history.
+    // Persist the clean spoken text — NOT the raw JSON/<math> blob — so the
+    // shared chat<->voice conversation stays readable for the text tutor.
+    await saveToHistory(userId, combinedText, spoken);
 
     res.json({
       response: spoken,
@@ -724,8 +727,9 @@ router.post('/process-orchestrated', isAuthenticated, async (req, res) => {
       dispatcher,
     );
 
-    // Persist the assistant turn to history (same shape as /process)
-    saveToHistory(userId, userMessage, aiRaw).catch(err => {
+    // Persist the assistant turn to history (same shape as /process).
+    // Store the clean spoken text, not the raw JSON blob.
+    saveToHistory(userId, userMessage, spoken).catch(err => {
       logger.warn('orchestrated: persist failed', { error: err.message });
     });
 
@@ -858,17 +862,10 @@ async function generateResponse(userId, userMessage, preloadedUser, opts = {}) {
   const selectedTutorId = user.selectedTutorId || 'default';
   const tutorProfile = TUTOR_CONFIG[selectedTutorId] || TUTOR_CONFIG['default'];
 
-  // Get conversation history (last 12 messages for voice context)
-  const conversation = await Conversation.findOne({ userId })
-    .sort({ updatedAt: -1 })
-    .select({ messages: { $slice: -12 } })
-    .lean();
-  const history = (conversation?.messages || [])
-    .filter(msg => msg.content && msg.content.trim().length > 0)
-    .map(msg => ({
-      role: msg.role === 'user' ? 'user' : 'assistant',
-      content: msg.content
-    }));
+  // Get conversation history (last 12 messages for voice context) from the
+  // SAME active conversation chat uses, so voice picks up the text session's
+  // context and vice versa.
+  const history = await loadActiveHistory(user, 12);
 
   const systemPrompt = await generateSystemPrompt(user, tutorProfile);
 
@@ -1103,8 +1100,9 @@ function extractMathFromSpokenText(text) {
  */
 async function getLastMathSteps(userId) {
   try {
-    const conversation = await Conversation.findOne({ userId })
-      .sort({ updatedAt: -1 })
+    const u = await User.findById(userId).select('activeConversationId').lean();
+    if (!u?.activeConversationId) return [];
+    const conversation = await Conversation.findById(u.activeConversationId)
       .select({ messages: { $slice: -12 } })
       .lean();
     if (!conversation?.messages) return [];
@@ -1136,23 +1134,17 @@ async function getLastMathSteps(userId) {
 }
 
 async function saveToHistory(userId, userMessage, aiResponse) {
-  const messagesToPush = [];
-  if (userMessage) {
-    messagesToPush.push({ role: 'user', content: userMessage.trim(), timestamp: new Date() });
-  }
-  if (aiResponse) {
-    messagesToPush.push({ role: 'assistant', content: aiResponse.trim(), timestamp: new Date() });
-  }
-  if (messagesToPush.length > 0) {
-    await Conversation.findOneAndUpdate(
-      { userId },
-      {
-        $push: { messages: { $each: messagesToPush } },
-        $set: { updatedAt: new Date() }
-      },
-      { upsert: true }
-    );
-  }
+  // Persist to the SAME active conversation chat uses so voice turns are
+  // visible when the student switches back to text. `user` may be passed
+  // (lean) to avoid a refetch; otherwise resolve activeConversationId by id.
+  const user = (userId && userId.activeConversationId !== undefined)
+    ? userId
+    : await User.findById(userId).select('activeConversationId').lean();
+  if (!user) return;
+  await appendToActiveConversation(user, [
+    { role: 'user', content: userMessage },
+    { role: 'assistant', content: aiResponse },
+  ]);
 }
 
 // ═══════════════════════════════════════
@@ -1219,14 +1211,11 @@ router.post('/end-session', isAuthenticated, async (req, res) => {
       'The student is back in chat now — pick up naturally from here.]',
     ].filter(Boolean).join('\n\n');
 
-    await Conversation.findOneAndUpdate(
-      { userId },
-      {
-        $push: { messages: { role: 'assistant', content: marker, timestamp: new Date() } },
-        $set: { updatedAt: new Date() },
-      },
-      { upsert: true }
-    );
+    // Write the continuity marker into the SAME active conversation the chat
+    // tutor reads, so it can pick up where the voice session left off.
+    await appendToActiveConversation(req.user, [
+      { role: 'assistant', content: marker },
+    ]);
 
     res.json({
       summary: {

--- a/utils/activeConversation.js
+++ b/utils/activeConversation.js
@@ -1,0 +1,113 @@
+// utils/activeConversation.js
+//
+// Single source of truth for "the conversation the student is currently in".
+//
+// Chat (routes/chat.js), the welcome greeting (routes/welcome.js), gradeWork,
+// rapport-building and others all key the live session off
+// `user.activeConversationId`. The voice paths historically did NOT — they
+// read "the most recent conversation by updatedAt" and wrote via
+// `findOneAndUpdate({ userId })` with no sort (which targets an arbitrary /
+// oldest document). That read/write split meant voice turns forked into a
+// different document than the one chat reads, so switching chat <-> voice
+// looked like "a brand new conversation began" and context was lost in both
+// directions.
+//
+// This module makes every mode read AND write the same `activeConversationId`
+// document, so a session is continuous across chat and voice.
+
+const Conversation = require('../models/conversation');
+const User = require('../models/user');
+
+// How many trailing messages voice loads for LLM context by default.
+const VOICE_HISTORY_DEPTH = 12;
+
+/**
+ * Resolve the user's active (general, non-mastery) conversation id, creating a
+ * fresh conversation if the current one is missing, inactive, or a mastery
+ * session. Mirrors the creation logic in chat.js / welcome.js so all modes
+ * converge on the same document.
+ *
+ * @param {Object} user - lean user object or mongoose doc (needs _id, activeConversationId)
+ * @returns {Promise<{ conversationId: import('mongoose').Types.ObjectId, created: boolean }>}
+ */
+async function resolveActiveConversationId(user) {
+    const userId = user._id;
+    const currentId = user.activeConversationId || null;
+
+    if (currentId) {
+        const existing = await Conversation.findById(currentId)
+            .select('isActive isMastery')
+            .lean();
+        if (existing && existing.isActive && !existing.isMastery) {
+            return { conversationId: currentId, created: false };
+        }
+    }
+
+    // No usable active conversation — create one and point the user at it.
+    const conv = await Conversation.create({ userId, messages: [], isMastery: false });
+    await User.updateOne({ _id: userId }, { $set: { activeConversationId: conv._id } });
+    // Keep the in-memory user in sync for the rest of this request / session
+    // (matters for long-lived voice WebSocket sessions that reuse `this.user`).
+    try { user.activeConversationId = conv._id; } catch (_) { /* frozen/lean — ignore */ }
+
+    return { conversationId: conv._id, created: true };
+}
+
+/**
+ * Load the trailing message tail of the user's active conversation as
+ * LLM-ready { role, content } entries. Read-only: never creates a
+ * conversation. Returns [] when there is no active conversation yet.
+ *
+ * @param {Object} user - needs activeConversationId
+ * @param {number} [depth=VOICE_HISTORY_DEPTH]
+ * @returns {Promise<Array<{role: 'user'|'assistant', content: string}>>}
+ */
+async function loadActiveHistory(user, depth = VOICE_HISTORY_DEPTH) {
+    const convId = user && user.activeConversationId;
+    if (!convId) return [];
+
+    const conv = await Conversation.findById(convId)
+        .select({ messages: { $slice: -depth } })
+        .lean();
+
+    return (conv?.messages || [])
+        .filter(m => m.content && m.content.trim().length > 0)
+        .map(m => ({
+            role: m.role === 'user' ? 'user' : 'assistant',
+            content: m.content,
+        }));
+}
+
+/**
+ * Append user/assistant turns to the user's active conversation, creating it
+ * if necessary. This is the write counterpart of loadActiveHistory — both
+ * target `user.activeConversationId`, so chat and voice stay in one thread.
+ *
+ * @param {Object} user - needs _id, activeConversationId
+ * @param {Array<{role: string, content: string}>} turns
+ * @returns {Promise<import('mongoose').Types.ObjectId|null>} conversationId written to, or null if nothing to write
+ */
+async function appendToActiveConversation(user, turns) {
+    const clean = (turns || [])
+        .filter(t => t && t.content && String(t.content).trim().length > 0)
+        .map(t => ({
+            role: t.role === 'user' ? 'user' : 'assistant',
+            content: String(t.content).trim(),
+            timestamp: new Date(),
+        }));
+    if (!clean.length) return null;
+
+    const { conversationId } = await resolveActiveConversationId(user);
+    await Conversation.updateOne(
+        { _id: conversationId },
+        { $push: { messages: { $each: clean } }, $set: { lastActivity: new Date() } }
+    );
+    return conversationId;
+}
+
+module.exports = {
+    VOICE_HISTORY_DEPTH,
+    resolveActiveConversationId,
+    loadActiveHistory,
+    appendToActiveConversation,
+};

--- a/utils/voiceSession.js
+++ b/utils/voiceSession.js
@@ -5,7 +5,6 @@
 // interrupt handling and per-turn metrics.
 
 const User = require('../models/user');
-const Conversation = require('../models/conversation');
 const TUTOR_CONFIG = require('./tutorConfig');
 const { generateSystemPrompt } = require('./prompt');
 const { callLLM, callLLMStream } = require('./llmGateway');
@@ -18,6 +17,7 @@ const metrics = require('./voiceMetrics');
 const orchestrator = require('./orchestrator');
 const { Dispatcher } = require('./orchestrator/dispatcher');
 const { loadOrCreatePlan, resolveCurrentTarget } = require('./tutorPlanManager');
+const { loadActiveHistory, appendToActiveConversation } = require('./activeConversation');
 const logger = require('./logger').child({ module: 'voiceSession' });
 
 const VOICE_MODEL = process.env.VOICE_LLM_MODEL || 'gpt-4o-mini';
@@ -169,14 +169,10 @@ class VoiceSession {
 
         this.systemPrompt = await generateSystemPrompt(this.user, this.tutorProfile);
 
-        // Load recent conversation for context
-        const conv = await Conversation.findOne({ userId: this.user._id })
-            .sort({ updatedAt: -1 })
-            .select({ messages: { $slice: -HISTORY_DEPTH } })
-            .lean();
-        this.history = (conv?.messages || [])
-            .filter(m => m.content && m.content.trim().length > 0)
-            .map(m => ({ role: m.role === 'user' ? 'user' : 'assistant', content: m.content }));
+        // Load recent conversation for context from the SAME active conversation
+        // chat uses (user.activeConversationId), so a student who was just typing
+        // continues seamlessly into voice.
+        this.history = await loadActiveHistory(this.user, HISTORY_DEPTH);
 
         // Persistent Cartesia pool — one WS per session, context_id per turn.
         // Saves ~50–100ms handshake on every turn vs opening a fresh WS.
@@ -1091,15 +1087,14 @@ Never speak math notation. Never include system tags. Always valid JSON.`;
     }
 
     async _persistTurn(userMessage, aiContent) {
-        const messagesToPush = [];
-        if (userMessage) messagesToPush.push({ role: 'user', content: userMessage.trim(), timestamp: new Date() });
-        if (aiContent) messagesToPush.push({ role: 'assistant', content: aiContent.trim(), timestamp: new Date() });
-        if (!messagesToPush.length) return;
-        await Conversation.findOneAndUpdate(
-            { userId: this.user._id },
-            { $push: { messages: { $each: messagesToPush } }, $set: { updatedAt: new Date() } },
-            { upsert: true }
-        );
+        // Persist to the SAME active conversation chat uses so the turn shows up
+        // when the student switches back to text. resolveActiveConversationId
+        // (inside the helper) also updates this.user.activeConversationId in
+        // place, so a long-lived session keeps targeting the right document.
+        await appendToActiveConversation(this.user, [
+            { role: 'user', content: userMessage },
+            { role: 'assistant', content: aiContent },
+        ]);
     }
 
     shutdown(reason = 'shutdown') {


### PR DESCRIPTION
## Problem

Switching between text chat and the voice tutor felt like starting a **brand-new conversation** — context was lost and the tutor re-greeted the student.

**Root cause:** chat keys the live session off `user.activeConversationId` (read **and** write). Every voice path instead:
- **read** "the most recent conversation by `updatedAt`", but
- **wrote** via `findOneAndUpdate({ userId })` with *no sort* (which targets an arbitrary / oldest document).

That read/write split forked voice turns into a *different* document than the one chat reads, so:
- chat → voice: voice saw chat history on the first turn but then drifted onto a forked doc;
- voice → chat: chat (reading `activeConversationId`) never saw the voice turns at all → "a new convo began";
- returning to `chat.html` re-fired the greeting.

## Fix

1. **New `utils/activeConversation.js`** — shared `loadActiveHistory` / `appendToActiveConversation` / `resolveActiveConversationId`, all keyed on `user.activeConversationId` (the same spine chat, welcome, gradeWork, etc. already use). Reads are side-effect-free; writes create-or-reuse the active conversation and keep the in-memory user in sync (important for long-lived voice WebSocket sessions).
2. **Route every voice read/write through it:**
   - `routes/voice.js` (legacy HTTP voice) — history load + turn persist
   - `routes/voiceTutor.js` — `generateResponse`, `getLastMathSteps`, `saveToHistory`, and the end-session continuity marker
   - `utils/voiceSession.js` — WebSocket history load + `_persistTurn`
3. **Persist clean spoken text** instead of raw JSON/`<math>` blobs in the `process-text` and `process-orchestrated` paths — now that chat and voice share one document, raw JSON would pollute the text tutor's context and the transcript.
4. **Suppress the re-greet** when returning from voice: `handleGreetingRequest` detects the `[Voice session … just ended]` continuity marker and continues silently (`text: ''`) instead of generating a fresh greeting. Scoped to that exact signal, so normal page refreshes are unaffected.

## Decisions confirmed with the user
- **AI-context continuity only** — the on-screen transcript is *not* back-filled with the other mode's bubbles when switching; the tutor silently carries context.
- **Keep the existing inactivity rule** for what starts a genuinely new conversation.

## Side effect (good)
Because voice turns now persist into the student's active conversation, the **voice transcript is now visible** in the normal surfaces (sidebar conversation history, `/:id/switch`, and the teacher/parent transcript viewer) — interleaved with chat, instead of scattered in a forked document.

## Testing notes
- `node --check` passes on all changed files.
- The repo's Jest suite can't run in this environment (`tests/setup.js` requires `dotenv`, dev-deps not installed); no test logic was changed.
- Suggested manual verification: chat a few turns → open voice tutor (should reference the chat context) → speak a couple turns → End session → land on chat (no new greeting; typing continues the same thread).


---
_Generated by [Claude Code](https://claude.ai/code/session_01CoTPjeYh386dmAdN7ZaaZL)_