### PR TITLE
feat(workboard): mobile inline cards — board work surfaces in the chat thread

### DIFF
--- a/public/css/workspace.css
+++ b/public/css/workspace.css
@@ -681,6 +681,42 @@
   background: #fff7ec;
 }
 
+/* ---- Mobile inline mirror: board cards surfaced in the chat thread ----
+   On phones the board is a hidden drawer, so each card is mirrored into the
+   chat stream (see appendBoardMirror). These wrappers center a real
+   .cr-ws-board-card (reusing all its variant styling) within the message flow. */
+.cr-ws-chat-mirror {
+  display: flex;
+  justify-content: center;
+  margin: 8px auto;
+  padding: 0 8px;
+}
+.cr-ws-chat-mirror .cr-ws-board-card {
+  width: 100%;
+  max-width: 520px;
+}
+/* Tap-chip for interactive/heavy cards (scaffold, graph, image, model). */
+.cr-ws-mirror-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  max-width: 520px;
+  padding: 11px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  text-align: left;
+  color: var(--cr-text);
+  background: var(--cr-bg-panel);
+  border: 1px dashed var(--cr-accent, #7b61ff);
+  border-radius: var(--cr-radius-md);
+  cursor: pointer;
+}
+.cr-ws-mirror-chip > span:first-of-type { flex: 1; }
+.cr-ws-mirror-chip-go { color: var(--cr-accent, #7b61ff); font-weight: 700; white-space: nowrap; }
+.cr-ws-mirror-chip i { color: var(--cr-accent, #7b61ff); }
+.cr-ws-mirror-chip:hover { background: var(--cr-pill-bg); }
+
 /* Worked example — a read-only step of a derivation the TUTOR is teaching, not
    the student's own work. A calm instructional blue (distinct from the student's
    purple work, the green SOLVED, and the amber scaffold) plus a "WORKED EXAMPLE"

--- a/public/js/workspace.js
+++ b/public/js/workspace.js
@@ -606,6 +606,78 @@
       var stack = WS.body.querySelector('.cr-ws-board-stack');
       appendStepCard(stack, step, /*animate*/ true);
     }
+    // On phones the board is a hidden drawer, so the running work is out of
+    // sight. Mirror each card straight into the chat thread, where the student
+    // already is — no drawer to open. (No-op on wider screens; see appendBoardMirror.)
+    appendBoardMirror(step);
+  }
+
+  // True on phone-width screens, where the board lives behind the FAB drawer.
+  function isMobileChat() {
+    return typeof window !== 'undefined' && typeof window.matchMedia === 'function' &&
+      window.matchMedia('(max-width: 768px)').matches;
+  }
+
+  function openBoardDrawer() {
+    openWorkspace();
+    if (window.MathWorkspace) window.MathWorkspace.showTool('board');
+  }
+
+  // Drop a compact reflection of a board card into the chat thread (phones only).
+  // Read-only math cards render in full so the student can follow the work inline;
+  // interactive/heavy cards (scaffold, graph, image, model) render as a chip that
+  // opens the drawer, where the real interaction/space lives.
+  function appendBoardMirror(step) {
+    if (!isMobileChat() || !step) return;
+    var chat = document.getElementById('chat-messages-container');
+    if (!chat) return;
+
+    var t = step.type;
+    var wrap = el('div', 'cr-ws-chat-mirror');
+    var INLINE = { pose: 1, resolve: 1, verify: 1, apply: 1, worked: 1 };
+    var HEAVY_LABEL = { graph: 'Graph', image: 'Diagram', model: 'Interactive model', diagram: 'Diagram', scaffold: 'Your turn — fill the blanks' };
+
+    if (INLINE[t]) {
+      var variant = 'cr-ws-board-card--' + t;
+      var card = el('div', 'cr-ws-board-card ' + variant);
+      if (t === 'apply') {
+        card.innerHTML =
+          '<span class="cr-ws-board-apply-arrow" aria-hidden="true">↓</span>' +
+          '<span class="cr-ws-board-apply-op"></span>';
+        card.querySelector('.cr-ws-board-apply-op').textContent = step.op || '';
+      } else {
+        var math = el('div', 'cr-ws-board-card-math');
+        card.appendChild(math);
+        renderTex(math, step.tex);
+        if (t === 'verify' && step.check) {
+          var checkRow = el('div', 'cr-ws-board-card-check');
+          checkRow.innerHTML =
+            '<i class="fas fa-check-circle" aria-hidden="true"></i> ' +
+            '<span class="cr-ws-board-card-check-math"></span>';
+          card.appendChild(checkRow);
+          renderTex(checkRow.querySelector('.cr-ws-board-card-check-math'), step.check);
+        }
+        if (t === 'worked' && step.label) {
+          var wcap = el('div', 'cr-ws-board-card-caption');
+          wcap.textContent = step.label;
+          card.appendChild(wcap);
+        }
+      }
+      wrap.appendChild(card);
+    } else {
+      // scaffold / graph / image / model / diagram → tap-chip to the drawer.
+      var chip = el('button', 'cr-ws-mirror-chip');
+      chip.type = 'button';
+      var label = HEAVY_LABEL[t] || 'Open board';
+      chip.innerHTML = '<i class="fas fa-up-right-from-square" aria-hidden="true"></i> ' +
+        '<span></span> <span class="cr-ws-mirror-chip-go">Open ↗</span>';
+      chip.querySelector('span').textContent = label;
+      chip.addEventListener('click', openBoardDrawer);
+      wrap.appendChild(chip);
+    }
+
+    chat.appendChild(wrap);
+    try { wrap.scrollIntoView({ behavior: 'smooth', block: 'nearest' }); } catch (_) { /* old browser */ }
   }
 
   // ---- Graph tool (live embed) -----------------------------------------
@@ -818,12 +890,12 @@
     boardPose: function (tex, opts) {
       tex = (tex == null ? '' : String(tex)).trim();
       if (!tex) return false;
-      openWorkspace();
-      // Switching only if the user isn't actively in another tab. For
-      // now we DO switch — Board is the natural home and a fresh pose
-      // is a new conversation move. Revisit if telemetry shows focus
-      // stealing is annoying.
-      this.showTool('board');
+      // Desktop: reveal + focus the board. Phones: stay in chat — the pose
+      // mirrors into the thread (appendBoardMirror); the drawer is one tap away.
+      if (!isMobileChat()) {
+        openWorkspace();
+        this.showTool('board');
+      }
       pushBoardStep({ type: 'pose', tex: tex, opts: opts || null });
       return true;
     },
@@ -861,8 +933,10 @@
     boardScaffold: function (tex) {
       tex = (tex == null ? '' : String(tex)).trim();
       if (!tex) return false;
-      openWorkspace();
-      this.showTool('board');
+      // On phones, don't auto-pop the drawer — the card surfaces inline in the
+      // chat thread instead (see appendBoardMirror). The drawer stays one tap
+      // away (FAB / mirror chip) for the full board.
+      if (!isMobileChat()) { openWorkspace(); this.showTool('board'); }
       pushBoardStep({ type: 'scaffold', tex: tex });
       return true;
     },
@@ -877,8 +951,10 @@
     boardExample: function (tex, label) {
       tex = (tex == null ? '' : String(tex)).trim();
       if (!tex) return false;
-      openWorkspace();
-      this.showTool('board');
+      // On phones, don't auto-pop the drawer — the card surfaces inline in the
+      // chat thread instead (see appendBoardMirror). The drawer stays one tap
+      // away (FAB / mirror chip) for the full board.
+      if (!isMobileChat()) { openWorkspace(); this.showTool('board'); }
       var step = { type: 'worked', tex: tex };
       if (label) step.label = String(label).trim();
       pushBoardStep(step);
@@ -909,8 +985,10 @@
     boardGraph: function (fn, caption) {
       fn = (fn == null ? '' : String(fn)).trim();
       if (!fn) return false;
-      openWorkspace();
-      this.showTool('board');
+      // On phones, don't auto-pop the drawer — the card surfaces inline in the
+      // chat thread instead (see appendBoardMirror). The drawer stays one tap
+      // away (FAB / mirror chip) for the full board.
+      if (!isMobileChat()) { openWorkspace(); this.showTool('board'); }
       var step = { type: 'graph', fn: fn };
       if (caption) step.caption = String(caption).trim();
       pushBoardStep(step);
@@ -926,8 +1004,10 @@
     boardImage: function (query, caption) {
       query = (query == null ? '' : String(query)).trim();
       if (!query) return false;
-      openWorkspace();
-      this.showTool('board');
+      // On phones, don't auto-pop the drawer — the card surfaces inline in the
+      // chat thread instead (see appendBoardMirror). The drawer stays one tap
+      // away (FAB / mirror chip) for the full board.
+      if (!isMobileChat()) { openWorkspace(); this.showTool('board'); }
       var step = { type: 'image', query: query };
       if (caption) step.caption = String(caption).trim();
       pushBoardStep(step);
@@ -954,8 +1034,10 @@
         model = model.spec || model.model;
       }
       if (!model) return false;
-      openWorkspace();
-      this.showTool('board');
+      // On phones, don't auto-pop the drawer — the card surfaces inline in the
+      // chat thread instead (see appendBoardMirror). The drawer stays one tap
+      // away (FAB / mirror chip) for the full board.
+      if (!isMobileChat()) { openWorkspace(); this.showTool('board'); }
       var step = { type: 'model', model: model };
       if (prompt) step.prompt = String(prompt).trim();
       pushBoardStep(step);


### PR DESCRIPTION
## What this does

This is **#2 (dock the board)** from the UX list, scoped to where the friction actually is.

The board already docks as a persistent side-by-side column **above 1200px**. Below that — laptops, tablets, **phones** — it hides behind the FAB drawer, so the running work is out of sight unless the student opens it. Now, on phones, **each board card mirrors straight into the chat thread**, where the student already is — no drawer to open.

## How it works

- **`appendBoardMirror(step)`** (called from `pushBoardStep`) drops a compact reflection into `#chat-messages-container` on phone widths (≤768px). It's a **no-op on wider screens**, where the docked board is already visible.
- **Read-only context cards** (pose / resolve / verify / apply / worked) render **in full inline**, reusing the real `.cr-ws-board-card` variant styling — eyebrows (PROBLEM / STEP n / SOLVED), the verify check line, captions — so they read identically to the board.
- **Interactive / heavy cards** (scaffold, graph, image, model) render as a **tap-chip** — `Your turn — fill the blanks  Open ↗` — that opens the drawer, where the interaction and the room to render it live.
- **Suppressed the drawer auto-open on phones** for every board-card method (pose, scaffold, example, graph, image, model, diagram). Otherwise the drawer covered the very thread the cards mirror into. The drawer stays one tap away (FAB / chip). The tutor's tab-switches (`showTool('tiles')`, `showGraph`) are untouched, and **desktop behavior is unchanged**.

## Mobile result (390px)

```
PROBLEM    2x + 4 = 20
STEP 1     2x = 16
SOLVED     x = 8   ✓ 2(8)+4 = 20
[ Your turn — fill the blanks        Open ↗ ]
[ Graph                              Open ↗ ]
```
…all in the chat thread, drawer closed.

## Verification

**Browser-verified at 390px:** five cards mirror into the thread (3 inline cards incl. the verify check row + 2 chips), the drawer does **not** auto-open, and tapping the scaffold chip opens it. **At 1340px:** zero mirrors and the docked board still gets all five cards. No console errors; lint clean. Screenshot shared in session.

## Scope note

Read-only cards are fully inline; interactive scaffolds use a one-tap chip into the drawer (avoids double-rendering an interactive card in two places / double-sending a Check). Fully-inline *interactive* scaffolds with no drawer at all would be a heavier follow-up — happy to do it if you want that.

https://claude.ai/code/session_01G5awZCfNt8pPgAeV9s6cw4

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5awZCfNt8pPgAeV9s6cw4)_