### PR TITLE
feat(concept-models): Tier-2 geometry + summon-with-intent wiring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,6 +104,15 @@ ENABLE_VISUAL_TOOLS=false
 # turning it on changes how live AI responses are produced.
 STRUCTURED_TUTOR_RESPONSE=false
 
+# CONCEPT_MODELS — when 'true', the tutor can summon interactive "concept models"
+# onto the WorkBoard (a manipulable model the student drags to discover a
+# relationship: slope-intercept line, function transformations, inscribed angle,
+# triangle angle sum, …). Adds a prompt section teaching the `model` board verb;
+# the engine (public/js/conceptModelSpec.js + conceptModelRenderer.js) measures
+# every value, so a model is correct by construction. Leave 'false' until verified
+# on a deploy — turning it on changes the live tutor prompt. See CONCEPT_MODELS.md.
+CONCEPT_MODELS=false
+
 # --- STRIPE BILLING ---
 # MASTER SWITCH: Set to 'true' to activate billing, usage limits, and paywall.
 # When false (or missing), all users get unlimited free access (pre-launch mode).

--- a/public/concept-model-demo.html
+++ b/public/concept-model-demo.html
@@ -103,6 +103,10 @@
       <h2>triangle_angle_sum — drag a corner; the three angles always sum to 180°</h2>
       <div class="host" id="host-tas"></div>
     </div>
+    <div class="demo-card">
+      <h2>linear_pair_angles — drag B; the two angles on the line always sum to 180°</h2>
+      <div class="host" id="host-lpa"></div>
+    </div>
   </div>
 
   <script src="/js/conceptModelSpec.js"></script>
@@ -123,6 +127,9 @@
       );
       window.ConceptModelRenderer.renderModel(
         document.getElementById('host-tas'), 'triangle_angle_sum'
+      );
+      window.ConceptModelRenderer.renderModel(
+        document.getElementById('host-lpa'), 'linear_pair_angles'
       );
     }
     if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', boot);

--- a/public/concept-model-demo.html
+++ b/public/concept-model-demo.html
@@ -95,6 +95,14 @@
       <h2>function_transformations — a·f(x−h)+k, swap the parent</h2>
       <div class="host" id="host-ft"></div>
     </div>
+    <div class="demo-card">
+      <h2>inscribed_angle — drag B; inscribed stays half the central (measured live)</h2>
+      <div class="host" id="host-ia"></div>
+    </div>
+    <div class="demo-card">
+      <h2>triangle_angle_sum — drag a corner; the three angles always sum to 180°</h2>
+      <div class="host" id="host-tas"></div>
+    </div>
   </div>
 
   <script src="/js/conceptModelSpec.js"></script>
@@ -109,6 +117,12 @@
       );
       window.ConceptModelRenderer.renderModel(
         document.getElementById('host-ft'), 'function_transformations'
+      );
+      window.ConceptModelRenderer.renderModel(
+        document.getElementById('host-ia'), 'inscribed_angle'
+      );
+      window.ConceptModelRenderer.renderModel(
+        document.getElementById('host-tas'), 'triangle_angle_sum'
       );
     }
     if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', boot);

--- a/public/js/conceptModelRenderer.js
+++ b/public/js/conceptModelRenderer.js
@@ -157,10 +157,33 @@
       compiledParents[key] = CMS.compileExpr(spec.parents[key].fn);
     });
 
+    // JSXGraph point objects, filled when elements are created below. Declared
+    // up here so measureValues()/scope() can close over the live objects.
+    var jpoints = {};
+
+    // Quantities the engine MEASURES off the live geometry (never asserted) —
+    // e.g. the angle between three live points. Read by readouts and derived.
+    function measureValues() {
+      var out = {};
+      if (!spec.measures) return out;
+      Object.keys(spec.measures).forEach(function (name) {
+        var def = spec.measures[name];
+        if (def.type === 'angle') {
+          var at = jpoints[def.at], p = jpoints[def.rays[0]], q = jpoints[def.rays[1]];
+          out[name] = (at && p && q)
+            ? CMS.measureAngle([at.X(), at.Y()], [p.X(), p.Y()], [q.X(), q.Y()])
+            : NaN;
+        }
+      });
+      return out;
+    }
+
     function scope() {
       var s = {};
       Object.keys(P).forEach(function (k) { s[k] = P[k]; });
-      // derived read numeric params (and earlier derived) — evaluate in order.
+      var mv = measureValues();
+      Object.keys(mv).forEach(function (k) { s[k] = mv[k]; });
+      // derived read params/measures (and earlier derived) — evaluate in order.
       Object.keys(compiledDerived).forEach(function (n) { s[n] = compiledDerived[n].eval(s); });
       return s;
     }
@@ -220,7 +243,7 @@
       zoom: { enabled: false }
     });
 
-    var jpoints = {};    // elementId -> JSXGraph point
+    var jcircles = {};   // elementId -> JSXGraph circle
     var bindMap = {};    // elementId -> { xParam, yParam }
     var readouts = [];   // { el, element }
 
@@ -239,20 +262,34 @@
       });
       return map;
     }
+    function hasBinds(e) { var m = bindMap[e.id]; return m && (m.xParam || m.yParam); }
 
-    // First pass: points (lines reference them by id).
+    // Pre-pass: circles (a point may glide on one).
+    spec.elements.forEach(function (e) {
+      if (e.type !== 'circle') return;
+      var isRef = e.role === 'reference';
+      jcircles[e.id] = board.create('circle', [
+        [resolveCoord(e.center[0]), resolveCoord(e.center[1])], resolveCoord(e.radius)
+      ], {
+        strokeColor: isRef ? '#b9b2e6' : '#5B3DF6',
+        strokeWidth: 2, fixed: true, highlight: false, fillOpacity: 0
+      });
+    });
+
+    // First pass: points (lines/polygons/angles reference them by id).
     spec.elements.forEach(function (e) {
       if (e.type !== 'point') return;
       var x0 = resolveCoord(e.at[0]);
       var y0 = resolveCoord(e.at[1]);
       var attrs = {
         name: e.label || '', size: 3, fixed: !e.draggable,
-        strokeColor: '#5B3DF6', fillColor: '#8B7BFF',
+        strokeColor: '#5B3DF6', fillColor: e.draggable ? '#8B7BFF' : '#5B3DF6',
         withLabel: !!e.label, label: { offset: [8, 8] }
       };
-      var pt;
+      var pt, onCircle = typeof e.on === 'string' && e.on.indexOf('circle:') === 0;
       if (e.on === 'yAxis') pt = board.create('glider', [0, y0, board.defaultAxes.y], attrs);
       else if (e.on === 'xAxis') pt = board.create('glider', [x0, 0, board.defaultAxes.x], attrs);
+      else if (onCircle) pt = board.create('glider', [x0, y0, jcircles[e.on.slice(7)]], attrs);
       else pt = board.create('point', [x0, y0], attrs);
       jpoints[e.id] = pt;
       bindMap[e.id] = computeBindMap(e);
@@ -260,16 +297,21 @@
       if (e.draggable) {
         pt.on('drag', function () {
           var m = bindMap[e.id];
-          if (m.xParam) P[m.xParam] = snapParam(m.xParam, pt.X());
-          if (m.yParam) P[m.yParam] = snapParam(m.yParam, pt.Y());
-          pushParamsToControls();
-          pushParamsToPoints();   // land on the snapped grid value
+          // Param-bound point: write the (snapped) position back to its params and
+          // resync the controls. Free/constrained geometry point: its position IS
+          // the state — just redraw so the live measures update.
+          if (m.xParam || m.yParam) {
+            if (m.xParam) P[m.xParam] = snapParam(m.xParam, pt.X());
+            if (m.yParam) P[m.yParam] = snapParam(m.yParam, pt.Y());
+            pushParamsToControls();
+            pushParamsToPoints();   // land on the snapped grid value
+          }
           redraw();
         });
       }
     });
 
-    // Second pass: functions, lines, readouts.
+    // Second pass: functions, lines, polygons, angles, readouts.
     spec.elements.forEach(function (e) {
       if (e.type === 'function') {
         var c = compiledFns[e.id];
@@ -299,12 +341,35 @@
       } else if (e.type === 'line' || e.type === 'segment' || e.type === 'ray') {
         var a = jpoints[e.through[0]], b2 = jpoints[e.through[1]];
         if (a && b2) {
+          var isRefLine = e.role === 'reference';
           var straight = e.type === 'segment'
             ? { straightFirst: false, straightLast: false }
             : e.type === 'ray' ? { straightFirst: false, straightLast: true } : {};
           board.create('line', [a, b2], Object.assign({
-            strokeColor: '#5B3DF6', strokeWidth: 3, fixed: true, highlight: false
+            strokeColor: isRefLine ? '#a9a2d6' : '#5B3DF6',
+            strokeWidth: isRefLine ? 1.5 : 2.5,
+            dash: isRefLine ? 2 : 0,
+            fixed: true, highlight: false
           }, straight));
+        }
+      } else if (e.type === 'polygon') {
+        var verts = e.vertices.map(function (id) { return jpoints[id]; }).filter(Boolean);
+        if (verts.length >= 3) {
+          board.create('polygon', verts, {
+            fillColor: '#8B7BFF', fillOpacity: e.fill === false ? 0 : 0.12,
+            borders: { strokeColor: '#5B3DF6', strokeWidth: 2.5, highlight: false },
+            vertices: { visible: false }, // the point elements own the vertices
+            fixed: true, highlight: false
+          });
+        }
+      } else if (e.type === 'angle') {
+        var av = jpoints[e.at], r0 = jpoints[e.rays[0]], r1 = jpoints[e.rays[1]];
+        if (av && r0 && r1) {
+          // JSXGraph marks the angle at the MIDDLE point: [rayA, vertex, rayB].
+          board.create('angle', [r0, av, r1], {
+            radius: 0.8, type: 'sector', fillColor: '#8B7BFF', fillOpacity: 0.35,
+            strokeColor: '#5B3DF6', withLabel: false, fixed: true, highlight: false
+          });
         }
       } else if (e.type === 'readout') {
         var host = el('div', 'cr-cm-readout');
@@ -390,8 +455,11 @@
       });
     }
     function pushParamsToPoints() {
+      // Only param-bound points are positioned FROM params. Free / circle-glider
+      // geometry points own their own position (the source of truth there is the
+      // board, read back via measures) — never yank them to their initial `at`.
       spec.elements.forEach(function (e) {
-        if (e.type !== 'point' || !e.draggable) return;
+        if (e.type !== 'point' || !e.draggable || !hasBinds(e)) return;
         var pt = jpoints[e.id]; if (!pt) return;
         var x = resolveCoord(e.at[0]);
         var y = resolveCoord(e.at[1]);

--- a/public/js/conceptModelSpec.js
+++ b/public/js/conceptModelSpec.js
@@ -52,6 +52,15 @@
     cot: function (v) { return 1 / Math.tan(v); }
   };
 
+  // Binary-op combiners. These take (l, r) as PARAMETERS so each call gets a
+  // fresh closure — critical inside the parser's left-associative while-loops,
+  // where a shared `var l = left` binding would make a 3+ term expression's
+  // closures reference themselves and recurse infinitely.
+  function fAdd(l, r) { return function (s) { return l(s) + r(s); }; }
+  function fSub(l, r) { return function (s) { return l(s) - r(s); }; }
+  function fMul(l, r) { return function (s) { return l(s) * r(s); }; }
+  function fDiv(l, r) { return function (s) { var d = r(s); return d === 0 ? NaN : l(s) / d; }; }
+
   function tokenize(expr) {
     var tokens = [];
     var i = 0;
@@ -105,8 +114,7 @@
       var left = parseTerm();
       while (peek() && (peek().value === '+' || peek().value === '-')) {
         var op = consume().value; var right = parseTerm();
-        var l = left, r = right;
-        left = op === '+' ? function (s) { return l(s) + r(s); } : function (s) { return l(s) - r(s); };
+        left = op === '+' ? fAdd(left, right) : fSub(left, right);
       }
       return left;
     }
@@ -114,10 +122,7 @@
       var left = parseUnary();
       while (peek() && (peek().value === '*' || peek().value === '/')) {
         var op = consume().value; var right = parseUnary();
-        var l = left, r = right;
-        left = op === '*'
-          ? function (s) { return l(s) * r(s); }
-          : function (s) { var d = r(s); return d === 0 ? NaN : l(s) / d; };
+        left = op === '*' ? fMul(left, right) : fDiv(left, right);
       }
       return left;
     }
@@ -139,8 +144,7 @@
       while (peek()) {
         var t = peek();
         if (t.type === 'num' || t.type === 'id' || t.value === '(' || t.value === '|') {
-          var right = parseAtom(); var l = left, r = right;
-          left = function (s) { return l(s) * r(s); };
+          left = fMul(left, parseAtom());
         } else break;
       }
       return left;
@@ -281,6 +285,72 @@
       reveal: ['plane', 'parentCurve', 'curve', 'anchor', 'eq'],
       drag: ['anchor'],
       prompt: 'Drag the key point and slide a/h/k. Now switch the parent — do the SAME rules still work?'
+    },
+
+    // First geometry model — folds in the diagramSpec.js inscribed-angle work as
+    // a LIVE interactive (Tier 2). A and C are fixed on the circle and define the
+    // arc; B is a draggable glider on the major arc. The inscribed angle ∠ABC and
+    // the central angle ∠AOC are MEASURED live by the engine from the point
+    // positions (never asserted). Two theorems fall out, correct by construction:
+    // the inscribed angle is invariant as B moves, and it is always half the
+    // central angle on the same arc.
+    inscribed_angle: {
+      model: 'inscribed_angle',
+      title: 'Inscribed Angle Theorem',
+      params: {},
+      controls: [],
+      measures: {
+        inscribed: { type: 'angle', at: 'B', rays: ['A', 'C'] },
+        central:   { type: 'angle', at: 'O', rays: ['A', 'C'] }
+      },
+      elements: [
+        { id: 'plane', type: 'plane', x: [-7, 7], y: [-7, 7], grid: false, axisLabels: false },
+        { id: 'circ', type: 'circle', center: [0, 0], radius: 5, role: 'reference' },
+        { id: 'O', type: 'point', at: [0, 0], label: 'O' },                 // center (fixed)
+        { id: 'A', type: 'point', at: [-4.3301, 2.5], label: 'A' },         // fixed arc endpoints
+        { id: 'C', type: 'point', at: [4.3301, 2.5], label: 'C' },
+        { id: 'B', type: 'point', at: [0, -5], on: 'circle:circ', draggable: true, label: 'B' },
+        { id: 'segOA', type: 'segment', through: ['O', 'A'], role: 'reference' },
+        { id: 'segOC', type: 'segment', through: ['O', 'C'], role: 'reference' },
+        { id: 'segBA', type: 'segment', through: ['B', 'A'] },
+        { id: 'segBC', type: 'segment', through: ['B', 'C'] },
+        { id: 'angB', type: 'angle', at: 'B', rays: ['A', 'C'], measure: true },
+        { id: 'angO', type: 'angle', at: 'O', rays: ['A', 'C'], measure: true },
+        { id: 'out', type: 'readout', text: 'inscribed = {inscribed}°   ·   central = {central}°', at: 'top' }
+      ],
+      reveal: ['plane', 'circ', 'O', 'A', 'C', 'B', 'segOA', 'segOC', 'segBA', 'segBC', 'angB', 'angO', 'out'],
+      drag: ['B'],
+      prompt: 'Drag B around the arc. The inscribed angle never changes — and it is always half the central angle.'
+    },
+
+    // Drag any vertex; the three interior angles are measured live and ALWAYS
+    // sum to 180°. Reuses the geometry vocabulary (polygon + angle measures +
+    // a derived sum) with no new primitives.
+    triangle_angle_sum: {
+      model: 'triangle_angle_sum',
+      title: 'Angles of a triangle sum to 180°',
+      params: {},
+      controls: [],
+      measures: {
+        angA: { type: 'angle', at: 'A', rays: ['B', 'C'] },
+        angB: { type: 'angle', at: 'B', rays: ['A', 'C'] },
+        angC: { type: 'angle', at: 'C', rays: ['A', 'B'] }
+      },
+      derived: { sum: 'angA + angB + angC' },
+      elements: [
+        { id: 'plane', type: 'plane', x: [-8, 8], y: [-6, 6], grid: true, axisLabels: false },
+        { id: 'A', type: 'point', at: [-4, -2], draggable: true, label: 'A' },
+        { id: 'B', type: 'point', at: [4, -2], draggable: true, label: 'B' },
+        { id: 'C', type: 'point', at: [1, 4], draggable: true, label: 'C' },
+        { id: 'tri', type: 'polygon', vertices: ['A', 'B', 'C'], fill: true },
+        { id: 'angA', type: 'angle', at: 'A', rays: ['B', 'C'], measure: true },
+        { id: 'angB', type: 'angle', at: 'B', rays: ['A', 'C'], measure: true },
+        { id: 'angC', type: 'angle', at: 'C', rays: ['A', 'B'], measure: true },
+        { id: 'out', type: 'readout', text: '{angA}° + {angB}° + {angC}° = {sum}°', at: 'top' }
+      ],
+      reveal: ['plane', 'tri', 'A', 'B', 'C', 'angA', 'angB', 'angC', 'out'],
+      drag: ['A', 'B', 'C'],
+      prompt: 'Drag any corner. The three angles change — but watch the sum.'
     }
   };
 
@@ -292,8 +362,12 @@
   // real elements. A spec that passes can be rendered without surprises; a spec
   // that fails is rejected before it reaches the engine.
 
-  var ELEMENT_TYPES = { plane: 1, function: 1, point: 1, line: 1, segment: 1, ray: 1, readout: 1 };
+  var ELEMENT_TYPES = {
+    plane: 1, function: 1, point: 1, line: 1, segment: 1, ray: 1, readout: 1,
+    circle: 1, polygon: 1, angle: 1
+  };
   var CONTROL_TYPES = { slider: 1, choice: 1 };
+  var MEASURE_TYPES = { angle: 1 };
 
   function isPlainObject(o) { return o && typeof o === 'object' && !Array.isArray(o); }
 
@@ -303,6 +377,23 @@
     var out = []; var re = /\{([a-zA-Z_][a-zA-Z_0-9.]*)\}/g; var m;
     while ((m = re.exec(text))) out.push(m[1]);
     return out;
+  }
+
+  // ─── Geometry measurement (pure, so the engine MEASURES, never asserts) ───
+  // The non-reflex angle at vertex `at` subtended by points `p` and `q`, in
+  // degrees. All three are [x, y]. This is the correctness core of the geometry
+  // models: the spec says "measure angle A-B-C", the engine computes it from the
+  // live point positions — a curated OR generated geometry spec cannot show a
+  // wrong angle. Returns NaN for a degenerate (zero-length) ray.
+  function measureAngle(at, p, q) {
+    if (!at || !p || !q) return NaN;
+    var v1x = p[0] - at[0], v1y = p[1] - at[1];
+    var v2x = q[0] - at[0], v2y = q[1] - at[1];
+    var m1 = Math.hypot(v1x, v1y), m2 = Math.hypot(v2x, v2y);
+    if (m1 === 0 || m2 === 0) return NaN;
+    var c = (v1x * v2x + v1y * v2y) / (m1 * m2);
+    c = Math.max(-1, Math.min(1, c)); // clamp FP drift outside acos domain
+    return Math.acos(c) * 180 / Math.PI;
   }
 
   /**
@@ -363,19 +454,39 @@
       }
     });
 
-    // derived names are computed from numeric params (and earlier derived);
-    // readable by readouts and functions, not user-controlled.
+    // measures are quantities the engine reads off the LIVE geometry (an angle
+    // between three points) — never params, never asserted. Collected before
+    // `derived` so a derived value (e.g. a triangle's angle sum) may read them;
+    // their point refs are validated in the deferred pass (after ids exist).
+    var measureSet = {};
+    if (spec.measures != null) {
+      if (!isPlainObject(spec.measures)) {
+        errors.push('spec.measures must be an object when present');
+      } else {
+        Object.keys(spec.measures).forEach(function (name) {
+          if (paramSet[name]) errors.push('measure "' + name + '" collides with a param of the same name');
+          var def = spec.measures[name];
+          if (!isPlainObject(def) || !MEASURE_TYPES[def.type]) {
+            errors.push('measure "' + name + '" needs a known type (' + Object.keys(MEASURE_TYPES).join(', ') + ')');
+          }
+          measureSet[name] = true;
+        });
+      }
+    }
+
+    // derived names are computed from numeric params, measures, and earlier
+    // derived; readable by readouts and functions, not user-controlled.
     var derivedSet = {};
     if (spec.derived != null) {
       if (!isPlainObject(spec.derived)) {
         errors.push('spec.derived must be an object when present');
       } else {
         Object.keys(spec.derived).forEach(function (name) {
-          if (paramSet[name]) errors.push('derived "' + name + '" collides with a param of the same name');
+          if (paramSet[name] || measureSet[name]) errors.push('derived "' + name + '" collides with a param/measure name');
           try {
             var c = compileExpr(spec.derived[name]);
             c.vars.forEach(function (v) {
-              if (!numericSet[v] && !derivedSet[v]) {
+              if (!numericSet[v] && !measureSet[v] && !derivedSet[v]) {
                 errors.push('derived "' + name + '" references unknown name "' + v + '"');
               }
             });
@@ -387,14 +498,16 @@
       }
     }
 
-    // math-readable: what a function/derived/point-coord expression may read.
+    // math-readable: what a function/point-coord expression may read.
     var mathSet = {};
     Object.keys(numericSet).forEach(function (k) { mathSet[k] = true; });
     Object.keys(derivedSet).forEach(function (k) { mathSet[k] = true; });
-    // name-resolvable: what a readout token may reference (math names + selectors).
+
+    // name-resolvable: what a readout token may reference (math + selectors + measures).
     var nameSet = {};
     Object.keys(mathSet).forEach(function (k) { nameSet[k] = true; });
     Object.keys(selectorSet).forEach(function (k) { nameSet[k] = true; });
+    Object.keys(measureSet).forEach(function (k) { nameSet[k] = true; });
 
     // controls
     if (spec.controls != null) {
@@ -506,6 +619,38 @@
           }
         }
 
+        if (el.type === 'circle') {
+          if (!Array.isArray(el.center) || el.center.length !== 2) {
+            errors.push('circle "' + el.id + '" needs center:[x,y]');
+          } else {
+            el.center.forEach(function (coord) {
+              if (typeof coord === 'string' && !mathSet[coord]) {
+                errors.push('circle "' + el.id + '" center references unknown name "' + coord + '"');
+              } else if (typeof coord !== 'string' && typeof coord !== 'number') {
+                errors.push('circle "' + el.id + '" center must be numbers or param names');
+              }
+            });
+          }
+          if (typeof el.radius === 'string') {
+            if (!mathSet[el.radius]) errors.push('circle "' + el.id + '" radius references unknown name "' + el.radius + '"');
+          } else if (!(typeof el.radius === 'number' && el.radius > 0)) {
+            errors.push('circle "' + el.id + '" needs a positive radius (number or param)');
+          }
+        }
+
+        if (el.type === 'polygon') {
+          if (!Array.isArray(el.vertices) || el.vertices.length < 3) {
+            errors.push('polygon "' + el.id + '" needs vertices:[idA, idB, idC, …] (3+)');
+          }
+        }
+
+        if (el.type === 'angle') {
+          if (typeof el.at !== 'string') errors.push('angle "' + el.id + '" needs at: <point id>');
+          if (!Array.isArray(el.rays) || el.rays.length !== 2) {
+            errors.push('angle "' + el.id + '" needs rays:[idA, idB]');
+          }
+        }
+
         if (el.type === 'readout') {
           readoutTokens(el.text).forEach(function (tok) {
             var parts = tok.split('.');
@@ -521,14 +666,43 @@
         }
       });
 
-      // line/segment/ray endpoints must reference real point ids — deferred
-      // until all ids are collected so order doesn't matter.
+      // Cross-element references (point/circle ids) — deferred until all ids are
+      // collected so element order doesn't matter.
+      var isPoint = function (ref) { return ids[ref] && ids[ref].type === 'point'; };
       spec.elements.forEach(function (el) {
         if ((el.type === 'line' || el.type === 'segment' || el.type === 'ray') && Array.isArray(el.through)) {
           el.through.forEach(function (ref) {
-            if (!ids[ref]) errors.push(el.type + ' "' + el.id + '" references unknown point "' + ref + '"');
+            if (!isPoint(ref)) errors.push(el.type + ' "' + el.id + '" references unknown point "' + ref + '"');
           });
         }
+        if (el.type === 'polygon' && Array.isArray(el.vertices)) {
+          el.vertices.forEach(function (ref) {
+            if (!isPoint(ref)) errors.push('polygon "' + el.id + '" references unknown point "' + ref + '"');
+          });
+        }
+        if (el.type === 'angle') {
+          if (el.at && !isPoint(el.at)) errors.push('angle "' + el.id + '" vertex "' + el.at + '" is not a point');
+          if (Array.isArray(el.rays)) el.rays.forEach(function (ref) {
+            if (!isPoint(ref)) errors.push('angle "' + el.id + '" ray "' + ref + '" is not a point');
+          });
+        }
+        // A point constrained on a circle: on:"circle:<id>".
+        if (el.type === 'point' && typeof el.on === 'string' && el.on.indexOf('circle:') === 0) {
+          var cid = el.on.slice('circle:'.length);
+          if (!ids[cid] || ids[cid].type !== 'circle') {
+            errors.push('point "' + el.id + '" on references unknown circle "' + cid + '"');
+          }
+        }
+      });
+
+      // measure point refs (deferred for the same reason).
+      Object.keys(measureSet).forEach(function (name) {
+        var def = spec.measures[name];
+        if (!isPlainObject(def)) return;
+        if (def.at && !isPoint(def.at)) errors.push('measure "' + name + '" vertex "' + def.at + '" is not a point');
+        if (Array.isArray(def.rays)) def.rays.forEach(function (ref) {
+          if (!isPoint(ref)) errors.push('measure "' + name + '" ray "' + ref + '" is not a point');
+        });
       });
     }
 
@@ -556,6 +730,7 @@
     validateModelSpec: validateModelSpec,
     getModel: getModel,
     readoutTokens: readoutTokens,
+    measureAngle: measureAngle,
     MODELS: Object.keys(CURATED)
   };
 });

--- a/public/js/conceptModelSpec.js
+++ b/public/js/conceptModelSpec.js
@@ -351,6 +351,37 @@
       reveal: ['plane', 'tri', 'A', 'B', 'C', 'angA', 'angB', 'angC', 'out'],
       drag: ['A', 'B', 'C'],
       prompt: 'Drag any corner. The three angles change — but watch the sum.'
+    },
+
+    // A straight line A—O—A′ with a ray O—B. The two adjacent angles (a linear
+    // pair) are measured live and always sum to 180°. Reuses the geometry
+    // vocabulary — no new primitives.
+    linear_pair_angles: {
+      model: 'linear_pair_angles',
+      title: 'Linear pair: angles on a line sum to 180°',
+      params: {},
+      controls: [],
+      measures: {
+        ang1: { type: 'angle', at: 'O', rays: ['A', 'B'] },
+        ang2: { type: 'angle', at: 'O', rays: ['A2', 'B'] }
+      },
+      derived: { sum: 'ang1 + ang2' },
+      elements: [
+        { id: 'plane', type: 'plane', x: [-7, 7], y: [-3, 7], grid: false, axisLabels: false },
+        { id: 'circ', type: 'circle', center: [0, 0], radius: 5, role: 'reference' },
+        { id: 'O', type: 'point', at: [0, 0], label: 'O' },
+        { id: 'A', type: 'point', at: [5, 0], label: 'A' },        // straight line A—O—A′
+        { id: 'A2', type: 'point', at: [-5, 0], label: 'A′' },
+        { id: 'B', type: 'point', at: [3, 4], on: 'circle:circ', draggable: true, label: 'B' },
+        { id: 'lineA', type: 'segment', through: ['A', 'A2'] },
+        { id: 'rayB', type: 'segment', through: ['O', 'B'] },
+        { id: 'ang1', type: 'angle', at: 'O', rays: ['A', 'B'], measure: true },
+        { id: 'ang2', type: 'angle', at: 'O', rays: ['A2', 'B'], measure: true },
+        { id: 'out', type: 'readout', text: '{ang1}° + {ang2}° = {sum}°', at: 'top' }
+      ],
+      reveal: ['plane', 'circ', 'O', 'A', 'A2', 'B', 'lineA', 'rayB', 'ang1', 'ang2', 'out'],
+      drag: ['B'],
+      prompt: 'Drag B along the arc. The two angles on the line always add to 180° — a linear pair.'
     }
   };
 

--- a/tests/unit/boardResponseSchema.test.js
+++ b/tests/unit/boardResponseSchema.test.js
@@ -271,10 +271,10 @@ describe('boardResponseSchema — buildStructuredResponseInstructions (Phase 4)'
   });
 
   test('documents each board action shape', () => {
-    // `diagram` and `model` are recognized end-to-end (verb + guard + client
-    // renderer) but intentionally NOT yet described to the model in the prompt —
-    // they're gated behind DIAGRAM_BOARD / CONCEPT_MODELS and the structured
-    // fields land alongside the prompt wiring in a follow-up. Exclude them here.
+    // `diagram` is recognized end-to-end but not yet described in any prompt.
+    // `model` IS taught to the tutor, but in its own flag-gated builder
+    // (utils/conceptModelPrompt.js), not in this structured block. Both are
+    // therefore absent from buildStructuredResponseInstructions() by design.
     const NOT_YET_PROMPTED = new Set(['diagram', 'model']);
     for (const action of BOARD_ACTIONS) {
       if (NOT_YET_PROMPTED.has(action)) continue;

--- a/tests/unit/conceptModelPrompt.test.js
+++ b/tests/unit/conceptModelPrompt.test.js
@@ -1,0 +1,58 @@
+const {
+  isConceptModelsEnabled,
+  buildConceptModelInstructions,
+  modelCatalogLines,
+} = require('../../utils/conceptModelPrompt');
+const { MODELS } = require('../../public/js/conceptModelSpec');
+
+describe('conceptModelPrompt — CONCEPT_MODELS flag', () => {
+  const original = process.env.CONCEPT_MODELS;
+  afterEach(() => {
+    if (original === undefined) delete process.env.CONCEPT_MODELS;
+    else process.env.CONCEPT_MODELS = original;
+  });
+
+  it('defaults OFF', () => {
+    delete process.env.CONCEPT_MODELS;
+    expect(isConceptModelsEnabled()).toBe(false);
+  });
+
+  it('reads the flag at call time ("true" / "1")', () => {
+    process.env.CONCEPT_MODELS = 'true';
+    expect(isConceptModelsEnabled()).toBe(true);
+    process.env.CONCEPT_MODELS = '1';
+    expect(isConceptModelsEnabled()).toBe(true);
+    process.env.CONCEPT_MODELS = 'false';
+    expect(isConceptModelsEnabled()).toBe(false);
+  });
+});
+
+describe('conceptModelPrompt — instruction text', () => {
+  it('lists every curated model from the single source of truth', () => {
+    const lines = modelCatalogLines();
+    MODELS.forEach((name) => {
+      expect(lines).toContain(name);
+    });
+  });
+
+  it('emits <BOARD> tag syntax in legacy mode', () => {
+    const text = buildConceptModelInstructions(false);
+    expect(text).toMatch(/<BOARD action="model"/);
+    expect(text).not.toMatch(/board_commands/);
+    expect(text).toContain('slope_intercept_line');
+  });
+
+  it('emits board_commands JSON syntax in structured mode', () => {
+    const text = buildConceptModelInstructions(true);
+    expect(text).toMatch(/board_commands/);
+    expect(text).toMatch(/action: "model"/);
+    expect(text).not.toMatch(/<BOARD/);
+  });
+
+  it('frames summoning with intent (a prompt) and the safety note', () => {
+    const text = buildConceptModelInstructions(false);
+    expect(text.toLowerCase()).toContain('intent');
+    expect(text).toMatch(/prompt/);
+    expect(text.toLowerCase()).toContain('never the student');
+  });
+});

--- a/tests/unit/conceptModelSpec.test.js
+++ b/tests/unit/conceptModelSpec.test.js
@@ -306,9 +306,19 @@ describe('conceptModelSpec — geometry (measure, never assert)', () => {
     expect(sum).toBeCloseTo(180, 4);
   });
 
-  it('both geometry models validate', () => {
+  it('a linear pair sums to 180°, by construction (at the catalog coords)', () => {
+    const s = getModel('linear_pair_angles');
+    const at = {};
+    s.elements.filter((e) => e.type === 'point').forEach((p) => { at[p.id] = p.at; });
+    const ang1 = measureAngle(at.O, at.A, at.B);
+    const ang2 = measureAngle(at.O, at.A2, at.B);
+    expect(ang1 + ang2).toBeCloseTo(180, 6);
+  });
+
+  it('the geometry models validate', () => {
     expect(validateModelSpec(getModel('inscribed_angle')).errors).toEqual([]);
     expect(validateModelSpec(getModel('triangle_angle_sum')).errors).toEqual([]);
+    expect(validateModelSpec(getModel('linear_pair_angles')).errors).toEqual([]);
   });
 
   function gbase() {

--- a/tests/unit/conceptModelSpec.test.js
+++ b/tests/unit/conceptModelSpec.test.js
@@ -3,6 +3,7 @@ const {
   validateModelSpec,
   getModel,
   readoutTokens,
+  measureAngle,
   MODELS,
 } = require('../../public/js/conceptModelSpec');
 
@@ -271,5 +272,101 @@ describe('conceptModelSpec — function_transformations vocabulary (selector / p
     const s = tbase();
     s.elements[2].text = 'f = {a.label}';
     expect(validateModelSpec(s).errors.join(' ')).toMatch(/needs a selector before the dot/);
+  });
+});
+
+describe('conceptModelSpec — geometry (measure, never assert)', () => {
+  it('measureAngle computes the non-reflex angle at a vertex', () => {
+    expect(measureAngle([0, 0], [1, 0], [0, 1])).toBeCloseTo(90, 6);
+    expect(measureAngle([0, 0], [1, 0], [-1, 0])).toBeCloseTo(180, 6);
+    expect(measureAngle([0, 0], [1, 0], [1, 1])).toBeCloseTo(45, 6);
+    expect(measureAngle([0, 0], [0, 0], [1, 1])).toBeNaN(); // degenerate ray
+  });
+
+  it('inscribed_angle is half the central angle, by construction (at the catalog coords)', () => {
+    const s = getModel('inscribed_angle');
+    const at = {};
+    s.elements.filter((e) => e.type === 'point').forEach((p) => { at[p.id] = p.at; });
+    const central = measureAngle(at.O, at.A, at.C);
+    const inscribed = measureAngle(at.B, at.A, at.C);
+    // Catalog coords are rounded to 4 dp, so allow ~0.01° slack on the absolutes;
+    // the half-angle relationship is the real invariant.
+    expect(central).toBeCloseTo(120, 2);
+    expect(inscribed).toBeCloseTo(60, 2);
+    expect(inscribed).toBeCloseTo(central / 2, 3);
+  });
+
+  it('triangle interior angles sum to 180°, by construction (at the catalog coords)', () => {
+    const s = getModel('triangle_angle_sum');
+    const at = {};
+    s.elements.filter((e) => e.type === 'point').forEach((p) => { at[p.id] = p.at; });
+    const sum = measureAngle(at.A, at.B, at.C) +
+                measureAngle(at.B, at.A, at.C) +
+                measureAngle(at.C, at.A, at.B);
+    expect(sum).toBeCloseTo(180, 4);
+  });
+
+  it('both geometry models validate', () => {
+    expect(validateModelSpec(getModel('inscribed_angle')).errors).toEqual([]);
+    expect(validateModelSpec(getModel('triangle_angle_sum')).errors).toEqual([]);
+  });
+
+  function gbase() {
+    return {
+      model: 'g',
+      params: {},
+      measures: { ang: { type: 'angle', at: 'B', rays: ['A', 'C'] } },
+      elements: [
+        { id: 'plane', type: 'plane', x: [-5, 5], y: [-5, 5] },
+        { id: 'A', type: 'point', at: [-2, 0], draggable: true },
+        { id: 'B', type: 'point', at: [0, 0], draggable: true },
+        { id: 'C', type: 'point', at: [2, 0], draggable: true },
+        { id: 'tri', type: 'polygon', vertices: ['A', 'B', 'C'] },
+        { id: 'angB', type: 'angle', at: 'B', rays: ['A', 'C'], measure: true },
+        { id: 'out', type: 'readout', text: 'angle = {ang}' },
+      ],
+    };
+  }
+
+  it('accepts a well-formed geometry spec', () => {
+    expect(validateModelSpec(gbase()).valid).toBe(true);
+  });
+
+  it('rejects a measure referencing a non-existent point', () => {
+    const s = gbase();
+    s.measures.ang.rays = ['A', 'Z'];
+    expect(validateModelSpec(s).errors.join(' ')).toMatch(/measure "ang" ray "Z" is not a point/);
+  });
+
+  it('rejects an angle whose vertex is not a point', () => {
+    const s = gbase();
+    s.elements.find((e) => e.id === 'angB').at = 'tri';
+    expect(validateModelSpec(s).errors.join(' ')).toMatch(/vertex "tri" is not a point/);
+  });
+
+  it('rejects a polygon with fewer than three vertices', () => {
+    const s = gbase();
+    s.elements.find((e) => e.id === 'tri').vertices = ['A', 'B'];
+    expect(validateModelSpec(s).errors.join(' ')).toMatch(/needs vertices/);
+  });
+
+  it('rejects a circle with a non-positive radius', () => {
+    const s = gbase();
+    s.elements.push({ id: 'c', type: 'circle', center: [0, 0], radius: 0 });
+    expect(validateModelSpec(s).errors.join(' ')).toMatch(/positive radius/);
+  });
+
+  it('rejects a point gliding on a non-existent circle', () => {
+    const s = gbase();
+    s.elements.find((e) => e.id === 'B').on = 'circle:ghost';
+    expect(validateModelSpec(s).errors.join(' ')).toMatch(/on references unknown circle "ghost"/);
+  });
+
+  it('lets a derived value read a measure (e.g. an angle sum)', () => {
+    const s = gbase();
+    s.measures.ang2 = { type: 'angle', at: 'A', rays: ['B', 'C'] };
+    s.derived = { total: 'ang + ang2' };
+    s.elements.find((e) => e.id === 'out').text = 'sum = {total}';
+    expect(validateModelSpec(s).valid).toBe(true);
   });
 });

--- a/utils/boardResponseSchema.js
+++ b/utils/boardResponseSchema.js
@@ -108,8 +108,16 @@ const BOARD_COMMAND_SCHEMA = {
       type: ['string', 'null'],
       description: 'Short caption rendered under a graph or image. Null for other actions.',
     },
+    model: {
+      type: ['string', 'null'],
+      description: 'Concept-model name for an interactive model card (e.g. "slope_intercept_line"). Required for the "model" action. Null otherwise.',
+    },
+    prompt: {
+      type: ['string', 'null'],
+      description: 'Short teaching intention shown above a concept model (e.g. "Slide m up — what happens?"). Optional on the "model" action; null for other actions.',
+    },
   },
-  required: ['action', 'tex', 'op', 'check', 'fn', 'query', 'caption'],
+  required: ['action', 'tex', 'op', 'check', 'fn', 'query', 'caption', 'model', 'prompt'],
   additionalProperties: false,
 };
 

--- a/utils/conceptModelPrompt.js
+++ b/utils/conceptModelPrompt.js
@@ -1,0 +1,85 @@
+// ============================================================
+// conceptModelPrompt.js — teach the tutor to SUMMON interactive
+// concept models onto the WorkBoard (CONCEPT_MODELS.md, "Summoned
+// with intent").
+//
+// The `model` board verb is already wired end-to-end — the tag
+// parser, the structured-schema normalize, the pedagogy guard, the
+// SSE serialization, and the client renderer all handle it. The one
+// missing piece is telling the LLM that the verb exists and when to
+// reach for it. This module builds that prompt section, gated behind
+// the CONCEPT_MODELS flag (default off, like DIAGRAM_BOARD) so
+// flag-off traffic sees byte-for-byte today's prompt.
+//
+// The catalog is derived from the single source of truth
+// (public/js/conceptModelSpec.js → MODELS) so a model added there
+// shows up here automatically; a per-model "summon when" blurb adds
+// the pedagogical framing the bare spec can't.
+// ============================================================
+
+'use strict';
+
+const ConceptModelSpec = require('../public/js/conceptModelSpec');
+
+/**
+ * Rollout flag. Default OFF. Read at call time (not module load) so a
+ * test can flip process.env.CONCEPT_MODELS without reloading modules.
+ */
+function isConceptModelsEnabled() {
+  const v = process.env.CONCEPT_MODELS;
+  return v === 'true' || v === '1';
+}
+
+// One-line "summon when" guidance per curated model. Keyed by model name; any
+// model without an entry falls back to its spec title, so the catalog never goes
+// stale silently.
+const SUMMON_WHEN = {
+  slope_intercept_line: 'teaching y = mx + b — slide m and b, drag the y-intercept',
+  two_point_line: 'slope as rise/run between two points — drag the two points',
+  function_transformations: 'transformations a·f(x−h)+k of any parent (x², |x|, x³, √x) — the whole transformations unit in one model',
+  inscribed_angle: 'the inscribed angle theorem — drag B, the inscribed angle stays half the central',
+  triangle_angle_sum: 'the triangle angle sum — drag a vertex, the three angles re-measure and always total 180°',
+  linear_pair_angles: 'a linear pair / supplementary angles on a line (the two angles total 180°)',
+};
+
+/** "  • name — blurb" lines for every curated model, from the catalog. */
+function modelCatalogLines() {
+  return ConceptModelSpec.MODELS.map(function (name) {
+    const spec = ConceptModelSpec.getModel(name);
+    const blurb = SUMMON_WHEN[name] || (spec && spec.title) || '';
+    return '  • ' + name + ' — ' + blurb;
+  }).join('\n');
+}
+
+/**
+ * Build the concept-model prompt section.
+ * @param {boolean} structured - true when STRUCTURED_TUTOR_RESPONSE is on, so the
+ *        emit syntax is a board_commands JSON object instead of a <BOARD/> tag.
+ * @returns {string} A stable prompt section (no per-request data, cache-safe).
+ */
+function buildConceptModelInstructions(structured) {
+  const emit = structured
+    ? 'Add it to board_commands as: { action: "model", model: "<name>", prompt: "Slide m up — what happens?" }'
+    : 'Emit it as a board command: <BOARD action="model" model="<name>" prompt="Slide m up — what happens?" />';
+
+  return `--- CONCEPT MODELS (interactive, manipulable models on the WorkBoard) ---
+You can summon an interactive model the student DRAGS to discover a relationship — correct by construction (the engine measures every value; you never assert one). Summon it WITH INTENT: include a short prompt that frames what to try.
+
+${emit}
+
+Available models — pick the one whose concept matches what you're teaching, and use the name verbatim:
+${modelCatalogLines()}
+
+When to summon:
+- Reach for it the moment it teaches the concept ("let's see this — drag the intercept and watch the line").
+- When the student asks to see or try it ("show me", "can I graph this?", "let me play with it") — honor it and add a light frame.
+
+Rules: use a model name from the list exactly; one model per turn is plenty; keep the prompt to one short sentence (the teaching intention). A concept model is a manipulable concept, never the student's graded answer — so it is always safe to show.`;
+}
+
+module.exports = {
+  isConceptModelsEnabled,
+  buildConceptModelInstructions,
+  modelCatalogLines,
+  SUMMON_WHEN,
+};

--- a/utils/pipeline/generate.js
+++ b/utils/pipeline/generate.js
@@ -26,6 +26,10 @@ const {
   isStructuredModeEnabled,
   buildStructuredResponseInstructions,
 } = require('../boardResponseSchema');
+const {
+  isConceptModelsEnabled,
+  buildConceptModelInstructions,
+} = require('../conceptModelPrompt');
 
 // Strip <BOARD …/> tags from a one-shot text chunk (deterministic /
 // replacement / narration paths). Streaming chunks use the stateful
@@ -354,6 +358,14 @@ function assemblePrompt(decision, promptContext) {
   // Flag off → this is a no-op and the prompt is byte-for-byte today's.
   if (isStructuredModeEnabled()) {
     fullSystemPrompt += '\n\n' + buildStructuredResponseInstructions();
+  }
+
+  // ── Concept models (CONCEPT_MODELS.md, "Summoned with intent") ──
+  // Teach the tutor that the interactive `model` board verb exists and when to
+  // summon it. Emits the right syntax for the active path (tag vs structured).
+  // Flag off → no-op, so the prompt is byte-for-byte today's.
+  if (isConceptModelsEnabled()) {
+    fullSystemPrompt += '\n\n' + buildConceptModelInstructions(isStructuredModeEnabled());
   }
 
   // Inject phase-specific prompt if available


### PR DESCRIPTION
## What this is

Two concept-model increments (CONCEPT_MODELS.md), three QA'd commits:

1. **Tier-2 geometry** — `inscribed_angle`, `triangle_angle_sum`
2. **`linear_pair_angles`** (reuses the geometry vocabulary, no new primitives)
3. **Summon with intent** (Build-order step 3) — teach the tutor to actually pull models onto the board, flag-gated

---

## Part 1+2 — Tier-2 geometry

Three interactive models proving the *"measure, never assert"* guarantee: the engine computes every angle from the live point positions, so a curated **or generated** geometry spec can't show a wrong angle.

**Engine additions (same validated-spec → render path):**
- New element types **`circle`**, **`polygon`**, **`angle`**; point constraint **`on:"circle:<id>"`** (glider); **`role:"reference"`** faint styling.
- **`measures`** — quantities read off the *live* geometry (the angle between three points), computed by a pure, unit-tested `measureAngle()`.
- **`derived` can now read measures**, so a model can display a measured *sum*.

| Model | What the student does | The invariant (measured live) |
|---|---|---|
| `inscribed_angle` | drag B around the arc | inscribed angle is constant **and** always half the central |
| `triangle_angle_sum` | drag any vertex | the three interior angles always total **180°** |
| `linear_pair_angles` | drag B along the arc | the two angles on the line always total **180°** |

**Also fixes a latent parser bug:** the expression compiler's left-associative loops shared a `var l = left` binding, so a **3+ term** expression's closures referenced themselves and recursed infinitely (surfaced by the triangle's `angA + angB + angC`). Combiners now capture `l`/`r` as parameters (`fAdd`/`fSub`/`fMul`/`fDiv`).

---

## Part 3 — Summon with intent (makes it reach students)

The `model` board verb was already wired end-to-end (tag parser, structured normalize, pedagogy guard, SSE, client renderer). The missing piece was **telling the LLM the verb exists and when to reach for it**. This adds that prompt section behind a new **`CONCEPT_MODELS`** flag (default off, like `DIAGRAM_BOARD`) — flag-off traffic sees byte-for-byte today's prompt.

- **`utils/conceptModelPrompt.js`** — `isConceptModelsEnabled()` + `buildConceptModelInstructions(structured)`. Derives the catalog from the single source of truth (`ConceptModelSpec.MODELS`) + a per-model "summon when" blurb, and emits the right syntax per path: `<BOARD action="model" …/>` for the legacy tag path, a `board_commands` JSON object for structured mode. Frames *summoned with intent* (a short teaching prompt) and the safety note (a manipulable concept, never the student's graded answer).
- **`generate.js` `assemblePrompt()`** — append the section when the flag is on (mirrors the structured-mode block).
- **`boardResponseSchema.js`** — add `model`/`prompt` to `BOARD_COMMAND_SCHEMA` (+`required`) so structured mode can carry them.
- **`.env.example`** — document `CONCEPT_MODELS`.

Both trigger paths from the doc now resolve to the same command — the tutor summons with intent, or the student asks. `mergeWithLlmCommands` preserves the model card; the visual gate leaves it untouched.

---

## Verification

- **+18 tests** across the spec/validator and the prompt module (`measureAngle`, all three geometry theorems "by construction", geometry validation, flag default/parse, legacy-vs-structured syntax, catalog coverage). **Full suite green (2916).** Lint: 0 errors.
- **Browser-verified** on `/concept-model-demo.html` (now six models) — geometry boards render and measure live (`inscribed=60° · central=120°`, triangle = 180°, `53.13° + 126.87° = 180°`), no console errors.
- **Prompt smoke test:** `CONCEPT_MODELS` off → no concept section (prompt unchanged); on → section present with all six models and the correct emit syntax.

## Rollout
Production stays unchanged until `CONCEPT_MODELS=true` on a deploy. With the flag on, the tutor can summon any of the six models onto the board with a framing prompt, and the student can ask for them.

https://claude.ai/code/session_01G5awZCfNt8pPgAeV9s6cw4

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5awZCfNt8pPgAeV9s6cw4)_