### PR TITLE
i18n: translate chat.shareCodeSteps into all supported locales

### DIFF
--- a/public/js/i18n-translations.js
+++ b/public/js/i18n-translations.js
@@ -400,9 +400,18 @@ window.I18N_TRANSLATIONS = {
     German: 'Teilen Sie diesen Code mit einem Elternteil oder Lehrer.'
   },
   'chat.shareCodeSteps': {
-    // English-only; i18n.js falls back to English for languages not listed.
-    // TODO(i18n): translate + match each locale's "Link to Existing Student" button label.
-    English: 'To follow your progress, your parent creates a free account at mathmatix.ai, opens the Parent Dashboard, chooses "Link to Existing Student," and enters this code.'
+    // The Parent Dashboard UI (parent-dashboard.html) is English-only, so the
+    // "Link to Existing Student" button label is intentionally left in English
+    // in every locale to match exactly what the parent sees and clicks.
+    English: 'To follow your progress, your parent creates a free account at mathmatix.ai, opens the Parent Dashboard, chooses "Link to Existing Student," and enters this code.',
+    Spanish: 'Para seguir tu progreso, tu padre o madre crea una cuenta gratuita en mathmatix.ai, abre el Panel para Padres, elige "Link to Existing Student" y escribe este código.',
+    Russian: 'Чтобы следить за твоими успехами, твой родитель создаёт бесплатный аккаунт на mathmatix.ai, открывает родительскую панель, выбирает «Link to Existing Student» и вводит этот код.',
+    Chinese: '为了跟踪你的学习进度，你的家长在 mathmatix.ai 上创建一个免费账户，打开家长面板，选择"Link to Existing Student"，然后输入此代码。',
+    Vietnamese: 'Để theo dõi tiến độ của bạn, phụ huynh của bạn tạo một tài khoản miễn phí tại mathmatix.ai, mở Bảng điều khiển Phụ huynh, chọn "Link to Existing Student" và nhập mã này.',
+    Arabic: 'لمتابعة تقدّمك، يُنشئ أحد والديك حساباً مجانياً على mathmatix.ai، ويفتح لوحة تحكم الوالدين، ويختار "Link to Existing Student"، ثم يُدخل هذا الرمز.',
+    Somali: 'Si loola socdo horumarkaaga, waalidkaaga wuxuu ka abuuraa akoon bilaash ah mathmatix.ai, wuxuu furaa Dashboard-ka Waalidka, wuxuu doortaa "Link to Existing Student," kadibna wuxuu galiyaa koodhkan.',
+    French: 'Pour suivre tes progrès, ton parent crée un compte gratuit sur mathmatix.ai, ouvre le tableau de bord parental, choisit « Link to Existing Student » et saisit ce code.',
+    German: 'Um deinen Fortschritt zu verfolgen, erstellt dein Elternteil ein kostenloses Konto auf mathmatix.ai, öffnet das Eltern-Dashboard, wählt „Link to Existing Student" und gibt diesen Code ein.'
   },
   'chat.stop': {
     English: 'Stop', Spanish: 'Detener', Russian: 'Стоп', Chinese: '停止',


### PR DESCRIPTION
## Summary

Resolves the `TODO(i18n)` in `public/js/i18n-translations.js:404` for the `chat.shareCodeSteps` string.

Previously this key only had an `English` value, so `i18n.js` fell back to English for all other languages. It now includes translations for all 8 supported non-English locales: Spanish, Russian, Chinese, Vietnamese, Arabic, Somali, French, and German.

## Note on the button label

The TODO asked to "match each locale's 'Link to Existing Student' button label." The Parent Dashboard UI (`public/parent-dashboard.html`) is English-only — that button literally renders as `Link to Existing Student` regardless of the student's chat language. So the quoted label is intentionally kept in English in every translation to match exactly what the parent sees and clicks. The surrounding instruction text is fully translated. A code comment documents this decision.

## Testing

- `node -c public/js/i18n-translations.js` passes (no syntax errors).

https://claude.ai/code/session_018HPvnn7GSqaxna1bGUd3mE

---
_Generated by [Claude Code](https://claude.ai/code/session_018HPvnn7GSqaxna1bGUd3mE)_