### PR TITLE
Show voice exchange as chat bubbles on return from voice tutor

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -615,6 +615,20 @@ document.addEventListener("DOMContentLoaded", () => {
             const data = await res.json();
             showThinkingIndicator(false);
 
+            // Continuation from the voice tutor: instead of a fresh greeting, the
+            // server returns the in-progress conversation. Paint its recent tail
+            // (chat + voice turns, interleaved) into the transcript so the just-
+            // finished voice exchange is visible, then stop — no new greeting.
+            if (data.continued && Array.isArray(data.messages)) {
+                if (data.messages.length > 0 && typeof window.updateChatForSession === 'function') {
+                    window.updateChatForSession(
+                        { _id: data.conversationId, conversationType: 'general' },
+                        data.messages
+                    );
+                }
+                return;
+            }
+
             if (data.text) {
                 appendMessage(data.text, "ai");
                 if (data.inlineCta) attachInlineCtaToLatestMessage(data.inlineCta);

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -1964,6 +1964,23 @@ async function handleGreetingRequest(req, res, userId) {
                 const contTutor = TUTOR_CONFIG[contTutorKey];
                 await Conversation.findByIdAndUpdate(activeConversation._id, { lastActivity: new Date() });
 
+                // Recent tail to paint into the chat transcript so the just-finished
+                // voice exchange shows up as bubbles (continuity is visible, not just
+                // implicit). The "[Voice session ... just ended]" marker is an
+                // LLM-facing recap — strip it so it never renders as a student bubble.
+                const visibleMessages = activeConversation.messages
+                    .slice(-50)
+                    .filter(m => !(
+                        m.role === 'assistant'
+                        && typeof m.content === 'string'
+                        && m.content.startsWith('[Voice session')
+                    ))
+                    .map(m => ({
+                        role: m.role,
+                        content: m.content,
+                        workCheckId: m.workCheckId || null,
+                    }));
+
                 const useStreaming = req.query.stream === 'true';
                 if (useStreaming) {
                     res.setHeader('Content-Type', 'text/event-stream');
@@ -1971,12 +1988,14 @@ async function handleGreetingRequest(req, res, userId) {
                     res.setHeader('Connection', 'keep-alive');
                     res.setHeader('X-Accel-Buffering', 'no');
                     res.flushHeaders();
-                    res.write(`data: ${JSON.stringify({ done: true, voiceId: contTutor.voiceId, isGreeting: true, continued: true })}\n\n`);
+                    res.write(`data: ${JSON.stringify({ done: true, voiceId: contTutor.voiceId, isGreeting: true, continued: true, conversationId: activeConversation._id, messages: visibleMessages })}\n\n`);
                     return res.end();
                 }
                 return res.json({
                     text: '',
                     continued: true,
+                    conversationId: activeConversation._id,
+                    messages: visibleMessages,
                     voiceId: contTutor.voiceId,
                     isGreeting: true,
                     userXp: user.xp || 0,


### PR DESCRIPTION
## What

Follow-up to #1058 (chat ↔ voice continuity). That PR made voice turns persist into the student's active conversation and suppressed the re-greet when returning from the voice tutor. This PR makes that continuity **visible**: the just-finished voice exchange now renders as chat bubbles when you land back on `chat.html`.

## How

- **Backend (`routes/chat.js`, `handleGreetingRequest`)** — the existing "returning from voice" branch (triggered by the `[Voice session … just ended]` continuity marker) now returns the conversation's recent tail (`messages` + `conversationId`) instead of an empty payload. The LLM-facing marker itself is stripped so it never renders as a student bubble.
- **Frontend (`public/js/script.js`, `getWelcomeMessage`)** — when the greeting response has `continued: true` with `messages`, it paints them into the transcript via the existing `updateChatForSession` renderer (the same path used by sidebar session-switching) and returns early — no new greeting.

Because chat and voice now share one conversation document, the rendered tail is chat + voice turns interleaved, so the student sees an unbroken thread.

## Scope / decision
This reverses the earlier "AI-context-only" call — per your follow-up that there's merit to merging visible bubbles. Scoped to the **voice-return** transition (the marker), so normal page refreshes and returning-user greetings are unchanged.

## Not included (possible follow-up)
The reverse direction — showing prior chat history as a scrollback on the immersive voice page — isn't part of this. The voice tutor already loads that context server-side for the model; rendering a chat-style scrollback there is a larger UI change. Happy to do it if you want it.

## Testing
- `node --check` passes on both changed files.
- Repo Jest suite can't run in this environment (`tests/setup.js` needs `dotenv`, dev-deps absent); no test logic changed.
- Manual check: chat a few turns → open voice tutor → speak → End session → land on chat: the chat + voice turns should appear as bubbles with no fresh greeting.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CoTPjeYh386dmAdN7ZaaZL)_