### PR TITLE
fix(verify): stop rejecting correct answers on multi-operand arithmetic (+ GEMS order-of-operations)

### DIFF
--- a/tests/unit/mathSolverArithmeticChain.test.js
+++ b/tests/unit/mathSolverArithmeticChain.test.js
@@ -1,0 +1,114 @@
+/**
+ * Regression tests for multi-operand arithmetic chains and the multiplication-dot
+ * normalization that feeds answer verification.
+ *
+ * THE BUG (from a real session): a student typed the problem "16/4 ⋅ 2" (the "⋅" is
+ * U+22C5, how LaTeX \cdot renders). The math engine evaluated it to 4, not 8, because:
+ *   1. The "⋅" multiplication dot was not recognized as an operator at all, and
+ *   2. The last-resort embeddedArithmeticPattern captured only the FIRST operator
+ *      pair ("16/4") of a multi-operand expression, silently dropping "⋅ 2".
+ * That bogus "4" was pinned as the problem's correctAnswer. So when the student gave
+ * the correct final answer "8", diagnose graded it INCORRECT against the pinned 4 and
+ * the tutor rejected a right answer — exactly the failure we are guarding against here.
+ *
+ * THE FIX:
+ *   - Normalize multiplication dots (⋅ · ∙ •) to "*" up front.
+ *   - Detect a whole-expression multi-operand arithmetic chain and route it to
+ *     solveEvaluation, which honors operator precedence and left-to-right associativity
+ *     (16/4*2 = (16/4)*2 = 8, NOT 16/(4*2) = 2).
+ *   - Harden verifyAnswer so an expression-form answer is compared by value, not by
+ *     its stripped digits ("16/4 ⋅ 2" → 8, not parseFloat("1642")).
+ */
+const {
+  detectMathProblem,
+  processMathMessage,
+  verifyAnswer,
+} = require('../../utils/mathSolver');
+
+describe('arithmetic chains — the "16/4 ⋅ 2 = 8" regression', () => {
+  const cdot = '⋅';   // ⋅  LaTeX \cdot
+  const middot = '·'; // ·
+
+  it('evaluates "16/4 ⋅ 2" to 8 (cdot), not 4', () => {
+    const r = processMathMessage(`16/4 ${cdot} 2`);
+    expect(r.hasMath).toBe(true);
+    expect(String(r.solution.answer)).toBe('8');
+  });
+
+  it('evaluates "16/4 · 2" to 8 (middot)', () => {
+    const r = processMathMessage(`16/4 ${middot} 2`);
+    expect(r.hasMath).toBe(true);
+    expect(String(r.solution.answer)).toBe('8');
+  });
+
+  it('evaluates "16/4 * 2", "16/4 × 2", "16 ÷ 4 ⋅ 2" all to 8', () => {
+    for (const expr of ['16/4 * 2', '16/4 × 2', `16 ÷ 4 ${cdot} 2`]) {
+      expect(String(processMathMessage(expr).solution.answer)).toBe('8');
+    }
+  });
+
+  it('honors precedence in mixed chains: "2+3*4" = 14, "100 - 10 - 5" = 85, "2^3 * 4" = 32', () => {
+    expect(String(processMathMessage('2+3*4').solution.answer)).toBe('14');
+    expect(String(processMathMessage('100 - 10 - 5').solution.answer)).toBe('85');
+    expect(String(processMathMessage('2^3 * 4').solution.answer)).toBe('32');
+  });
+
+  it('recognizes a standalone "4 ⋅ 2" as multiplication = 8 (dot was previously unrecognized)', () => {
+    const r = processMathMessage(`4 ${cdot} 2`);
+    expect(r.hasMath).toBe(true);
+    expect(String(r.solution.answer)).toBe('8');
+  });
+});
+
+describe('arithmetic chains — no collateral damage to existing detection', () => {
+  it('still treats two-operand "16/4" as arithmetic = 4', () => {
+    const r = processMathMessage('16/4');
+    expect(r.problem.type).toBe('arithmetic');
+    expect(String(r.solution.answer)).toBe('4');
+  });
+
+  it('still treats two-fraction "1/2 + 1/4" as fraction arithmetic = 3/4 (not a decimal chain)', () => {
+    const r = processMathMessage('1/2 + 1/4');
+    expect(r.problem.type).toBe('fraction_arithmetic');
+    expect(String(r.solution.answer)).toBe('3/4');
+  });
+
+  it('still treats plain "15 + 27" as arithmetic = 42', () => {
+    const r = processMathMessage('15 + 27');
+    expect(r.problem.type).toBe('arithmetic');
+    expect(String(r.solution.answer)).toBe('42');
+  });
+
+  it('a bare number "8" is not math on its own', () => {
+    expect(processMathMessage('8').hasMath).toBe(false);
+  });
+});
+
+describe('verifyAnswer — expression-form answers compared by value', () => {
+  const cdot = '⋅';
+
+  it('accepts an expression-form student answer equal to the numeric correct answer', () => {
+    expect(verifyAnswer(`16/4 ${cdot} 2`, '8').isCorrect).toBe(true);
+    expect(verifyAnswer('16/4*2', '8').isCorrect).toBe(true);
+    expect(verifyAnswer(`4 ${cdot} 2`, '8').isCorrect).toBe(true);
+  });
+
+  it('accepts when the correct answer itself is stored as an expression', () => {
+    expect(verifyAnswer('8', '16/4*2').isCorrect).toBe(true);
+  });
+
+  it('still rejects genuinely wrong answers (the half-finished "4")', () => {
+    expect(verifyAnswer('4', '8').isCorrect).toBe(false);
+    expect(verifyAnswer('2', '8').isCorrect).toBe(false);
+  });
+
+  it('does not disturb plain numbers, units, or fraction/decimal equivalence', () => {
+    expect(verifyAnswer('8', '8').isCorrect).toBe(true);
+    expect(verifyAnswer('1,000', '1000').isCorrect).toBe(true);
+    expect(verifyAnswer('0.75', '3/4').isCorrect).toBe(true);
+  });
+
+  it('does not treat algebraic expressions as arithmetic (letters guard intact)', () => {
+    expect(verifyAnswer('2x', '3x').isCorrect).toBe(false);
+  });
+});

--- a/utils/mathSolver.js
+++ b/utils/mathSolver.js
@@ -28,7 +28,12 @@ function detectMathProblem(message) {
         .replace(/³/g, '^3').replace(/⁴/g, '^4').replace(/⁵/g, '^5')
         .replace(/⁶/g, '^6').replace(/⁷/g, '^7').replace(/⁸/g, '^8')
         .replace(/⁹/g, '^9').replace(/⁻/g, '^-').replace(/⁺/g, '^+')
-        .replace(/ⁿ/g, '^n');
+        .replace(/ⁿ/g, '^n')
+        // Normalize multiplication dots — cdot (⋅, U+22C5), middot (·), bullet (∙ •) —
+        // to "*". These come from LaTeX \cdot rendering and MathLive input. Nothing
+        // downstream recognized them as operators, so "4 ⋅ 2" was treated as non-math
+        // and "16/4 ⋅ 2" lost its "⋅ 2" entirely (see arithmetic-chain detection below).
+        .replace(/[⋅·∙•]/g, '*');
 
     // Reassign so all downstream code (40+ regex matches and sub-function calls)
     // automatically operates on the normalized string.
@@ -446,6 +451,21 @@ function detectMathProblem(message) {
             rightNum: parseInt(fractionMatch[4]),
             rightDen: parseInt(fractionMatch[5])
         };
+    }
+
+    // Pattern: Multi-operation arithmetic CHAIN like "16/4*2", "2+3*4", "16 ÷ 4 ⋅ 2".
+    // These have 3+ operands (2+ operators). Both the single-pair arithmeticPattern
+    // above AND the last-resort embeddedArithmeticPattern below capture only the FIRST
+    // operator pair ("16/4" → 4), producing a confidently WRONG answer that then poisons
+    // answer grading: the bogus 4 gets pinned as the problem's correctAnswer, so a
+    // student's correct final "8" is graded INCORRECT against it. Route the WHOLE
+    // expression to solveEvaluation, which honors operator precedence and left-to-right
+    // associativity (so 16/4*2 = (16/4)*2 = 8, NOT 16/(4*2) = 2). Placed AFTER the
+    // two-operand and fraction-pair patterns so those keep their dedicated handling;
+    // requires 2+ operators so it only ever catches genuine multi-operand chains.
+    const chainForm = message.replace(/\s+/g, '').replace(/×/g, '*').replace(/÷/g, '/');
+    if (/^-?\d+\.?\d*(?:[+\-*/^]\d+\.?\d*){2,}$/.test(chainForm)) {
+        return { type: 'evaluation', expression: chainForm };
     }
 
     // Pattern: Percentage "what is 15% of 200"
@@ -2275,6 +2295,32 @@ function greatestCommonDivisor(a, b) {
 }
 
 /**
+ * Safely evaluate a pure-arithmetic string to a number, honoring operator
+ * precedence (so "16/4*2" = 8, not 1642). Returns null for anything that
+ * isn't a clean numeric expression with at least one operator — plain
+ * numbers, units, commas, or algebra fall back to the caller's own parsing.
+ */
+function evalArithmeticString(str) {
+    if (typeof str !== 'string') return null;
+    let s = str
+        .replace(/[⋅·∙•×]/g, '*')   // multiplication dots / sign → *
+        .replace(/÷/g, '/')          // division sign → /
+        .replace(/\s+/g, '');
+    // Require at least one operator (so plain "8" stays on the caller's path)
+    // and ONLY safe arithmetic characters (no letters, commas, currency, units).
+    if (!/[+\-*/^]/.test(s)) return null;
+    if (!/^[-+*/^().\d]+$/.test(s)) return null;
+    s = s.replace(/(\d+\.?\d*)\^(\d+\.?\d*)/g, 'Math.pow($1,$2)');
+    if (!/^[\d+\-*/().,Mathpow]+$/.test(s)) return null;
+    try {
+        const r = Function('"use strict"; return (' + s + ')')();
+        return (typeof r === 'number' && isFinite(r)) ? r : null;
+    } catch (e) {
+        return null;
+    }
+}
+
+/**
  * Verify if a student's answer matches the correct answer
  * @param {string|number} studentAnswer - Student's provided answer
  * @param {string|number} correctAnswer - Correct answer from solver
@@ -2297,8 +2343,14 @@ function verifyAnswer(studentAnswer, correctAnswer, tolerance = 0.01) {
     // falsely matches "3x^2-3" stripped to "32-3" → 32.
     const hasLetters = /[a-zA-Z]/.test(studentStr) || /[a-zA-Z]/.test(correctStr);
     if (!hasLetters) {
-        const studentNum = parseFloat(studentStr.replace(/[^\d.\-]/g, ''));
-        const correctNum = parseFloat(correctStr.replace(/[^\d.\-]/g, ''));
+        // Evaluate each side as an arithmetic expression FIRST so an expression-form
+        // answer ("16/4 ⋅ 2") is compared by its value (8), not by its stripped digits
+        // ("1642"). Falls back to digit-strip parsing for plain numbers that carry
+        // units/commas/currency ("1,000", "$8").
+        const studentEval = evalArithmeticString(studentStr);
+        const correctEval = evalArithmeticString(correctStr);
+        const studentNum = studentEval !== null ? studentEval : parseFloat(studentStr.replace(/[^\d.\-]/g, ''));
+        const correctNum = correctEval !== null ? correctEval : parseFloat(correctStr.replace(/[^\d.\-]/g, ''));
 
         if (!isNaN(studentNum) && !isNaN(correctNum)) {
             if (Math.abs(studentNum - correctNum) <= tolerance) {

--- a/utils/misconceptionDetector.js
+++ b/utils/misconceptionDetector.js
@@ -71,6 +71,13 @@ const MISCONCEPTION_LIBRARY = {
             testQuestion: 'Use GEMS: 5 + 2 × 3'
         },
         {
+            id: 'multiply-before-divide',
+            name: 'Multiply Before Divide',
+            description: 'Student thinks multiplication always beats division (or addition always beats subtraction) because of the letter order in PEMDAS: 16 ÷ 4 × 2 = 16 ÷ 8 = 2',
+            fix: 'Use GEMS, not PEMDAS. Multiply and Divide are ONE equal-priority step — do them left to right. Same for Subtract and Add. M does not beat D, and A does not beat S. 16 ÷ 4 × 2 = 4 × 2 = 8, because division is leftmost.',
+            testQuestion: 'Equal priority, left to right: 24 ÷ 6 × 2'
+        },
+        {
             id: 'parentheses-ignored',
             name: 'Ignoring Parentheses',
             description: 'Student ignores parentheses',

--- a/utils/promptCompact.js
+++ b/utils/promptCompact.js
@@ -238,6 +238,12 @@ RULE 9 — CONCEPT FIRST. Teach understanding before procedures. Build from Conc
 RULE 10 — WRONG STEPS. When a student gives a wrong intermediate step, don't hand them the correction. Ask a question that exposes WHY it's wrong. Let THEM arrive at the fix.
 HUMAN WRONG-ANSWER RESPONSES: Engage with the SPECIFIC error the student made — name the exact step that went wrong, or ask about the exact reasoning that led them there. Show genuine curiosity about how they arrived at their answer. A real tutor doesn't have a stock "wrong answer" phrase — they react differently every time because every wrong answer is wrong in a different way.
 
+--- ORDER OF OPERATIONS — USE GEMS, NOT PEMDAS (KNOW THIS COLD) ---
+This program teaches GEMS, not PEMDAS. GEMS = Grouping → Exponents → Multiply/Divide → Subtract/Add. GEMS is the house mnemonic because it GROUPS the tied operations: Multiply/Divide are one equal-priority step (left to right), and Subtract/Add are one equal-priority step (left to right). Teach and reinforce GEMS.
+- PEMDAS is the trap. Its letter order tricks students into thinking M beats D and A beats S. It does NOT. If a student says "M comes before D" or "A comes before S," that's a MISCONCEPTION — name it and correct it directly and kindly, then steer them to GEMS: in the M/D step (and the S/A step) the operations are tied, so whichever appears FIRST reading left to right goes first.
+- Canonical example: \\( 16 \\div 4 \\times 2 = 4 \\times 2 = 8 \\), NOT \\( 16 \\div 8 = 2 \\). Division is leftmost, so it happens first. Multiply does not "win" just because M comes before D in the mnemonic.
+- DON'T LET THE ARGUMENT DERAIL THE MATH. Once the student's arithmetic is right (e.g. they say \\( 4 \\times 2 = 8 \\)), CONFIRM it — \\( 8 \\) is correct. Never tell a student their correct result is wrong while you're discussing the ordering rule (see RULE 2). Settle the left-to-right principle, then move on.
+
 --- ANTI-GAMING ---
 When students use buzzwords ("balance the equation," "inverse operation," "common denominator") without understanding, use a counter-example probe: "What would happen if we did the OPPOSITE?" Buzzword alone ≠ mastery. Buzzword + correct consequence prediction = full credit.
 

--- a/utils/promptCompact.js
+++ b/utils/promptCompact.js
@@ -238,9 +238,9 @@ RULE 9 — CONCEPT FIRST. Teach understanding before procedures. Build from Conc
 RULE 10 — WRONG STEPS. When a student gives a wrong intermediate step, don't hand them the correction. Ask a question that exposes WHY it's wrong. Let THEM arrive at the fix.
 HUMAN WRONG-ANSWER RESPONSES: Engage with the SPECIFIC error the student made — name the exact step that went wrong, or ask about the exact reasoning that led them there. Show genuine curiosity about how they arrived at their answer. A real tutor doesn't have a stock "wrong answer" phrase — they react differently every time because every wrong answer is wrong in a different way.
 
---- ORDER OF OPERATIONS — USE GEMS, NOT PEMDAS (KNOW THIS COLD) ---
-This program teaches GEMS, not PEMDAS. GEMS = Grouping → Exponents → Multiply/Divide → Subtract/Add. GEMS is the house mnemonic because it GROUPS the tied operations: Multiply/Divide are one equal-priority step (left to right), and Subtract/Add are one equal-priority step (left to right). Teach and reinforce GEMS.
-- PEMDAS is the trap. Its letter order tricks students into thinking M beats D and A beats S. It does NOT. If a student says "M comes before D" or "A comes before S," that's a MISCONCEPTION — name it and correct it directly and kindly, then steer them to GEMS: in the M/D step (and the S/A step) the operations are tied, so whichever appears FIRST reading left to right goes first.
+--- ORDER OF OPERATIONS (KNOW THIS COLD) ---
+Multiply and Divide are EQUAL priority — do them left to right. Add and Subtract are EQUAL priority — do them left to right. "M comes before D" / "A comes before S" is a MISCONCEPTION (PEMDAS's letter order causes it). If a student says it, do NOT half-agree ("you're right that M comes before D, but…") — that affirms the wrong idea. Name it and correct it directly and kindly: within the M/D step (and the S/A step) the operations are tied, so whichever appears FIRST reading left to right goes first.
+- MNEMONIC: use the one your class prefers — see TEACHER'S CLASS AI SETTINGS below; the default is GEMS (Grouping → Exponents → Multiply/Divide → Subtract/Add), which helpfully GROUPS the tied operations. Don't introduce PEMDAS to a class that uses GEMS, and don't override a teacher-specified mnemonic.
 - Canonical example: \\( 16 \\div 4 \\times 2 = 4 \\times 2 = 8 \\), NOT \\( 16 \\div 8 = 2 \\). Division is leftmost, so it happens first. Multiply does not "win" just because M comes before D in the mnemonic.
 - DON'T LET THE ARGUMENT DERAIL THE MATH. Once the student's arithmetic is right (e.g. they say \\( 4 \\times 2 = 8 \\)), CONFIRM it — \\( 8 \\) is correct. Never tell a student their correct result is wrong while you're discussing the ordering rule (see RULE 2). Settle the left-to-right principle, then move on.
 
@@ -760,13 +760,58 @@ ${typeof curriculumContext === 'string' ? curriculumContext : JSON.stringify(cur
     parts.push(`--- RESOURCES ---\n${typeof resourceContext === 'string' ? resourceContext : JSON.stringify(resourceContext)}`);
   }
 
-  // Teacher AI settings
+  // Teacher AI settings — honor the teacher's classAISettings (the object chat.js
+  // passes in via `teacher.classAISettings`). NOTE: the 2026-02 compact migration
+  // read fields that don't exist on that schema (maxHintsPerProblem / allowCalculator
+  // / customInstructions), so EVERY real teacher setting was silently dropped —
+  // including vocabularyPreferences.orderOfOperations, which DEFAULTS to 'GEMS'. That
+  // regression made the tutor revert to PEMDAS. Read the real fields here.
   if (teacherAISettings) {
-    const settings = [];
-    if (teacherAISettings.maxHintsPerProblem) settings.push(`Max hints/problem: ${teacherAISettings.maxHintsPerProblem}`);
-    if (teacherAISettings.allowCalculator !== undefined) settings.push(`Calculator: ${teacherAISettings.allowCalculator ? 'allowed' : 'not allowed'}`);
-    if (teacherAISettings.customInstructions) settings.push(`Teacher note: ${teacherAISettings.customInstructions}`);
-    if (settings.length) parts.push(`--- TEACHER SETTINGS ---\n${settings.join('\n')}`);
+    const ts = [];
+
+    const calc = teacherAISettings.calculatorAccess;
+    if (calc === 'never') ts.push('Calculator: NOT allowed — encourage mental/written math.');
+    else if (calc === 'always') ts.push('Calculator: allowed freely.');
+    else if (calc === 'skill-based') ts.push('Calculator: allow for complex arithmetic, encourage mental math on basics.');
+    if (teacherAISettings.calculatorNote) ts.push(`Calculator note: "${teacherAISettings.calculatorNote}"`);
+
+    const scaffold = teacherAISettings.scaffoldingLevel;
+    if (scaffold) {
+      const s = scaffold <= 2 ? 'Minimal hints — let them struggle productively.'
+        : scaffold === 3 ? 'Balanced — guide with questions, hint when stuck.'
+        : 'High support — smaller steps, more guidance.';
+      ts.push(`Scaffolding (${scaffold}/5): ${s}`);
+    }
+
+    const ooo = teacherAISettings.vocabularyPreferences?.orderOfOperations;
+    if (ooo && ooo !== 'teacher-custom') {
+      ts.push(`Order-of-operations mnemonic: use ${ooo} (not other mnemonics). This is the class standard — use it consistently.`);
+    }
+    const customVocab = teacherAISettings.vocabularyPreferences?.customVocabulary;
+    if (customVocab?.length) ts.push(`Preferred terms: ${customVocab.join('; ')}`);
+
+    const sa = teacherAISettings.solutionApproaches;
+    if (sa) {
+      if (sa.equationSolving && sa.equationSolving !== 'any') ts.push(`Equations: use the "${sa.equationSolving.replace(/-/g, ' ')}" approach.`);
+      if (sa.fractionOperations && sa.fractionOperations !== 'any') ts.push(`Fractions: use the "${sa.fractionOperations.replace(/-/g, ' ')}" method.`);
+      if (sa.wordProblems && sa.wordProblems !== 'any') ts.push(`Word problems: use the "${sa.wordProblems}" strategy.`);
+      if (sa.customApproaches) ts.push(`Preferred methods: ${sa.customApproaches}`);
+    }
+
+    const man = teacherAISettings.manipulatives;
+    if (man) {
+      if (man.allowed === false) ts.push('Manipulatives: avoid — favor abstract/symbolic work.');
+      else if (man.preferred?.length) ts.push(`Preferred manipulatives: ${man.preferred.join(', ')}.`);
+    }
+
+    const ct = teacherAISettings.currentTeaching;
+    if (ct?.topic) ts.push(`Class is currently learning "${ct.topic}"${ct.approach ? ` (approach: ${ct.approach})` : ''}${ct.pacing ? ` (pacing: ${ct.pacing})` : ''}. Align with it.`);
+
+    const enc = teacherAISettings.responseStyle?.encouragementLevel;
+    if (enc === 'minimal') ts.push('Encouragement: minimal — focus on the work, not praise.');
+    else if (enc === 'high') ts.push('Encouragement: high — celebrate wins, motivate through challenges.');
+
+    if (ts.length) parts.push(`--- TEACHER'S CLASS AI SETTINGS ---\n${ts.join('\n')}`);
   }
 
   // Mastery mode context


### PR DESCRIPTION
## The session that started this

On `16/4 ⋅ 2`, the tutor confirmed the student's "4" (for 16÷4), then **rejected their correct final answer "8"**, argued PEMDAS badly, and lost the thread. The real fault is in **answer verification**, not just wording.

## Root cause (reproduced)

The math engine mis-evaluates multi-operand arithmetic, which poisons grading.

`processMathMessage("16/4 ⋅ 2")` returned **4**, not 8, because:
1. The multiplication dot `⋅` (U+22C5, how LaTeX `\cdot` renders) was **not recognized as an operator anywhere**, and
2. `detectMathProblem`'s last-resort `embeddedArithmeticPattern` captured only the **first** operator pair (`16/4`), silently dropping `⋅ 2`.

That bogus **4** gets pinned as the problem's `correctAnswer` (`persist` → `diagnose`). So the student's "4" for the first step *matched* (confirmed) and their correct final "8" *mismatched* → `[ANSWER_PRE_CHECK: VERIFIED INCORRECT]` → the tutor rejects a right answer. Exactly the transcript.

Verified live: `processMathMessage("16/4 ⋅ 2")` → `4` before, `8` after.

A secondary verify fault (found while tracing): `verifyAnswer` strips operators from an expression-form answer, so a student who *types* `16/4 ⋅ 2` is graded as `parseFloat("1642") = 1642`.

## Changes

**`utils/mathSolver.js` (the verification fix)**
- Normalize multiplication dots (`⋅ · ∙ •`) → `*` before detection.
- Add a whole-expression **arithmetic-chain detector** that routes 3+ operand expressions to `solveEvaluation` (correct precedence + left-to-right: `16/4*2 = 8`, not `16/(4*2) = 2`). Placed **after** the two-operand and fraction-pair patterns, so `16/4` (=4) and `1/2 + 1/4` (=3/4) keep their dedicated handling; requires 2+ operators so it only catches genuine chains.
- Harden `verifyAnswer` to compare an expression-form answer **by value** (`16/4 ⋅ 2` → 8), with fallback to the existing digit-strip for plain numbers with units/commas. Algebra is untouched (letters guard).

**`utils/promptCompact.js` (the live system prompt)**
- **Restore dropped teacher settings.** The 2026-02 compact migration read fields that don't exist on the `classAISettings` schema (`maxHintsPerProblem` / `allowCalculator` / `customInstructions`), silently dropping every teacher setting — including `vocabularyPreferences.orderOfOperations` (**default `'GEMS'`**), which made the tutor revert to PEMDAS. Now wired to the real schema (calculator policy, scaffolding, OoO mnemonic, solution approaches, manipulatives, current topic, encouragement).
- Add a mnemonic-agnostic **order-of-operations** block: M/D and S/A are equal priority left-to-right; correct the "M before D" misconception without half-agreeing; never call a correct result wrong while arguing ordering; defer the mnemonic name to the teacher setting (default GEMS).

**`utils/misconceptionDetector.js`**
- Add a `multiply-before-divide` entry to the `order-of-operations` misconception library.

## Testing

- New regression suite `tests/unit/mathSolverArithmeticChain.test.js` (cdot/middot/×/÷ variants → 8; precedence chains; no collateral damage to `16/4`, `1/2 + 1/4`, plain arithmetic; `verifyAnswer` expression-form acceptance).
- **Full mathSolver suite: 417 passing, 0 failing** (incl. the prose-`331` regression-guard control).
- `node --check` clean on all changed files; system prompt verified to emit the GEMS mnemonic from the real schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)