### PR TITLE
Hide visual math board behind feature flag; keep inline chat cards

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -17,6 +17,16 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <meta name="apple-mobile-web-app-status-bar-style" content="default" />
   <meta name="apple-mobile-web-app-title" content="MATHMATIX" />
   <title>M∆THM∆TIΧ AI Chat</title>
+  <!-- Feature flags. The visual math board (right-column workspace, whiteboard,
+       graph/tiles/calc tools) is hidden until it's polished; students keep chat
+       with the tutor's work mirrored inline as cards. To bring the board back,
+       set boardPanel: true (or delete this block). -->
+  <script>
+    window.MM_FEATURES = Object.assign({ boardPanel: false }, window.MM_FEATURES || {});
+    if (window.MM_FEATURES.boardPanel === false) {
+      document.documentElement.classList.add('mm-board-hidden');
+    }
+  </script>
   <link rel="stylesheet" href="/style.css" />
   <link rel="stylesheet" href="/css/file-upload.css" />
   <link rel="stylesheet" href="/css/calculator.css" />

--- a/public/css/chat-redesign.css
+++ b/public/css/chat-redesign.css
@@ -212,6 +212,19 @@ body.cr-mode #app-layout-wrapper { background: var(--cr-bg-0); }
   box-sizing: border-box;
 }
 
+/* Feature flag (MM_FEATURES.boardPanel=false → html.mm-board-hidden): hide the
+   visual math board until it's polished. Students keep chat with the tutor's
+   work mirrored inline as cards (see appendBoardMirror in workspace.js). The
+   stage drops to a 2-column hero | chat grid and every board surface is hidden.
+   Remove the flag in chat.html to restore the panel. */
+html.mm-board-hidden .cr-stage {
+  grid-template-columns: var(--cr-hero-w) minmax(0, 1fr);
+}
+html.mm-board-hidden .cr-workspace,
+html.mm-board-hidden .cr-ws-fab,
+html.mm-board-hidden .cr-ws-backdrop,
+html.mm-board-hidden #mathmatix-whiteboard-panel { display: none !important; }
+
 @media (max-width: 1200px) {
   /* Workspace leaves grid flow here (becomes a drawer — see workspace.css). */
   .cr-stage { grid-template-columns: 260px minmax(0, 1fr); }

--- a/public/js/workspace.js
+++ b/public/js/workspace.js
@@ -37,6 +37,14 @@
     return n;
   }
 
+  // Feature flag: the visual board panel is hidden until it's polished
+  // (set window.MM_FEATURES.boardPanel = false in chat.html). When off, the
+  // panel/FAB/drawer never mount; the tutor's work still reaches the student
+  // as inline mirror cards in the chat thread (see appendBoardMirror).
+  function boardPanelEnabled() {
+    return !(window.MM_FEATURES && window.MM_FEATURES.boardPanel === false);
+  }
+
   // KaTeX renderer with a safe text fallback if KaTeX hasn't loaded yet
   // (very early in page life) or the expression doesn't parse.
   function renderTex(target, tex) {
@@ -633,7 +641,11 @@
   // interactive/heavy cards (scaffold, graph, image, model) render as a chip that
   // opens the drawer, where the real interaction/space lives.
   function appendBoardMirror(step) {
-    if (!isMobileChat() || !step) return;
+    // Mirror inline when the board lives behind the phone drawer, OR whenever
+    // the board panel is hidden by feature flag — in that mode the chat thread
+    // is the only place the tutor's work can surface, on every screen size.
+    var boardHidden = !boardPanelEnabled();
+    if ((!isMobileChat() && !boardHidden) || !step) return;
     var chat = document.getElementById('chat-messages-container');
     if (!chat) return;
 
@@ -671,6 +683,9 @@
       wrap.appendChild(card);
     } else {
       // scaffold / graph / image / model / diagram → tap-chip to the drawer.
+      // With the board hidden there's no drawer to open, so drop these heavy
+      // cards rather than surfacing a dead chip.
+      if (boardHidden) return;
       var chip = el('button', 'cr-ws-mirror-chip');
       chip.type = 'button';
       var label = HEAVY_LABEL[t] || 'Open board';
@@ -775,6 +790,9 @@
   };
 
   function switchTool(key) {
+    // Board hidden by feature flag → nothing to render into; callers (incl. the
+    // public API) become no-ops while inline mirroring carries the work.
+    if (!boardPanelEnabled()) return;
     if (!TOOLS[key] || WS.current === key) return;
     var prev = WS.current && TOOLS[WS.current];
     if (prev && prev.teardown) prev.teardown();
@@ -812,7 +830,7 @@
     return b;
   }
   function openWorkspace() {
-    if (!WS.el) return;
+    if (!WS.el || !boardPanelEnabled()) return;
     WS.el.classList.add('is-open');
     ensureBackdrop().classList.add('is-open');
     document.body.classList.add('cr-ws-drawer-open');
@@ -1066,6 +1084,11 @@
     WS.el = document.getElementById('cr-workspace');
     WS.body = document.getElementById('cr-ws-body');
     if (!WS.el || !WS.body) return;
+
+    // Board hidden by feature flag: skip the panel/FAB wiring entirely. The
+    // public board API still mirrors each step into the chat thread, so the
+    // student sees the tutor's work inline (see appendBoardMirror).
+    if (!boardPanelEnabled()) return;
 
     WS.el.querySelectorAll('.cr-ws-tab').forEach(function (tab) {
       tab.addEventListener('click', function () {


### PR DESCRIPTION
## What & why

The visual math board (right-column workspace, the legacy whiteboard, and the graph/tiles/calc tools) isn't polished yet. This ships the **chat-first** experience now: students see chat only, with the tutor's work surfaced as **inline mirror cards** in the thread. The board is hidden behind a single feature flag so it can be re-enabled with a one-line flip once it's ready.

## How it works

A single flag — `window.MM_FEATURES.boardPanel` (default `false`) — controls everything:

- **`public/chat.html`** — defines `MM_FEATURES` early in `<head>` and adds `html.mm-board-hidden` before paint (no flash of the panel).
- **`public/css/chat-redesign.css`** — collapses the stage to a 2-column `hero | chat` grid and hides the workspace, the mobile FAB, the drawer backdrop, and the legacy `#mathmatix-whiteboard-panel`. `!important` overrides the legacy whiteboard's inline `display` toggles, so board commands can't pop it back open.
- **`public/js/workspace.js`** — `boardPanelEnabled()` guards `init`, `openWorkspace`, and `switchTool`, so the panel/FAB never mount. `appendBoardMirror` now also fires on desktop when the board is hidden (so inline cards appear on every screen size, not just phones), and skips the "open drawer" chips for heavy/interactive cards since there's no drawer to open.

The inline mirror cards reuse the existing, already-shipped mobile mirror styling (`.cr-ws-chat-mirror` / `.cr-ws-board-card`), so the inline experience is the same one phones already get today.

## Re-enabling the board

Set `boardPanel: true` (or delete the flag block) in `chat.html`.

## Testing notes

- Verify students on desktop and mobile see chat with inline math cards (pose / resolve / apply / verify / worked steps) and no board panel, FAB, or whiteboard.
- Confirm the stage renders as a clean 2-column layout (no empty right-hand gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0127NBQw5yeEHHbLqwJQzYSd)_