### PR TITLE
fix(concept-models): harden + extend the generative path (audit follow-up #1–8, #10)

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -2288,6 +2288,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
        see CONCEPT_MODELS.md). Loaded before workspace.js, which references them. -->
   <script src="/js/conceptModelSpec.js"></script>
   <script defer src="/js/conceptModelRenderer.js"></script>
+  <script defer src="/js/conceptModelTokenRenderer.js"></script>
   <!-- Interactive math workspace (chat right slot) — after the tools it can launch -->
   <script src="/js/workspace.js"></script>
   <!-- Phase B: executes server-emitted <BOARD> commands against the embedded WorkBoard -->

--- a/public/concept-model-demo.html
+++ b/public/concept-model-demo.html
@@ -47,6 +47,7 @@
 
     /* ── concept-model renderer styles (mirrors public/css/workspace.css) ── */
     .cr-cm { display: flex; flex-direction: column; gap: 8px; }
+    .cr-cm-title { font-size: 14px; font-weight: 700; color: var(--cr-text); text-align: center; }
     .cr-cm-prompt {
       font-size: 13px; line-height: 1.45; color: var(--cr-accent);
       background: var(--cr-pill-bg); border-left: 3px solid var(--cr-accent);
@@ -113,6 +114,10 @@
       <h2>GENERATED spec (long-tail) — an LLM-authored model, validated then rendered</h2>
       <div class="host" id="host-gen"></div>
     </div>
+    <div class="demo-card">
+      <h2>GENERATED — length &amp; area measures (drag a vertex; side and area update live)</h2>
+      <div class="host" id="host-gen2"></div>
+    </div>
   </div>
 
   <script src="/js/conceptModelSpec.js"></script>
@@ -159,6 +164,32 @@
           ],
           reveal: ['plane', 'curve', 'out'],
           prompt: 'Slide a (height) and b (how tight the waves are) — what changes?'
+        }
+      );
+
+      // A second generated model exercising length + area measures: the side AB
+      // and the triangle's area are MEASURED off the live vertices, never typed.
+      window.ConceptModelRenderer.renderModel(
+        document.getElementById('host-gen2'),
+        {
+          model: 'right_triangle_measures',
+          title: 'Right triangle — side & area',
+          params: {},
+          measures: {
+            side: { type: 'length', between: ['A', 'B'] },
+            region: { type: 'area', of: ['A', 'B', 'C'] }
+          },
+          elements: [
+            { id: 'plane', type: 'plane', x: [-2, 8], y: [-2, 6], grid: true, axisLabels: true },
+            { id: 'A', type: 'point', at: [0, 0], draggable: true, label: 'A' },
+            { id: 'B', type: 'point', at: [4, 0], draggable: true, label: 'B' },
+            { id: 'C', type: 'point', at: [0, 3], draggable: true, label: 'C' },
+            { id: 'tri', type: 'polygon', vertices: ['A', 'B', 'C'], fill: true },
+            { id: 'out', type: 'readout', text: 'AB = {side}   ·   area = {region}', at: 'top' }
+          ],
+          reveal: ['plane', 'A', 'B', 'C', 'tri', 'out'],
+          drag: ['A', 'B', 'C'],
+          prompt: 'Drag a vertex — the side length and area are measured live.'
         }
       );
     }

--- a/public/concept-model-demo.html
+++ b/public/concept-model-demo.html
@@ -72,6 +72,13 @@
     }
     .cr-cm-choice-btn:hover { color: var(--cr-text); border-color: var(--cr-accent); }
     .cr-cm-choice-btn.is-active { color: #fff; background: var(--cr-accent-grad); border-color: transparent; }
+    /* token (discrete chip) engine */
+    .cr-cm-mat { position: relative; width: 100%; min-height: 220px; border-radius: var(--cr-radius-sm); background: var(--cr-bg-deep); border: 1px solid var(--cr-border); overflow: hidden; touch-action: none; }
+    .cr-cm-chip { position: absolute; display: flex; align-items: center; justify-content: center; border-radius: 50%; border: 2px solid; font-weight: 800; font-size: 16px; cursor: grab; user-select: none; touch-action: none; box-shadow: 0 2px 5px rgba(28,21,48,0.18); }
+    .cr-cm-chip.is-dragging { cursor: grabbing; box-shadow: 0 5px 12px rgba(28,21,48,0.32); z-index: 5; }
+    .cr-cm-token-input { display: flex; gap: 8px; align-items: center; padding: 2px 4px 0; }
+    .cr-cm-token-field { flex: 1 1 auto; min-width: 0; padding: 7px 10px; font-size: 14px; border: 1px solid var(--cr-border); border-radius: var(--cr-radius-sm); background: var(--cr-bg-2); color: var(--cr-text); }
+    .cr-cm-token-field.is-invalid { border-color: #e0556e; background: #fff2f4; }
   </style>
 </head>
 <body>
@@ -118,10 +125,15 @@
       <h2>GENERATED — length &amp; area measures (drag a vertex; side and area update live)</h2>
       <div class="host" id="host-gen2"></div>
     </div>
+    <div class="demo-card">
+      <h2>integer_counters — DISCRETE token engine (type −7+10; drag a red onto a yellow to cancel)</h2>
+      <div class="host" id="host-ic"></div>
+    </div>
   </div>
 
   <script src="/js/conceptModelSpec.js"></script>
   <script src="/js/conceptModelRenderer.js"></script>
+  <script src="/js/conceptModelTokenRenderer.js"></script>
   <script>
     function boot() {
       window.ConceptModelRenderer.renderModel(
@@ -191,6 +203,12 @@
           drag: ['A', 'B', 'C'],
           prompt: 'Drag a vertex — the side length and area are measured live.'
         }
+      );
+
+      // The discrete substrate: a curated token model (engine:"tokens"). Dispatched
+      // to ConceptModelTokenRenderer — inline chips, not the algebra-tiles modal.
+      window.ConceptModelRenderer.renderModel(
+        document.getElementById('host-ic'), 'integer_counters'
       );
     }
     if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', boot);

--- a/public/css/workspace.css
+++ b/public/css/workspace.css
@@ -651,8 +651,14 @@
   color: var(--cr-text-dim);
   font-size: 12px;
 }
-/* Renderer-owned layout (prompt frame · readouts · board · controls). */
+/* Renderer-owned layout (title · prompt frame · readouts · board · controls). */
 .cr-cm { display: flex; flex-direction: column; gap: 8px; }
+.cr-cm-title {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--cr-text);
+  text-align: center;
+}
 .cr-cm-prompt {
   font-size: 13px;
   line-height: 1.45;

--- a/public/css/workspace.css
+++ b/public/css/workspace.css
@@ -736,6 +736,47 @@
   border-color: transparent;
 }
 
+/* ── token (discrete chip) engine — integer counters / algebra tiles ── */
+.cr-cm-mat {
+  position: relative;
+  width: 100%;
+  min-height: 220px;
+  border-radius: var(--cr-radius-sm);
+  background: var(--cr-bg-deep);
+  border: 1px solid var(--cr-border);
+  overflow: hidden;
+  touch-action: none;
+}
+.cr-cm-chip {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: 2px solid;
+  font-weight: 800;
+  font-size: 16px;
+  cursor: grab;
+  user-select: none;
+  touch-action: none;
+  box-shadow: 0 2px 5px rgba(28, 21, 48, 0.18);
+  transition: box-shadow 0.12s ease;
+}
+.cr-cm-chip.is-dragging { cursor: grabbing; box-shadow: 0 5px 12px rgba(28, 21, 48, 0.32); z-index: 5; }
+.cr-cm-token-input { display: flex; gap: 8px; align-items: center; padding: 2px 4px 0; }
+.cr-cm-token-field {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 7px 10px;
+  font-size: 14px;
+  border: 1px solid var(--cr-border);
+  border-radius: var(--cr-radius-sm);
+  background: var(--cr-bg-2);
+  color: var(--cr-text);
+}
+.cr-cm-token-field:focus { outline: none; border-color: var(--cr-accent); }
+.cr-cm-token-field.is-invalid { border-color: #e0556e; background: #fff2f4; }
+
 /* Shared caption styling for graph + image cards. */
 .cr-ws-board-card-caption {
   margin-top: 8px;

--- a/public/js/conceptModelRenderer.js
+++ b/public/js/conceptModelRenderer.js
@@ -173,6 +173,16 @@
           out[name] = (at && p && q)
             ? CMS.measureAngle([at.X(), at.Y()], [p.X(), p.Y()], [q.X(), q.Y()])
             : NaN;
+        } else if (def.type === 'length') {
+          var la = jpoints[def.between[0]], lb = jpoints[def.between[1]];
+          out[name] = (la && lb)
+            ? CMS.measureDistance([la.X(), la.Y()], [lb.X(), lb.Y()])
+            : NaN;
+        } else if (def.type === 'area') {
+          var pts = def.of.map(function (id) { return jpoints[id]; });
+          out[name] = pts.every(Boolean)
+            ? CMS.measureArea(pts.map(function (pt) { return [pt.X(), pt.Y()]; }))
+            : NaN;
         }
       });
       return out;
@@ -206,8 +216,14 @@
       return round4(v);
     }
 
-    // ── DOM scaffold: prompt frame · readout row · board · controls row ──────
+    // ── DOM scaffold: title · prompt frame · readout row · board · controls ──
     var root = el('div', 'cr-cm');
+
+    if (spec.title) {
+      var titleEl = el('div', 'cr-cm-title');
+      titleEl.textContent = spec.title;
+      root.appendChild(titleEl);
+    }
 
     var promptText = opts.prompt || spec.prompt;
     if (promptText) {
@@ -244,6 +260,7 @@
     });
 
     var jcircles = {};   // elementId -> JSXGraph circle
+    var jobjects = {};   // elementId -> JSXGraph object (any) — for staged reveal
     var bindMap = {};    // elementId -> { xParam, yParam }
     var readouts = [];   // { el, element }
 
@@ -274,6 +291,7 @@
         strokeColor: isRef ? '#b9b2e6' : '#5B3DF6',
         strokeWidth: 2, fixed: true, highlight: false, fillOpacity: 0
       });
+      jobjects[e.id] = jcircles[e.id];
     });
 
     // First pass: points (lines/polygons/angles reference them by id).
@@ -292,6 +310,7 @@
       else if (onCircle) pt = board.create('glider', [x0, y0, jcircles[e.on.slice(7)]], attrs);
       else pt = board.create('point', [x0, y0], attrs);
       jpoints[e.id] = pt;
+      jobjects[e.id] = pt;
       bindMap[e.id] = computeBindMap(e);
 
       if (e.draggable) {
@@ -332,7 +351,7 @@
           return c.eval(s);
         };
         var isRef = e.role === 'reference';
-        board.create('functiongraph', [evalCurve], {
+        jobjects[e.id] = board.create('functiongraph', [evalCurve], {
           strokeColor: isRef ? '#b9b2e6' : '#5B3DF6',
           strokeWidth: isRef ? 2 : 3,
           dash: isRef ? 2 : 0,
@@ -345,7 +364,7 @@
           var straight = e.type === 'segment'
             ? { straightFirst: false, straightLast: false }
             : e.type === 'ray' ? { straightFirst: false, straightLast: true } : {};
-          board.create('line', [a, b2], Object.assign({
+          jobjects[e.id] = board.create('line', [a, b2], Object.assign({
             strokeColor: isRefLine ? '#a9a2d6' : '#5B3DF6',
             strokeWidth: isRefLine ? 1.5 : 2.5,
             dash: isRefLine ? 2 : 0,
@@ -355,7 +374,7 @@
       } else if (e.type === 'polygon') {
         var verts = e.vertices.map(function (id) { return jpoints[id]; }).filter(Boolean);
         if (verts.length >= 3) {
-          board.create('polygon', verts, {
+          jobjects[e.id] = board.create('polygon', verts, {
             fillColor: '#8B7BFF', fillOpacity: e.fill === false ? 0 : 0.12,
             borders: { strokeColor: '#5B3DF6', strokeWidth: 2.5, highlight: false },
             vertices: { visible: false }, // the point elements own the vertices
@@ -366,7 +385,7 @@
         var av = jpoints[e.at], r0 = jpoints[e.rays[0]], r1 = jpoints[e.rays[1]];
         if (av && r0 && r1) {
           // JSXGraph marks the angle at the MIDDLE point: [rayA, vertex, rayB].
-          board.create('angle', [r0, av, r1], {
+          jobjects[e.id] = board.create('angle', [r0, av, r1], {
             radius: 0.8, type: 'sector', fillColor: '#8B7BFF', fillOpacity: 0.35,
             strokeColor: '#5B3DF6', withLabel: false, fixed: true, highlight: false
           });
@@ -498,6 +517,32 @@
     pushParamsToControls();
     renderReadouts();
     board.update();
+
+    // Staged reveal (CONCEPT_MODELS.md: `reveal` = animation order). Bring the
+    // board objects in one at a time, in the spec's order, as a light entrance —
+    // a real teacher draws the figure piece by piece, not all at once. Only the
+    // board objects animate (readouts/axes are always present); ids not in
+    // `jobjects` (e.g. the plane, or a readout) are skipped. Honors
+    // prefers-reduced-motion by showing everything immediately.
+    var reduceMotion = typeof window !== 'undefined' && window.matchMedia
+      && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    var revealOrder = (spec.reveal || []).filter(function (id) { return jobjects[id]; });
+    if (revealOrder.length > 1 && !reduceMotion) {
+      var STAGGER_MS = 90;
+      revealOrder.forEach(function (id) { setVisible(jobjects[id], false); });
+      board.update();
+      revealOrder.forEach(function (id, i) {
+        setTimeout(function () {
+          setVisible(jobjects[id], true);
+          board.update();
+        }, (i + 1) * STAGGER_MS);
+      });
+    }
+  }
+
+  // Toggle a JSXGraph object's visibility (no-op for anything without the API).
+  function setVisible(obj, vis) {
+    if (obj && typeof obj.setAttribute === 'function') obj.setAttribute({ visible: vis });
   }
 
   if (typeof window !== 'undefined') {

--- a/public/js/conceptModelRenderer.js
+++ b/public/js/conceptModelRenderer.js
@@ -119,6 +119,24 @@
       return Promise.resolve(false);
     }
 
+    // Dispatch by substrate (CONCEPT_MODELS.md: "two rendering engines, one
+    // spec"). Discrete/token models are inline chips — no JSXGraph, no plane — so
+    // they go to the token renderer instead of the JSXGraph build below.
+    if (spec.engine === 'tokens') {
+      if (!window.ConceptModelTokenRenderer) {
+        container.textContent = 'Concept-model token engine unavailable.';
+        return Promise.resolve(false);
+      }
+      try {
+        window.ConceptModelTokenRenderer.render(container, spec, opts);
+        return Promise.resolve(true);
+      } catch (e) {
+        if (window.console) console.error('[ConceptModel] token render failed', e);
+        container.textContent = 'Concept-model token engine error.';
+        return Promise.resolve(false);
+      }
+    }
+
     return loadJSXGraph().then(function () {
       try {
         build(container, spec, opts);

--- a/public/js/conceptModelSpec.js
+++ b/public/js/conceptModelSpec.js
@@ -398,7 +398,9 @@
     circle: 1, polygon: 1, angle: 1
   };
   var CONTROL_TYPES = { slider: 1, choice: 1 };
-  var MEASURE_TYPES = { angle: 1 };
+  // Quantities the engine can MEASURE off the live geometry. Each needs its own
+  // point refs (validated below) and a pure measurement fn (used by the renderer).
+  var MEASURE_TYPES = { angle: 1, length: 1, area: 1 };
 
   function isPlainObject(o) { return o && typeof o === 'object' && !Array.isArray(o); }
 
@@ -425,6 +427,29 @@
     var c = (v1x * v2x + v1y * v2y) / (m1 * m2);
     c = Math.max(-1, Math.min(1, c)); // clamp FP drift outside acos domain
     return Math.acos(c) * 180 / Math.PI;
+  }
+
+  // The distance between two points [x,y]. The length analog of measureAngle:
+  // the spec says "measure the segment A-B", the engine reads it off the live
+  // positions — so a side length / radius / perimeter term is never asserted.
+  function measureDistance(a, b) {
+    if (!a || !b) return NaN;
+    return Math.hypot(b[0] - a[0], b[1] - a[1]);
+  }
+
+  // The (unsigned) area of the polygon through `points` ([x,y] each), via the
+  // shoelace formula. Absolute value so vertex winding (CW/CCW) doesn't flip the
+  // sign — a generated area readout reads the same regardless of order. NaN for
+  // fewer than three points.
+  function measureArea(points) {
+    if (!Array.isArray(points) || points.length < 3) return NaN;
+    var sum = 0;
+    for (var i = 0; i < points.length; i++) {
+      var p = points[i], q = points[(i + 1) % points.length];
+      if (!p || !q) return NaN;
+      sum += p[0] * q[1] - q[0] * p[1];
+    }
+    return Math.abs(sum) / 2;
   }
 
   /**
@@ -499,6 +524,18 @@
           var def = spec.measures[name];
           if (!isPlainObject(def) || !MEASURE_TYPES[def.type]) {
             errors.push('measure "' + name + '" needs a known type (' + Object.keys(MEASURE_TYPES).join(', ') + ')');
+          } else if (def.type === 'angle') {
+            if (typeof def.at !== 'string' || !Array.isArray(def.rays) || def.rays.length !== 2) {
+              errors.push('measure "' + name + '" (angle) needs at:<point> and rays:[ptA, ptB]');
+            }
+          } else if (def.type === 'length') {
+            if (!Array.isArray(def.between) || def.between.length !== 2) {
+              errors.push('measure "' + name + '" (length) needs between:[ptA, ptB]');
+            }
+          } else if (def.type === 'area') {
+            if (!Array.isArray(def.of) || def.of.length < 3) {
+              errors.push('measure "' + name + '" (area) needs of:[ptA, ptB, ptC, …]');
+            }
           }
           measureSet[name] = true;
         });
@@ -740,6 +777,12 @@
         if (Array.isArray(def.rays)) def.rays.forEach(function (ref) {
           if (!isPoint(ref)) errors.push('measure "' + name + '" ray "' + ref + '" is not a point');
         });
+        if (Array.isArray(def.between)) def.between.forEach(function (ref) {
+          if (!isPoint(ref)) errors.push('measure "' + name + '" endpoint "' + ref + '" is not a point');
+        });
+        if (Array.isArray(def.of)) def.of.forEach(function (ref) {
+          if (!isPoint(ref)) errors.push('measure "' + name + '" vertex "' + ref + '" is not a point');
+        });
       });
     }
 
@@ -768,6 +811,8 @@
     getModel: getModel,
     readoutTokens: readoutTokens,
     measureAngle: measureAngle,
+    measureDistance: measureDistance,
+    measureArea: measureArea,
     MODELS: Object.keys(CURATED)
   };
 });

--- a/public/js/conceptModelSpec.js
+++ b/public/js/conceptModelSpec.js
@@ -628,11 +628,15 @@
           if (!Array.isArray(el.at) || el.at.length !== 2) {
             errors.push('point "' + el.id + '" needs at:[x,y]');
           } else {
+            // Coords resolve live from the param object (P) in the renderer, so a
+            // string coord must be a NUMERIC param — not a derived/measure (those
+            // aren't in P, so they'd render as NaN). Tighter than mathSet on
+            // purpose: keep the validator from passing a spec the renderer breaks.
             el.at.forEach(function (coord) {
-              if (typeof coord === 'string' && !mathSet[coord]) {
-                errors.push('point "' + el.id + '" at references unknown name "' + coord + '"');
+              if (typeof coord === 'string' && !numericSet[coord]) {
+                errors.push('point "' + el.id + '" at references unknown numeric param "' + coord + '"');
               } else if (typeof coord !== 'string' && typeof coord !== 'number') {
-                errors.push('point "' + el.id + '" at coordinate must be a number or param name');
+                errors.push('point "' + el.id + '" at coordinate must be a number or numeric param');
               }
             });
           }
@@ -654,18 +658,20 @@
           if (!Array.isArray(el.center) || el.center.length !== 2) {
             errors.push('circle "' + el.id + '" needs center:[x,y]');
           } else {
+            // Same as point coords: numeric params or literals only (renderer
+            // resolves these from the live param object, not derived/measures).
             el.center.forEach(function (coord) {
-              if (typeof coord === 'string' && !mathSet[coord]) {
-                errors.push('circle "' + el.id + '" center references unknown name "' + coord + '"');
+              if (typeof coord === 'string' && !numericSet[coord]) {
+                errors.push('circle "' + el.id + '" center references unknown numeric param "' + coord + '"');
               } else if (typeof coord !== 'string' && typeof coord !== 'number') {
-                errors.push('circle "' + el.id + '" center must be numbers or param names');
+                errors.push('circle "' + el.id + '" center must be numbers or numeric params');
               }
             });
           }
           if (typeof el.radius === 'string') {
-            if (!mathSet[el.radius]) errors.push('circle "' + el.id + '" radius references unknown name "' + el.radius + '"');
+            if (!numericSet[el.radius]) errors.push('circle "' + el.id + '" radius references unknown numeric param "' + el.radius + '"');
           } else if (!(typeof el.radius === 'number' && el.radius > 0)) {
-            errors.push('circle "' + el.id + '" needs a positive radius (number or param)');
+            errors.push('circle "' + el.id + '" needs a positive radius (number or numeric param)');
           }
         }
 

--- a/public/js/conceptModelSpec.js
+++ b/public/js/conceptModelSpec.js
@@ -382,6 +382,25 @@
       reveal: ['plane', 'circ', 'O', 'A', 'A2', 'B', 'lineA', 'rayB', 'ang1', 'ang2', 'out'],
       drag: ['B'],
       prompt: 'Drag B along the arc. The two angles on the line always add to 180° — a linear pair.'
+    },
+
+    // First DISCRETE model (engine:"tokens", not JSXGraph). Two-color counters
+    // for integer arithmetic: type an expression -> chips appear (yellow = +1,
+    // red = −1) -> drag a red onto a yellow to make a zero pair -> what's left is
+    // the answer. The Sum is MEASURED from the chips on the mat (never asserted)
+    // and is invariant as zero pairs cancel — that invariance is the lesson.
+    integer_counters: {
+      model: 'integer_counters',
+      engine: 'tokens',
+      title: 'Integer counters — zero pairs',
+      input: { expression: true, placeholder: '-7 + 10' },
+      tokens: [
+        { value: 1, color: 'yellow', label: '+' },
+        { value: -1, color: 'red', label: '−' }
+      ],
+      rules: [{ when: 'overlap-opposite', do: 'annihilate' }],
+      readout: { text: 'Sum: {net}', format: 'signedInt' },
+      prompt: 'Type an expression, then drag a red onto a yellow to cancel — what is left?'
     }
   };
 
@@ -452,6 +471,84 @@
     return Math.abs(sum) / 2;
   }
 
+  // ─── Discrete / token engine (the second substrate) ─────────────────────
+  // Integer counters & algebra tiles: discrete draggable CHIPS the student
+  // arranges, with zero-pair cancellation. The "measure, never assert" property
+  // holds here too — the net (the sum of the chips on the mat) is COMPUTED from
+  // what's present, never typed. This module owns the pure logic + validation;
+  // the inline chip renderer is public/js/conceptModelTokenRenderer.js.
+
+  var TOKEN_RULE_WHEN = { 'overlap-opposite': 1 };
+  var TOKEN_RULE_DO = { annihilate: 1 };
+  var MAX_TOKENS = 60; // cap chips spawned from one expression (UI + DoS guard)
+
+  // Expand an integer add/subtract expression into chip counts:
+  // "-7 + 10" -> { positives: 10, negatives: 7, net: 3 }. Returns null for
+  // anything that isn't a sum/difference of integers (the only thing integer
+  // counters model). `net` is the live measured quantity a {net} readout shows —
+  // and it is INVARIANT under zero-pair cancellation, which is the whole lesson.
+  function expandIntegerExpression(str) {
+    if (typeof str !== 'string') return null;
+    var s = str.replace(/[−–—]/g, '-').replace(/\s+/g, '');
+    if (!/^[+-]?\d+([+-]\d+)*$/.test(s)) return null;
+    var terms = s.match(/[+-]?\d+/g).map(Number);
+    var positives = 0, negatives = 0;
+    terms.forEach(function (t) { if (t >= 0) positives += t; else negatives += -t; });
+    return { positives: positives, negatives: negatives, net: positives - negatives, terms: terms };
+  }
+
+  // Validate a token-engine spec (engine:"tokens"). Different shape from the
+  // JSXGraph path: chip TYPES (value + color), an optional expression input,
+  // optional interaction rules (zero-pair cancel), and a readout that may show
+  // the live {net}.
+  function validateTokenSpec(spec) {
+    var errors = [];
+    if (typeof spec.model !== 'string' || !spec.model) errors.push('spec.model must be a non-empty string');
+
+    if (!Array.isArray(spec.tokens) || spec.tokens.length === 0) {
+      errors.push('token spec needs a non-empty tokens array');
+    } else {
+      spec.tokens.forEach(function (t, i) {
+        if (!isPlainObject(t)) { errors.push('token[' + i + '] must be an object'); return; }
+        if (typeof t.value !== 'number') errors.push('token[' + i + '] needs a numeric value');
+        if (typeof t.color !== 'string' || !t.color) errors.push('token[' + i + '] needs a color');
+      });
+    }
+
+    if (spec.input != null) {
+      if (!isPlainObject(spec.input)) errors.push('token spec input must be an object');
+      else if (spec.input.placeholder != null && typeof spec.input.placeholder !== 'string') {
+        errors.push('token input placeholder must be a string');
+      }
+    }
+
+    if (spec.rules != null) {
+      if (!Array.isArray(spec.rules)) {
+        errors.push('token spec rules must be an array');
+      } else {
+        spec.rules.forEach(function (r, i) {
+          if (!isPlainObject(r)) { errors.push('rule[' + i + '] must be an object'); return; }
+          if (!TOKEN_RULE_WHEN[r.when]) errors.push('rule[' + i + '] has unknown when "' + r.when + '"');
+          if (!TOKEN_RULE_DO[r.do]) errors.push('rule[' + i + '] has unknown do "' + r.do + '"');
+        });
+      }
+    }
+
+    if (spec.readout != null) {
+      if (!isPlainObject(spec.readout)) {
+        errors.push('token spec readout must be an object');
+      } else if (typeof spec.readout.text !== 'string') {
+        errors.push('token readout needs text');
+      } else {
+        readoutTokens(spec.readout.text).forEach(function (tok) {
+          if (tok !== 'net') errors.push('token readout references unknown name "' + tok + '" (only {net})');
+        });
+      }
+    }
+
+    return { valid: errors.length === 0, errors: errors };
+  }
+
   /**
    * Validate a concept-model spec.
    * @param {object} spec
@@ -460,6 +557,9 @@
   function validateModelSpec(spec) {
     var errors = [];
     if (!isPlainObject(spec)) return { valid: false, errors: ['spec must be an object'] };
+    // The discrete/token substrate has a different shape (chips, not a plane of
+    // elements), so it validates on its own path.
+    if (spec.engine === 'tokens') return validateTokenSpec(spec);
     if (typeof spec.model !== 'string' || !spec.model) errors.push('spec.model must be a non-empty string');
     if (!isPlainObject(spec.params)) errors.push('spec.params must be an object');
 
@@ -813,6 +913,8 @@
     measureAngle: measureAngle,
     measureDistance: measureDistance,
     measureArea: measureArea,
+    expandIntegerExpression: expandIntegerExpression,
+    MAX_TOKENS: MAX_TOKENS,
     MODELS: Object.keys(CURATED)
   };
 });

--- a/public/js/conceptModelTokenRenderer.js
+++ b/public/js/conceptModelTokenRenderer.js
@@ -1,0 +1,246 @@
+/**
+ * conceptModelTokenRenderer.js — the DISCRETE substrate for WorkBoard concept
+ * models (CONCEPT_MODELS.md: "two rendering engines, one spec").
+ *
+ * Where conceptModelRenderer.js draws continuous geometry with JSXGraph, this
+ * draws discrete, draggable CHIPS for integer/algebra-tile reasoning — inline in
+ * a board card, summoned with intent, not the heavyweight algebra-tiles.js modal.
+ *
+ * The flagship is `integer_counters`: type an expression -> chips appear (yellow
+ * = +1, red = −1) -> drag a red onto a yellow to make a ZERO PAIR (they cancel)
+ * -> what's left is the answer. The keystone "measure, never assert" property
+ * holds here too: the Sum readout is COMPUTED from the chips on the mat, never
+ * typed — and it stays the same as zero pairs cancel, which is the whole point.
+ *
+ * All correctness/structure lives in window.ConceptModelSpec (pure, tested): the
+ * validator, and expandIntegerExpression (the expression -> chip-count math).
+ * This file only draws and wires the drag-to-cancel interaction. No external
+ * deps — no JSXGraph, no network.
+ */
+(function () {
+  'use strict';
+
+  var CHIP = 38;          // chip diameter (px)
+  var GAP = 8;            // gap between chips in the spawn layout
+  var ANNIHILATE_DIST = 30; // center-to-center px to count as a zero-pair overlap
+
+  // Spec colors -> {bg, border, text}. Falls back to using the literal color.
+  var COLORS = {
+    yellow: { bg: '#FFD24A', border: '#E0A800', text: '#5a4500' },
+    red: { bg: '#FF6B6B', border: '#E04C4C', text: '#5a0000' }
+  };
+
+  function el(tag, cls) { var n = document.createElement(tag); if (cls) n.className = cls; return n; }
+
+  function signedInt(n) {
+    if (!isFinite(n)) return '—';
+    n = Math.round(n);
+    return n > 0 ? '+' + n : String(n); // +3, 0, -2
+  }
+
+  function render(container, spec, opts) {
+    opts = opts || {};
+    if (!container) return false;
+    var CMS = window.ConceptModelSpec;
+    if (CMS && CMS.validateModelSpec) {
+      var check = CMS.validateModelSpec(spec);
+      if (!check.valid) {
+        container.textContent = "Couldn't build that model.";
+        if (window.console) console.warn('[ConceptModelToken] invalid spec', spec.model, check.errors);
+        return false;
+      }
+    }
+    container.innerHTML = '';
+
+    // Chip TYPES from the spec (value + color + label). For integer counters
+    // there are two: +1 (yellow) and −1 (red).
+    var tokens = spec.tokens || [];
+    var posType = tokens.filter(function (t) { return t.value > 0; })[0] || null;
+    var negType = tokens.filter(function (t) { return t.value < 0; })[0] || null;
+    var maxTokens = (CMS && CMS.MAX_TOKENS) || 60;
+
+    // ── DOM scaffold ────────────────────────────────────────────────────────
+    var root = el('div', 'cr-cm cr-cm--tokens');
+    if (spec.title) { var t = el('div', 'cr-cm-title'); t.textContent = spec.title; root.appendChild(t); }
+    var promptText = opts.prompt || spec.prompt;
+    if (promptText) { var pf = el('div', 'cr-cm-prompt'); pf.textContent = promptText; root.appendChild(pf); }
+
+    var readoutRow = el('div', 'cr-cm-readouts');
+    var readoutHost = el('div', 'cr-cm-readout');
+    var readoutMath = el('span', 'cr-cm-readout-math');
+    readoutHost.appendChild(readoutMath);
+    readoutRow.appendChild(readoutHost);
+    root.appendChild(readoutRow);
+
+    var mat = el('div', 'cr-cm-mat');
+    root.appendChild(mat);
+
+    var inputRow = null, inputField = null;
+    if (spec.input) {
+      inputRow = el('div', 'cr-cm-token-input');
+      inputField = document.createElement('input');
+      inputField.type = 'text';
+      inputField.className = 'cr-cm-token-field';
+      inputField.placeholder = spec.input.placeholder || 'e.g. -7 + 10';
+      inputField.setAttribute('aria-label', 'expression to build with counters');
+      var buildBtn = el('button', 'cr-cm-choice-btn cr-cm-token-build');
+      buildBtn.type = 'button'; buildBtn.textContent = 'Build';
+      var clearBtn = el('button', 'cr-cm-choice-btn cr-cm-token-clear');
+      clearBtn.type = 'button'; clearBtn.textContent = 'Clear';
+      inputRow.appendChild(inputField);
+      inputRow.appendChild(buildBtn);
+      inputRow.appendChild(clearBtn);
+      root.appendChild(inputRow);
+
+      buildBtn.addEventListener('click', buildFromInput);
+      clearBtn.addEventListener('click', function () { clearChips(); renderReadout(); });
+      inputField.addEventListener('keydown', function (e) { if (e.key === 'Enter') buildFromInput(); });
+    }
+
+    container.appendChild(root);
+
+    // ── chip state + the live measure ─────────────────────────────────────────
+    var chips = [];      // { id, value, el, x, y }
+    var chipId = 0;
+    var hasAnnihilate = (spec.rules || []).some(function (r) {
+      return r.when === 'overlap-opposite' && r.do === 'annihilate';
+    });
+
+    function net() { return chips.reduce(function (s, c) { return s + c.value; }, 0); }
+
+    function renderReadout() {
+      var template = (spec.readout && spec.readout.text) || 'Sum: {net}';
+      var fmt = spec.readout && spec.readout.format;
+      var n = net();
+      readoutMath.textContent = template.replace(/\{net\}/g, fmt === 'signedInt' ? signedInt(n) : String(Math.round(n)));
+    }
+
+    function colorOf(type) { return COLORS[type.color] || { bg: type.color, border: '#0003', text: '#000' }; }
+
+    function clearChips() {
+      chips.forEach(function (c) { if (c.el && c.el.parentNode) c.el.parentNode.removeChild(c.el); });
+      chips = [];
+    }
+
+    function matWidth() { return mat.clientWidth || 320; }
+
+    function addChip(type, x, y) {
+      var c = colorOf(type);
+      var node = el('div', 'cr-cm-chip');
+      node.style.width = node.style.height = CHIP + 'px';
+      node.style.background = c.bg;
+      node.style.borderColor = c.border;
+      node.style.color = c.text;
+      node.textContent = type.label != null ? type.label : (type.value > 0 ? '+' : '−');
+      node.style.left = x + 'px';
+      node.style.top = y + 'px';
+      mat.appendChild(node);
+      var chip = { id: ++chipId, value: type.value, el: node, x: x, y: y };
+      chips.push(chip);
+      attachDrag(chip);
+      return chip;
+    }
+
+    // Lay a count of one chip type out in a row-major grid, starting at (x0,y0).
+    function layout(count, type, x0, y0) {
+      var cols = Math.max(1, Math.floor((matWidth() - GAP) / (CHIP + GAP)));
+      for (var i = 0; i < count; i++) {
+        var col = i % cols, rowi = Math.floor(i / cols);
+        addChip(type, x0 + col * (CHIP + GAP), y0 + rowi * (CHIP + GAP));
+      }
+    }
+
+    function spawn(positives, negatives) {
+      clearChips();
+      // Yellows in the top band; reds in a lower band — so the two stacks read as
+      // separate quantities before the student starts cancelling.
+      if (posType) layout(positives, posType, GAP, GAP);
+      var posRows = posType ? Math.ceil(positives / Math.max(1, Math.floor((matWidth() - GAP) / (CHIP + GAP)))) : 0;
+      var redY = GAP + posRows * (CHIP + GAP) + GAP;
+      if (negType) layout(negatives, negType, GAP, redY);
+      renderReadout();
+    }
+
+    function buildFromInput() {
+      if (!inputField) return;
+      var parsed = CMS && CMS.expandIntegerExpression(inputField.value);
+      if (!parsed) { flashInvalid(); return; }
+      if (parsed.positives + parsed.negatives > maxTokens) { flashInvalid('Too many counters — try smaller numbers.'); return; }
+      spawn(parsed.positives, parsed.negatives);
+    }
+
+    function flashInvalid(msg) {
+      inputField.classList.add('is-invalid');
+      inputField.title = msg || 'Enter integers to add/subtract, e.g. -7 + 10';
+      setTimeout(function () { inputField.classList.remove('is-invalid'); }, 800);
+    }
+
+    // ── drag-to-cancel (the zero-pair interaction) ────────────────────────────
+    function attachDrag(chip) {
+      var node = chip.el;
+      var startX, startY, originX, originY, dragging = false;
+      node.addEventListener('pointerdown', function (e) {
+        dragging = true;
+        node.classList.add('is-dragging');
+        node.setPointerCapture(e.pointerId);
+        startX = e.clientX; startY = e.clientY;
+        originX = chip.x; originY = chip.y;
+        e.preventDefault();
+      });
+      node.addEventListener('pointermove', function (e) {
+        if (!dragging) return;
+        var w = matWidth(), h = mat.clientHeight || 220;
+        chip.x = Math.max(0, Math.min(w - CHIP, originX + (e.clientX - startX)));
+        chip.y = Math.max(0, Math.min(h - CHIP, originY + (e.clientY - startY)));
+        node.style.left = chip.x + 'px';
+        node.style.top = chip.y + 'px';
+      });
+      function end() {
+        if (!dragging) return;
+        dragging = false;
+        node.classList.remove('is-dragging');
+        if (hasAnnihilate) tryAnnihilate(chip);
+      }
+      node.addEventListener('pointerup', end);
+      node.addEventListener('pointercancel', end);
+    }
+
+    // If `chip` overlaps an OPPOSITE-sign chip, the two make a zero pair and
+    // cancel. The Sum is unchanged by this (it removes +1 and −1 together) — the
+    // chips just collapse toward the answer.
+    function tryAnnihilate(chip) {
+      var partner = null, best = ANNIHILATE_DIST;
+      for (var i = 0; i < chips.length; i++) {
+        var o = chips[i];
+        if (o === chip || (o.value > 0) === (chip.value > 0)) continue; // same sign
+        var dx = (o.x - chip.x), dy = (o.y - chip.y);
+        var d = Math.sqrt(dx * dx + dy * dy);
+        if (d < best) { best = d; partner = o; }
+      }
+      if (partner) { removeChip(chip); removeChip(partner); renderReadout(); }
+    }
+
+    function removeChip(chip) {
+      var i = chips.indexOf(chip);
+      if (i !== -1) chips.splice(i, 1);
+      if (chip.el && chip.el.parentNode) chip.el.parentNode.removeChild(chip.el);
+    }
+
+    // ── initial paint ─────────────────────────────────────────────────────────
+    // Start populated from the placeholder so the model is alive on arrival
+    // (like the slider models start with a line drawn).
+    var seed = spec.input && spec.input.placeholder;
+    var seedParsed = seed && CMS && CMS.expandIntegerExpression(seed);
+    if (seedParsed && seedParsed.positives + seedParsed.negatives <= maxTokens) {
+      if (inputField) inputField.value = seed;
+      // Defer one frame so mat.clientWidth is known for the grid layout.
+      requestAnimationFrame(function () { spawn(seedParsed.positives, seedParsed.negatives); });
+    }
+    renderReadout();
+    return true;
+  }
+
+  if (typeof window !== 'undefined') {
+    window.ConceptModelTokenRenderer = { render: render };
+  }
+})();

--- a/tests/unit/conceptModelCommand.test.js
+++ b/tests/unit/conceptModelCommand.test.js
@@ -102,6 +102,36 @@ describe('conceptModelCommand — resolveModelCommands (generative long-tail gat
     expect(dropped[0].reason).toBe('model_missing_spec_and_name');
   });
 
+  it('strips a Markdown code fence the LLM wrapped around the spec', () => {
+    const fenced = '```json\n' + JSON.stringify(validGeneratedSpec()) + '\n```';
+    const { commands, dropped } = resolveModelCommands([{ action: 'model', spec: fenced }]);
+    expect(dropped).toHaveLength(0);
+    expect(commands).toHaveLength(1);
+    expect(commands[0].spec.model).toBe('cosine_wave');
+  });
+
+  it('falls back to a curated name when the generated spec is invalid', () => {
+    // A dropped spec would leave the tutor referencing a model that never appears.
+    // If the command also names a real curated model, render that instead.
+    const { commands, dropped, fallbacks } = resolveModelCommands([
+      { action: 'model', spec: '{ not valid json', model: 'slope_intercept_line', prompt: 'here' },
+    ]);
+    expect(dropped).toHaveLength(0);
+    expect(commands).toHaveLength(1);
+    expect(commands[0].model).toBe('slope_intercept_line');
+    expect(commands[0].spec).toBeUndefined();        // the bad spec is dropped
+    expect(commands[0].prompt).toBe('here');         // framing preserved
+    expect(fallbacks[0].reason).toBe('model_spec_unparseable');
+  });
+
+  it('drops (no fallback) when the spec is invalid and the curated name is bogus', () => {
+    const { commands, dropped } = resolveModelCommands([
+      { action: 'model', spec: '{ not valid json', model: 'not_a_real_model' },
+    ]);
+    expect(commands).toHaveLength(0);
+    expect(dropped[0].reason).toBe('model_spec_unparseable');
+  });
+
   it('leaves non-model commands untouched and in order', () => {
     const cmds = [
       { action: 'pose', tex: '2x + 4 = 20' },
@@ -114,6 +144,6 @@ describe('conceptModelCommand — resolveModelCommands (generative long-tail gat
   });
 
   it('returns empty for a non-array input', () => {
-    expect(resolveModelCommands(null)).toEqual({ commands: [], dropped: [] });
+    expect(resolveModelCommands(null)).toEqual({ commands: [], dropped: [], fallbacks: [] });
   });
 });

--- a/tests/unit/conceptModelPrompt.test.js
+++ b/tests/unit/conceptModelPrompt.test.js
@@ -2,6 +2,7 @@ const {
   isConceptModelsEnabled,
   isConceptModelsGenerativeEnabled,
   buildConceptModelInstructions,
+  GENERATIVE_EXAMPLES,
   modelCatalogLines,
 } = require('../../utils/conceptModelPrompt');
 const { MODELS, validateModelSpec } = require('../../public/js/conceptModelSpec');
@@ -98,22 +99,32 @@ describe('conceptModelPrompt — instruction text', () => {
     expect(structured).toMatch(/spec/);
   });
 
-  it("the generative section's worked example is itself a valid spec", () => {
-    // The example we hand the LLM must pass the very validator that gates its
-    // output — otherwise we'd be teaching a shape we'd then reject.
-    const example = {
-      model: 'cosine_wave',
-      title: 'y = a·cos(bx)',
-      params: { a: 1, b: 1 },
-      controls: [{ type: 'slider', param: 'a', label: 'a', range: [-3, 3], step: 0.25 }],
-      elements: [
-        { id: 'plane', type: 'plane', x: [-10, 10], y: [-10, 10], grid: true, axisLabels: true },
-        { id: 'curve', type: 'function', fn: 'a*cos(b*x)' },
-        { id: 'out', type: 'readout', text: 'y = {a}cos({b}x)', at: 'top' },
-      ],
-      reveal: ['plane', 'curve', 'out'],
-      prompt: 'Slide a and b — how does the wave change?',
-    };
-    expect(validateModelSpec(example).valid).toBe(true);
+  it('every example the LLM is shown is itself a valid spec', () => {
+    // The examples we hand the LLM must pass the very validator that gates its
+    // output — otherwise we'd be teaching a shape we'd then reject. Validate the
+    // EXPORTED objects (the actual source of the shown JSON), so an example can't
+    // drift out of validity unnoticed.
+    Object.keys(GENERATIVE_EXAMPLES).forEach((key) => {
+      const result = validateModelSpec(GENERATIVE_EXAMPLES[key]);
+      expect(result.errors).toEqual([]);
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  it('the shown examples are emitted as strict, parseable JSON (no comments)', () => {
+    // Regression for the foot-gun where the template carried `//` comments that
+    // would make a copied spec unparseable. The JSON blocks must round-trip and
+    // re-validate.
+    const text = buildConceptModelInstructions(false, { generative: true });
+    expect(text).not.toMatch(/^\s*\/\//m);            // no comment lines
+    const fnJson = JSON.stringify(GENERATIVE_EXAMPLES.fn, null, 2);
+    expect(text).toContain(fnJson);                   // the literal JSON is present
+    expect(validateModelSpec(JSON.parse(fnJson)).valid).toBe(true);
+  });
+
+  it('documents that measures are angle-only and coords take numbers/params', () => {
+    const text = buildConceptModelInstructions(false, { generative: true });
+    expect(text).toMatch(/ANGLES ONLY/);
+    expect(text.toLowerCase()).toContain('draws the arc');
   });
 });

--- a/tests/unit/conceptModelPrompt.test.js
+++ b/tests/unit/conceptModelPrompt.test.js
@@ -122,9 +122,10 @@ describe('conceptModelPrompt — instruction text', () => {
     expect(validateModelSpec(JSON.parse(fnJson)).valid).toBe(true);
   });
 
-  it('documents that measures are angle-only and coords take numbers/params', () => {
+  it('documents the angle/length/area measures and the arc-vs-measure split', () => {
     const text = buildConceptModelInstructions(false, { generative: true });
-    expect(text).toMatch(/ANGLES ONLY/);
+    expect(text).toMatch(/"type":"length"/);
+    expect(text).toMatch(/"type":"area"/);
     expect(text.toLowerCase()).toContain('draws the arc');
   });
 });

--- a/tests/unit/conceptModelSpec.test.js
+++ b/tests/unit/conceptModelSpec.test.js
@@ -4,6 +4,8 @@ const {
   getModel,
   readoutTokens,
   measureAngle,
+  measureDistance,
+  measureArea,
   MODELS,
 } = require('../../public/js/conceptModelSpec');
 
@@ -295,6 +297,20 @@ describe('conceptModelSpec — geometry (measure, never assert)', () => {
     expect(measureAngle([0, 0], [0, 0], [1, 1])).toBeNaN(); // degenerate ray
   });
 
+  it('measureDistance computes the segment length (3-4-5)', () => {
+    expect(measureDistance([0, 0], [3, 4])).toBeCloseTo(5, 9);
+    expect(measureDistance([1, 1], [1, 1])).toBe(0);
+    expect(measureDistance(null, [1, 1])).toBeNaN();
+  });
+
+  it('measureArea computes polygon area via shoelace, winding-agnostic', () => {
+    const square = [[0, 0], [2, 0], [2, 2], [0, 2]];
+    expect(measureArea(square)).toBeCloseTo(4, 9);
+    expect(measureArea([...square].reverse())).toBeCloseTo(4, 9); // CW == CCW
+    expect(measureArea([[0, 0], [4, 0], [0, 3]])).toBeCloseTo(6, 9); // right triangle
+    expect(measureArea([[0, 0], [1, 1]])).toBeNaN(); // fewer than 3 points
+  });
+
   it('inscribed_angle is half the central angle, by construction (at the catalog coords)', () => {
     const s = getModel('inscribed_angle');
     const at = {};
@@ -358,6 +374,26 @@ describe('conceptModelSpec — geometry (measure, never assert)', () => {
     const s = gbase();
     s.measures.ang.rays = ['A', 'Z'];
     expect(validateModelSpec(s).errors.join(' ')).toMatch(/measure "ang" ray "Z" is not a point/);
+  });
+
+  it('accepts length and area measures and lets a readout read them', () => {
+    const s = gbase();
+    s.measures.side = { type: 'length', between: ['A', 'B'] };
+    s.measures.region = { type: 'area', of: ['A', 'B', 'C'] };
+    s.elements.find((e) => e.id === 'out').text = '{ang}° · {side} · {region}';
+    expect(validateModelSpec(s).errors).toEqual([]);
+  });
+
+  it('rejects a length measure missing its endpoints', () => {
+    const s = gbase();
+    s.measures.side = { type: 'length', between: ['A'] };
+    expect(validateModelSpec(s).errors.join(' ')).toMatch(/measure "side" \(length\) needs between/);
+  });
+
+  it('rejects an area measure whose vertex is not a point', () => {
+    const s = gbase();
+    s.measures.region = { type: 'area', of: ['A', 'B', 'Z'] };
+    expect(validateModelSpec(s).errors.join(' ')).toMatch(/measure "region" vertex "Z" is not a point/);
   });
 
   it('rejects an angle whose vertex is not a point', () => {

--- a/tests/unit/conceptModelSpec.test.js
+++ b/tests/unit/conceptModelSpec.test.js
@@ -130,7 +130,19 @@ describe('conceptModelSpec — validator (generated specs cannot render broken)'
     s.elements.push({ id: 'dot', type: 'point', at: ['zzz', 'b'] });
     const r = validateModelSpec(s);
     expect(r.valid).toBe(false);
-    expect(r.errors.join(' ')).toMatch(/at references unknown name "zzz"/);
+    expect(r.errors.join(' ')).toMatch(/at references unknown numeric param "zzz"/);
+  });
+
+  it('rejects a coordinate that names a DERIVED value (renderer resolves only params)', () => {
+    // A derived name isn't in the live param object, so a point/circle placed at
+    // it would render NaN. The validator must reject it rather than pass a spec
+    // the renderer breaks — the "validate before render" guarantee.
+    const s = base();
+    s.derived = { mid: 'm + b' };
+    s.elements.push({ id: 'dot', type: 'point', at: ['mid', 0] });
+    const r = validateModelSpec(s);
+    expect(r.valid).toBe(false);
+    expect(r.errors.join(' ')).toMatch(/at references unknown numeric param "mid"/);
   });
 
   it('rejects a line referencing a non-existent point', () => {

--- a/tests/unit/conceptModelSpec.test.js
+++ b/tests/unit/conceptModelSpec.test.js
@@ -6,6 +6,7 @@ const {
   measureAngle,
   measureDistance,
   measureArea,
+  expandIntegerExpression,
   MODELS,
 } = require('../../public/js/conceptModelSpec');
 
@@ -426,5 +427,76 @@ describe('conceptModelSpec — geometry (measure, never assert)', () => {
     s.derived = { total: 'ang + ang2' };
     s.elements.find((e) => e.id === 'out').text = 'sum = {total}';
     expect(validateModelSpec(s).valid).toBe(true);
+  });
+});
+
+describe('conceptModelSpec — token engine (discrete chips, zero pairs)', () => {
+  it('expandIntegerExpression splits an expression into chip counts + net', () => {
+    expect(expandIntegerExpression('-7 + 10')).toEqual({ positives: 10, negatives: 7, net: 3, terms: [-7, 10] });
+    expect(expandIntegerExpression('5 - 8')).toEqual({ positives: 5, negatives: 8, net: -3, terms: [5, -8] });
+    expect(expandIntegerExpression('+6')).toEqual({ positives: 6, negatives: 0, net: 6, terms: [6] });
+  });
+
+  it('net is invariant under zero-pair cancellation (the lesson)', () => {
+    // -7 + 10 → 10 yellow, 7 red, net +3. Cancelling all 7 pairs leaves 3 yellow,
+    // still +3 — removing a +1 and a −1 together never changes the sum.
+    const e = expandIntegerExpression('-7 + 10');
+    const afterCancel = (e.positives - 7) - (e.negatives - 7);
+    expect(afterCancel).toBe(e.net);
+  });
+
+  it('returns null for anything that is not integer add/subtract', () => {
+    expect(expandIntegerExpression('2 * 3')).toBeNull();
+    expect(expandIntegerExpression('x + 1')).toBeNull();
+    expect(expandIntegerExpression('3.5 + 1')).toBeNull();
+    expect(expandIntegerExpression('')).toBeNull();
+    expect(expandIntegerExpression(null)).toBeNull();
+  });
+
+  it('normalizes a unicode minus', () => {
+    expect(expandIntegerExpression('−7 + 10').net).toBe(3); // − (U+2212)
+  });
+
+  function tbase() {
+    return {
+      model: 'counters',
+      engine: 'tokens',
+      input: { expression: true, placeholder: '-7 + 10' },
+      tokens: [
+        { value: 1, color: 'yellow', label: '+' },
+        { value: -1, color: 'red', label: '−' },
+      ],
+      rules: [{ when: 'overlap-opposite', do: 'annihilate' }],
+      readout: { text: 'Sum: {net}', format: 'signedInt' },
+    };
+  }
+
+  it('validates a well-formed token spec on its own path', () => {
+    expect(validateModelSpec(tbase()).errors).toEqual([]);
+  });
+
+  it('the curated integer_counters validates and is in the catalog', () => {
+    expect(MODELS).toContain('integer_counters');
+    expect(validateModelSpec(getModel('integer_counters')).errors).toEqual([]);
+  });
+
+  it('rejects a token spec with no tokens', () => {
+    const s = tbase(); s.tokens = [];
+    expect(validateModelSpec(s).errors.join(' ')).toMatch(/non-empty tokens array/);
+  });
+
+  it('rejects a token whose value is not numeric', () => {
+    const s = tbase(); s.tokens[0].value = 'one';
+    expect(validateModelSpec(s).errors.join(' ')).toMatch(/token\[0\] needs a numeric value/);
+  });
+
+  it('rejects an unknown interaction rule', () => {
+    const s = tbase(); s.rules[0].do = 'explode';
+    expect(validateModelSpec(s).errors.join(' ')).toMatch(/unknown do "explode"/);
+  });
+
+  it('rejects a readout that references anything but {net}', () => {
+    const s = tbase(); s.readout.text = 'Sum: {total}';
+    expect(validateModelSpec(s).errors.join(' ')).toMatch(/unknown name "total" \(only \{net\}\)/);
   });
 });

--- a/utils/conceptModelCommand.js
+++ b/utils/conceptModelCommand.js
@@ -75,40 +75,71 @@ function boundsErrors(spec) {
  *   On success the returned command has `spec` replaced by the PARSED + validated
  *   object (generated path) or is passed through unchanged (curated path).
  */
-function resolveOne(cmd) {
-  // GENERATED — a JSON spec string. Parse, bound, validate.
-  if (typeof cmd.spec === 'string' && cmd.spec.trim()) {
-    if (cmd.spec.length > LIMITS.specChars) {
-      return { dropped: 'model_spec_too_large' };
-    }
-    let parsed;
+// Strip a Markdown code fence (```json … ``` or ``` … ```) that an LLM sometimes
+// wraps around the JSON spec. A common, harmless mistake that would otherwise
+// fail JSON.parse and drop the whole model — peel it before parsing.
+function stripCodeFences(s) {
+  const t = String(s).trim();
+  const m = t.match(/^```[a-zA-Z0-9]*\s*([\s\S]*?)\s*```$/);
+  return m ? m[1].trim() : t;
+}
+
+// A curated catalog name on this command that we can fall back to. Returns the
+// name or null.
+function curatedNameOf(cmd) {
+  return (typeof cmd.model === 'string' && ConceptModelSpec.MODELS.indexOf(cmd.model) !== -1)
+    ? cmd.model
+    : null;
+}
+
+// Validate a spec payload (a JSON string or an already-parsed object) and return
+// either { spec } (the parsed, validated object) or { reason, errors }.
+function validateSpecPayload(rawSpec) {
+  let parsed;
+  if (typeof rawSpec === 'string') {
+    const text = stripCodeFences(rawSpec);
+    if (text.length > LIMITS.specChars) return { reason: 'model_spec_too_large' };
     try {
-      parsed = JSON.parse(cmd.spec);
+      parsed = JSON.parse(text);
     } catch (e) {
-      return { dropped: 'model_spec_unparseable', errors: [e.message] };
+      return { reason: 'model_spec_unparseable', errors: [e.message] };
     }
-    const bounds = boundsErrors(parsed);
-    if (bounds.length) return { dropped: 'model_spec_exceeds_limits', errors: bounds };
-    const check = ConceptModelSpec.validateModelSpec(parsed);
-    if (!check.valid) return { dropped: 'model_spec_invalid', errors: check.errors };
-
-    const out = Object.assign({}, cmd, { spec: parsed });
-    // Surface the spec's own name as the command's model name when the command
-    // didn't carry a separate one — handy for logging / downstream identity.
-    if (!out.model && typeof parsed.model === 'string') out.model = parsed.model;
-    return { command: out };
+  } else {
+    parsed = rawSpec; // already an object (renderer-shaped input or a test)
   }
+  const bounds = boundsErrors(parsed);
+  if (bounds.length) return { reason: 'model_spec_exceeds_limits', errors: bounds };
+  const check = ConceptModelSpec.validateModelSpec(parsed);
+  if (!check.valid) return { reason: 'model_spec_invalid', errors: check.errors };
+  return { spec: parsed };
+}
 
-  // GENERATED — a spec the parser already turned into an object (renderer-shaped
-  // input, or a test). Validate it the same way.
-  if (cmd.spec && typeof cmd.spec === 'object') {
-    const bounds = boundsErrors(cmd.spec);
-    if (bounds.length) return { dropped: 'model_spec_exceeds_limits', errors: bounds };
-    const check = ConceptModelSpec.validateModelSpec(cmd.spec);
-    if (!check.valid) return { dropped: 'model_spec_invalid', errors: check.errors };
-    const out = Object.assign({}, cmd);
-    if (!out.model && typeof cmd.spec.model === 'string') out.model = cmd.spec.model;
-    return { command: out };
+function resolveOne(cmd) {
+  const hasSpec = (typeof cmd.spec === 'string' && cmd.spec.trim()) ||
+    (cmd.spec && typeof cmd.spec === 'object');
+
+  // GENERATED — a spec the tutor authored. Parse + bound + validate.
+  if (hasSpec) {
+    const r = validateSpecPayload(cmd.spec);
+    if (r.spec) {
+      const out = Object.assign({}, cmd, { spec: r.spec });
+      // Surface the spec's own name when the command didn't carry one — handy for
+      // logging / downstream identity.
+      if (!out.model && typeof r.spec.model === 'string') out.model = r.spec.model;
+      return { command: out };
+    }
+    // The generated spec didn't hold up. If the command ALSO names a real curated
+    // model, fall back to it rather than dropping the card entirely — the tutor's
+    // chat may already reference "this model", so a curated stand-in beats a
+    // dangling reference. Otherwise drop with the reason.
+    const fallback = curatedNameOf(cmd);
+    if (fallback) {
+      const out = Object.assign({}, cmd);
+      delete out.spec;
+      out.model = fallback;
+      return { command: out, fallback: r.reason };
+    }
+    return { dropped: r.reason, errors: r.errors };
   }
 
   // CURATED — a catalog name. Must resolve to a real model.
@@ -128,19 +159,26 @@ function resolveOne(cmd) {
  * commands pass through untouched and in order.
  *
  * @param {Array<object>} commands
- * @returns {{ commands: Array<object>, dropped: Array<{command:object, reason:string, errors?:string[]}> }}
+ * @returns {{ commands: Array<object>, dropped: Array<{command,reason,errors?}>, fallbacks: Array<{command,reason}> }}
+ *   `fallbacks` are commands whose generated spec failed but that fell back to a
+ *   curated name (rendered, but worth logging that the spec was rejected).
  */
 function resolveModelCommands(commands) {
   const out = [];
   const dropped = [];
-  if (!Array.isArray(commands)) return { commands: out, dropped };
+  const fallbacks = [];
+  if (!Array.isArray(commands)) return { commands: out, dropped, fallbacks };
   for (const cmd of commands) {
     if (!cmd || cmd.action !== 'model') { out.push(cmd); continue; }
     const r = resolveOne(cmd);
-    if (r.command) out.push(r.command);
-    else dropped.push({ command: cmd, reason: r.dropped, errors: r.errors });
+    if (r.command) {
+      out.push(r.command);
+      if (r.fallback) fallbacks.push({ command: r.command, reason: r.fallback });
+    } else {
+      dropped.push({ command: cmd, reason: r.dropped, errors: r.errors });
+    }
   }
-  return { commands: out, dropped };
+  return { commands: out, dropped, fallbacks };
 }
 
 module.exports = {

--- a/utils/conceptModelPrompt.js
+++ b/utils/conceptModelPrompt.js
@@ -149,7 +149,11 @@ ${geoExample}
 Vocabulary you may use:
 - elements: plane, function (fn: an expression of x + numeric params, e.g. "a*x^2 + b"), point (at:[x,y] of NUMBERS or numeric-param names; draggable; binds a param), line/segment/ray (through:[ptId,ptId]), circle (center:[x,y], radius), polygon (vertices:[ptIds]), angle (at: ptId, rays:[ptId,ptId]) — DRAWS the arc, readout (text with {param}/{derived}/{measure} tokens).
 - controls: slider (numeric param; needs range:[lo,hi]).
-- measures: a quantity read off the LIVE geometry — currently ANGLES ONLY: "ang": { "type":"angle", "at":"B", "rays":["A","C"] }. A readout/derived then uses {ang}. To SHOW an angle you need BOTH: an angle element (draws the arc) AND a measures entry (supplies the number) — the angle element alone shows no value. (Lengths/areas aren't measurable yet, so don't build a model that needs them.)
+- measures: a quantity read off the LIVE geometry — angle, length, or area:
+    angle:  { "type":"angle",  "at":"B", "rays":["A","C"] }   (degrees at vertex B)
+    length: { "type":"length", "between":["A","B"] }          (distance from A to B)
+    area:   { "type":"area",   "of":["A","B","C"] }           (polygon through the points)
+  A readout/derived then uses {name}. To SHOW an angle you need BOTH an angle element (draws the arc) AND a measures entry (supplies the number) — the angle element alone shows no value.
 - derived: a value computed from params/measures, e.g. "sum": "ang1 + ang2".
 
 Hard rules: every "through"/"vertices"/"rays"/"at"(angle) must name a point id you defined; every name in an fn/derived/readout must be a declared param, derived, or measure; point/circle coordinates must be NUMBERS or numeric-param names (not derived/measures); numeric params only inside fn; give sliders a valid range. NEVER write a measured value as a literal — declare a measure and let the engine compute it. Keep it to one focused model. Like every concept model, it's a manipulable idea, never the student's graded answer.`;

--- a/utils/conceptModelPrompt.js
+++ b/utils/conceptModelPrompt.js
@@ -64,6 +64,58 @@ function modelCatalogLines() {
 }
 
 /**
+ * Worked examples shown to the tutor in the generative section. Defined as real
+ * objects (not hand-written JSON text) so that (a) what the LLM sees is ALWAYS
+ * valid JSON — JSON.stringify can't emit the `//` comments that would make a
+ * copied spec unparseable — and (b) a unit test can run them through the very
+ * validator that gates generated output, so the examples can't silently rot.
+ *
+ * Two cases on purpose: a function/graph model, and a GEOMETRY model — the harder
+ * case, where the `angle` element draws the arc while a separate `measures` entry
+ * supplies the live number a readout shows.
+ */
+const GENERATIVE_EXAMPLES = {
+  // Function/graph: params drive a curve, readout echoes them.
+  fn: {
+    model: 'cosine_wave',
+    title: 'y = a·cos(bx)',
+    params: { a: 2, b: 1 },
+    controls: [
+      { type: 'slider', param: 'a', label: 'a', range: [-3, 3], step: 0.25 },
+      { type: 'slider', param: 'b', label: 'b', range: [0.25, 4], step: 0.25 },
+    ],
+    elements: [
+      { id: 'plane', type: 'plane', x: [-7, 7], y: [-4, 4], grid: true, axisLabels: true },
+      { id: 'curve', type: 'function', fn: 'a*cos(b*x)' },
+      { id: 'out', type: 'readout', text: 'y = {a}·cos({b}x)', at: 'top' },
+    ],
+    reveal: ['plane', 'curve', 'out'],
+    prompt: 'Slide a and b — how does the wave change?',
+  },
+  // Geometry: the `angle` element DRAWS the arc; the `measures` entry MEASURES the
+  // number; the readout shows the measured value. Three distinct things.
+  geometry: {
+    model: 'angle_at_a_point',
+    title: 'Measuring an angle',
+    params: {},
+    measures: { ang: { type: 'angle', at: 'O', rays: ['A', 'B'] } },
+    elements: [
+      { id: 'plane', type: 'plane', x: [-7, 7], y: [-7, 7], grid: false, axisLabels: false },
+      { id: 'O', type: 'point', at: [0, 0], label: 'O' },
+      { id: 'A', type: 'point', at: [5, 0], label: 'A' },
+      { id: 'B', type: 'point', at: [3, 4], draggable: true, label: 'B' },
+      { id: 'rayA', type: 'segment', through: ['O', 'A'] },
+      { id: 'rayB', type: 'segment', through: ['O', 'B'] },
+      { id: 'arc', type: 'angle', at: 'O', rays: ['A', 'B'], measure: true },
+      { id: 'out', type: 'readout', text: 'angle = {ang}°', at: 'top' },
+    ],
+    reveal: ['plane', 'O', 'A', 'B', 'rayA', 'rayB', 'arc', 'out'],
+    drag: ['B'],
+    prompt: 'Drag B — the angle is measured live, never typed.',
+  },
+};
+
+/**
  * The GENERATED long-tail authoring section. Teaches the tutor to write a
  * brand-new spec in the fixed vocabulary when NO curated model fits. The spec is
  * validated before it can render (every id/param/ref must resolve, and any
@@ -78,35 +130,29 @@ function buildGenerativeSection(structured) {
     ? 'Put the WHOLE spec, as a JSON string, in the spec field: { action: "model", spec: "{ ...spec JSON... }", prompt: "Slide a and b — how does the wave change?" }'
     : 'Put the WHOLE spec JSON inside the tag body: <BOARD action="model" prompt="Slide a and b — how does the wave change?">{ ...spec JSON... }</BOARD>';
 
+  const fnExample = JSON.stringify(GENERATIVE_EXAMPLES.fn, null, 2);
+  const geoExample = JSON.stringify(GENERATIVE_EXAMPLES.geometry, null, 2);
+
   return `
 GENERATIVE LONG-TAIL — author a NEW model when none above fits:
 Only when no curated model matches the concept, you may write your OWN spec in this vocabulary. It is validated before it renders: every id/param/reference must resolve, and any MEASURED quantity is computed live by the engine — so you literally cannot make it show wrong math. Prefer a curated model whenever one fits; reach for this only for the long tail.
 
 ${emit}
+The spec is strict JSON — no comments, no trailing commas. Emit only the JSON object.
 
-Spec shape (JSON):
-{
-  "model": "snake_case_name",
-  "title": "Short title",
-  "params":  { "a": 1, "b": 1 },                       // numeric knobs (single source of truth)
-  "controls":[ { "type":"slider", "param":"a", "label":"a", "range":[-3,3], "step":0.25 } ],
-  "derived": { "name": "expr of params" },             // optional: computed, never asserted
-  "elements":[
-    { "id":"plane", "type":"plane", "x":[-10,10], "y":[-10,10], "grid":true, "axisLabels":true },
-    { "id":"curve", "type":"function", "fn":"a*cos(b*x)" },
-    { "id":"out",   "type":"readout", "text":"y = {a}·cos({b}x)", "at":"top" }
-  ],
-  "reveal": ["plane","curve","out"],
-  "prompt": "Slide a and b — how does the wave change?"
-}
+Example — a function/graph model:
+${fnExample}
+
+Example — a geometry model (note how the angle is shown):
+${geoExample}
 
 Vocabulary you may use:
-- elements: plane, function (fn: an expression of x + numeric params, e.g. "a*x^2 + b"), point (at:[x,y] with draggable/binds to a param), line/segment/ray (through:[ptId,ptId]), circle (center:[x,y], radius), polygon (vertices:[ptIds]), angle (at: ptId, rays:[ptId,ptId], measure:true), readout (text with {param}/{derived}/{measure} tokens).
+- elements: plane, function (fn: an expression of x + numeric params, e.g. "a*x^2 + b"), point (at:[x,y] of NUMBERS or numeric-param names; draggable; binds a param), line/segment/ray (through:[ptId,ptId]), circle (center:[x,y], radius), polygon (vertices:[ptIds]), angle (at: ptId, rays:[ptId,ptId]) — DRAWS the arc, readout (text with {param}/{derived}/{measure} tokens).
 - controls: slider (numeric param; needs range:[lo,hi]).
-- measures: read a quantity off the LIVE geometry, e.g. "ang": { "type":"angle", "at":"B", "rays":["A","C"] } — then a readout/derived can use {ang}. THIS is how you show an angle correctly: measure it, never type a number.
+- measures: a quantity read off the LIVE geometry — currently ANGLES ONLY: "ang": { "type":"angle", "at":"B", "rays":["A","C"] }. A readout/derived then uses {ang}. To SHOW an angle you need BOTH: an angle element (draws the arc) AND a measures entry (supplies the number) — the angle element alone shows no value. (Lengths/areas aren't measurable yet, so don't build a model that needs them.)
 - derived: a value computed from params/measures, e.g. "sum": "ang1 + ang2".
 
-Hard rules: every "through"/"vertices"/"rays"/"at"(angle) must name a point id you defined; every name in an fn/derived/readout must be a declared param, derived, or measure; numeric params only inside fn; give sliders a valid range. NEVER write a measured value as a literal — declare a measure and let the engine compute it. Keep it to one focused model. Like every concept model, it's a manipulable idea, never the student's graded answer.`;
+Hard rules: every "through"/"vertices"/"rays"/"at"(angle) must name a point id you defined; every name in an fn/derived/readout must be a declared param, derived, or measure; point/circle coordinates must be NUMBERS or numeric-param names (not derived/measures); numeric params only inside fn; give sliders a valid range. NEVER write a measured value as a literal — declare a measure and let the engine compute it. Keep it to one focused model. Like every concept model, it's a manipulable idea, never the student's graded answer.`;
 }
 
 /**
@@ -146,6 +192,7 @@ module.exports = {
   isConceptModelsGenerativeEnabled,
   buildConceptModelInstructions,
   buildGenerativeSection,
+  GENERATIVE_EXAMPLES,
   modelCatalogLines,
   SUMMON_WHEN,
 };

--- a/utils/conceptModelPrompt.js
+++ b/utils/conceptModelPrompt.js
@@ -52,6 +52,7 @@ const SUMMON_WHEN = {
   inscribed_angle: 'the inscribed angle theorem — drag B, the inscribed angle stays half the central',
   triangle_angle_sum: 'the triangle angle sum — drag a vertex, the three angles re-measure and always total 180°',
   linear_pair_angles: 'a linear pair / supplementary angles on a line (the two angles total 180°)',
+  integer_counters: 'integer arithmetic with zero pairs — type an expression like −7+10, drag a red onto a yellow to cancel, see what is left (a discrete chip model)',
 };
 
 /** "  • name — blurb" lines for every curated model, from the catalog. */

--- a/utils/pipeline/index.js
+++ b/utils/pipeline/index.js
@@ -480,6 +480,13 @@ async function runPipeline(message, ctx) {
         errors: errors || null,
       });
     }
+    // Generated spec rejected but a curated name carried the card instead.
+    for (const { command, reason } of resolvedModels.fallbacks) {
+      boardLogger.warn('Concept-model spec rejected; fell back to curated model', {
+        reason,
+        model: command.model || null,
+      });
+    }
   }
 
   // ── Stage 5b.0: BOARD LLM (advisory board-card source) ──


### PR DESCRIPTION
## What this is

The follow-up to the merged generative long-tail (#1064): I audited the capability by cross-checking the three things that must agree — the **prompt** (what the LLM is told it can emit), the **validator** (what's accepted), and the **renderer** (what's actually drawn) — and fixed every place they diverged, then extended the measure system so real geometry is reachable. Two commits.

## Correctness & reliability (commit 1)

| # | Fix | Why it mattered |
|---|-----|-----------------|
| 1 | LLM-facing examples are now `JSON.stringify`'d real objects + "strict JSON, no comments" | The template carried `//` comments → a copied spec failed `JSON.parse` → **silently dropped** 🔴 |
| 2 | Added a geometry example + arc-vs-measure clarification | The harder case (where "measure, never assert" matters most) had no template |
| 3 | Test validates the **exported** examples + strict-JSON regression | The shown example couldn't rot unnoticed |
| 4 | Validator restricts coords to numbers/numeric-params | A `derived` coord **validated but rendered `NaN`** 🔴 |

## Honor what the spec declares + extend measures (commit 2)

**#6 — the renderer now honors `title` and `reveal`.** `title` is displayed (was dead metadata); `reveal` drives a **staged entrance** — board objects appear one at a time in spec order (honoring `prefers-reduced-motion`). The doc promised "reveal = animation order"; now it's true. Every board object is tracked by id to do it.

**#10 — length & area measures.** `measureDistance` (segment) and `measureArea` (polygon, shoelace, winding-agnostic) join `measureAngle` as pure, tested measurement fns. `MEASURE_TYPES` gains `length` (`{between:[A,B]}`) and `area` (`{of:[A,B,C,…]}`), validated structurally + by point-ref. **This unlocks the distance/perimeter/area geometry the prompt previously had to warn against** (Pythagorean, area models, …). The prompt now teaches all three measure kinds.

**#7 — transport robustness.** The resolver strips a Markdown code fence (` ```json … ``` `) an LLM sometimes wraps around the spec before `JSON.parse` — a common mistake that used to drop the whole model.

**#8 — no dangling references.** When a generated spec fails validation but the command also names a real curated model, fall back to it instead of dropping the card (the tutor's chat may already reference "this model"); logged as a fallback.

## Verification

- **Browser-verified on the demo with the real engine**: titles render, the angle example measures live (**53.13°**), and a generated right-triangle shows **`AB = 4 · area = 6`** from the new length/area measures, staged reveal completes with nothing left hidden, no console errors. Two new generated cards added to `/concept-model-demo.html` for ongoing verification.
- **Full suite green: 2983.** Lint: 0 errors. New tests: `measureDistance`/`measureArea`, length/area validation, derived-coord rejection, fence-strip, curated fallback, exported-example validation, strict-JSON regression.

## Deferred (need their own focused PRs)

- **#9 — the discrete/token engine.** `integer_counters` / `equation_tiles` / `area_model_factor` run on `algebra-tiles.js`, which is a **2,677-line self-contained modal** (`openAlgebraTiles` opens its own panel), not a spec-driven inline renderer. Wiring it behind the `model` verb is a real integration project, not a fold-in.
- **3-D / `intersection` primitives** (the `volume` substrate and `triangle_inequality`'s meet-point) — new rendering surface; out of scope here.

Happy to take either next.

https://claude.ai/code/session_01G5awZCfNt8pPgAeV9s6cw4