### PR TITLE
feat(concept-models): function_transformations — the universal-parent model

### DIFF
--- a/public/concept-model-demo.html
+++ b/public/concept-model-demo.html
@@ -63,6 +63,14 @@
     .cr-cm-slider-label { flex: 0 0 auto; min-width: 46px; font-size: 13px; font-weight: 700; color: var(--cr-text); font-style: italic; }
     .cr-cm-slider-value { font-weight: 600; font-style: normal; color: var(--cr-accent); }
     .cr-cm-slider-input { flex: 1 1 auto; accent-color: var(--cr-accent); cursor: pointer; }
+    .cr-cm-choice { display: flex; align-items: center; gap: 10px; }
+    .cr-cm-choice-group { display: flex; flex-wrap: wrap; gap: 6px; }
+    .cr-cm-choice-btn {
+      font-size: 13px; font-weight: 600; padding: 5px 12px; color: var(--cr-text-dim);
+      background: var(--cr-bg-2); border: 1px solid var(--cr-border); border-radius: 999px; cursor: pointer;
+    }
+    .cr-cm-choice-btn:hover { color: var(--cr-text); border-color: var(--cr-accent); }
+    .cr-cm-choice-btn.is-active { color: #fff; background: var(--cr-accent-grad); border-color: transparent; }
   </style>
 </head>
 <body>
@@ -83,6 +91,10 @@
       <h2>two_point_line — slope as rise/run, measured live</h2>
       <div class="host" id="host-tpl"></div>
     </div>
+    <div class="demo-card">
+      <h2>function_transformations — a·f(x−h)+k, swap the parent</h2>
+      <div class="host" id="host-ft"></div>
+    </div>
   </div>
 
   <script src="/js/conceptModelSpec.js"></script>
@@ -94,6 +106,9 @@
       );
       window.ConceptModelRenderer.renderModel(
         document.getElementById('host-tpl'), 'two_point_line'
+      );
+      window.ConceptModelRenderer.renderModel(
+        document.getElementById('host-ft'), 'function_transformations'
       );
     }
     if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', boot);

--- a/public/css/workspace.css
+++ b/public/css/workspace.css
@@ -687,6 +687,25 @@
   accent-color: var(--cr-accent);
   cursor: pointer;
 }
+.cr-cm-choice { display: flex; align-items: center; gap: 10px; }
+.cr-cm-choice-group { display: flex; flex-wrap: wrap; gap: 6px; }
+.cr-cm-choice-btn {
+  font-size: 13px;
+  font-weight: 600;
+  padding: 5px 12px;
+  color: var(--cr-text-dim);
+  background: var(--cr-bg-2, var(--cr-bg-panel));
+  border: 1px solid var(--cr-border);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background var(--cr-transition-fast), color var(--cr-transition-fast), border-color var(--cr-transition-fast);
+}
+.cr-cm-choice-btn:hover { color: var(--cr-text); border-color: var(--cr-accent); }
+.cr-cm-choice-btn.is-active {
+  color: #fff;
+  background: var(--cr-accent-grad);
+  border-color: transparent;
+}
 
 /* Shared caption styling for graph + image cards. */
 .cr-ws-board-card-caption {

--- a/public/js/conceptModelRenderer.js
+++ b/public/js/conceptModelRenderer.js
@@ -151,11 +151,16 @@
     if (spec.derived) Object.keys(spec.derived).forEach(function (n) {
       compiledDerived[n] = CMS.compileExpr(spec.derived[n]);
     });
+    // Parent library (named pure functions of x) for the universal-parent model.
+    var compiledParents = {}; // parentKey -> {eval}
+    if (spec.parents) Object.keys(spec.parents).forEach(function (key) {
+      compiledParents[key] = CMS.compileExpr(spec.parents[key].fn);
+    });
 
     function scope() {
       var s = {};
       Object.keys(P).forEach(function (k) { s[k] = P[k]; });
-      // derived read params (and earlier derived) — evaluate in declared order.
+      // derived read numeric params (and earlier derived) — evaluate in order.
       Object.keys(compiledDerived).forEach(function (n) { s[n] = compiledDerived[n].eval(s); });
       return s;
     }
@@ -268,9 +273,29 @@
     spec.elements.forEach(function (e) {
       if (e.type === 'function') {
         var c = compiledFns[e.id];
-        board.create('functiongraph', [function (x) {
-          var s = scope(); s.x = x; return c.eval(s);
-        }], { strokeColor: '#5B3DF6', strokeWidth: 3, fixed: true, highlight: false });
+        // `compose` evaluates the SELECTED parent at a shifted argument and
+        // exposes it to the outer fn as a placeholder var (a*P + k where P is the
+        // parent of (x-h)). Generic — no per-parent code.
+        var composers = [];
+        if (e.compose) Object.keys(e.compose).forEach(function (ph) {
+          composers.push({ ph: ph, sel: e.compose[ph].parent, argFn: CMS.compileExpr(e.compose[ph].arg) });
+        });
+        var evalCurve = function (x) {
+          var s = scope(); s.x = x;
+          for (var ci = 0; ci < composers.length; ci++) {
+            var cm = composers[ci];
+            var pf = compiledParents[P[cm.sel]];
+            s[cm.ph] = pf ? pf.eval({ x: cm.argFn.eval(s) }) : NaN;
+          }
+          return c.eval(s);
+        };
+        var isRef = e.role === 'reference';
+        board.create('functiongraph', [evalCurve], {
+          strokeColor: isRef ? '#b9b2e6' : '#5B3DF6',
+          strokeWidth: isRef ? 2 : 3,
+          dash: isRef ? 2 : 0,
+          fixed: true, highlight: false
+        });
       } else if (e.type === 'line' || e.type === 'segment' || e.type === 'ray') {
         var a = jpoints[e.through[0]], b2 = jpoints[e.through[1]];
         if (a && b2) {
@@ -290,35 +315,63 @@
       }
     });
 
-    // ── controls (HTML range sliders bound to params) ────────────────────────
-    var sliderInputs = {}; // param -> { input, valueEl }
+    // ── controls (sliders for numeric params, choice for selectors) ──────────
+    var sliderInputs = {};  // param -> { input, valueEl }
+    var choiceGroups = {};  // param -> [ { key, btn } ]
     (spec.controls || []).forEach(function (c) {
-      if (c.type !== 'slider') return; // `choice` lands with function_transformations
-      var wrap = el('div', 'cr-cm-slider');
-      var label = el('label', 'cr-cm-slider-label');
-      label.textContent = c.label || c.param;
-      var valueEl = el('span', 'cr-cm-slider-value');
-      label.appendChild(valueEl);
+      if (c.type === 'slider') {
+        var wrap = el('div', 'cr-cm-slider');
+        var label = el('label', 'cr-cm-slider-label');
+        label.textContent = c.label || c.param;
+        var valueEl = el('span', 'cr-cm-slider-value');
+        label.appendChild(valueEl);
 
-      var input = document.createElement('input');
-      input.type = 'range';
-      input.className = 'cr-cm-slider-input';
-      input.min = c.range[0]; input.max = c.range[1];
-      input.step = c.step || 'any';
-      input.value = P[c.param];
-      input.setAttribute('aria-label', (c.label || c.param) + ' control');
+        var input = document.createElement('input');
+        input.type = 'range';
+        input.className = 'cr-cm-slider-input';
+        input.min = c.range[0]; input.max = c.range[1];
+        input.step = c.step || 'any';
+        input.value = P[c.param];
+        input.setAttribute('aria-label', (c.label || c.param) + ' control');
 
-      input.addEventListener('input', function () {
-        P[c.param] = round4(parseFloat(input.value));
-        pushParamsToPoints();
-        pushParamsToControls();
-        redraw();
-      });
+        input.addEventListener('input', function () {
+          P[c.param] = round4(parseFloat(input.value));
+          pushParamsToPoints();
+          pushParamsToControls();
+          redraw();
+        });
 
-      wrap.appendChild(label);
-      wrap.appendChild(input);
-      controlsRow.appendChild(wrap);
-      sliderInputs[c.param] = { input: input, valueEl: valueEl };
+        wrap.appendChild(label);
+        wrap.appendChild(input);
+        controlsRow.appendChild(wrap);
+        sliderInputs[c.param] = { input: input, valueEl: valueEl };
+      } else if (c.type === 'choice') {
+        // Segmented selector: pick the parent f. Options come from the spec or
+        // default to the parents-library keys; the button label is the parent's
+        // display label.
+        var crow = el('div', 'cr-cm-choice');
+        var clabel = el('span', 'cr-cm-slider-label');
+        clabel.textContent = c.label || c.param;
+        crow.appendChild(clabel);
+        var group = el('div', 'cr-cm-choice-group');
+        var options = Array.isArray(c.options) ? c.options : Object.keys(spec.parents || {});
+        choiceGroups[c.param] = [];
+        options.forEach(function (key) {
+          var btn = document.createElement('button');
+          btn.type = 'button';
+          btn.className = 'cr-cm-choice-btn';
+          btn.textContent = (spec.parents && spec.parents[key] && spec.parents[key].label) || key;
+          btn.addEventListener('click', function () {
+            P[c.param] = key;
+            pushParamsToControls();
+            redraw();
+          });
+          group.appendChild(btn);
+          choiceGroups[c.param].push({ key: key, btn: btn });
+        });
+        crow.appendChild(group);
+        controlsRow.appendChild(crow);
+      }
     });
 
     // ── sync helpers (the binding glue) ──────────────────────────────────────
@@ -327,6 +380,13 @@
         var si = sliderInputs[param];
         si.input.value = P[param];
         si.valueEl.textContent = ' = ' + toPlainNumber(P[param]);
+      });
+      Object.keys(choiceGroups).forEach(function (param) {
+        choiceGroups[param].forEach(function (opt) {
+          var on = opt.key === P[param];
+          opt.btn.classList.toggle('is-active', on);
+          opt.btn.setAttribute('aria-pressed', on ? 'true' : 'false');
+        });
       });
     }
     function pushParamsToPoints() {
@@ -343,9 +403,16 @@
       readouts.forEach(function (r) {
         var fmt = r.element.format;
         var tex = String(r.element.text || '').replace(/\{([a-zA-Z_][a-zA-Z_0-9.]*)\}/g, function (_, key) {
-          var base = key.split('.')[0];
-          var val = s[base];
-          if (typeof val !== 'number') return '?';
+          var parts = key.split('.');
+          // {selector.field} → look the field up on the chosen parent (e.g.
+          // {parent.label} → the selected parent's display label).
+          if (parts.length > 1) {
+            var entry = spec.parents && spec.parents[P[parts[0]]];
+            var field = entry && entry[parts[1]];
+            return field == null ? '?' : String(field);
+          }
+          var val = s[parts[0]];
+          if (typeof val !== 'number') return typeof val === 'string' ? val : '?';
           return fmt === 'smartFraction' ? toFractionTex(val) : toPlainNumber(val);
         });
         // Collapse "+ -" / "+ \frac{-…" into a clean minus so "y = 2x + -3"

--- a/public/js/conceptModelSpec.js
+++ b/public/js/conceptModelSpec.js
@@ -153,12 +153,17 @@
       if (t.type === 'num') { consume(); var val = t.value; return function () { return val; }; }
       if (t.type === 'id') {
         consume();
-        var name = t.value.toLowerCase();
-        if (Object.prototype.hasOwnProperty.call(KNOWN_CONSTS, name) && !(peek() && peek().value === '(')) {
-          var cval = KNOWN_CONSTS[name]; return function () { return cval; };
+        // Functions/constants match case-insensitively (SIN == sin, PI == pi),
+        // but VARIABLE names preserve case — so a param/placeholder named `P` is
+        // distinct from `p`, and `s[name]` lookups in the renderer line up
+        // exactly with the declared param keys.
+        var raw = t.value;
+        var lower = raw.toLowerCase();
+        if (Object.prototype.hasOwnProperty.call(KNOWN_CONSTS, lower) && !(peek() && peek().value === '(')) {
+          var cval = KNOWN_CONSTS[lower]; return function () { return cval; };
         }
-        if (Object.prototype.hasOwnProperty.call(FN_MAP, name)) {
-          var fn = FN_MAP[name];
+        if (Object.prototype.hasOwnProperty.call(FN_MAP, lower)) {
+          var fn = FN_MAP[lower];
           if (peek() && peek().value === '(') {
             consume('('); var args = [parseExpr()];
             while (peek() && peek().value === ',') { consume(','); args.push(parseExpr()); }
@@ -168,9 +173,9 @@
           return function (s) { return fn(s.x); };
         }
         // Otherwise it's a scope variable (the graphing var x, or a param/derived).
-        if (name !== 'x') vars[name] = true;
+        if (lower !== 'x') vars[raw] = true;
         return function (s) {
-          var v = s ? s[name] : undefined;
+          var v = s ? s[raw] : undefined;
           return typeof v === 'number' ? v : NaN;
         };
       }
@@ -229,6 +234,53 @@
       reveal: ['plane', 'line', 'p1', 'p2', 'slopeOut'],
       drag: ['p1', 'p2'],
       prompt: 'Drag A and B. Watch the slope — it is rise over run between the two points.'
+    },
+
+    // The universal-parent model — highest leverage in the catalog. `a·f(x−h)+k`
+    // is parent-agnostic: `a` stretches/flips, `h` shifts left/right, `k` shifts
+    // up/down, for ANY parent f. Swap the parent (x², |x|, x³, √x) and the SAME
+    // rules hold — which is exactly the concept. One model = the whole
+    // transformations unit (subsumes the standalone quadratic). The faint parent
+    // is ALWAYS shown so the transform reads as a change from the original.
+    //
+    // New vocabulary it forges (no new primitives, just attributes):
+    //   • a string-valued "selector" param + a `choice` control to pick it
+    //   • a `parents` library (named fn + anchor + label + optional domain)
+    //   • `compose` on a function: evaluate the SELECTED parent at a shifted
+    //     argument, exposed to the outer fn as a placeholder (so a*P + k means
+    //     "a times the parent of (x-h), plus k") — generic, no per-parent code
+    //   • `role:"reference"` + `always:true` (the faint, fixed comparison curve)
+    //   • a point that binds a PAIR of params (the draggable key point ↔ h,k)
+    //   • `{selector.field}` readout tokens (resolve to the parent's label, …)
+    function_transformations: {
+      model: 'function_transformations',
+      title: 'a · f(x − h) + k',
+      params: { parent: 'quadratic', a: 1, h: 0, k: 0 },
+      parents: {
+        quadratic:   { fn: 'x^2',     anchor: 'vertex',     label: 'x²' },
+        absolute:    { fn: 'abs(x)',  anchor: 'vertex',     label: '|x|' },
+        cubic:       { fn: 'x^3',     anchor: 'inflection', label: 'x³' },
+        square_root: { fn: 'sqrt(x)', anchor: 'endpoint',   label: '√x', domain: [0, null] }
+      },
+      controls: [
+        { type: 'choice', param: 'parent', label: 'parent' },
+        { type: 'slider', param: 'a', label: 'a', range: [-3, 3], step: 0.25, ticks: false },
+        { type: 'slider', param: 'h', label: 'h', range: [-6, 6], step: 0.5, ticks: true },
+        { type: 'slider', param: 'k', label: 'k', range: [-6, 6], step: 0.5, ticks: true }
+      ],
+      elements: [
+        { id: 'plane', type: 'plane', x: [-10, 10], y: [-10, 10], grid: true, axisLabels: true },
+        // The faint parent f(x), always shown; switches with the selection.
+        { id: 'parentCurve', type: 'function', fn: 'P', compose: { P: { parent: 'parent', arg: 'x' } }, role: 'reference', always: true },
+        // The transform a·f(x−h)+k of the SELECTED parent.
+        { id: 'curve', type: 'function', fn: 'a*P + k', compose: { P: { parent: 'parent', arg: 'x - h' } } },
+        // The parent's key point (vertex / inflection / endpoint) lives at (h,k).
+        { id: 'anchor', type: 'point', at: ['h', 'k'], draggable: true, binds: ['h', 'k'] },
+        { id: 'eq', type: 'readout', text: 'f = {parent.label}   ·   a = {a},  h = {h},  k = {k}', at: 'top' }
+      ],
+      reveal: ['plane', 'parentCurve', 'curve', 'anchor', 'eq'],
+      drag: ['anchor'],
+      prompt: 'Drag the key point and slide a/h/k. Now switch the parent — do the SAME rules still work?'
     }
   };
 
@@ -264,15 +316,55 @@
     if (typeof spec.model !== 'string' || !spec.model) errors.push('spec.model must be a non-empty string');
     if (!isPlainObject(spec.params)) errors.push('spec.params must be an object');
 
+    // Params come in two flavours:
+    //   • numeric  — a quantity the math reads (m, b, a, h, k). Slider-driven.
+    //   • selector — a STRING key naming a choice (e.g. parent: "quadratic").
+    //     Choice-driven; not a math quantity, so it can't appear inside an fn,
+    //     but it can be read by `{selector.field}` readout tokens and used by a
+    //     function's `compose` to pick which parent to evaluate.
     var paramNames = isPlainObject(spec.params) ? Object.keys(spec.params) : [];
-    var paramSet = {};
+    var paramSet = {};      // all params (numeric + selector)
+    var numericSet = {};    // numeric params only — the math-readable ones
+    var selectorSet = {};   // string-valued selector params
     paramNames.forEach(function (p) {
       paramSet[p] = true;
-      if (typeof spec.params[p] !== 'number') errors.push('param "' + p + '" must have a numeric default');
+      var d = spec.params[p];
+      if (typeof d === 'number') numericSet[p] = true;
+      else if (typeof d === 'string') selectorSet[p] = true;
+      else errors.push('param "' + p + '" must default to a number or a selector string');
     });
 
-    // derived names are computed from params (and earlier derived); they're
-    // readable by readouts and the function curve but are not user-controlled.
+    // parents library — named pure functions of x (the swappable f). Each entry
+    // is { fn, label?, anchor?, domain? }; the fn may only read x / constants.
+    var parentSet = {};
+    if (spec.parents != null) {
+      if (!isPlainObject(spec.parents)) {
+        errors.push('spec.parents must be an object when present');
+      } else {
+        Object.keys(spec.parents).forEach(function (key) {
+          parentSet[key] = true;
+          var entry = spec.parents[key];
+          if (!isPlainObject(entry)) { errors.push('parent "' + key + '" must be an object'); return; }
+          try {
+            var pc = compileExpr(entry.fn);
+            pc.vars.forEach(function (v) {
+              errors.push('parent "' + key + '" fn may only use x; references "' + v + '"');
+            });
+          } catch (e) {
+            errors.push('parent "' + key + '" fn does not compile: ' + e.message);
+          }
+        });
+      }
+    }
+    // A selector's default must name a real parent (when a parents library exists).
+    Object.keys(selectorSet).forEach(function (s) {
+      if (spec.parents && !parentSet[spec.params[s]]) {
+        errors.push('selector "' + s + '" default "' + spec.params[s] + '" is not a parent');
+      }
+    });
+
+    // derived names are computed from numeric params (and earlier derived);
+    // readable by readouts and functions, not user-controlled.
     var derivedSet = {};
     if (spec.derived != null) {
       if (!isPlainObject(spec.derived)) {
@@ -283,7 +375,7 @@
           try {
             var c = compileExpr(spec.derived[name]);
             c.vars.forEach(function (v) {
-              if (!paramSet[v] && !derivedSet[v]) {
+              if (!numericSet[v] && !derivedSet[v]) {
                 errors.push('derived "' + name + '" references unknown name "' + v + '"');
               }
             });
@@ -294,9 +386,15 @@
         });
       }
     }
-    var readableSet = {};
-    Object.keys(paramSet).forEach(function (k) { readableSet[k] = true; });
-    Object.keys(derivedSet).forEach(function (k) { readableSet[k] = true; });
+
+    // math-readable: what a function/derived/point-coord expression may read.
+    var mathSet = {};
+    Object.keys(numericSet).forEach(function (k) { mathSet[k] = true; });
+    Object.keys(derivedSet).forEach(function (k) { mathSet[k] = true; });
+    // name-resolvable: what a readout token may reference (math names + selectors).
+    var nameSet = {};
+    Object.keys(mathSet).forEach(function (k) { nameSet[k] = true; });
+    Object.keys(selectorSet).forEach(function (k) { nameSet[k] = true; });
 
     // controls
     if (spec.controls != null) {
@@ -308,6 +406,7 @@
           if (!CONTROL_TYPES[c.type]) errors.push('control[' + i + '] has unknown type "' + c.type + '"');
           if (!paramSet[c.param]) errors.push('control[' + i + '] binds unknown param "' + c.param + '"');
           if (c.type === 'slider') {
+            if (!numericSet[c.param]) errors.push('slider for "' + c.param + '" must drive a numeric param');
             if (!Array.isArray(c.range) || c.range.length !== 2 ||
               typeof c.range[0] !== 'number' || typeof c.range[1] !== 'number' || c.range[0] >= c.range[1]) {
               errors.push('slider for "' + c.param + '" needs range [lo, hi] with lo < hi');
@@ -315,6 +414,14 @@
             if (c.step != null && !(typeof c.step === 'number' && c.step > 0)) {
               errors.push('slider for "' + c.param + '" has a non-positive step');
             }
+          }
+          if (c.type === 'choice') {
+            if (!selectorSet[c.param]) errors.push('choice for "' + c.param + '" must drive a selector param');
+            var opts = Array.isArray(c.options) ? c.options : Object.keys(parentSet);
+            if (!opts.length) errors.push('choice for "' + c.param + '" has no options');
+            opts.forEach(function (o) {
+              if (spec.parents && !parentSet[o]) errors.push('choice option "' + o + '" is not a parent');
+            });
           }
         });
       }
@@ -333,10 +440,40 @@
         if (!ELEMENT_TYPES[el.type]) errors.push('element "' + (el.id || i) + '" has unknown type "' + el.type + '"');
 
         if (el.type === 'function') {
+          // `compose` lets the fn call the SELECTED parent at a shifted argument,
+          // exposing the result as a placeholder var. Validate the placeholders
+          // first, then allow the outer fn to read them.
+          var fnReadable = {};
+          Object.keys(mathSet).forEach(function (k) { fnReadable[k] = true; });
+          if (el.compose != null) {
+            if (!isPlainObject(el.compose)) {
+              errors.push('function "' + el.id + '" compose must be an object');
+            } else {
+              Object.keys(el.compose).forEach(function (ph) {
+                var spec2 = el.compose[ph];
+                if (!isPlainObject(spec2) || !spec2.parent) {
+                  errors.push('function "' + el.id + '" compose."' + ph + '" needs { parent, arg }');
+                  return;
+                }
+                if (!selectorSet[spec2.parent]) {
+                  errors.push('function "' + el.id + '" compose parent "' + spec2.parent + '" is not a selector');
+                }
+                try {
+                  var ac = compileExpr(spec2.arg);
+                  ac.vars.forEach(function (v) {
+                    if (!mathSet[v]) errors.push('function "' + el.id + '" compose arg references unknown name "' + v + '"');
+                  });
+                } catch (e) {
+                  errors.push('function "' + el.id + '" compose arg does not compile: ' + e.message);
+                }
+                fnReadable[ph] = true;
+              });
+            }
+          }
           try {
             var cf = compileExpr(el.fn);
             cf.vars.forEach(function (v) {
-              if (!readableSet[v]) errors.push('function "' + el.id + '" references unknown name "' + v + '"');
+              if (!fnReadable[v]) errors.push('function "' + el.id + '" references unknown name "' + v + '"');
             });
           } catch (e) {
             errors.push('function "' + el.id + '" does not compile: ' + e.message);
@@ -348,7 +485,7 @@
             errors.push('point "' + el.id + '" needs at:[x,y]');
           } else {
             el.at.forEach(function (coord) {
-              if (typeof coord === 'string' && !readableSet[coord]) {
+              if (typeof coord === 'string' && !mathSet[coord]) {
                 errors.push('point "' + el.id + '" at references unknown name "' + coord + '"');
               } else if (typeof coord !== 'string' && typeof coord !== 'number') {
                 errors.push('point "' + el.id + '" at coordinate must be a number or param name');
@@ -358,7 +495,7 @@
           if (el.binds != null) {
             var binds = Array.isArray(el.binds) ? el.binds : [el.binds];
             binds.forEach(function (p) {
-              if (!paramSet[p]) errors.push('point "' + el.id + '" binds unknown param "' + p + '"');
+              if (!numericSet[p]) errors.push('point "' + el.id + '" binds unknown numeric param "' + p + '"');
             });
           }
         }
@@ -371,8 +508,15 @@
 
         if (el.type === 'readout') {
           readoutTokens(el.text).forEach(function (tok) {
-            var base = tok.split('.')[0];
-            if (!readableSet[base]) errors.push('readout "' + el.id + '" references unknown name "' + tok + '"');
+            var parts = tok.split('.');
+            var base = parts[0];
+            if (parts.length > 1) {
+              // "{selector.field}" — the base must be a selector param; the field
+              // resolves against the chosen parent (e.g. {parent.label}).
+              if (!selectorSet[base]) errors.push('readout "' + el.id + '" token "' + tok + '" needs a selector before the dot');
+            } else if (!nameSet[base]) {
+              errors.push('readout "' + el.id + '" references unknown name "' + tok + '"');
+            }
           });
         }
       });

--- a/tests/unit/conceptModelSpec.test.js
+++ b/tests/unit/conceptModelSpec.test.js
@@ -121,7 +121,7 @@ describe('conceptModelSpec — validator (generated specs cannot render broken)'
     s.elements.push({ id: 'dot', type: 'point', at: [0, 'b'], draggable: true, binds: 'q' });
     const r = validateModelSpec(s);
     expect(r.valid).toBe(false);
-    expect(r.errors.join(' ')).toMatch(/binds unknown param "q"/);
+    expect(r.errors.join(' ')).toMatch(/binds unknown numeric param "q"/);
   });
 
   it('rejects a point whose `at` names an undeclared param', () => {
@@ -184,5 +184,92 @@ describe('conceptModelSpec — validator (generated specs cannot render broken)'
     expect(validateModelSpec(null).valid).toBe(false);
     expect(validateModelSpec({}).valid).toBe(false);
     expect(validateModelSpec({ model: 'x', params: {}, elements: [] }).valid).toBe(false);
+  });
+});
+
+describe('conceptModelSpec — function_transformations vocabulary (selector / parents / choice / compose)', () => {
+  it('the universal-parent model is in the catalog and validates', () => {
+    expect(MODELS).toContain('function_transformations');
+    const r = validateModelSpec(getModel('function_transformations'));
+    expect(r.errors).toEqual([]);
+    expect(r.valid).toBe(true);
+  });
+
+  it('composes the SELECTED parent at a shifted argument, correct by construction', () => {
+    // curve = a * f(x - h) + k. With f = x^2, a=2, h=1, k=3 at x=2:
+    //   f(2-1) = 1^2 = 1 → 2*1 + 3 = 5
+    const spec = getModel('function_transformations');
+    const parentFn = compileExpr(spec.parents.quadratic.fn);    // x^2
+    const argFn = compileExpr(spec.elements[2].compose.P.arg);  // x - h
+    const outerFn = compileExpr(spec.elements[2].fn);           // a*P + k
+    const P = { a: 2, h: 1, k: 3 };
+    const argVal = argFn.eval({ x: 2, h: P.h });
+    const Pval = parentFn.eval({ x: argVal });
+    expect(outerFn.eval({ a: P.a, k: P.k, P: Pval })).toBe(5);
+  });
+
+  it('preserves identifier case so placeholder P is distinct from param p', () => {
+    const c = compileExpr('a*P + k');
+    expect(c.vars.sort()).toEqual(['P', 'a', 'k']); // P kept uppercase
+  });
+
+  function tbase() {
+    return {
+      model: 't',
+      params: { parent: 'quadratic', a: 1 },
+      parents: { quadratic: { fn: 'x^2', label: 'x²' }, cubic: { fn: 'x^3', label: 'x³' } },
+      controls: [{ type: 'choice', param: 'parent', label: 'f' }],
+      elements: [
+        { id: 'plane', type: 'plane', x: [-10, 10], y: [-10, 10] },
+        { id: 'curve', type: 'function', fn: 'a*P', compose: { P: { parent: 'parent', arg: 'x' } } },
+        { id: 'eq', type: 'readout', text: 'f = {parent.label}' },
+      ],
+    };
+  }
+
+  it('accepts a well-formed selector/choice/compose spec', () => {
+    expect(validateModelSpec(tbase()).valid).toBe(true);
+  });
+
+  it('rejects a selector default that is not a parent', () => {
+    const s = tbase();
+    s.params.parent = 'octic';
+    expect(validateModelSpec(s).errors.join(' ')).toMatch(/is not a parent/);
+  });
+
+  it('rejects a choice bound to a numeric (non-selector) param', () => {
+    const s = tbase();
+    s.controls[0].param = 'a';
+    expect(validateModelSpec(s).errors.join(' ')).toMatch(/must drive a selector param/);
+  });
+
+  it('rejects a slider bound to a selector param', () => {
+    const s = tbase();
+    s.controls.push({ type: 'slider', param: 'parent', range: [0, 1] });
+    expect(validateModelSpec(s).errors.join(' ')).toMatch(/must drive a numeric param/);
+  });
+
+  it('rejects a parent fn that uses anything other than x', () => {
+    const s = tbase();
+    s.parents.quadratic.fn = 'a*x^2';
+    expect(validateModelSpec(s).errors.join(' ')).toMatch(/may only use x/);
+  });
+
+  it('rejects compose whose parent is not a selector', () => {
+    const s = tbase();
+    s.elements[1].compose.P.parent = 'a';
+    expect(validateModelSpec(s).errors.join(' ')).toMatch(/compose parent "a" is not a selector/);
+  });
+
+  it('rejects a function reading the placeholder without declaring compose', () => {
+    const s = tbase();
+    delete s.elements[1].compose;
+    expect(validateModelSpec(s).errors.join(' ')).toMatch(/references unknown name "P"/);
+  });
+
+  it('rejects a {selector.field} token whose base is not a selector', () => {
+    const s = tbase();
+    s.elements[2].text = 'f = {a.label}';
+    expect(validateModelSpec(s).errors.join(' ')).toMatch(/needs a selector before the dot/);
   });
 });


### PR DESCRIPTION
## What this is

Adds the **highest-leverage** model from `CONCEPT_MODELS.md` — `function_transformations`, the universal-parent model — on the concept-model engine shipped in #1057.

`a·f(x−h)+k` is parent-agnostic: `a` stretches/flips, `h` shifts left/right, `k` shifts up/down, for **any** parent `f`. Swap the parent (x² / |x| / x³ / √x) and the **same** a/h/k rules hold — which is exactly the concept. So **one model = the whole transformations unit** (it subsumes the standalone quadratic). The faint parent is **always shown** so the transform reads as a change *from the original*.

## How it extends the engine

No new primitives — just attributes, all driven by the same validated-spec → render path:

- **string-valued "selector" params** + a **`choice`** control (a segmented picker)
- a **`parents`** library — named pure-of-`x` functions with `label` / `anchor` / optional `domain`
- **`compose`** on a function: evaluate the *selected* parent at a shifted argument and expose it to the outer fn as a placeholder (`a*P + k` where `P` = parent of `(x−h)`). Generic — zero per-parent code.
- **`role:"reference"` + `always:true`** — the faint, fixed comparison curve
- a point that **binds a pair of params** (the draggable key point ↔ `h,k`)
- **`{selector.field}`** readout tokens — resolve against the chosen parent (e.g. `{parent.label}`)

The expression compiler now **preserves identifier case for variables** (functions/constants stay case-insensitive), so the placeholder `P` is distinct from a param `p` and renderer scope lookups line up exactly with declared keys. The validator splits param kinds (numeric vs. selector) and checks every new reference resolves — a generated `function_transformations` spec still can't render wrong math.

## Verification

- **+11 spec/validator tests** (33 in the suite), including a "composes the selected parent at a shifted argument, correct by construction" check. **Full suite green (2898).** Lint: 0 errors.
- **Browser-verified** on `/concept-model-demo.html` (headless): the choice picker switches the parent live, the a/h/k sliders and the draggable (h,k) anchor stay in sync, the faint dashed reference parent renders alongside the bolder transform, and the `{parent.label}` readout updates. No console errors.

*(Demo: `/concept-model-demo.html` — now three cards: slope_intercept_line, two_point_line, function_transformations.)*

## Status / not in scope
Still **inert in production** — the model isn't yet told to emit `model` commands (same posture as `DIAGRAM_BOARD`). The "summon with intent" prompt wiring (Build-order step 3) and Tier-2 geometry remain follow-ups.

https://claude.ai/code/session_01G5awZCfNt8pPgAeV9s6cw4

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5awZCfNt8pPgAeV9s6cw4)_