### PR TITLE
feat(concept-models): discrete token engine — integer_counters (zero pairs)

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -2288,6 +2288,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
        see CONCEPT_MODELS.md). Loaded before workspace.js, which references them. -->
   <script src="/js/conceptModelSpec.js"></script>
   <script defer src="/js/conceptModelRenderer.js"></script>
+  <script defer src="/js/conceptModelTokenRenderer.js"></script>
   <!-- Interactive math workspace (chat right slot) — after the tools it can launch -->
   <script src="/js/workspace.js"></script>
   <!-- Phase B: executes server-emitted <BOARD> commands against the embedded WorkBoard -->

--- a/public/concept-model-demo.html
+++ b/public/concept-model-demo.html
@@ -72,6 +72,13 @@
     }
     .cr-cm-choice-btn:hover { color: var(--cr-text); border-color: var(--cr-accent); }
     .cr-cm-choice-btn.is-active { color: #fff; background: var(--cr-accent-grad); border-color: transparent; }
+    /* token (discrete chip) engine */
+    .cr-cm-mat { position: relative; width: 100%; min-height: 220px; border-radius: var(--cr-radius-sm); background: var(--cr-bg-deep); border: 1px solid var(--cr-border); overflow: hidden; touch-action: none; }
+    .cr-cm-chip { position: absolute; display: flex; align-items: center; justify-content: center; border-radius: 50%; border: 2px solid; font-weight: 800; font-size: 16px; cursor: grab; user-select: none; touch-action: none; box-shadow: 0 2px 5px rgba(28,21,48,0.18); }
+    .cr-cm-chip.is-dragging { cursor: grabbing; box-shadow: 0 5px 12px rgba(28,21,48,0.32); z-index: 5; }
+    .cr-cm-token-input { display: flex; gap: 8px; align-items: center; padding: 2px 4px 0; }
+    .cr-cm-token-field { flex: 1 1 auto; min-width: 0; padding: 7px 10px; font-size: 14px; border: 1px solid var(--cr-border); border-radius: var(--cr-radius-sm); background: var(--cr-bg-2); color: var(--cr-text); }
+    .cr-cm-token-field.is-invalid { border-color: #e0556e; background: #fff2f4; }
   </style>
 </head>
 <body>
@@ -118,10 +125,15 @@
       <h2>GENERATED — length &amp; area measures (drag a vertex; side and area update live)</h2>
       <div class="host" id="host-gen2"></div>
     </div>
+    <div class="demo-card">
+      <h2>integer_counters — DISCRETE token engine (type −7+10; drag a red onto a yellow to cancel)</h2>
+      <div class="host" id="host-ic"></div>
+    </div>
   </div>
 
   <script src="/js/conceptModelSpec.js"></script>
   <script src="/js/conceptModelRenderer.js"></script>
+  <script src="/js/conceptModelTokenRenderer.js"></script>
   <script>
     function boot() {
       window.ConceptModelRenderer.renderModel(
@@ -191,6 +203,12 @@
           drag: ['A', 'B', 'C'],
           prompt: 'Drag a vertex — the side length and area are measured live.'
         }
+      );
+
+      // The discrete substrate: a curated token model (engine:"tokens"). Dispatched
+      // to ConceptModelTokenRenderer — inline chips, not the algebra-tiles modal.
+      window.ConceptModelRenderer.renderModel(
+        document.getElementById('host-ic'), 'integer_counters'
       );
     }
     if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', boot);

--- a/public/css/workspace.css
+++ b/public/css/workspace.css
@@ -736,6 +736,47 @@
   border-color: transparent;
 }
 
+/* ── token (discrete chip) engine — integer counters / algebra tiles ── */
+.cr-cm-mat {
+  position: relative;
+  width: 100%;
+  min-height: 220px;
+  border-radius: var(--cr-radius-sm);
+  background: var(--cr-bg-deep);
+  border: 1px solid var(--cr-border);
+  overflow: hidden;
+  touch-action: none;
+}
+.cr-cm-chip {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: 2px solid;
+  font-weight: 800;
+  font-size: 16px;
+  cursor: grab;
+  user-select: none;
+  touch-action: none;
+  box-shadow: 0 2px 5px rgba(28, 21, 48, 0.18);
+  transition: box-shadow 0.12s ease;
+}
+.cr-cm-chip.is-dragging { cursor: grabbing; box-shadow: 0 5px 12px rgba(28, 21, 48, 0.32); z-index: 5; }
+.cr-cm-token-input { display: flex; gap: 8px; align-items: center; padding: 2px 4px 0; }
+.cr-cm-token-field {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 7px 10px;
+  font-size: 14px;
+  border: 1px solid var(--cr-border);
+  border-radius: var(--cr-radius-sm);
+  background: var(--cr-bg-2);
+  color: var(--cr-text);
+}
+.cr-cm-token-field:focus { outline: none; border-color: var(--cr-accent); }
+.cr-cm-token-field.is-invalid { border-color: #e0556e; background: #fff2f4; }
+
 /* Shared caption styling for graph + image cards. */
 .cr-ws-board-card-caption {
   margin-top: 8px;

--- a/public/js/conceptModelRenderer.js
+++ b/public/js/conceptModelRenderer.js
@@ -119,6 +119,24 @@
       return Promise.resolve(false);
     }
 
+    // Dispatch by substrate (CONCEPT_MODELS.md: "two rendering engines, one
+    // spec"). Discrete/token models are inline chips — no JSXGraph, no plane — so
+    // they go to the token renderer instead of the JSXGraph build below.
+    if (spec.engine === 'tokens') {
+      if (!window.ConceptModelTokenRenderer) {
+        container.textContent = 'Concept-model token engine unavailable.';
+        return Promise.resolve(false);
+      }
+      try {
+        window.ConceptModelTokenRenderer.render(container, spec, opts);
+        return Promise.resolve(true);
+      } catch (e) {
+        if (window.console) console.error('[ConceptModel] token render failed', e);
+        container.textContent = 'Concept-model token engine error.';
+        return Promise.resolve(false);
+      }
+    }
+
     return loadJSXGraph().then(function () {
       try {
         build(container, spec, opts);

--- a/public/js/conceptModelSpec.js
+++ b/public/js/conceptModelSpec.js
@@ -382,6 +382,25 @@
       reveal: ['plane', 'circ', 'O', 'A', 'A2', 'B', 'lineA', 'rayB', 'ang1', 'ang2', 'out'],
       drag: ['B'],
       prompt: 'Drag B along the arc. The two angles on the line always add to 180° — a linear pair.'
+    },
+
+    // First DISCRETE model (engine:"tokens", not JSXGraph). Two-color counters
+    // for integer arithmetic: type an expression -> chips appear (yellow = +1,
+    // red = −1) -> drag a red onto a yellow to make a zero pair -> what's left is
+    // the answer. The Sum is MEASURED from the chips on the mat (never asserted)
+    // and is invariant as zero pairs cancel — that invariance is the lesson.
+    integer_counters: {
+      model: 'integer_counters',
+      engine: 'tokens',
+      title: 'Integer counters — zero pairs',
+      input: { expression: true, placeholder: '-7 + 10' },
+      tokens: [
+        { value: 1, color: 'yellow', label: '+' },
+        { value: -1, color: 'red', label: '−' }
+      ],
+      rules: [{ when: 'overlap-opposite', do: 'annihilate' }],
+      readout: { text: 'Sum: {net}', format: 'signedInt' },
+      prompt: 'Type an expression, then drag a red onto a yellow to cancel — what is left?'
     }
   };
 
@@ -452,6 +471,84 @@
     return Math.abs(sum) / 2;
   }
 
+  // ─── Discrete / token engine (the second substrate) ─────────────────────
+  // Integer counters & algebra tiles: discrete draggable CHIPS the student
+  // arranges, with zero-pair cancellation. The "measure, never assert" property
+  // holds here too — the net (the sum of the chips on the mat) is COMPUTED from
+  // what's present, never typed. This module owns the pure logic + validation;
+  // the inline chip renderer is public/js/conceptModelTokenRenderer.js.
+
+  var TOKEN_RULE_WHEN = { 'overlap-opposite': 1 };
+  var TOKEN_RULE_DO = { annihilate: 1 };
+  var MAX_TOKENS = 60; // cap chips spawned from one expression (UI + DoS guard)
+
+  // Expand an integer add/subtract expression into chip counts:
+  // "-7 + 10" -> { positives: 10, negatives: 7, net: 3 }. Returns null for
+  // anything that isn't a sum/difference of integers (the only thing integer
+  // counters model). `net` is the live measured quantity a {net} readout shows —
+  // and it is INVARIANT under zero-pair cancellation, which is the whole lesson.
+  function expandIntegerExpression(str) {
+    if (typeof str !== 'string') return null;
+    var s = str.replace(/[−–—]/g, '-').replace(/\s+/g, '');
+    if (!/^[+-]?\d+([+-]\d+)*$/.test(s)) return null;
+    var terms = s.match(/[+-]?\d+/g).map(Number);
+    var positives = 0, negatives = 0;
+    terms.forEach(function (t) { if (t >= 0) positives += t; else negatives += -t; });
+    return { positives: positives, negatives: negatives, net: positives - negatives, terms: terms };
+  }
+
+  // Validate a token-engine spec (engine:"tokens"). Different shape from the
+  // JSXGraph path: chip TYPES (value + color), an optional expression input,
+  // optional interaction rules (zero-pair cancel), and a readout that may show
+  // the live {net}.
+  function validateTokenSpec(spec) {
+    var errors = [];
+    if (typeof spec.model !== 'string' || !spec.model) errors.push('spec.model must be a non-empty string');
+
+    if (!Array.isArray(spec.tokens) || spec.tokens.length === 0) {
+      errors.push('token spec needs a non-empty tokens array');
+    } else {
+      spec.tokens.forEach(function (t, i) {
+        if (!isPlainObject(t)) { errors.push('token[' + i + '] must be an object'); return; }
+        if (typeof t.value !== 'number') errors.push('token[' + i + '] needs a numeric value');
+        if (typeof t.color !== 'string' || !t.color) errors.push('token[' + i + '] needs a color');
+      });
+    }
+
+    if (spec.input != null) {
+      if (!isPlainObject(spec.input)) errors.push('token spec input must be an object');
+      else if (spec.input.placeholder != null && typeof spec.input.placeholder !== 'string') {
+        errors.push('token input placeholder must be a string');
+      }
+    }
+
+    if (spec.rules != null) {
+      if (!Array.isArray(spec.rules)) {
+        errors.push('token spec rules must be an array');
+      } else {
+        spec.rules.forEach(function (r, i) {
+          if (!isPlainObject(r)) { errors.push('rule[' + i + '] must be an object'); return; }
+          if (!TOKEN_RULE_WHEN[r.when]) errors.push('rule[' + i + '] has unknown when "' + r.when + '"');
+          if (!TOKEN_RULE_DO[r.do]) errors.push('rule[' + i + '] has unknown do "' + r.do + '"');
+        });
+      }
+    }
+
+    if (spec.readout != null) {
+      if (!isPlainObject(spec.readout)) {
+        errors.push('token spec readout must be an object');
+      } else if (typeof spec.readout.text !== 'string') {
+        errors.push('token readout needs text');
+      } else {
+        readoutTokens(spec.readout.text).forEach(function (tok) {
+          if (tok !== 'net') errors.push('token readout references unknown name "' + tok + '" (only {net})');
+        });
+      }
+    }
+
+    return { valid: errors.length === 0, errors: errors };
+  }
+
   /**
    * Validate a concept-model spec.
    * @param {object} spec
@@ -460,6 +557,9 @@
   function validateModelSpec(spec) {
     var errors = [];
     if (!isPlainObject(spec)) return { valid: false, errors: ['spec must be an object'] };
+    // The discrete/token substrate has a different shape (chips, not a plane of
+    // elements), so it validates on its own path.
+    if (spec.engine === 'tokens') return validateTokenSpec(spec);
     if (typeof spec.model !== 'string' || !spec.model) errors.push('spec.model must be a non-empty string');
     if (!isPlainObject(spec.params)) errors.push('spec.params must be an object');
 
@@ -813,6 +913,8 @@
     measureAngle: measureAngle,
     measureDistance: measureDistance,
     measureArea: measureArea,
+    expandIntegerExpression: expandIntegerExpression,
+    MAX_TOKENS: MAX_TOKENS,
     MODELS: Object.keys(CURATED)
   };
 });

--- a/public/js/conceptModelTokenRenderer.js
+++ b/public/js/conceptModelTokenRenderer.js
@@ -1,0 +1,246 @@
+/**
+ * conceptModelTokenRenderer.js — the DISCRETE substrate for WorkBoard concept
+ * models (CONCEPT_MODELS.md: "two rendering engines, one spec").
+ *
+ * Where conceptModelRenderer.js draws continuous geometry with JSXGraph, this
+ * draws discrete, draggable CHIPS for integer/algebra-tile reasoning — inline in
+ * a board card, summoned with intent, not the heavyweight algebra-tiles.js modal.
+ *
+ * The flagship is `integer_counters`: type an expression -> chips appear (yellow
+ * = +1, red = −1) -> drag a red onto a yellow to make a ZERO PAIR (they cancel)
+ * -> what's left is the answer. The keystone "measure, never assert" property
+ * holds here too: the Sum readout is COMPUTED from the chips on the mat, never
+ * typed — and it stays the same as zero pairs cancel, which is the whole point.
+ *
+ * All correctness/structure lives in window.ConceptModelSpec (pure, tested): the
+ * validator, and expandIntegerExpression (the expression -> chip-count math).
+ * This file only draws and wires the drag-to-cancel interaction. No external
+ * deps — no JSXGraph, no network.
+ */
+(function () {
+  'use strict';
+
+  var CHIP = 38;          // chip diameter (px)
+  var GAP = 8;            // gap between chips in the spawn layout
+  var ANNIHILATE_DIST = 30; // center-to-center px to count as a zero-pair overlap
+
+  // Spec colors -> {bg, border, text}. Falls back to using the literal color.
+  var COLORS = {
+    yellow: { bg: '#FFD24A', border: '#E0A800', text: '#5a4500' },
+    red: { bg: '#FF6B6B', border: '#E04C4C', text: '#5a0000' }
+  };
+
+  function el(tag, cls) { var n = document.createElement(tag); if (cls) n.className = cls; return n; }
+
+  function signedInt(n) {
+    if (!isFinite(n)) return '—';
+    n = Math.round(n);
+    return n > 0 ? '+' + n : String(n); // +3, 0, -2
+  }
+
+  function render(container, spec, opts) {
+    opts = opts || {};
+    if (!container) return false;
+    var CMS = window.ConceptModelSpec;
+    if (CMS && CMS.validateModelSpec) {
+      var check = CMS.validateModelSpec(spec);
+      if (!check.valid) {
+        container.textContent = "Couldn't build that model.";
+        if (window.console) console.warn('[ConceptModelToken] invalid spec', spec.model, check.errors);
+        return false;
+      }
+    }
+    container.innerHTML = '';
+
+    // Chip TYPES from the spec (value + color + label). For integer counters
+    // there are two: +1 (yellow) and −1 (red).
+    var tokens = spec.tokens || [];
+    var posType = tokens.filter(function (t) { return t.value > 0; })[0] || null;
+    var negType = tokens.filter(function (t) { return t.value < 0; })[0] || null;
+    var maxTokens = (CMS && CMS.MAX_TOKENS) || 60;
+
+    // ── DOM scaffold ────────────────────────────────────────────────────────
+    var root = el('div', 'cr-cm cr-cm--tokens');
+    if (spec.title) { var t = el('div', 'cr-cm-title'); t.textContent = spec.title; root.appendChild(t); }
+    var promptText = opts.prompt || spec.prompt;
+    if (promptText) { var pf = el('div', 'cr-cm-prompt'); pf.textContent = promptText; root.appendChild(pf); }
+
+    var readoutRow = el('div', 'cr-cm-readouts');
+    var readoutHost = el('div', 'cr-cm-readout');
+    var readoutMath = el('span', 'cr-cm-readout-math');
+    readoutHost.appendChild(readoutMath);
+    readoutRow.appendChild(readoutHost);
+    root.appendChild(readoutRow);
+
+    var mat = el('div', 'cr-cm-mat');
+    root.appendChild(mat);
+
+    var inputRow = null, inputField = null;
+    if (spec.input) {
+      inputRow = el('div', 'cr-cm-token-input');
+      inputField = document.createElement('input');
+      inputField.type = 'text';
+      inputField.className = 'cr-cm-token-field';
+      inputField.placeholder = spec.input.placeholder || 'e.g. -7 + 10';
+      inputField.setAttribute('aria-label', 'expression to build with counters');
+      var buildBtn = el('button', 'cr-cm-choice-btn cr-cm-token-build');
+      buildBtn.type = 'button'; buildBtn.textContent = 'Build';
+      var clearBtn = el('button', 'cr-cm-choice-btn cr-cm-token-clear');
+      clearBtn.type = 'button'; clearBtn.textContent = 'Clear';
+      inputRow.appendChild(inputField);
+      inputRow.appendChild(buildBtn);
+      inputRow.appendChild(clearBtn);
+      root.appendChild(inputRow);
+
+      buildBtn.addEventListener('click', buildFromInput);
+      clearBtn.addEventListener('click', function () { clearChips(); renderReadout(); });
+      inputField.addEventListener('keydown', function (e) { if (e.key === 'Enter') buildFromInput(); });
+    }
+
+    container.appendChild(root);
+
+    // ── chip state + the live measure ─────────────────────────────────────────
+    var chips = [];      // { id, value, el, x, y }
+    var chipId = 0;
+    var hasAnnihilate = (spec.rules || []).some(function (r) {
+      return r.when === 'overlap-opposite' && r.do === 'annihilate';
+    });
+
+    function net() { return chips.reduce(function (s, c) { return s + c.value; }, 0); }
+
+    function renderReadout() {
+      var template = (spec.readout && spec.readout.text) || 'Sum: {net}';
+      var fmt = spec.readout && spec.readout.format;
+      var n = net();
+      readoutMath.textContent = template.replace(/\{net\}/g, fmt === 'signedInt' ? signedInt(n) : String(Math.round(n)));
+    }
+
+    function colorOf(type) { return COLORS[type.color] || { bg: type.color, border: '#0003', text: '#000' }; }
+
+    function clearChips() {
+      chips.forEach(function (c) { if (c.el && c.el.parentNode) c.el.parentNode.removeChild(c.el); });
+      chips = [];
+    }
+
+    function matWidth() { return mat.clientWidth || 320; }
+
+    function addChip(type, x, y) {
+      var c = colorOf(type);
+      var node = el('div', 'cr-cm-chip');
+      node.style.width = node.style.height = CHIP + 'px';
+      node.style.background = c.bg;
+      node.style.borderColor = c.border;
+      node.style.color = c.text;
+      node.textContent = type.label != null ? type.label : (type.value > 0 ? '+' : '−');
+      node.style.left = x + 'px';
+      node.style.top = y + 'px';
+      mat.appendChild(node);
+      var chip = { id: ++chipId, value: type.value, el: node, x: x, y: y };
+      chips.push(chip);
+      attachDrag(chip);
+      return chip;
+    }
+
+    // Lay a count of one chip type out in a row-major grid, starting at (x0,y0).
+    function layout(count, type, x0, y0) {
+      var cols = Math.max(1, Math.floor((matWidth() - GAP) / (CHIP + GAP)));
+      for (var i = 0; i < count; i++) {
+        var col = i % cols, rowi = Math.floor(i / cols);
+        addChip(type, x0 + col * (CHIP + GAP), y0 + rowi * (CHIP + GAP));
+      }
+    }
+
+    function spawn(positives, negatives) {
+      clearChips();
+      // Yellows in the top band; reds in a lower band — so the two stacks read as
+      // separate quantities before the student starts cancelling.
+      if (posType) layout(positives, posType, GAP, GAP);
+      var posRows = posType ? Math.ceil(positives / Math.max(1, Math.floor((matWidth() - GAP) / (CHIP + GAP)))) : 0;
+      var redY = GAP + posRows * (CHIP + GAP) + GAP;
+      if (negType) layout(negatives, negType, GAP, redY);
+      renderReadout();
+    }
+
+    function buildFromInput() {
+      if (!inputField) return;
+      var parsed = CMS && CMS.expandIntegerExpression(inputField.value);
+      if (!parsed) { flashInvalid(); return; }
+      if (parsed.positives + parsed.negatives > maxTokens) { flashInvalid('Too many counters — try smaller numbers.'); return; }
+      spawn(parsed.positives, parsed.negatives);
+    }
+
+    function flashInvalid(msg) {
+      inputField.classList.add('is-invalid');
+      inputField.title = msg || 'Enter integers to add/subtract, e.g. -7 + 10';
+      setTimeout(function () { inputField.classList.remove('is-invalid'); }, 800);
+    }
+
+    // ── drag-to-cancel (the zero-pair interaction) ────────────────────────────
+    function attachDrag(chip) {
+      var node = chip.el;
+      var startX, startY, originX, originY, dragging = false;
+      node.addEventListener('pointerdown', function (e) {
+        dragging = true;
+        node.classList.add('is-dragging');
+        node.setPointerCapture(e.pointerId);
+        startX = e.clientX; startY = e.clientY;
+        originX = chip.x; originY = chip.y;
+        e.preventDefault();
+      });
+      node.addEventListener('pointermove', function (e) {
+        if (!dragging) return;
+        var w = matWidth(), h = mat.clientHeight || 220;
+        chip.x = Math.max(0, Math.min(w - CHIP, originX + (e.clientX - startX)));
+        chip.y = Math.max(0, Math.min(h - CHIP, originY + (e.clientY - startY)));
+        node.style.left = chip.x + 'px';
+        node.style.top = chip.y + 'px';
+      });
+      function end() {
+        if (!dragging) return;
+        dragging = false;
+        node.classList.remove('is-dragging');
+        if (hasAnnihilate) tryAnnihilate(chip);
+      }
+      node.addEventListener('pointerup', end);
+      node.addEventListener('pointercancel', end);
+    }
+
+    // If `chip` overlaps an OPPOSITE-sign chip, the two make a zero pair and
+    // cancel. The Sum is unchanged by this (it removes +1 and −1 together) — the
+    // chips just collapse toward the answer.
+    function tryAnnihilate(chip) {
+      var partner = null, best = ANNIHILATE_DIST;
+      for (var i = 0; i < chips.length; i++) {
+        var o = chips[i];
+        if (o === chip || (o.value > 0) === (chip.value > 0)) continue; // same sign
+        var dx = (o.x - chip.x), dy = (o.y - chip.y);
+        var d = Math.sqrt(dx * dx + dy * dy);
+        if (d < best) { best = d; partner = o; }
+      }
+      if (partner) { removeChip(chip); removeChip(partner); renderReadout(); }
+    }
+
+    function removeChip(chip) {
+      var i = chips.indexOf(chip);
+      if (i !== -1) chips.splice(i, 1);
+      if (chip.el && chip.el.parentNode) chip.el.parentNode.removeChild(chip.el);
+    }
+
+    // ── initial paint ─────────────────────────────────────────────────────────
+    // Start populated from the placeholder so the model is alive on arrival
+    // (like the slider models start with a line drawn).
+    var seed = spec.input && spec.input.placeholder;
+    var seedParsed = seed && CMS && CMS.expandIntegerExpression(seed);
+    if (seedParsed && seedParsed.positives + seedParsed.negatives <= maxTokens) {
+      if (inputField) inputField.value = seed;
+      // Defer one frame so mat.clientWidth is known for the grid layout.
+      requestAnimationFrame(function () { spawn(seedParsed.positives, seedParsed.negatives); });
+    }
+    renderReadout();
+    return true;
+  }
+
+  if (typeof window !== 'undefined') {
+    window.ConceptModelTokenRenderer = { render: render };
+  }
+})();

--- a/tests/unit/conceptModelSpec.test.js
+++ b/tests/unit/conceptModelSpec.test.js
@@ -6,6 +6,7 @@ const {
   measureAngle,
   measureDistance,
   measureArea,
+  expandIntegerExpression,
   MODELS,
 } = require('../../public/js/conceptModelSpec');
 
@@ -426,5 +427,76 @@ describe('conceptModelSpec — geometry (measure, never assert)', () => {
     s.derived = { total: 'ang + ang2' };
     s.elements.find((e) => e.id === 'out').text = 'sum = {total}';
     expect(validateModelSpec(s).valid).toBe(true);
+  });
+});
+
+describe('conceptModelSpec — token engine (discrete chips, zero pairs)', () => {
+  it('expandIntegerExpression splits an expression into chip counts + net', () => {
+    expect(expandIntegerExpression('-7 + 10')).toEqual({ positives: 10, negatives: 7, net: 3, terms: [-7, 10] });
+    expect(expandIntegerExpression('5 - 8')).toEqual({ positives: 5, negatives: 8, net: -3, terms: [5, -8] });
+    expect(expandIntegerExpression('+6')).toEqual({ positives: 6, negatives: 0, net: 6, terms: [6] });
+  });
+
+  it('net is invariant under zero-pair cancellation (the lesson)', () => {
+    // -7 + 10 → 10 yellow, 7 red, net +3. Cancelling all 7 pairs leaves 3 yellow,
+    // still +3 — removing a +1 and a −1 together never changes the sum.
+    const e = expandIntegerExpression('-7 + 10');
+    const afterCancel = (e.positives - 7) - (e.negatives - 7);
+    expect(afterCancel).toBe(e.net);
+  });
+
+  it('returns null for anything that is not integer add/subtract', () => {
+    expect(expandIntegerExpression('2 * 3')).toBeNull();
+    expect(expandIntegerExpression('x + 1')).toBeNull();
+    expect(expandIntegerExpression('3.5 + 1')).toBeNull();
+    expect(expandIntegerExpression('')).toBeNull();
+    expect(expandIntegerExpression(null)).toBeNull();
+  });
+
+  it('normalizes a unicode minus', () => {
+    expect(expandIntegerExpression('−7 + 10').net).toBe(3); // − (U+2212)
+  });
+
+  function tbase() {
+    return {
+      model: 'counters',
+      engine: 'tokens',
+      input: { expression: true, placeholder: '-7 + 10' },
+      tokens: [
+        { value: 1, color: 'yellow', label: '+' },
+        { value: -1, color: 'red', label: '−' },
+      ],
+      rules: [{ when: 'overlap-opposite', do: 'annihilate' }],
+      readout: { text: 'Sum: {net}', format: 'signedInt' },
+    };
+  }
+
+  it('validates a well-formed token spec on its own path', () => {
+    expect(validateModelSpec(tbase()).errors).toEqual([]);
+  });
+
+  it('the curated integer_counters validates and is in the catalog', () => {
+    expect(MODELS).toContain('integer_counters');
+    expect(validateModelSpec(getModel('integer_counters')).errors).toEqual([]);
+  });
+
+  it('rejects a token spec with no tokens', () => {
+    const s = tbase(); s.tokens = [];
+    expect(validateModelSpec(s).errors.join(' ')).toMatch(/non-empty tokens array/);
+  });
+
+  it('rejects a token whose value is not numeric', () => {
+    const s = tbase(); s.tokens[0].value = 'one';
+    expect(validateModelSpec(s).errors.join(' ')).toMatch(/token\[0\] needs a numeric value/);
+  });
+
+  it('rejects an unknown interaction rule', () => {
+    const s = tbase(); s.rules[0].do = 'explode';
+    expect(validateModelSpec(s).errors.join(' ')).toMatch(/unknown do "explode"/);
+  });
+
+  it('rejects a readout that references anything but {net}', () => {
+    const s = tbase(); s.readout.text = 'Sum: {total}';
+    expect(validateModelSpec(s).errors.join(' ')).toMatch(/unknown name "total" \(only \{net\}\)/);
   });
 });

--- a/utils/conceptModelPrompt.js
+++ b/utils/conceptModelPrompt.js
@@ -52,6 +52,7 @@ const SUMMON_WHEN = {
   inscribed_angle: 'the inscribed angle theorem — drag B, the inscribed angle stays half the central',
   triangle_angle_sum: 'the triangle angle sum — drag a vertex, the three angles re-measure and always total 180°',
   linear_pair_angles: 'a linear pair / supplementary angles on a line (the two angles total 180°)',
+  integer_counters: 'integer arithmetic with zero pairs — type an expression like −7+10, drag a red onto a yellow to cancel, see what is left (a discrete chip model)',
 };
 
 /** "  • name — blurb" lines for every curated model, from the catalog. */


### PR DESCRIPTION
## What this is

**Audit item #9 — the discrete/token substrate**, wired into the `model` verb. This is the biggest remaining capability gap from the concept-models arc, now closed for its flagship model.

> **Stacked on #1067** (base is its branch, so the diff shows only the token-engine commit). GitHub will auto-retarget this to `main` when #1067 merges.

## The approach (and why not "just configure algebra-tiles.js")

The doc framed the token half as *"configure, don't build."* But `algebra-tiles.js` is a **2,677-line self-contained modal** — its own header, close button, sidebar, tool palette (select/text/arrow/eraser), undo/redo, mat selector. Dropping that into an inline board card would be the wrong UX entirely (a concept model is *summoned with intent*, focused, inline — not a tool drawer).

So this follows the doc's actual architecture — **"two rendering engines, one spec; dispatch by `engine`"** — and adds a small, spec-driven token renderer parallel to the JSXGraph one. Clean, inline, no entanglement with the modal.

## Changes

- **`conceptModelTokenRenderer.js` (new)** — inline two-color counters. Type an expression → chips appear (yellow `+1`, red `−1`) → **drag a red onto a yellow** to make a zero pair → they cancel. The `Sum` readout is **measured from the chips on the mat** (never asserted) and is **invariant as pairs cancel** — that invariance is the whole lesson. Pointer-based drag, no deps.
- **`conceptModelSpec.js`** — `validateModelSpec` dispatches `engine:"tokens"` to a new `validateTokenSpec` (tokens/input/rules/readout shape; readout may only read `{net}`). Pure `expandIntegerExpression` (`"-7 + 10"` → `{positives:10, negatives:7, net:3}`) owns the chip-count math, Node-tested. Curated **`integer_counters`** added to the catalog.
- **`conceptModelRenderer.js`** — `renderModel` dispatches `engine:"tokens"` to the token renderer (no JSXGraph load); the JSXGraph path is unchanged.
- **Wiring** — token-renderer script added to `chat.html` + the demo; chip/mat CSS in `workspace.css` + demo; `integer_counters` catalog blurb in `conceptModelPrompt`; demo gains an `integer_counters` card.

## Verification

**Browser-verified with the real engine** (pointer-driven drag): `-7 + 10` spawns **10 yellow + 7 red**, readout **`Sum: +3`**; dragging a red onto a yellow **cancels the pair** (→ 9/6) with the sum **still `+3`**, no console errors. Screenshot shared in session.

**Full suite green: 2993.** Lint: 0 errors. New tests: `expandIntegerExpression` (incl. unicode-minus, non-integer rejection, net-invariance), `validateTokenSpec`, and that curated `integer_counters` validates + is in the catalog.

## What's next on the token half (follow-ups)

`equation_tiles` (solve `2x+3=7`: cross-the-`=` sign flip, both-sides) and `area_model_factor` (box method / factoring) — both extend this same renderer with variable tiles + zones. And the geometry `intersection` primitive + 3-D `volume` substrate remain. Happy to take any next.

https://claude.ai/code/session_01G5awZCfNt8pPgAeV9s6cw4

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5awZCfNt8pPgAeV9s6cw4)_