### PR TITLE
fix(workboard): never render garbage board math — sanitize tex at the source + safe fallback

### DIFF
--- a/public/css/workspace.css
+++ b/public/css/workspace.css
@@ -694,7 +694,12 @@
 .cr-ws-chat-mirror .cr-ws-board-card {
   width: 100%;
   max-width: 520px;
+  /* The chat thread can sit over a busy poster/tutor background — keep the
+     mirrored card fully opaque with a clear shadow so the math always reads. */
+  background: var(--cr-bg-panel);
+  box-shadow: 0 2px 12px rgba(7, 9, 15, 0.28);
 }
+.cr-ws-chat-mirror .cr-ws-board-card-math { color: var(--cr-text); }
 /* Tap-chip for interactive/heavy cards (scaffold, graph, image, model). */
 .cr-ws-mirror-chip {
   display: inline-flex;

--- a/public/js/boardCommandHandler.js
+++ b/public/js/boardCommandHandler.js
@@ -27,12 +27,52 @@
         return typeof window !== 'undefined' ? window.MathWorkspace : null;
     }
 
+    // Scrub a LaTeX/text field of leaked JSON structure. Upstream a fallback
+    // parser can capture a board_commands array boundary into a field — e.g.
+    // tex = "3x = 21},{" — which then renders as a red KaTeX error. A real math
+    // expression never contains an UNescaped  } , {  or  " , "  (LaTeX braces are
+    // \{ \}), so cut at that boundary and drop the residue.
+    function cleanField(s) {
+        if (typeof s !== 'string') return s;
+        // Stray wrapping JSON quotes.
+        s = s.replace(/^\s*["']+|["']+\s*$/g, '');
+        // Truncate at a JSON object/array boundary that leaked in.
+        var cut = s.search(/[}\]"]\s*,\s*["{[]/);
+        if (cut !== -1) s = s.slice(0, cut + 1);
+        s = s.trim();
+        // Drop a trailing unbalanced } (residue from the cut). LaTeX braces pair
+        // up; a lone trailing close is junk. Count unescaped braces only.
+        var opens = (s.match(/(?:^|[^\\])\{/g) || []).length;
+        var closes = (s.match(/(?:^|[^\\])\}/g) || []).length;
+        while (closes > opens && /\}\s*$/.test(s)) {
+            s = s.replace(/\}\s*$/, '').trim();
+            closes--;
+        }
+        return s;
+    }
+
+    function sanitizeCommand(command) {
+        if (!command || typeof command !== 'object') return command;
+        var out = command;
+        ['tex', 'check', 'op', 'caption'].forEach(function (k) {
+            if (typeof command[k] === 'string') {
+                var cleaned = cleanField(command[k]);
+                if (cleaned !== command[k]) {
+                    if (out === command) out = Object.assign({}, command);
+                    out[k] = cleaned;
+                }
+            }
+        });
+        return out;
+    }
+
     function executeOne(command) {
         var W = getWorkspace();
         if (!W) {
             console.warn('[BoardCommandHandler] MathWorkspace not available; dropping command', command);
             return;
         }
+        command = sanitizeCommand(command);
         try {
             switch (command.action) {
                 case 'pose':

--- a/public/js/workspace.js
+++ b/public/js/workspace.js
@@ -41,17 +41,22 @@
   // (very early in page life) or the expression doesn't parse.
   function renderTex(target, tex) {
     if (!target) return;
+    var s = String(tex || '');
     if (window.katex && typeof window.katex.render === 'function') {
       try {
-        window.katex.render(String(tex || ''), target, {
+        window.katex.render(s, target, {
           throwOnError: false,
           displayMode: true,
           output: 'html'
         });
-        return;
+        // With throwOnError:false KaTeX doesn't throw on bad input — it paints
+        // the unparseable part in a red .katex-error span. Treat that as a
+        // failure and degrade to plain text, so a malformed command never shows
+        // a scary red string (or leaked JSON like "3x = 21},{") on the board.
+        if (!target.querySelector('.katex-error')) return;
       } catch (_) { /* fall through to text */ }
     }
-    target.textContent = String(tex || '');
+    target.textContent = s;
   }
 
   // Give empty \boxed{} scaffold slots a visible width so they read as

--- a/tests/unit/boardCommandGuard.test.js
+++ b/tests/unit/boardCommandGuard.test.js
@@ -4,7 +4,59 @@ const {
   opMatchesStudentText,
   hasStartOverIntent,
   texHasBlank,
+  cleanField,
+  sanitizeCommand,
 } = require('../../utils/boardCommandGuard');
+
+describe('boardCommandGuard — tex sanitation (cannot display wrong math)', () => {
+  describe('cleanField', () => {
+    it('strips a leaked JSON array boundary from tex', () => {
+      expect(cleanField('3x = 21},{')).toBe('3x = 21');
+      expect(cleanField('3x - 5 = 16},{"action":"resolve"')).toBe('3x - 5 = 16');
+    });
+    it('strips stray wrapping JSON quotes', () => {
+      expect(cleanField('"x = 8"')).toBe('x = 8');
+    });
+    it('leaves valid LaTeX untouched', () => {
+      expect(cleanField('\\frac{1}{2} = 0.5')).toBe('\\frac{1}{2} = 0.5');
+      expect(cleanField('x^{2} + 4x + 4 = 16')).toBe('x^{2} + 4x + 4 = 16');
+      expect(cleanField('x = \\boxed{}')).toBe('x = \\boxed{}'); // scaffold blank survives
+      expect(cleanField('\\{1, 2\\}')).toBe('\\{1, 2\\}'); // escaped set braces, not JSON
+    });
+    it('drops a trailing unbalanced residue brace but keeps balanced ones', () => {
+      expect(cleanField('3x = 21}')).toBe('3x = 21');
+      expect(cleanField('\\frac{1}{2}')).toBe('\\frac{1}{2}');
+    });
+  });
+
+  describe('sanitizeCommand', () => {
+    it('cleans tex + check and returns the same ref when nothing changed', () => {
+      const clean = { action: 'verify', tex: 'x = 8', check: '2(8)+4=20' };
+      expect(sanitizeCommand(clean)).toBe(clean);
+      const dirty = sanitizeCommand({ action: 'resolve', tex: '3x = 21},{' });
+      expect(dirty.tex).toBe('3x = 21');
+    });
+  });
+
+  describe('enforcePedagogyRule', () => {
+    it('passes the CLEANED command downstream (pose with leaked JSON)', () => {
+      const { allowed, dropped } = enforcePedagogyRule({
+        commands: [{ action: 'pose', tex: '3x - 5 = 16},{' }],
+        userMessage: 'help me solve 3x - 5 = 16',
+      });
+      expect(dropped).toHaveLength(0);
+      expect(allowed[0].tex).toBe('3x - 5 = 16');
+    });
+    it('drops a command whose tex scrubs away to nothing', () => {
+      const { allowed, dropped } = enforcePedagogyRule({
+        commands: [{ action: 'resolve', tex: '},{' }],
+        userMessage: '3x = 21',
+      });
+      expect(allowed).toHaveLength(0);
+      expect(dropped[0].reason).toBe('malformed_tex');
+    });
+  });
+});
 
 describe('boardCommandGuard', () => {
   describe('pose', () => {

--- a/utils/boardCommandGuard.js
+++ b/utils/boardCommandGuard.js
@@ -194,6 +194,48 @@ function revealsPinnedProblem(text, ctx) {
     return false;
 }
 
+// Scrub a LaTeX/text field of leaked JSON structure. A fallback parser upstream
+// can capture a board_commands array boundary into a field — e.g. tex = "3x = 21},{"
+// — which would then render as a red KaTeX error on the board. A real math
+// expression never contains an UNescaped  } , {  or  " , "  (LaTeX braces are
+// \{ \}), so cut at that boundary and drop the residue. Mirrors the client-side
+// guard in public/js/boardCommandHandler.js (defense in depth).
+function cleanField(s) {
+    if (typeof s !== 'string') return s;
+    // Stray wrapping JSON quotes.
+    s = s.replace(/^\s*["']+|["']+\s*$/g, '');
+    // Truncate at a leaked JSON object/array boundary.
+    const cut = s.search(/[}\]"]\s*,\s*["{[]/);
+    if (cut !== -1) s = s.slice(0, cut + 1);
+    s = s.trim();
+    // Drop a trailing unbalanced } left over from the cut (LaTeX braces pair up;
+    // a lone trailing close is residue). Count unescaped braces only.
+    const opens = (s.match(/(?:^|[^\\])\{/g) || []).length;
+    let closes = (s.match(/(?:^|[^\\])\}/g) || []).length;
+    while (closes > opens && /\}\s*$/.test(s)) {
+        s = s.replace(/\}\s*$/, '').trim();
+        closes--;
+    }
+    return s;
+}
+
+// Return a copy of the command with its math/text fields scrubbed. Cheap no-op
+// (returns the same ref) when nothing needed cleaning.
+function sanitizeCommand(command) {
+    if (!command || typeof command !== 'object') return command;
+    let out = command;
+    for (const k of ['tex', 'check', 'op', 'caption']) {
+        if (typeof command[k] === 'string') {
+            const cleaned = cleanField(command[k]);
+            if (cleaned !== command[k]) {
+                if (out === command) out = { ...command };
+                out[k] = cleaned;
+            }
+        }
+    }
+    return out;
+}
+
 function enforcePedagogyRule({
     commands,
     userMessage,
@@ -227,7 +269,19 @@ function enforcePedagogyRule({
     let runningLastAction = lastBoardActionInConversation;
 
     for (let i = 0; i < commands.length; i++) {
-        const command = commands[i];
+        const original = commands[i];
+        // Scrub leaked JSON/garbage out of the math fields FIRST, so the clean
+        // command is what we judge, allow, and pass downstream (board + stored
+        // history + voice all get the cleaned tex).
+        const command = sanitizeCommand(original);
+        // If a tex that was present scrubbed away to nothing, it was pure garbage
+        // — drop it rather than paint a blank/wrong card ("cannot display wrong
+        // math", the board's #1 guarantee).
+        if (typeof original.tex === 'string' && original.tex.trim() && !(command.tex || '').trim()) {
+            dropped.push({ command: original, reason: 'malformed_tex' });
+            runningLastAction = original.action;
+            continue;
+        }
         const nextAction = commands[i + 1] ? commands[i + 1].action : null;
         const decision = evaluate(command, {
             currentText,
@@ -426,4 +480,6 @@ module.exports = {
     opMatchesStudentText,
     hasStartOverIntent,
     texHasBlank,
+    cleanField,
+    sanitizeCommand,
 };


### PR DESCRIPTION
## The bug (from the live screenshot)

A board card rendered raw **`3x = 21},{`** in red KaTeX-error text on a phone. The `},{` is a leaked `board_commands` JSON-array boundary captured into the `tex` field by a fallback parser, and red = KaTeX parse failure.

## Reframe: this is a correctness leak, not a render glitch

The board's #1 guarantee is *"can pick a weird layout but **cannot display wrong math**."* A card showing garbage math **violates that guarantee** — so this is fixed **in depth, rooted at the authoritative server guard**, not just papered over at the renderer.

## The fix (defense in depth)

**1. Server — the root, authoritative fix** (`boardCommandGuard.enforcePedagogyRule`)
- Scrubs each command's math fields (`cleanField`) **before** judging/allowing it, so the *clean* tex flows to the board, **stored history, and the voice path** alike.
- A tex that scrubs to nothing was pure garbage → **dropped** (`reason: 'malformed_tex'`) rather than painting a blank/wrong card.
- `cleanField` cuts at a leaked JSON boundary (unescaped `},{` / `","` — which never occurs in real LaTeX, since braces are `\{ \}`) and drops trailing residue braces, while leaving valid LaTeX (`\frac`, `x^{2}`, `\boxed{}`, escaped `\{set\}`) **untouched**.

**2. Client — belt-and-suspenders** (`boardCommandHandler` + `workspace.renderTex`)
- Same scrub applied before dispatch, and `renderTex` now detects KaTeX's `.katex-error` span (it doesn't *throw* with `throwOnError:false`) and **degrades to plain text** — so a malformed expression can never paint a red string even if something slips past the server.

**3. UI legibility**
- Mirrored chat cards get an **opaque background + clearer shadow** so math stays readable over a busy poster/portrait background.

## "Smartest solution / best UX?" — the reasoning

- **Smartest = fix at the source + never trust it downstream.** The server guard is where every command (structured, legacy tag, synthesizer, voice) funnels, so cleaning there fixes *all* paths and keeps stored history clean. The client defenses guarantee a broken card can never *paint*, even from a path I haven't reproduced.
- **Best UX = the board never shows broken/red/garbage math.** It either renders clean or the card is dropped (the tutor's words still carry the step). A wrong card is worse than no card.

## Verification

- New unit tests: `cleanField` (JSON-boundary strip, valid-LaTeX preserved, residue-brace handling), `sanitizeCommand`, and `enforcePedagogyRule` (cleaned command passes through; scrub-to-empty dropped).
- **53 guard + 279 pipeline/board tests pass**; lint clean.
- Browser-verified: `3x = 21},{` → clean **`3x=21`** with no error span; a genuinely broken `\frac{1` degrades to plain text instead of red.

## Recommended follow-up (your call, not bundled here)
The dominant readability hit in the screenshot is the **full-bleed tutor portrait** behind the chat. Dimming/blurring it (or capping it to a header) would lift legibility of *everything* — but that's a deliberate design element (`.cr-tutor-portrait`), so I left it for you to decide rather than change unilaterally.

https://claude.ai/code/session_01G5awZCfNt8pPgAeV9s6cw4

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5awZCfNt8pPgAeV9s6cw4)_