### PR TITLE
feat(workboard): mirror tutor derivations as read-only worked-example…

### DIFF
--- a/public/css/workspace.css
+++ b/public/css/workspace.css
@@ -530,6 +530,29 @@
   background: rgba(255, 184, 77, 0.10);
 }
 
+/* Worked example — a read-only step of a derivation the TUTOR is teaching, not
+   the student's own work. A calm instructional blue (distinct from the student's
+   purple work, the green SOLVED, and the amber scaffold) plus a "WORKED EXAMPLE"
+   eyebrow so it reads as "I'm showing you", never as a step the student stated.
+   No counter: these are a demonstration, not the student's numbered solve. */
+.cr-ws-board-card--worked {
+  border-color: rgba(74, 163, 223, 0.35);
+  background: linear-gradient(180deg,
+    rgba(74, 163, 223, 0.08) 0%,
+    var(--cr-bg-panel) 100%);
+}
+.cr-ws-board-card--worked::before {
+  content: "WORKED EXAMPLE";
+  position: absolute;
+  top: 8px;
+  left: 14px;
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.10em;
+  color: #4AA3DF;
+  opacity: 0.95;
+}
+
 /* Math display inside cards — KaTeX renders into here. */
 .cr-ws-board-card-math {
   padding-top: 14px;

--- a/public/js/boardCommandHandler.js
+++ b/public/js/boardCommandHandler.js
@@ -21,7 +21,7 @@
     'use strict';
 
     var STAGGER_MS = 250;
-    var STAGGER_ACTIONS = { apply: true, resolve: true, verify: true, graph: true, image: true, scaffold: true, model: true };
+    var STAGGER_ACTIONS = { apply: true, resolve: true, verify: true, graph: true, image: true, scaffold: true, model: true, example: true };
 
     function getWorkspace() {
         return typeof window !== 'undefined' ? window.MathWorkspace : null;
@@ -72,6 +72,11 @@
                     break;
                 case 'image':
                     if (command.query) W.boardImage(command.query, command.caption || '');
+                    break;
+                case 'example':
+                    // Read-only worked-example derivation step. caption is an
+                    // optional short label (e.g. "Trig substitution").
+                    if (command.tex) W.boardExample(command.tex, command.caption || '');
                     break;
                 case 'diagram':
                     // Deterministic JSXGraph geometry (DIAGRAM_BOARD, flag-off).

--- a/public/js/workspace.js
+++ b/public/js/workspace.js
@@ -281,6 +281,20 @@
       var sMath = el('div', 'cr-ws-board-card-math');
       card.appendChild(sMath);
       renderTex(sMath, widenScaffoldBlanks(step.tex));
+    } else if (step.type === 'worked') {
+      // Read-only worked-example step — one line of a derivation the tutor is
+      // teaching (NOT the student's own problem). A distinct accent + a
+      // "Worked example" eyebrow (CSS ::before) so it reads as "I'm showing
+      // you", never as the student's stated work. No interaction handlers.
+      card = el('div', 'cr-ws-board-card cr-ws-board-card--worked');
+      var wMath = el('div', 'cr-ws-board-card-math');
+      card.appendChild(wMath);
+      renderTex(wMath, step.tex);
+      if (step.label) {
+        var wCap = el('div', 'cr-ws-board-card-caption');
+        wCap.textContent = step.label;
+        card.appendChild(wCap);
+      }
     } else {
       // Equation card — pose / resolve / verify all share the same shape;
       // verify gets a badge + an expanded check line.
@@ -582,6 +596,24 @@
       openWorkspace();
       this.showTool('board');
       pushBoardStep({ type: 'scaffold', tex: tex });
+      return true;
+    },
+
+    /**
+     * Drop a read-only worked-example step into the board timeline. One line of
+     * a derivation the tutor is TEACHING (not the student's own problem); the
+     * board renders it with a "Worked example" eyebrow and no interaction.
+     * @param {string} tex     LaTeX of the derivation step
+     * @param {string} [label] optional short step label, e.g. "Trig substitution"
+     */
+    boardExample: function (tex, label) {
+      tex = (tex == null ? '' : String(tex)).trim();
+      if (!tex) return false;
+      openWorkspace();
+      this.showTool('board');
+      var step = { type: 'worked', tex: tex };
+      if (label) step.label = String(label).trim();
+      pushBoardStep(step);
       return true;
     },
 

--- a/tests/unit/boardGuardWorkedExample.test.js
+++ b/tests/unit/boardGuardWorkedExample.test.js
@@ -80,3 +80,80 @@ describe('boardCommandGuard — worked-example relaxation', () => {
     expect(allowed).toHaveLength(1);
   });
 });
+
+// Read-only `example` cards mirror a derivation the tutor is TEACHING. They have
+// no student-text fallback: admitted ONLY in worked-example mode, always
+// re-checked against the student's pinned problem/answer.
+describe('boardCommandGuard — example (worked-example derivation step)', () => {
+  const derivation = [
+    { action: 'example', tex: '\\int x^2\\,dx = \\tfrac{1}{3}x^3 + C' },
+    { action: 'example', tex: 'A = \\int_{-r}^{r} \\sqrt{r^2 - x^2}\\,dx' },
+  ];
+
+  it('DROPPED by default (not worked-example mode) — example never leaks into normal turns', () => {
+    const { allowed, dropped } = enforcePedagogyRule({
+      commands: derivation,
+      userMessage: 'why does the integral give area?',
+      lastBoardActionInConversation: null,
+    });
+    expect(allowed).toEqual([]);
+    expect(dropped.map(d => d.reason)).toEqual([
+      'example_outside_worked_example_mode', 'example_outside_worked_example_mode',
+    ]);
+  });
+
+  it('allowed in worked-example mode, in order', () => {
+    const { allowed, dropped } = enforcePedagogyRule({
+      commands: derivation,
+      userMessage: 'show me how a circle area is derived',
+      workedExample: true,
+      lastBoardActionInConversation: null,
+    });
+    expect(allowed).toHaveLength(2);
+    expect(allowed.map(c => c.tex)).toEqual(derivation.map(c => c.tex));
+    expect(dropped).toEqual([]);
+  });
+
+  it('drops a malformed example (missing tex) even in worked-example mode', () => {
+    const { allowed, dropped } = enforcePedagogyRule({
+      commands: [{ action: 'example' }],
+      userMessage: 'example',
+      workedExample: true,
+    });
+    expect(allowed).toEqual([]);
+    expect(dropped[0].reason).toBe('example_missing_tex');
+  });
+
+  it('BACKSTOP: an example that matches the student\'s pinned problem is blocked', () => {
+    const { allowed, dropped } = enforcePedagogyRule({
+      commands: [{ action: 'example', tex: '3x^2 + 4x - 7 = 0' }],
+      userMessage: 'walk me through it',
+      workedExample: true,
+      pinnedProblemTex: '3x^2 + 4x - 7 = 0',
+    });
+    expect(allowed).toEqual([]);
+    expect(dropped[0].reason).toBe('worked_example_reveals_active_problem');
+  });
+
+  it('BACKSTOP: an example that matches the student\'s pinned answer is blocked', () => {
+    const { allowed, dropped } = enforcePedagogyRule({
+      commands: [{ action: 'example', tex: 'x = 8' }],
+      userMessage: 'walk me through it',
+      workedExample: true,
+      pinnedAnswer: 'x = 8',
+    });
+    expect(allowed).toEqual([]);
+    expect(dropped[0].reason).toBe('worked_example_reveals_active_problem');
+  });
+
+  it('a parallel example (different numbers) survives the backstop', () => {
+    const { allowed } = enforcePedagogyRule({
+      commands: [{ action: 'example', tex: '2x + 7 = 15' }],
+      userMessage: 'show me a similar one',
+      workedExample: true,
+      pinnedProblemTex: '3x + 5 = 14',
+      pinnedAnswer: 'x = 3',
+    });
+    expect(allowed).toHaveLength(1);
+  });
+});

--- a/tests/unit/boardResponseSchema.test.js
+++ b/tests/unit/boardResponseSchema.test.js
@@ -290,7 +290,7 @@ describe('boardResponseSchema — schema shape (OpenAI strict mode)', () => {
 
   test('BOARD_ACTIONS lists the supported actions', () => {
     expect(BOARD_ACTIONS).toEqual([
-      'pose', 'apply', 'resolve', 'verify', 'clear', 'graph', 'image', 'scaffold', 'diagram', 'model',
+      'pose', 'apply', 'resolve', 'verify', 'clear', 'graph', 'image', 'scaffold', 'diagram', 'model', 'example',
     ]);
   });
 
@@ -326,7 +326,7 @@ describe('boardResponseSchema — schema shape (OpenAI strict mode)', () => {
     expect(BOARD_RESPONSE_SCHEMA.required).toContain('turn_type');
   });
 
-  test('TURN_TYPES has the eight expected values', () => {
+  test('TURN_TYPES has the nine expected values', () => {
     expect(TURN_TYPES).toEqual([
       'problem_introduction',
       'step_acknowledgment',
@@ -336,6 +336,7 @@ describe('boardResponseSchema — schema shape (OpenAI strict mode)', () => {
       'scaffold',
       'redirect',
       'small_talk',
+      'worked_example',
     ]);
   });
 

--- a/tests/unit/boardTagParser.test.js
+++ b/tests/unit/boardTagParser.test.js
@@ -185,6 +185,26 @@ describe('boardTagParser', () => {
     });
   });
 
+  describe('example (worked-example step)', () => {
+    it('extracts an example with tex', () => {
+      const input = '<BOARD action="example" tex="\\int x^2\\,dx = \\tfrac{1}{3}x^3 + C" />';
+      expect(parseBoardTags(input).boardCommands).toEqual([
+        { action: 'example', tex: '\\int x^2\\,dx = \\tfrac{1}{3}x^3 + C' },
+      ]);
+    });
+
+    it('keeps an optional caption as the step label', () => {
+      const input = '<BOARD action="example" tex="A = \\pi r^2" caption="Final result" />';
+      expect(parseBoardTags(input).boardCommands).toEqual([
+        { action: 'example', tex: 'A = \\pi r^2', caption: 'Final result' },
+      ]);
+    });
+
+    it('drops an example with no tex', () => {
+      expect(parseBoardTags('<BOARD action="example" />').boardCommands).toEqual([]);
+    });
+  });
+
   describe('hasBoardTags', () => {
     it('returns true when a tag is present', () => {
       expect(hasBoardTags('<BOARD action="pose" tex="x=1"/>')).toBe(true);

--- a/tests/unit/boardWorkedExampleAssembly.test.js
+++ b/tests/unit/boardWorkedExampleAssembly.test.js
@@ -1,0 +1,76 @@
+const {
+  synthesizeWorkedExampleSteps,
+  mergeWithLlmCommands,
+} = require('../../utils/pipeline/boardSynthesizer');
+const { enforcePedagogyRule } = require('../../utils/boardCommandGuard');
+
+// Exercises the worked-example mirror the way the pipeline assembles it
+// (utils/pipeline/index.js Stage 5c.0a0): extract derivation steps from the
+// tutor's reply → run them through the pedagogy guard in worked-example mode →
+// merge. No LLM mock; this is the deterministic backfill path that fixes the
+// reviewed screenshot (circle area derived via integration, board showed only a
+// stray image).
+describe('worked-example mirror — assembly (circle-derivation turn)', () => {
+  // The actual derivation Maya gave: multi-step, no pinned student problem.
+  const tutorResponse = [
+    "Awesome! Let's solve the integral to find the area of a semicircle:",
+    '\\[ A = \\int_{-r}^{r} \\sqrt{r^2 - x^2}\\,dx \\]',
+    'Using the substitution x = r sin(theta) this becomes:',
+    '\\[ A = r^2 \\int \\cos^2(\\theta)\\,d\\theta \\]',
+    'which evaluates to:',
+    '$$ A = \\frac{r^2}{2}\\cdot\\pi $$',
+    'Finally, doubling the semicircle:',
+    '$$ A = \\pi r^2 $$',
+  ].join('\n');
+
+  // Mirror of how index.js gates + guards the backfill on this turn:
+  //   no pinned problem → workedExampleBoard true (flag on), backstop is a no-op.
+  function assemble() {
+    const workedExampleBoard = true; // WORKED_EXAMPLE_BOARD on + noPinnedProblem
+    const llmBoardCommands = [];      // model emitted no example cards
+    const steps = synthesizeWorkedExampleSteps({ tutorResponse });
+    const { allowed } = enforcePedagogyRule({
+      commands: steps,
+      userMessage: 'yep, show me',
+      workedExample: workedExampleBoard,
+      pinnedProblemTex: null,
+      pinnedAnswer: null,
+    });
+    return mergeWithLlmCommands(llmBoardCommands, allowed).all;
+  }
+
+  it('mirrors the derivation as ordered, read-only example cards', () => {
+    const board = assemble();
+    expect(board.length).toBe(4);
+    expect(board.every(c => c.action === 'example')).toBe(true);
+    // Order preserved — a derivation read top to bottom.
+    expect(board[0].tex).toContain('\\int_{-r}^{r}');
+    expect(board[board.length - 1].tex).toBe('A = \\pi r^2');
+  });
+
+  it('emits NO stray image — the board carries the actual math, not clip-art', () => {
+    const board = assemble();
+    expect(board.some(c => c.action === 'image')).toBe(false);
+  });
+
+  it('merge keeps a leading pose before the example steps, examples in order', () => {
+    const steps = synthesizeWorkedExampleSteps({ tutorResponse });
+    const guarded = enforcePedagogyRule({
+      commands: steps, userMessage: 'go', workedExample: true,
+    }).allowed;
+    // A parallel-problem pose the model emitted alongside the derivation.
+    const llm = [{ action: 'pose', tex: 'find the area of a circle' }];
+    const all = mergeWithLlmCommands(llm, guarded).all;
+    expect(all[0].action).toBe('pose');
+    expect(all.slice(1).every(c => c.action === 'example')).toBe(true);
+    expect(all[all.length - 1].tex).toBe('A = \\pi r^2');
+  });
+
+  it('with the flag OFF (workedExample:false) nothing is admitted — default unchanged', () => {
+    const steps = synthesizeWorkedExampleSteps({ tutorResponse });
+    const { allowed } = enforcePedagogyRule({
+      commands: steps, userMessage: 'yep, show me', workedExample: false,
+    });
+    expect(allowed).toEqual([]);
+  });
+});

--- a/tests/unit/boardWorkedExampleSteps.test.js
+++ b/tests/unit/boardWorkedExampleSteps.test.js
@@ -1,0 +1,53 @@
+const { synthesizeWorkedExampleSteps } = require('../../utils/pipeline/boardSynthesizer');
+
+// The hybrid backfill: when a teaching turn carries a multi-step derivation but
+// the model emitted no `example` cards, mirror the tutor's own math spans onto
+// the board. Conservative — ground truth only, and nothing on prose / a lone
+// equation (a half-board is worse than none).
+describe('synthesizeWorkedExampleSteps — derivation extraction', () => {
+  it('extracts ordered steps from display math ($$ and \\[ \\])', () => {
+    const tutor = [
+      'Awesome! First we set up the integral:',
+      '$$ A = \\int_{-r}^{r} \\sqrt{r^2 - x^2}\\,dx $$',
+      'Using a trig substitution this becomes:',
+      '\\[ A = r^2 \\int \\cos^2(\\theta)\\,d\\theta \\]',
+      'and finally:',
+      '$$ A = \\pi r^2 $$',
+    ].join('\n');
+
+    const steps = synthesizeWorkedExampleSteps({ tutorResponse: tutor });
+    expect(steps.map(s => s.action)).toEqual(['example', 'example', 'example']);
+    expect(steps[0].tex).toContain('\\int_{-r}^{r}');
+    expect(steps[2].tex).toBe('A = \\pi r^2');
+  });
+
+  it('returns [] on prose with no math', () => {
+    const tutor = 'Great question! Integrals add up infinitely many thin rectangles. '
+      + 'As they get thinner, the sum approaches the exact area under the curve.';
+    expect(synthesizeWorkedExampleSteps({ tutorResponse: tutor })).toEqual([]);
+  });
+
+  it('returns [] on a single equation (not a derivation)', () => {
+    const tutor = 'The integral of x squared is $$ \\int x^2\\,dx = \\tfrac{1}{3}x^3 + C $$.';
+    expect(synthesizeWorkedExampleSteps({ tutorResponse: tutor })).toEqual([]);
+  });
+
+  it('skips inline non-math spans (a lone variable) — no false steps', () => {
+    const tutor = 'Here \\(x\\) is the input and \\(y\\) is the output, '
+      + 'so \\(f\\) is a function.';
+    expect(synthesizeWorkedExampleSteps({ tutorResponse: tutor })).toEqual([]);
+  });
+
+  it('dedupes exact repeats', () => {
+    const tutor = '$$ 2x = 16 $$ ... restating ... $$ 2x = 16 $$ then $$ x = 8 $$';
+    const steps = synthesizeWorkedExampleSteps({ tutorResponse: tutor });
+    expect(steps).toHaveLength(2);
+    expect(steps.map(s => s.tex)).toEqual(['2x = 16', 'x = 8']);
+  });
+
+  it('safe on empty / non-string input', () => {
+    expect(synthesizeWorkedExampleSteps({ tutorResponse: '' })).toEqual([]);
+    expect(synthesizeWorkedExampleSteps({})).toEqual([]);
+    expect(synthesizeWorkedExampleSteps({ tutorResponse: null })).toEqual([]);
+  });
+});

--- a/utils/boardCommandGuard.js
+++ b/utils/boardCommandGuard.js
@@ -317,6 +317,27 @@ function evaluate(command, ctx) {
         return { allowed: false, reason: 'verify_tex_not_in_student_message' };
     }
 
+    // Worked-example derivation step (read-only). Unlike apply/resolve/verify,
+    // an `example` card has NO student-mirror fallback: it carries the tutor's
+    // own derivation, so it is admitted ONLY in teaching mode (ctx.workedExample,
+    // established by runPipeline from an I-do decision + WORKED_EXAMPLE_BOARD).
+    // Outside teaching mode it is always dropped — the strict default is
+    // unchanged. Even in teaching mode, the pinned-problem backstop stands: a
+    // step that names the student's graded problem or its answer is the model
+    // solving the homework under cover of "example", and is blocked.
+    if (action === 'example') {
+        if (!command.tex) {
+            return { allowed: false, reason: 'example_missing_tex' };
+        }
+        if (!ctx.workedExample) {
+            return { allowed: false, reason: 'example_outside_worked_example_mode' };
+        }
+        if (revealsPinnedProblem(command.tex, ctx)) {
+            return { allowed: false, reason: 'worked_example_reveals_active_problem' };
+        }
+        return { allowed: true, reason: 'worked_example_step' };
+    }
+
     if (action === 'clear') {
         if (hasStartOverIntent(ctx.currentText)) {
             return { allowed: true };

--- a/utils/boardResponseSchema.js
+++ b/utils/boardResponseSchema.js
@@ -51,7 +51,14 @@
 // exercised end-to-end, but the strict structured-output JSON fields aren't
 // added to the schema yet — the model isn't told to emit it. Flag-off, inert in
 // production until enabled (see CONCEPT_MODELS.md, Build order).
-const BOARD_ACTIONS = ['pose', 'apply', 'resolve', 'verify', 'clear', 'graph', 'image', 'scaffold', 'diagram', 'model'];
+// 'example' is a READ-ONLY worked-example step — one card per step of a
+// derivation the tutor is teaching (NOT the student's graded problem). Unlike
+// pose/resolve/verify (which mirror the STUDENT's stated work and are guarded
+// to the student's text), example cards carry the tutor's own derivation and
+// are only admitted in teaching mode (WORKED_EXAMPLE_BOARD + an "I-do" decision
+// action), still re-checked against the student's pinned problem/answer so a
+// "worked example" can never become a cover for solving the graded problem.
+const BOARD_ACTIONS = ['pose', 'apply', 'resolve', 'verify', 'clear', 'graph', 'image', 'scaffold', 'diagram', 'model', 'example'];
 
 // The kind of turn Maya is serving. The model self-declares this
 // on every structured response. Server-side audit (utils/turnTypeAudit.js)
@@ -74,6 +81,7 @@ const TURN_TYPES = [
   'scaffold',              // tutor lowers difficulty, hints, or breaks into sub-question
   'redirect',              // off-topic redirect back to math
   'small_talk',            // greeting, closing, off-task chitchat
+  'worked_example',        // tutor demonstrates/derives on a teaching example — example cards expected
 ];
 
 const BOARD_COMMAND_SCHEMA = {
@@ -86,7 +94,7 @@ const BOARD_COMMAND_SCHEMA = {
     },
     tex: {
       type: ['string', 'null'],
-      description: 'LaTeX expression. Required for pose, resolve, verify, and scaffold. For scaffold it MUST contain at least one empty slot the student fills, written as \\boxed{} (e.g. "x^2 + 4x + \\boxed{} = 12 + \\boxed{}"). Null for apply, clear, graph, image.',
+      description: 'LaTeX expression. Required for pose, resolve, verify, scaffold, and example. For scaffold it MUST contain at least one empty slot the student fills, written as \\boxed{} (e.g. "x^2 + 4x + \\boxed{} = 12 + \\boxed{}"). For example it is one step of the tutor\'s derivation. Null for apply, clear, graph, image.',
     },
     op: {
       type: ['string', 'null'],
@@ -106,7 +114,7 @@ const BOARD_COMMAND_SCHEMA = {
     },
     caption: {
       type: ['string', 'null'],
-      description: 'Short caption rendered under a graph or image. Null for other actions.',
+      description: 'Short caption rendered under a graph or image. For an example card it is an OPTIONAL short label for the step (e.g. "Trig substitution"). Null for other actions.',
     },
   },
   required: ['action', 'tex', 'op', 'check', 'fn', 'query', 'caption'],
@@ -119,7 +127,7 @@ const BOARD_RESPONSE_SCHEMA = {
     turn_type: {
       type: 'string',
       enum: TURN_TYPES,
-      description: 'What kind of turn this is. "problem_introduction" when you put a new problem in front of the student (board_commands MUST include a pose). "step_acknowledgment" when responding to a step they took in an open problem. "verification" when they stated a final answer (board_commands SHOULD include verify). "concept_reference" when they asked about a concept and you are showing reference content (board_commands MAY include image). "feedback" for praise or correction without advancing. "scaffold" when lowering difficulty / hinting. "redirect" when steering back to math. "small_talk" for greetings, closings, off-task chitchat.',
+      description: 'What kind of turn this is. "problem_introduction" when you put a new problem in front of the student (board_commands MUST include a pose). "step_acknowledgment" when responding to a step they took in an open problem. "verification" when they stated a final answer (board_commands SHOULD include verify). "concept_reference" when they asked about a concept and you are showing reference content (board_commands MAY include image). "feedback" for praise or correction without advancing. "scaffold" when lowering difficulty / hinting. "worked_example" when you DEMONSTRATE or DERIVE on a teaching example that is NOT the student\'s graded problem (board_commands SHOULD include example cards, one per step). "redirect" when steering back to math. "small_talk" for greetings, closings, off-task chitchat.',
     },
     chat_message: {
       type: 'string',
@@ -253,6 +261,7 @@ Your reply is a structured object, not free text. You fill three fields:
   • concept_reference — the student asked about a concept and you're showing reference content. board_commands SHOULD include an image or graph card.
   • feedback — praise or correction that does NOT advance the work. board_commands SHOULD be empty (an image/graph reference aid is fine; a pose/apply/resolve/verify here usually means you mislabeled the turn).
   • scaffold — you lowered difficulty, hinted, or broke the problem into a sub-question. Pair it with a scaffold card when a visual hint helps (see below); never an apply/resolve/verify that does the step for them.
+  • worked_example — you are DEMONSTRATING or DERIVING on a teaching example (a parallel problem with DIFFERENT numbers, or a general concept derivation) — NOT the student's graded problem. board_commands SHOULD mirror your derivation as ordered example cards, one per step. This is the one place you may write the full worked steps on the board, BECAUSE the work is yours on a teaching example, not the student's graded problem — never put the student's own problem or its answer in an example card.
   • redirect — steering an off-topic student back to math. Usually no cards.
   • small_talk — greeting, closing, or off-task chitchat. board_commands empty.
 
@@ -265,6 +274,7 @@ CARD SHAPE (fields not used for an action are null):
 - graph:   { action: "graph", fn: "x^2 - 4", caption: "Where it crosses zero" } — reference plot in the board timeline.
 - image:   { action: "image", query: "unit circle labeled", caption: "Reference" } — reference diagram from the safe whitelist.
 - scaffold:{ action: "scaffold", tex: "x^2 + 4x + \\boxed{} = 12 + \\boxed{}" } — show the NEXT step's structure on the student's own problem with the new terms left as empty \\boxed{} slots for THEM to fill. This is the one card you may put on the student's own problem without them stating it first, BECAUSE the blanks reveal nothing — they're a hint, not the answer. Every scaffold MUST contain at least one \\boxed{} blank; never fill the boxes in yourself (that would be handing over the answer). Use it when a student is stuck and a partially-drawn step would unstick them.
+- example: { action: "example", tex: "\\int x^2\\,dx = \\tfrac{1}{3}x^3 + C", caption: "Power rule" } — ONE step of a derivation YOU are teaching (worked_example turns only). Emit them in order, one card per step; caption is an optional short label. These carry your full worked steps, which is allowed ONLY because the work is yours on a teaching example — never put the student's graded problem or its answer in an example card.
 
 If the student references the board ("show me on the board", "draw it", "use the board"), you MUST include a relevant card (pose for an equation, graph for a function, image for a geometry concept). An empty board while a problem is on screen is the worst-case defect.`;
 }

--- a/utils/boardTagParser.js
+++ b/utils/boardTagParser.js
@@ -25,7 +25,7 @@
 
 'use strict';
 
-const VALID_ACTIONS = new Set(['pose', 'apply', 'resolve', 'verify', 'clear', 'graph', 'image', 'scaffold', 'model']);
+const VALID_ACTIONS = new Set(['pose', 'apply', 'resolve', 'verify', 'clear', 'graph', 'image', 'scaffold', 'model', 'example']);
 
 // Matches a single <BOARD …/> or <BOARD …>…</BOARD> tag. The `g` flag
 // lets us iterate multiple occurrences in one response. The inner
@@ -82,10 +82,14 @@ function parseBoardTags(aiResponseText) {
         const innerTrim = innerBody ? innerBody.trim() : '';
 
         const command = { action };
-        if (action === 'pose' || action === 'resolve' || action === 'verify' || action === 'scaffold') {
+        if (action === 'pose' || action === 'resolve' || action === 'verify' || action === 'scaffold' || action === 'example') {
             const tex = texAttr || innerTrim || null;
             if (!tex) continue; // require tex for these actions
             command.tex = tex;
+        }
+        if (action === 'example' && captionAttr) {
+            // Optional short step label, e.g. caption="Trig substitution".
+            command.caption = captionAttr;
         }
         if (action === 'apply') {
             const op = opAttr || innerTrim || null;

--- a/utils/pipeline/boardSynthesizer.js
+++ b/utils/pipeline/boardSynthesizer.js
@@ -669,7 +669,10 @@ function mergeWithLlmCommands(llmCommands, synthesized) {
   // Order by canonical sequence — the frontend renders in array
   // order, so pose-first / verify-last produces the cleanest
   // animation when both LLM and synthesizer fire in the same turn.
-  const ORDER = { clear: 0, pose: 1, scaffold: 2, apply: 3, resolve: 4, verify: 5, graph: 6, image: 7 };
+  // `example` cards (read-only derivation steps) sit right after scaffold and
+  // before the solve-cycle cards. Multiple examples share one rank; Array.sort
+  // is stable, so their emission order — the order of the derivation — is kept.
+  const ORDER = { clear: 0, pose: 1, scaffold: 2, example: 3, apply: 4, resolve: 5, verify: 6, graph: 7, image: 8 };
   const all = [...llm, ...added].sort((a, b) => {
     const ai = ORDER[a.action] ?? 99;
     const bi = ORDER[b.action] ?? 99;
@@ -848,12 +851,64 @@ function synthesizeFallbackImage({ tutorResponse, activeSkill } = {}) {
   return { action: 'image', query, caption: concept };
 }
 
+// ---------------------------------------------------------------------------
+// Worked-example step extraction (hybrid backfill)
+//
+// When the tutor DERIVES something (area of a circle via integration, deriving
+// the quadratic formula), the steps live as display-math in the chat bubble and
+// never reach the board. The structured path SHOULD emit `example` cards, but
+// compliance is unreliable — so when a teaching turn carries a multi-step
+// derivation and no example card survived, we mirror the tutor's own math spans
+// onto the board deterministically. This is the worked-example analogue of
+// synthesizeFallbackImage: ground truth is the tutor's literal LaTeX, so there
+// is no guessing about the math.
+// ---------------------------------------------------------------------------
+
+// Capture the inner LaTeX of a display- or inline-math span. Fenced display
+// forms ($$…$$, \[…\]) come first; \(…\) inline last. Bare single-$ is
+// deliberately NOT matched — it false-positives on currency ("$5 and $10").
+const MATH_SPAN_RE = /\$\$([\s\S]+?)\$\$|\\\[([\s\S]+?)\\\]|\\\(([\s\S]+?)\\\)/g;
+
+// A span is "math enough" to mirror only if it carries a relation or a
+// recognizable operator/function. A stray variable in prose (\(x\)) is skipped,
+// so inline references don't pollute the derivation.
+const MATH_SIGNAL_RE = /[=<>]|\\(?:int|frac|sqrt|sum|lim|cdot|times|div|pi|theta|sin|cos|tan|log|ln|infty)\b|\d\s*[+\-*/^]\s*\d/;
+
+/**
+ * Extract a tutor derivation's steps as ordered, read-only `example` cards.
+ * Conservative: returns [] unless at least two DISTINCT math steps are found —
+ * a lone equation isn't a derivation worth mirroring, and emitting a half-board
+ * is worse than emitting nothing (same bar as synthesizeFallbackImage).
+ *
+ * @param {object} params
+ * @param {string} params.tutorResponse - the tutor's visible reply (LaTeX intact)
+ * @returns {Array<{action:'example', tex:string}>}
+ */
+function synthesizeWorkedExampleSteps({ tutorResponse } = {}) {
+  if (!tutorResponse || typeof tutorResponse !== 'string') return [];
+  const steps = [];
+  const seen = new Set();
+  const re = new RegExp(MATH_SPAN_RE.source, MATH_SPAN_RE.flags);
+  let m;
+  while ((m = re.exec(tutorResponse)) !== null) {
+    const raw = (m[1] || m[2] || m[3] || '').replace(/\s+/g, ' ').trim();
+    if (!raw || raw.length > 240) continue;     // empty or runaway capture
+    if (!MATH_SIGNAL_RE.test(raw)) continue;     // prose / lone symbol — skip
+    const key = raw.replace(/\s+/g, '');
+    if (seen.has(key)) continue;                 // drop exact repeats
+    seen.add(key);
+    steps.push({ action: 'example', tex: raw });
+  }
+  return steps.length >= 2 ? steps : [];
+}
+
 module.exports = {
   synthesizeBoardCommands,
   mergeWithLlmCommands,
   dropRedundantPoses,
   synthesizeFallbackPose,
   synthesizeFallbackImage,
+  synthesizeWorkedExampleSteps,
   detectBoardReference,
   // Exposed for tests
   _detectVisualPromise: detectVisualPromise,

--- a/utils/pipeline/index.js
+++ b/utils/pipeline/index.js
@@ -45,7 +45,7 @@ const { parseBoardTags } = require('../boardTagParser');
 const { enforcePedagogyRule } = require('../boardCommandGuard');
 const { parseXpTags } = require('../xpTagParser');
 const { parseVisualTabTags } = require('../visualTabTagParser');
-const { synthesizeBoardCommands, mergeWithLlmCommands, dropRedundantPoses, synthesizeFallbackPose, synthesizeFallbackImage, detectBoardReference } = require('./boardSynthesizer');
+const { synthesizeBoardCommands, mergeWithLlmCommands, dropRedundantPoses, synthesizeFallbackPose, synthesizeFallbackImage, synthesizeWorkedExampleSteps, detectBoardReference } = require('./boardSynthesizer');
 const { applyVisualGate } = require('../visualGate');
 const { buildDecisionDoc, persistVisualDecisions } = require('../visualDecisionLog');
 const { auditTurn } = require('../turnTypeAudit');
@@ -53,6 +53,23 @@ const structuredMetrics = require('../structuredTutorMetrics');
 const log = require('../logger');
 const boardLogger = log.child({ service: 'board-tag-protocol' });
 const turnTypeLogger = log.child({ service: 'turn-type-audit' });
+
+// The "I-do" decision actions — the tutor is directly teaching/demonstrating on
+// a teaching example, not the student's graded problem. These are the moves
+// where worked-example steps belong on the board (see workedExampleBoard).
+// Deliberately excludes the "we-do"/"you-do" practice moves (guided_practice,
+// independent_practice) and strengthen_challenge, where the student works and
+// the strict student-mirror rule must stand.
+const TEACHING_ACTIONS = new Set([
+  ACTIONS.WORKED_EXAMPLE,
+  ACTIONS.DIRECT_INSTRUCTION,
+  ACTIONS.PREREQUISITE_BRIDGE,
+  ACTIONS.LEVERAGE_BRIDGE,
+]);
+
+function isTeachingMove(decision) {
+  return !!decision && TEACHING_ACTIONS.has(decision.action);
+}
 
 /**
  * Run the full tutoring pipeline.
@@ -426,15 +443,24 @@ async function runPipeline(message, ctx) {
     }
   }
 
-  // I_DO worked-example board: when the engine's move is WORKED_EXAMPLE, the
-  // tutor is demonstrating on a teaching example that is NOT the student's
-  // graded problem, so the board may carry the full worked steps — the same
-  // basis on which worked steps on PARALLEL problems are allowed under the #1
-  // rule. Gated behind a default-off flag pending live verification: a phase/
-  // move mislabel must never silently relax the guard, so it requires BOTH the
-  // explicit flag AND an explicit WORKED_EXAMPLE decision. Off → fully strict.
+  // Worked-example board: when the tutor is TEACHING — demonstrating or deriving
+  // on a teaching example that is NOT the student's graded problem — the board
+  // may carry the full worked steps, the same basis on which worked steps on
+  // PARALLEL problems are allowed under the #1 rule. This relaxes apply/resolve/
+  // verify off the student-text match AND admits read-only `example` cards.
+  //
+  // Triggers on any "I-do" decision action (worked_example, direct_instruction,
+  // prerequisite_bridge, leverage_bridge) OR when there is no pinned problem at
+  // all — a free conceptual derivation ("why does the integral give area?") has
+  // no graded answer to protect, so mirroring its steps can't leak anything.
+  // Gated behind a default-off flag: a phase/move mislabel must never silently
+  // relax the guard, so it requires BOTH the explicit flag AND a teaching
+  // context. Off → fully strict (byte-identical to today). In every case the
+  // pinnedProblem/pinnedAnswer backstop below still blocks a "worked example"
+  // that is secretly the student's own problem.
+  const noPinnedProblem = !(ctx.conversation?.boardProblem?.tex);
   const workedExampleBoard = process.env.WORKED_EXAMPLE_BOARD === 'true'
-    && decision?.action === ACTIONS.WORKED_EXAMPLE;
+    && (isTeachingMove(decision) || noPinnedProblem);
 
   if (rawLlmBoardCommands.length > 0) {
     const guardResult = enforcePedagogyRule({
@@ -574,6 +600,37 @@ async function runPipeline(message, ctx) {
       actions: merged.added.map(c => c.action),
       llmEmitted: llmBoardCommands.length,
     });
+  }
+
+  // ── Stage 5c.0a0: WORKED-EXAMPLE STEP BACKFILL (hybrid) ──
+  // The structured path SHOULD emit `example` cards when the tutor derives
+  // something, but compliance is unreliable (the same reason pose/verify get
+  // synthesized). When this is a teaching turn (workedExampleBoard) and the
+  // tutor's reply carries a multi-step derivation yet no example card survived,
+  // mirror the tutor's own math spans onto the board. The LLM wins when it did
+  // emit examples — we only backfill the gap. Routed through the same guard, so
+  // the pinned-problem backstop applies to every backfilled step too.
+  if (workedExampleBoard
+      && !verified.boardCommands.some(c => c.action === 'example')) {
+    const workedSteps = synthesizeWorkedExampleSteps({ tutorResponse: verified.text });
+    if (workedSteps.length > 0) {
+      const workedGuard = enforcePedagogyRule({
+        commands: workedSteps,
+        userMessage: message,
+        recentUserMessages: recentUserMessagesForBoard,
+        lastBoardActionInConversation: ctx.conversation?.lastBoardAction || null,
+        workedExample: workedExampleBoard,
+        pinnedProblemTex: ctx.conversation?.boardProblem?.tex || null,
+        pinnedAnswer: diagnosis.correctAnswer || null,
+      });
+      if (workedGuard.allowed.length > 0) {
+        verified.boardCommands = mergeWithLlmCommands(verified.boardCommands, workedGuard.allowed).all;
+        boardLogger.info('Worked-example step backfill added cards', {
+          count: workedGuard.allowed.length,
+          dropped: workedGuard.dropped.length,
+        });
+      }
+    }
   }
 
   // ── Stage 5c.0a: VISUAL-PROMISE BACKFILL ──
@@ -809,8 +866,14 @@ async function runPipeline(message, ctx) {
     }
   }
 
-  if (verified.boardCommands.length > 0 && ctx.conversation) {
-    const lastEmitted = verified.boardCommands[verified.boardCommands.length - 1].action;
+  // Read-only `example` cards are teaching aids, not moves in the student's
+  // solve cycle — they must not advance lastBoardAction (which gates clear-after-
+  // verify and the synthesizer's cycle-closed logic) or touch the pin. Track
+  // state on the solve-cycle cards only; a turn that emitted ONLY example cards
+  // leaves conversation state exactly as it was.
+  const cycleCards = verified.boardCommands.filter(c => c.action !== 'example');
+  if (cycleCards.length > 0 && ctx.conversation) {
+    const lastEmitted = cycleCards[cycleCards.length - 1].action;
     ctx.conversation.lastBoardAction = lastEmitted;
 
     // Pin / unpin the canonical board problem so future turns anchor to
@@ -818,7 +881,7 @@ async function runPipeline(message, ctx) {
     // stale problem on the board). A pose — including an auto-advance
     // clear+pose or a turn-type backfill — sets the pin; a verify/clear
     // that ends the cycle drops it.
-    const poseCard = [...verified.boardCommands].reverse().find(c => c.action === 'pose');
+    const poseCard = [...cycleCards].reverse().find(c => c.action === 'pose');
     if (poseCard && poseCard.tex) {
       ctx.conversation.boardProblem = { tex: poseCard.tex, posedAt: new Date() };
       ctx.conversation.markModified?.('boardProblem');


### PR DESCRIPTION
… cards

When the tutor TEACHES a multi-step derivation (e.g. deriving a circle's area via integration), the steps lived only in the chat bubble — the board showed nothing, or a stray safe-search image. Add a read-only `example` board card so a teaching derivation mirrors onto the Work Board, visually distinct from the student's own solving cards.

- schema/parser: new `example` action + `worked_example` turn_type; the existing nullable `caption` doubles as an optional step label.
- guard: `example` is admitted ONLY in teaching mode and is always re-checked against the student's pinned problem/answer (revealsPinnedProblem), so a "worked example" can never become cover for solving the graded problem.
- pipeline: broaden the WORKED_EXAMPLE_BOARD relaxation from the lone worked_example action to all "I-do" teaching moves (direct_instruction, prerequisite/leverage bridges) plus the no-pinned-problem conceptual case (nothing to leak). Hybrid step source: LLM-emitted example cards win; a conservative deterministic extractor (synthesizeWorkedExampleSteps,
  >=2 distinct math spans) backfills when the model narrates a derivation
  but emits none. Example cards are excluded from solve-cycle state (lastBoardAction / pin) and bypass the graph/image visual gate.
- frontend: `boardExample` -> `worked` step -> `.cr-ws-board-card--worked` with a "WORKED EXAMPLE" eyebrow in an instructional blue.

Still behind WORKED_EXAMPLE_BOARD (default off) -> byte-identical when unset. Out of scope: the generic-image backfill that produced the function box.

Tests: extractor, guard (incl. pinned-problem backstop), tag parser, schema, and an end-to-end assembly test simulating the circle-derivation turn. Full unit suite green (2768).