### PR TITLE
Onboarding guide + golden safety net + answer-verifier accuracy work (problem-context fix, tiered escalation, metrics)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,10 @@ stages in the same dir (`xpEngine`, `sessionMood`, `boardLlm`, `boardSynthesizer
 
 1. **observe** — classify the message (answer attempt / question / confusion / off-topic / …).
 2. **diagnose** — verify the student's answer two ways in parallel: deterministic `utils/mathSolver.js`
-   (~30% of topics, fast/exact) **and** an LLM verifier (`pipeline/llmVerifier.js`, `gpt-4o-mini`) for the rest.
+   (~30% of topics, fast/exact) **and** an LLM verifier (`pipeline/llmVerifier.js`). The verifier is
+   **tiered**: `gpt-4o-mini` first, escalating to `gpt-4o` when it can't resolve (low confidence / parse
+   fail) instead of silently giving up. Outcomes (incl. the `unverifiableRate`) are tracked in
+   `utils/verifyMetrics.js`, surfaced on `GET /api/admin/structured-tutor-metrics`.
 3. **decide** — pick an instructional action (scaffold, direct-instruction, worked-example,
    prerequisite-bridge, guided/independent practice, verify, redirect, …) using BKT state, lesson phase, mood.
 4. **generate** — build the system prompt + history, call the LLM (streamed via SSE), emit board/visual commands.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,292 @@
+# CLAUDE.md — MATHMATIX.AI Engineering Guide
+
+> Onboarding map for anyone (human or AI) working in this repo. Read this first.
+> It's an **index + mental model**, not a spec — when in doubt, read the file it points to.
+> The `docs/` folder holds deep design docs; this file tells you which one to open.
+
+---
+
+## 1. What this is
+
+**MATHMATIX.AI** — an AI-powered, personalized K-12 math tutor. Tagline: *"See the Patterns,
+Solve with Ease."* Mission: *"An Affordable Math Tutor for Every Child."*
+
+Four roles, each with its own dashboard and permission set:
+
+| Role | Primary page | What they do |
+|------|-------------|--------------|
+| **Student** | `chat.html` | 1:1 AI tutoring, practice, assessments, gamification |
+| **Teacher** | `teacher-dashboard.html` | Rosters, live monitoring, IEPs, class AI settings, resources |
+| **Parent** | `parent-dashboard.html` | Child progress, reports, teacher messaging |
+| **Admin** | `admin-dashboard.html` | User mgmt, bulk email, school licenses, system health |
+
+Live at https://www.mathmatix.ai (Render, Oregon). ~70 shipped features (see
+`docs/SITE_OVERVIEW.md` for the full catalog).
+
+---
+
+## 2. Stack at a glance
+
+| Layer | Tech |
+|-------|------|
+| Backend | Node.js ≥20.14 (pinned 20.11.1) / Express 4 |
+| DB | MongoDB + Mongoose 8 (`connect-mongo` session store) |
+| **LLM (runtime)** | **OpenAI only** — `gpt-4o-mini` (chat/teaching), `gpt-4o` (vision grading). See §7. |
+| Voice STT | Deepgram (`nova-2`/`nova-3`), Whisper-1 fallback |
+| Voice TTS | Cartesia (`sonic-2`), streaming over WebSocket |
+| Math OCR | Mathpix (`/v3/text`, `/v3/pdf`) |
+| Math render | KaTeX + MathLive (client); JSXGraph for interactive diagrams |
+| Auth | Passport (local, Google, Microsoft, Clever SSO) |
+| Billing | Stripe (subscriptions + school licenses) |
+| Storage | AWS S3 (or R2/Spaces/MinIO via `S3_ENDPOINT`) |
+| Email | Nodemailer (SendGrid/SES/Postmark) |
+| Observability | Sentry + Winston + Better Stack (Logtail) |
+| Frontend | **Vanilla JS + Vite** (multi-page, no SPA framework) |
+| Hosting | Render (Docker); Puppeteer headless-shell + Python3/matplotlib in image |
+
+> ⚠️ `ANTHROPIC_API_KEY_*` appears in `.env.example`, but **Claude is not wired in at runtime** —
+> the only reference (`utils/pipeline/llmVerifier.js`) is a comment about a *future* swap. Treat the
+> app as OpenAI-only until that path is actually built.
+
+---
+
+## 3. Boot sequence & request lifecycle
+
+`server.js` → validates required env → `initSentry` → `configureMiddleware` →
+`connectDatabase` → `registerRoutes` → `initSentryErrorHandler` → `listen` →
+attach voice WebSockets (`routes/voiceTutor.js`, `routes/voice.js`).
+
+Middleware order (`config/middleware.js`) is load-bearing — **don't reorder casually**:
+trust-proxy → HTTPS/www redirect (prod) → CORS → **Stripe webhook raw-body** (before JSON parse) →
+compression → static assets → request-id → body parse (1MB) → **session (MongoStore)** →
+passport → impersonation swap → CSP nonce → helmet → rate limit → **CSRF (double-submit)** → request logging.
+
+Required env to boot (`server.js` exits if missing): `MONGO_URI`, `SESSION_SECRET`,
+`GOOGLE_*`, `MICROSOFT_*`, `MATHPIX_*`, `OPENAI_API_KEY`.
+
+---
+
+## 4. Directory map
+
+```
+server.js              Entry point (bootstrap + graceful shutdown + WS attach)
+instrument.js          Sentry pre-require hook (loaded via `node --require`)
+config/                database.js · middleware.js · routes.js · sentry.js
+auth/                  passport-config.js (Google/Microsoft/Clever/local strategies)
+middleware/  (12)      auth · csrf · impersonation · usageGate · consentGate ·
+                       promptInjection · uploadSecurity · ferpaAccessLog · errorTracking · …
+models/      (34)      Mongoose schemas — see §6
+routes/      (77)      HTTP surface, grouped by domain — see §5
+services/    (7)       chatService · sessionService · assessmentService · userService ·
+                       aiService(legacy) · cleverApi · cleverSync
+utils/       (160)     The brains: pipeline/, prompts, learning engines, voice, OCR — see §7
+public/      (~1220)   Vanilla-JS + Vite frontend — see §8
+scripts/     (85)      Seeding, data migration, problem/skill gen & QA, crons — see §10
+seeds/                 Skill/problem/curriculum seed JSON (incl. pattern skills)
+docs/        (65)      Design docs + data dumps (skills.json, problems.json)
+tests/                 unit/ · integration/ (supertest) · load/ (k6)
+Dockerfile render.yaml .puppeteerrc.cjs   Deploy
+```
+
+---
+
+## 5. HTTP API surface (`routes/`, registered in `config/routes.js`)
+
+77 files, ~270 endpoints. Guards: `isAuthenticated`, `isAdmin/isTeacher/isParent/isStudent`,
+`aiEndpointLimiter`, `usageGate`, `premiumFeatureGate`. Roles checked via `user.roles[]` (array,
+preferred) with fallback to legacy `user.role` (string).
+
+| Domain | Key files |
+|--------|-----------|
+| **Chat/tutor core** ⭐ | `chat.js` (the main endpoint), `conversations.js`, `courseChat.js`, `trialChat.js`, `voiceTutor.js`, `voice.js` |
+| Assessment | `screener.js` (IRT placement), `assessment.js`, `growthCheck.js`, `checkpoint.js`, `mastery.js` (badges), `review.js` |
+| Student | `student.js`, `learningCurve.js`, `notifications.js`, `session.js`, `user.js` |
+| Teacher | `teacher.js`, `teacherResources.js`, `iepTemplates.js`, `announcements.js`, `curriculum.js`, `course.js`, `courseSession.js` |
+| Parent | `parent.js`, `analytics.js` |
+| Admin | `admin.js`, `adminEmail.js`, `adminImport.js`, `schoolLicense.js`, `cleverSync.js`, `dataPrivacy.js`, `consent.js`, `onboarding.js` |
+| Gamification | `dailyQuests.js`, `weeklyChallenges.js`, `challenges.js`, `leaderboard.js`, `nudges.js`, `rapportBuilding.js` |
+| Billing | `billing.js` (Stripe), `affiliate.js`, `waitlist.js` |
+| Specialized | `guidedLesson.js`, `gradeWork.js` (Show Your Work), `speak.js` (TTS), `avatar.js`, `practicePack.js`, `imageSearch.js`, `browserLock.js` |
+
+`/api/billing/webhook` is **CSRF-exempt and raw-body** (Stripe signature). Trial/demo/waitlist
+endpoints are unauthenticated but IP-rate-limited.
+
+---
+
+## 6. Data model (`models/`)
+
+**`user.js` is the spine (~1,332 lines).** Embeds a lot — read it before touching anything user-facing:
+- Identity/roles/OAuth ids; parent↔child↔teacher links; `subscriptionTier`, `schoolLicenseId`
+- `skillMastery: Map<skillId, {...}>` — per-skill state machine with **4 pillars**
+  (accuracy/independence/transfer/retention), SM-2/FSRS `reviewSchedule`, and `fluencyTracking`
+- `learningProfile` — interests, learning style, math-anxiety, rapport answers, fluency baseline
+- `badges` / `strategyBadges` / `habitBadges` / `metaBadges`; `courseEnrollments`; `consentRecords`
+
+| Model | Role |
+|-------|------|
+| `conversation.js` | Chat history (decoupled from user); `messages[]`, board state, `phaseTracker`, `sessionScorecard`, `sessionMood`, alerts. Fields like `summary`/`strugglingWith` are field-level encrypted. |
+| `tutorPlan.js` | **The tutor's persistent "mental model"** of a student — skill focuses, notes, current instructional mode. Updated every turn by the pipeline. |
+| `skill.js` | Master catalog (K→Calc 3). Prereqs/enables graph, `irtDifficulty`, `fluencyMetadata`, `teachingGuidance`. |
+| `problem.js` | Practice items. `answer.equivalents[]`, `answerType`, MC `options`/`correctOption`, `difficulty` 1-5. |
+| `iepPlan.js` | IEP in its **own collection** for privacy/audit; user doc keeps a lightweight cache. |
+| `screenerSession.js` | IRT CAT state (theta, SE, responses, frontier). |
+| `course.js` / `courseSession.js` | Structured courses; lessons use **Gradual Release** (I-do / we-do / you-do) phases. |
+| Others | `gradingResult`, `message` (teacher↔parent), `section` (Clever roster), `schoolLicense`, `enrollmentCode`, `webhookEvent` (Stripe idempotency), `impersonationLog`, `deleteAudit`, `supportTicket`, `notification`, `challenge`, `announcement`, `browserLockSession`, `studentUpload`, `transcriptFlag`, `curriculum`. |
+
+---
+
+## 7. The tutoring engine (`utils/`, esp. `utils/pipeline/`) ⭐ the heart
+
+Every student turn runs through a multi-stage pipeline (`utils/pipeline/index.js`).
+Conceptually: **observe → diagnose → decide → generate → verify → persist**, plus supporting
+stages in the same dir (`xpEngine`, `sessionMood`, `boardLlm`, `boardSynthesizer`, `stepEvaluator`,
+`evidenceAccumulator`, `sidecar`, `suggestions`, course adapters).
+
+1. **observe** — classify the message (answer attempt / question / confusion / off-topic / …).
+2. **diagnose** — verify the student's answer two ways in parallel: deterministic `utils/mathSolver.js`
+   (~30% of topics, fast/exact) **and** an LLM verifier (`pipeline/llmVerifier.js`, `gpt-4o-mini`) for the rest.
+3. **decide** — pick an instructional action (scaffold, direct-instruction, worked-example,
+   prerequisite-bridge, guided/independent practice, verify, redirect, …) using BKT state, lesson phase, mood.
+4. **generate** — build the system prompt + history, call the LLM (streamed via SSE), emit board/visual commands.
+5. **verify** — schema-check board commands, enforce visual-teaching & **anti-cheat** rules, simplify to reading level.
+6. **persist** — save messages, update `skillMastery` (BKT + FSRS), award XP/badges, update `tutorPlan`, mood.
+
+### LLM access — always go through the gateway
+- **`utils/llmGateway.js`** is the single entry point. It does **PII anonymization** (strips student
+  names → `[Student]` → rehydrates) before/after the API call. Routes/pipeline should call this, **not**
+  `openaiClient` directly.
+- **`utils/openaiClient.js`** wraps the OpenAI SDK (retry/backoff, 90s timeout, structured outputs,
+  `max_completion_tokens` vs `max_tokens` per model). 35 files import one of these two.
+
+### Prompts (token-sensitive)
+- `utils/prompt.js` delegates to **`utils/promptCompact.js`** (the live, ~3-4K-token builder). The
+  giant legacy `prompt.js` body is kept for rollback — **use compact**.
+- `coursePrompt.js` (course mode / Gradual Release), `masteryPrompt.js` (badge sessions),
+  `promptPlanLayer.js` (injects `tutorPlan`). `tutorConfig.js` = the personas (Bob, Maya, Ms. Maria,
+  Mr. Nappier + unlockables), each with personality, catchphrase, OpenAI + Cartesia voice ids.
+
+### Learning engines
+`knowledgeTracer.js` (Bayesian Knowledge Tracing, per-category params), `fsrsScheduler.js` (spaced
+repetition), `masteryEngine.js` (4-pillar score + tiers), `irt.js`/`adaptiveScreener.js`/`catConfig.js`/
+`skillSelector.js`/`catConvergence.js` (IRT CAT screener), `misconceptionDetector.js`,
+`interleavingEngine.js`, `antiCheatSafeguards.js`/`antiGaming.js`/`worksheetGuard.js`.
+
+### Voice (WebSocket, attached in `server.js`)
+`sttStream.js` (Deepgram) → LLM → `ttsStream.js`/`ttsProvider.js` (Cartesia). `voiceSession.js`
+orchestrates one socket; modes: `math-steps`, `board-actions`, `orchestrated`. Idle Deepgram sessions
+close after 30s (cost) and lazily reopen.
+
+### OCR
+`utils/ocr.js` (image) + `utils/pdfOcr.js` (PDF, poll w/ backoff). Uploads flow into `routes/chat.js`
+(multer → Sharp EXIF-strip → Mathpix → injected into prompt as context).
+
+---
+
+## 8. Frontend (`public/`)
+
+Multi-page, **vanilla JS + Vite** (no React/Vue). 55 HTML pages; Vite (`vite.config.js`) bundles JS/CSS
+only — HTML is served as-is, so i18n/feature-flags/user-data are injected client-side.
+
+- **`public/js/script.js`** is the chat engine (~2000 lines): `appendMessage()`, speech recognition,
+  markdown+KaTeX rendering, visual `[VISUAL_TYPE:params]` blocks.
+- ES modules in `public/js/modules/`: `gamification.js`, `billing.js`, `audio.js` (TTS queue),
+  `iep.js`, `assessment.js`, `session.js`, `age-tier.js`, `whiteboard.js` (shelved).
+- Heavy reliance on globals (`window.currentUser`, `window.TUTOR_CONFIG`, `window.MM_FEATURES`).
+- CSS is **dual-system**: legacy sheets hardcode colors; newer ones use `--cr-*` design tokens
+  (`design-system.css`, `chat-redesign.css`). 70 CSS files, no CSS-modules.
+- **Feature flags / shelved**: whiteboard panel (`MM_FEATURES.boardPanel`, default off — tutor work
+  shows as inline chat cards instead), voice-mode-in-chat, course catalog UI.
+
+---
+
+## 9. Cross-cutting concerns
+
+- **Security**: helmet/CSP+nonce, custom **double-submit CSRF** (`middleware/csrf.js`, constant-time),
+  rate limiters (`authLimiter` 5/15m, `signupLimiter`, `apiLimiter` 300/15m, `aiEndpointLimiter`,
+  trial 30/hr), prompt-injection middleware, upload validation + 30-day auto-delete, optional
+  AES-256-GCM field encryption (`FIELD_ENCRYPTION_KEY`).
+- **Compliance (FERPA/COPPA)**: `consentGate`/`consent.js`/`consentManager.js`, `ferpaAccessLog`,
+  `dataPrivacy.js` (export/delete/amend), `dataRetention.js`, PII anonymization in the LLM gateway,
+  `impersonation.js` (read-only, 20-min timeout, fully audited).
+- **Billing/gating**: `routes/billing.js` + `middleware/usageGate.js`. Free = 30 AI-min/wk (students);
+  teachers/parents/admins/licensed students unlimited. Voice/upload/AI-grading are premium-gated.
+- **Observability**: `/api/health` (DB + keys + memory), Sentry (5xx only, 10% trace sample in prod),
+  Winston with secret redaction → Logtail + rotating files.
+
+---
+
+## 10. Dev & ops workflow
+
+```bash
+npm run dev            # nodemon + instrument.js
+npm start              # node --require ./instrument.js server.js
+npm run build          # Vite → ../dist
+npm test               # jest --coverage  (unit + integration)
+npm run test:unit | test:integration
+npm run lint           # eslint
+npm run loadtest:chat  # k6 (also :screener :auth :stress :chat:peak)
+npm run seed:playground / seed:test / seed:skills   # seed data
+```
+
+- **CI** (`.github/workflows/ci.yml`): test + lint + build on PRs to `main`. Coverage thresholds are
+  low (~25%) — raise for new critical code (auth, IRT, mastery, billing).
+- **Deploy**: Render builds the `Dockerfile` (Node-slim + Puppeteer headless-shell + Python3/matplotlib;
+  build-time Puppeteer smoke test). `render.yaml` is **reference/doc only** — the live service and the
+  two cron jobs (`weeklyDigest`, `archiveOldConversations`) are configured manually in the Render dashboard.
+- **Local setup**: see `docs/LOCAL_SETUP.md`. Needs Mongo + the boot env vars; use Stripe CLI for webhooks.
+- **scripts/** (85): seeding, problem/skill **generation + QA** (huge `generate*.js`), distractor fixes,
+  dedup/cleanup, migrations, IRT calibration, crons. Many are wired as `npm run …` aliases — check
+  `package.json` scripts before writing a new one-off.
+
+---
+
+## 11. "I need to change X → start here"
+
+| Task | Start in |
+|------|----------|
+| Tutor reply behavior / teaching logic | `utils/pipeline/{decide,generate,verify}.js`, then `promptCompact.js` |
+| Add/adjust a tutor persona | `utils/tutorConfig.js` (+ voice ids) |
+| Answer grading / correctness | `utils/mathSolver.js` (deterministic) + `pipeline/diagnose.js` / `llmVerifier.js` |
+| Placement screener / IRT | `routes/screener.js`, `utils/{adaptiveScreener,irt,catConfig,skillSelector}.js`; docs: `PLACEMENT_TEST_SYSTEM.md`, `SCREENER_STATE_ANALYSIS.md` |
+| Mastery / badges | `routes/mastery.js`, `utils/{masteryEngine,badgeAwarder,patternBadges}.js`; docs: `MASTER_MODE_BADGE_SYSTEM.md`, `PATTERN_BADGE_GUIDE.md` |
+| Skills/problems data | `models/{skill,problem}.js`, `seeds/`, `scripts/generate*.js` + QA scripts |
+| IEP / accommodations | `models/iepPlan.js`, `routes/iepTemplates.js`, `utils/iepTemplates.js`; docs: `IEP_*` |
+| Voice | `routes/voiceTutor.js`, `utils/{voiceSession,sttStream,ttsStream}.js` |
+| Whiteboard / board commands | `utils/{boardCommandGuard,boardResponseSchema}.js`, `pipeline/board*.js`; docs: `WHITEBOARD_*`, `BOARD_LLM_STAGE_DESIGN.md` |
+| Auth / roles / SSO | `auth/passport-config.js`, `middleware/auth.js`, `services/cleverSync.js` |
+| Billing / plans | `routes/billing.js`, `middleware/usageGate.js` |
+| Teacher/parent/admin dashboards | `routes/{teacher,parent,admin}.js` + matching `public/*-dashboard.html`/`.js` |
+| Chat UI / rendering | `public/js/script.js`, `public/js/inlineChatVisuals.js`, `public/css/chat*.css` |
+
+---
+
+## 12. Gotchas & sharp edges
+
+- **`role` vs `roles`** — dual fields exist; always read via the `hasRole()` helper (`roles[]` first).
+- **Use `promptCompact`, not the legacy `prompt.js` body** — the latter is rollback-only and huge.
+- **Use `llmGateway`, never `openaiClient` directly** from routes — you'd bypass PII anonymization.
+- **`config/middleware.js` order matters** — Stripe raw-body must precede `express.json`; CSP nonce
+  must precede helmet; CSRF after session.
+- **Per-user chat lock** in `routes/chat.js` serializes a user's concurrent messages — don't remove it.
+- **Math-answer injection gate**: the verified answer is injected into context **only** on an
+  `ANSWER_ATTEMPT`, never when the student is *asking* — preserve this or you'll leak answers.
+- **Conversations >100 msgs are summarized** before hitting the LLM — mind token budgets.
+- **IEP is split** (collection + cached copy on user) — update both / sync on read.
+- **Skill inference**: mastery can be *inferred* from prerequisites with no cascade-invalidation if a
+  prereq later fails — be careful trusting `masteryType: inferred`.
+- **Clever sync is non-blocking** — roster failures are swallowed; surface them when debugging "missing students."
+- **`render.yaml` ≠ prod config** — it's documentation; real config/crons live in the Render dashboard.
+- **Known doc↔code drift** (see `docs/SCREENER_STATE_ANALYSIS.md`): screener grade-based start / theta-reset,
+  IEP UI vs schema mismatch, pattern-skill coverage incomplete (~59 of ~204).
+
+---
+
+## 13. Where the design intent lives (`docs/`)
+
+Start with `SITE_OVERVIEW.md` (feature catalog) and `STUDENT_UX_FLOW.md`. Then by area:
+pedagogy → `PEDAGOGY_ANALYSIS_AND_RECOMMENDATIONS.md`, `MATH_SKILLS_VERTICAL_ALIGNMENT.md`,
+`DUAL_MODE_SYSTEM_DESIGN.md`; assessment → `PLACEMENT_TEST_SYSTEM.md`; gamification →
+`BADGE_SYSTEM_DESIGN.md`, `MASTER_MODE_BADGE_SYSTEM.md`, `PATTERN_BADGE_GUIDE.md`; whiteboard →
+`WHITEBOARD_AI_INTEGRATION.md`, `BOARD_LLM_STAGE_DESIGN.md`, `CHAT_BOARD_AI_INTEGRATION.md`;
+security/compliance → `SECURITY.md`, `STUDENT_DATA_SECURITY_AUDIT.md`, `CSRF_PROTECTION.md`;
+cost → `AI_COST_PROJECTIONS.md`. **Docs describe intent and may lag code — verify against the source.**

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:watch": "jest --watch",
     "test:unit": "jest --testPathPattern=tests/unit",
     "test:integration": "jest --testPathPattern=tests/integration",
+    "test:golden": "jest --testPathPattern=tests/golden",
     "seed:test": "node scripts/seedTestData.js",
     "seed:playground": "node scripts/seedPlaygroundAccounts.js",
     "seed:playground:clear": "node scripts/seedPlaygroundAccounts.js --clear",

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1430,6 +1430,7 @@ router.get('/health-check', isAdmin, (req, res) => {
 router.get('/structured-tutor-metrics', isAdmin, (req, res) => {
   const os = require('os');
   const structuredMetrics = require('../utils/structuredTutorMetrics');
+  const verifyMetrics = require('../utils/verifyMetrics');
   const { isStructuredModeEnabled } = require('../utils/boardResponseSchema');
   res.json({
     flagEnabled: isStructuredModeEnabled(),
@@ -1445,6 +1446,13 @@ router.get('/structured-tutor-metrics', isAdmin, (req, res) => {
     },
     aggregate: structuredMetrics.aggregate(),
     recent: structuredMetrics.snapshot(50),
+    // Answer-verifier health: the unverifiableRate is the headline — the share
+    // of answer attempts the engine couldn't give a usable verdict on — plus how
+    // often escalation to the stronger judge rescues those cases.
+    verify: {
+      aggregate: verifyMetrics.aggregate(),
+      recent: verifyMetrics.snapshot(50),
+    },
   });
 });
 

--- a/tests/golden/README.md
+++ b/tests/golden/README.md
@@ -1,0 +1,84 @@
+# Golden Transcripts
+
+A behavior + **safety** regression net for the tutoring pipeline (`utils/pipeline/`).
+
+The pipeline *is* the product. Prompts and models change constantly. This suite locks
+the **deterministic teaching decisions** (`observe` → `decide`) and a set of
+non-negotiable **safety invariants**, so a prompt tweak, a model swap, or a refactor
+can't silently change how the tutor reads a student — or, worse, start affirming
+answers it never verified.
+
+It runs in CI with the normal `npm test` (no API keys, no DB, fast).
+
+## Run it
+
+```bash
+npm run test:golden      # just this suite
+npm test                 # full unit+integration suite (includes this)
+```
+
+## Add a case — no code required
+
+Edit **`transcripts.json`**. Copy an existing block and change the values.
+
+### Classification case — "this message should be read as type X"
+
+```json
+{ "name": "skip request is recognized", "message": "skip this one", "expectMessageType": "skip_request" }
+```
+
+`expectMessageType` must be one of the `MESSAGE_TYPES` in `utils/pipeline/observe.js`
+(`answer_attempt`, `idk`, `frustration`, `help_request`, `question`, `affirmative`,
+`skip_request`, `progress_report`, `general_math`, `greeting`, …).
+
+### Decision case — "given this situation, the tutor should do Y (and stay safe)"
+
+```json
+{
+  "name": "incorrect answer is guided, never confirmed",
+  "message": "x = 5",
+  "decide": {
+    "from": "synthesize",
+    "messageType": "answer_attempt",
+    "answer": { "value": "5" },
+    "streaks": { "recentWrongCount": 0 },
+    "diagnosis": { "type": "incorrect", "isCorrect": false, "answer": "5", "correctAnswer": "7" },
+    "expectAction": "guide_incorrect"
+  }
+}
+```
+
+- `from`: `"synthesize"` builds the observation from the fields you give (precise control of
+  the situation). `"observe"` runs the real classifier on `message` first, then decides
+  (true end-to-end). Use `synthesize` for answer-attempt cases where you want to inject a
+  specific `diagnosis`; use `observe` for intent cases (give-up, idk, help, off-task).
+- `diagnosis.type`: one of `correct`, `incorrect`, `unverifiable`, `correct_partial`,
+  `no_answer`. This is *injected* — the suite does not call the math engine or LLM, so you
+  decide what the verdict was and assert how the tutor responds to it.
+- `expectAction` (or `expectActionOneOf`): an `ACTIONS` value from `utils/pipeline/decide.js`
+  (`confirm_correct`, `guide_incorrect`, `hint`, `worked_example`, `reteach_misconception`,
+  `scaffold_down`, `exit_ramp`, `redirect_to_math`, `acknowledge_frustration`,
+  `acknowledge_progress`, `continue_conversation`, …).
+
+## Safety invariants
+
+These run automatically and are the reason this suite matters. They assert *properties*,
+not exact wording, so they survive refactors but catch real regressions:
+
+| Invariant | When it runs | Guarantees |
+|-----------|--------------|------------|
+| `confirm_implies_correct` | every decision | The tutor only emits `confirm_correct` when the diagnosis was actually `correct` — never for `incorrect`, `unverifiable`, or `no_answer`. The core "don't affirm a wrong/unverified answer" guard. |
+| `no_autoconfirm_unverified` | every decision | When the math engine couldn't verify the answer, the tutor never auto-confirms and is handed a "verify before responding" directive. |
+| `giveup_no_reveal` | cases that opt in via `"safety": ["giveup_no_reveal"]` | An exit-ramp/give-up turn carries a "never reveal the answer" guard. |
+
+Add a new invariant in `goldenTranscripts.test.js` under `SAFETY_INVARIANTS`. Set
+`default: true` to run it on every decision, or `default: false` and opt cases in via the
+fixture's `"safety": [...]` array.
+
+## Why a golden file encodes *current* behavior
+
+These fixtures were seeded from the real output of `observe`/`decide` at the time of
+writing. That's the point: the file is the agreed-upon baseline. If a change moves a
+decision, the test fails — and you make a deliberate choice: was the change intended (update
+the fixture) or a regression (fix the code)? Never edit a fixture just to make a red test
+green without understanding which case you're in.

--- a/tests/golden/README.md
+++ b/tests/golden/README.md
@@ -60,6 +60,29 @@ Edit **`transcripts.json`**. Copy an existing block and change the values.
   `scaffold_down`, `exit_ramp`, `redirect_to_math`, `acknowledge_frustration`,
   `acknowledge_progress`, `continue_conversation`, …).
 
+### Problem-context case — "verify against the actual problem, not the last pleasantry"
+
+The LLM answer-verifier (`utils/pipeline/llmVerifier.js`) must check a student's answer
+against the message that *posed the problem*, not whatever the tutor said most recently
+(often "Nice — ready for the next one?"). `pickProblemContext` is a pure function, so these
+fixtures call it directly and assert which message it selects.
+
+```json
+{
+  "name": "picks the math problem over a trailing pleasantry",
+  "messages": [
+    { "content": "Solve 2x + 3 = 13 for x." },
+    { "content": "Take your time — what do you think?" }
+  ],
+  "expectPicked": "Solve 2x + 3 = 13 for x."
+}
+```
+
+Each message may carry `problemInfo` (the metadata the persist stage stores on a posed
+problem); a message with `problemInfo.correctAnswer` is the strongest signal and wins over a
+more recent math-looking hint. Set `expectPicked` to the chosen `content`, or `null` for an
+empty history.
+
 ## Safety invariants
 
 These run automatically and are the reason this suite matters. They assert *properties*,

--- a/tests/golden/goldenTranscripts.test.js
+++ b/tests/golden/goldenTranscripts.test.js
@@ -18,8 +18,15 @@
  * See tests/golden/README.md.
  */
 
+// llmVerifier (imported below for pickProblemContext) pulls the LLM gateway in at
+// module load. Mock it so this suite stays hermetic and key-free — pickProblemContext
+// itself is a pure function and makes no LLM calls.
+jest.mock('../../utils/llmGateway', () => ({ callLLM: jest.fn() }));
+jest.mock('../../utils/openaiClient', () => ({ chat: { completions: { create: jest.fn() } } }));
+
 const { observe, MESSAGE_TYPES } = require('../../utils/pipeline/observe');
 const { decide, ACTIONS } = require('../../utils/pipeline/decide');
+const { pickProblemContext } = require('../../utils/pipeline/llmVerifier');
 const fixtures = require('./transcripts.json');
 
 // ── Build a synthesized observation (mirrors the shape observe() emits, the way
@@ -133,10 +140,25 @@ describe('Golden transcripts: decide() actions + safety invariants', () => {
   }
 });
 
+// ── Problem-context selection ──
+// The LLM verifier must check the student's answer against the message that POSED
+// the problem — not the last pleasantry/follow-up. Verifying against the wrong text
+// yields spurious verdicts. pickProblemContext is a pure function, so we assert it
+// directly (no LLM call).
+describe('Golden transcripts: pickProblemContext picks the real problem', () => {
+  for (const fx of fixtures.problemContext || []) {
+    test(fx.name, () => {
+      const picked = pickProblemContext(fx.messages);
+      expect(picked).toBe(fx.expectPicked);
+    });
+  }
+});
+
 // ── Meta: the suite must actually be exercising cases (guards an empty/parse-broken fixture file) ──
 describe('Golden transcripts: suite integrity', () => {
   test('fixtures loaded and non-trivial', () => {
     expect((fixtures.classification || []).length).toBeGreaterThan(3);
     expect((fixtures.decisions || []).length).toBeGreaterThan(3);
+    expect((fixtures.problemContext || []).length).toBeGreaterThan(2);
   });
 });

--- a/tests/golden/goldenTranscripts.test.js
+++ b/tests/golden/goldenTranscripts.test.js
@@ -1,0 +1,142 @@
+/**
+ * GOLDEN TRANSCRIPTS — behavior + safety regression net for the tutoring pipeline.
+ *
+ * WHY THIS EXISTS
+ * The pipeline (utils/pipeline/) IS the product. Prompts and models change often;
+ * this suite locks the *deterministic* teaching decisions (observe + decide) and a
+ * set of non-negotiable SAFETY invariants so that a prompt tweak, a model swap, or a
+ * refactor can't silently change how the tutor classifies a student or — worse —
+ * start affirming answers it never verified.
+ *
+ * WHAT IT DOES NOT DO
+ * It does not call the LLM or the DB. The `generate` stage's wording and the live
+ * `diagnose` verdict are out of scope here (the diagnosis is injected as a controlled
+ * variable). Pair this with tests/unit/pipelineIntegration.test.js for the mocked
+ * end-to-end path.
+ *
+ * ADD A CASE: edit tests/golden/transcripts.json — no code changes needed.
+ * See tests/golden/README.md.
+ */
+
+const { observe, MESSAGE_TYPES } = require('../../utils/pipeline/observe');
+const { decide, ACTIONS } = require('../../utils/pipeline/decide');
+const fixtures = require('./transcripts.json');
+
+// ── Build a synthesized observation (mirrors the shape observe() emits, the way
+//    the existing decide unit tests construct it) ──
+function synthObservation(d) {
+  return {
+    messageType: d.messageType,
+    answer: d.answer || null,
+    contextSignals: d.contextSignals || [],
+    streaks: { idkCount: 0, giveUpCount: 0, recentWrongCount: 0, ...(d.streaks || {}) },
+  };
+}
+
+function decisionDirectives(decision) {
+  return Array.isArray(decision.directives) ? decision.directives : [];
+}
+
+// ── Safety invariants. Each returns null when satisfied, or a string describing
+//    the violation. `default: true` invariants run on EVERY decide case. ──
+const SAFETY_INVARIANTS = {
+  // The cardinal rule: only confirm an answer the system actually verified as correct.
+  // This is the guard against affirming wrong OR unverified answers.
+  confirm_implies_correct: {
+    default: true,
+    check: (decision, diagnosis) => {
+      if (decision.action !== ACTIONS.CONFIRM_CORRECT) return null;
+      return diagnosis && diagnosis.type === 'correct'
+        ? null
+        : `confirm_correct emitted for diagnosis.type="${diagnosis && diagnosis.type}" (only "correct" may be confirmed)`;
+    },
+  },
+
+  // When the math engine couldn't verify, never auto-confirm, and the tutor must be
+  // told to compute/verify before responding.
+  no_autoconfirm_unverified: {
+    default: true,
+    check: (decision, diagnosis) => {
+      if (!diagnosis || diagnosis.type !== 'unverifiable') return null;
+      if (decision.action === ACTIONS.CONFIRM_CORRECT) {
+        return 'unverifiable answer reached confirm_correct';
+      }
+      const hasVerifyGuard = decisionDirectives(decision).some((d) =>
+        /verif|compute the correct answer/i.test(d)
+      );
+      return hasVerifyGuard
+        ? null
+        : 'unverifiable answer carried no "verify before responding" directive';
+    },
+  },
+
+  // A give-up / exit-ramp must never leak the answer.
+  giveup_no_reveal: {
+    default: false,
+    check: (decision) => {
+      const hasNoRevealGuard = decisionDirectives(decision).some((d) =>
+        /never reveal|don't reveal|do not reveal|without revealing/i.test(d)
+      );
+      return hasNoRevealGuard ? null : 'exit ramp carried no "never reveal the answer" directive';
+    },
+  },
+};
+
+function runSafety(names, decision, diagnosis) {
+  const violations = [];
+  for (const [name, inv] of Object.entries(SAFETY_INVARIANTS)) {
+    const requested = inv.default || (names && names.includes(name));
+    if (!requested) continue;
+    const result = inv.check(decision, diagnosis);
+    if (result) violations.push(`[${name}] ${result}`);
+  }
+  return violations;
+}
+
+// ── Classification cases ──
+describe('Golden transcripts: observe() classification', () => {
+  for (const fx of fixtures.classification || []) {
+    test(fx.name, () => {
+      const obs = observe(fx.message, fx.context || {});
+      expect(obs.messageType).toBe(fx.expectMessageType);
+      // Every known expected type must be a real member of the enum (guards typos in fixtures).
+      expect(Object.values(MESSAGE_TYPES)).toContain(fx.expectMessageType);
+    });
+  }
+});
+
+// ── Decision + safety cases ──
+describe('Golden transcripts: decide() actions + safety invariants', () => {
+  for (const fx of fixtures.decisions || []) {
+    test(fx.name, () => {
+      const cfg = fx.decide || {};
+      const observation =
+        cfg.from === 'observe' ? observe(fx.message, fx.context || {}) : synthObservation(cfg);
+      const diagnosis = cfg.diagnosis || { type: 'no_answer' };
+
+      const decision = decide(observation, diagnosis, fx.context || {});
+
+      if (cfg.expectAction) {
+        expect(decision.action).toBe(cfg.expectAction);
+      }
+      if (cfg.expectActionOneOf) {
+        expect(cfg.expectActionOneOf).toContain(decision.action);
+      }
+
+      const violations = runSafety(fx.safety, decision, diagnosis);
+      if (violations.length) {
+        throw new Error(
+          `Safety invariant(s) violated for "${fx.name}":\n  - ${violations.join('\n  - ')}`
+        );
+      }
+    });
+  }
+});
+
+// ── Meta: the suite must actually be exercising cases (guards an empty/parse-broken fixture file) ──
+describe('Golden transcripts: suite integrity', () => {
+  test('fixtures loaded and non-trivial', () => {
+    expect((fixtures.classification || []).length).toBeGreaterThan(3);
+    expect((fixtures.decisions || []).length).toBeGreaterThan(3);
+  });
+});

--- a/tests/golden/transcripts.json
+++ b/tests/golden/transcripts.json
@@ -1,0 +1,97 @@
+{
+  "_README": "Golden transcripts for the tutoring pipeline. Each entry asserts real, current behavior of the deterministic stages (observe + decide). Add a case by copying an existing block — no test code required. See ./README.md. Fields: name, message, context?, expectMessageType?, decide{from,messageType?,answer?,streaks?,diagnosis?,expectAction?,expectActionOneOf?}?, safety?[]. Global safety invariants run on every decide case automatically.",
+
+  "classification": [
+    { "name": "variable assignment is an answer attempt", "message": "x = 7", "expectMessageType": "answer_attempt" },
+    { "name": "answer phrase is an answer attempt", "message": "the answer is 12", "expectMessageType": "answer_attempt" },
+    { "name": "idk is recognized", "message": "idk", "expectMessageType": "idk" },
+    { "name": "quitting reads as frustration", "message": "this is stupid I quit", "expectMessageType": "frustration" },
+    { "name": "explicit help ask", "message": "can you help me?", "expectMessageType": "help_request" },
+    { "name": "how-do-I is a help request", "message": "how do I start?", "expectMessageType": "help_request" },
+    { "name": "non-math trivia is an off-topic question", "message": "what is the capital of France?", "expectMessageType": "question" },
+    { "name": "bare yes is affirmative", "message": "yes", "expectMessageType": "affirmative" },
+    { "name": "skip request", "message": "skip this one", "expectMessageType": "skip_request" },
+    { "name": "process narration is a progress report", "message": "first I divided both sides by 2", "expectMessageType": "progress_report" }
+  ],
+
+  "decisions": [
+    {
+      "name": "correct answer is confirmed",
+      "message": "x = 7",
+      "decide": {
+        "from": "synthesize", "messageType": "answer_attempt", "answer": { "value": "7" },
+        "diagnosis": { "type": "correct", "isCorrect": true, "answer": "7", "correctAnswer": "7", "misconception": null },
+        "expectAction": "confirm_correct"
+      }
+    },
+    {
+      "name": "incorrect answer is guided, never confirmed",
+      "message": "x = 5",
+      "decide": {
+        "from": "synthesize", "messageType": "answer_attempt", "answer": { "value": "5" },
+        "diagnosis": { "type": "incorrect", "isCorrect": false, "answer": "5", "correctAnswer": "7", "misconception": null },
+        "expectAction": "guide_incorrect"
+      }
+    },
+    {
+      "name": "incorrect + known misconception is re-taught",
+      "message": "3x + 2 (got 3x+2 from 3(x+2))",
+      "decide": {
+        "from": "synthesize", "messageType": "answer_attempt", "answer": { "value": "3x+2" },
+        "diagnosis": { "type": "incorrect", "isCorrect": false, "answer": "3x+2", "correctAnswer": "3x+6", "misconception": { "name": "Partial Distribution", "fix": "Distribute to all terms" } },
+        "expectAction": "reteach_misconception"
+      }
+    },
+    {
+      "name": "repeated wrongs escalate to a worked example",
+      "message": "x = 5",
+      "decide": {
+        "from": "synthesize", "messageType": "answer_attempt", "answer": { "value": "5" },
+        "streaks": { "idkCount": 0, "giveUpCount": 0, "recentWrongCount": 4 },
+        "diagnosis": { "type": "incorrect", "isCorrect": false, "answer": "5", "correctAnswer": "7", "misconception": null },
+        "expectAction": "worked_example"
+      }
+    },
+    {
+      "name": "UNVERIFIABLE answer is never auto-confirmed — hands off with a self-verify directive",
+      "message": "x = 7",
+      "decide": {
+        "from": "synthesize", "messageType": "answer_attempt", "answer": { "value": "7" },
+        "diagnosis": { "type": "unverifiable", "isCorrect": null, "answer": "7", "correctAnswer": null, "misconception": null },
+        "expectAction": "continue_conversation"
+      },
+      "safety": ["no_autoconfirm_unverified"]
+    },
+    {
+      "name": "partial multi-root answer is acknowledged, not marked wrong",
+      "message": "x = 3",
+      "decide": {
+        "from": "synthesize", "messageType": "answer_attempt", "answer": { "value": "3" },
+        "diagnosis": { "type": "correct_partial", "isCorrect": null, "answer": "3", "correctAnswer": "3,2", "misconception": null, "multiRoot": { "remainingCount": 1 } },
+        "expectAction": "acknowledge_progress"
+      }
+    },
+    {
+      "name": "give-up triggers an exit ramp that never reveals the answer",
+      "message": "I give up",
+      "decide": { "from": "observe", "expectAction": "exit_ramp" },
+      "safety": ["giveup_no_reveal"]
+    },
+    {
+      "name": "idk scaffolds down rather than answering",
+      "message": "idk",
+      "decide": { "from": "observe", "expectAction": "scaffold_down" }
+    },
+    {
+      "name": "off-topic redirects back to math",
+      "message": "what is the capital of France?",
+      "context": { "onTask": true },
+      "decide": { "from": "synthesize", "messageType": "off_task", "diagnosis": { "type": "no_answer" }, "expectAction": "redirect_to_math" }
+    },
+    {
+      "name": "help request offers a hint, not the solution",
+      "message": "can you help me?",
+      "decide": { "from": "observe", "expectAction": "hint" }
+    }
+  ]
+}

--- a/tests/golden/transcripts.json
+++ b/tests/golden/transcripts.json
@@ -93,5 +93,45 @@
       "message": "can you help me?",
       "decide": { "from": "observe", "expectAction": "hint" }
     }
+  ],
+
+  "problemContext": [
+    {
+      "name": "picks the math problem over a trailing pleasantry",
+      "messages": [
+        { "content": "Solve 2x + 3 = 13 for x." },
+        { "content": "Take your time — what do you think?" }
+      ],
+      "expectPicked": "Solve 2x + 3 = 13 for x."
+    },
+    {
+      "name": "prefers the problem tagged with stored metadata over a later mathy hint",
+      "messages": [
+        { "content": "A train travels 60 miles in 2 hours. What is its speed?", "problemInfo": { "correctAnswer": "30 mph" } },
+        { "content": "Remember, speed = distance / time." }
+      ],
+      "expectPicked": "A train travels 60 miles in 2 hours. What is its speed?"
+    },
+    {
+      "name": "ignores the pleasantry and finds the LaTeX problem above it",
+      "messages": [
+        { "content": "Find the derivative of \\(x^2\\)." },
+        { "content": "Awesome hustle — ready for the next one?" }
+      ],
+      "expectPicked": "Find the derivative of \\(x^2\\)."
+    },
+    {
+      "name": "falls back to most recent non-empty when nothing looks like a problem",
+      "messages": [
+        { "content": "" },
+        { "content": "Great effort, keep it going!" }
+      ],
+      "expectPicked": "Great effort, keep it going!"
+    },
+    {
+      "name": "returns null for empty history",
+      "messages": [],
+      "expectPicked": null
+    }
   ]
 }

--- a/tests/unit/llmVerifierEscalation.test.js
+++ b/tests/unit/llmVerifierEscalation.test.js
@@ -1,0 +1,95 @@
+/**
+ * Tests for verifyWithEscalation — the tiered answer verifier.
+ *
+ * Tier 1 (gpt-4o-mini) handles the common case; when it can't produce a usable
+ * verdict (low confidence, parse failure, error) we escalate to Tier 2 (gpt-4o)
+ * instead of giving up. These tests drive the tier transitions by scripting the
+ * mocked LLM gateway, asserting both the resulting verdict and the call counts
+ * (so we don't escalate when we shouldn't, or skip escalation when we should).
+ */
+
+jest.mock('../../utils/llmGateway', () => ({ callLLM: jest.fn() }));
+
+const { callLLM } = require('../../utils/llmGateway');
+const {
+  verifyWithEscalation,
+  VERIFIER_MODEL,
+  ESCALATION_MODEL,
+} = require('../../utils/pipeline/llmVerifier');
+
+// Helpers: shape callLLM's return like the OpenAI SDK does.
+const wrap = (obj) => ({ choices: [{ message: { content: JSON.stringify(obj) } }] });
+const computeReply = (answer) => wrap({ answer, form: 'simplified' });
+const judgeReply = (matches, confidence) => wrap({ matches, confidence, rationale: 'r' });
+const isJudgeCall = (messages) => /equivalence judge/i.test(messages[0].content);
+
+beforeEach(() => callLLM.mockReset());
+
+test('tier 1 resolves a confident answer — no escalation', async () => {
+  callLLM.mockImplementation((model, messages) =>
+    Promise.resolve(isJudgeCall(messages) ? judgeReply(true, 0.95) : computeReply('7'))
+  );
+
+  const v = await verifyWithEscalation('Solve 2x + 3 = 13', '7');
+
+  expect(v.isCorrect).toBe(true);
+  expect(v.escalated).toBe(false);
+  expect(v.tier).toBe(VERIFIER_MODEL);
+  expect(callLLM).toHaveBeenCalledTimes(2); // compute + judge, mini only
+  expect(callLLM.mock.calls.every(([model]) => model === VERIFIER_MODEL)).toBe(true);
+});
+
+test('low-confidence tier 1 escalates and the stronger judge resolves it', async () => {
+  callLLM.mockImplementation((model, messages) => {
+    const judging = isJudgeCall(messages);
+    if (model === VERIFIER_MODEL) return Promise.resolve(judging ? judgeReply(true, 0.4) : computeReply('7'));
+    return Promise.resolve(judging ? judgeReply(true, 0.95) : computeReply('7')); // ESCALATION_MODEL
+  });
+
+  const v = await verifyWithEscalation('Find the derivative of x^2', '2x');
+
+  expect(v.escalated).toBe(true);
+  expect(v.escalationResolved).toBe(true);
+  expect(v.isCorrect).toBe(true);
+  expect(v.tier).toBe(ESCALATION_MODEL);
+  expect(callLLM).toHaveBeenCalledTimes(4); // mini (2) + gpt-4o (2)
+  expect(callLLM.mock.calls.some(([model]) => model === ESCALATION_MODEL)).toBe(true);
+});
+
+test('a tier-1 parse failure escalates (and tier 2 can return incorrect)', async () => {
+  callLLM.mockImplementation((model, messages) => {
+    if (model === VERIFIER_MODEL) {
+      return Promise.resolve({ choices: [{ message: { content: 'not json at all' } }] }); // step1 parse fail
+    }
+    return Promise.resolve(isJudgeCall(messages) ? judgeReply(false, 0.9) : computeReply('8'));
+  });
+
+  const v = await verifyWithEscalation('A word problem', '7');
+
+  expect(v.escalated).toBe(true);
+  expect(v.isCorrect).toBe(false);
+  expect(v.tier).toBe(ESCALATION_MODEL);
+  // tier 1 bails after the failed compute (1 call); tier 2 runs compute + judge (2).
+  expect(callLLM).toHaveBeenCalledTimes(3);
+});
+
+test('when both tiers are uncertain, the result stays unverifiable', async () => {
+  callLLM.mockImplementation((model, messages) =>
+    Promise.resolve(isJudgeCall(messages) ? judgeReply(true, 0.3) : computeReply('7'))
+  );
+
+  const v = await verifyWithEscalation('A hard proof', '7');
+
+  expect(v.escalated).toBe(true);
+  expect(v.escalationResolved).toBe(false);
+  expect(v.isCorrect).toBeNull();
+  expect(callLLM).toHaveBeenCalledTimes(4);
+});
+
+test('missing input never escalates — nothing to verify', async () => {
+  const v = await verifyWithEscalation('', '7');
+
+  expect(v.escalated).toBe(false);
+  expect(v.error).toBe('missing_input');
+  expect(callLLM).not.toHaveBeenCalled();
+});

--- a/tests/unit/verifyMetrics.test.js
+++ b/tests/unit/verifyMetrics.test.js
@@ -1,0 +1,62 @@
+/**
+ * Tests for verifyMetrics — the in-memory answer-verifier metrics ring.
+ * Focus: outcome classification and the aggregate (the unverifiableRate headline).
+ */
+
+const vm = require('../../utils/verifyMetrics');
+
+beforeEach(() => vm.reset());
+
+describe('classifyOutcome', () => {
+  test('maps verdicts to outcome buckets', () => {
+    expect(vm.classifyOutcome({ isCorrect: true })).toBe('verified_correct');
+    expect(vm.classifyOutcome({ isCorrect: false })).toBe('verified_incorrect');
+    expect(vm.classifyOutcome({ isCorrect: null, error: 'missing_input' })).toBe('error');
+    expect(vm.classifyOutcome({ isCorrect: null, error: 'step1_parse_failed' })).toBe('unverifiable');
+    expect(vm.classifyOutcome({ isCorrect: null, error: null })).toBe('low_confidence');
+    expect(vm.classifyOutcome(null)).toBe('error');
+  });
+});
+
+describe('aggregate', () => {
+  test('computes unverifiableRate and escalation stats over the ring', () => {
+    vm.recordVerification({ verdict: { isCorrect: true, confidence: 0.95 }, tier: 'gpt-4o-mini' });
+    vm.recordVerification({ verdict: { isCorrect: false, confidence: 0.9 }, tier: 'gpt-4o-mini' });
+    vm.recordVerification({ verdict: { isCorrect: null, error: null, confidence: 0.4 }, tier: 'gpt-4o-mini' });
+    vm.recordVerification({
+      verdict: { isCorrect: null, error: 'step2_parse_failed', confidence: 0 },
+      escalated: true,
+      escalationResolved: false,
+      tier: 'gpt-4o',
+    });
+    vm.recordVerification({
+      verdict: { isCorrect: true, confidence: 0.92 },
+      escalated: true,
+      escalationResolved: true,
+      tier: 'gpt-4o',
+    });
+
+    const agg = vm.aggregate();
+    expect(agg.sampleSize).toBe(5);
+    expect(agg.byOutcome.verified_correct).toBe(2);
+    expect(agg.byOutcome.verified_incorrect).toBe(1);
+    expect(agg.byOutcome.low_confidence).toBe(1);
+    expect(agg.byOutcome.unverifiable).toBe(1);
+
+    // 2 unresolved (low_confidence + unverifiable) out of 5.
+    expect(agg.unverifiableRate).toBeCloseTo(0.4, 5);
+    // 3 resolved (2 correct + 1 incorrect) out of 5.
+    expect(agg.resolvedRate).toBeCloseTo(0.6, 5);
+
+    // 2 escalations, 1 resolved.
+    expect(agg.escalated).toBe(2);
+    expect(agg.escalationResolveRate).toBeCloseTo(0.5, 5);
+  });
+
+  test('empty ring yields zeroed rates, not NaN', () => {
+    const agg = vm.aggregate();
+    expect(agg.sampleSize).toBe(0);
+    expect(agg.unverifiableRate).toBe(0);
+    expect(agg.escalationResolveRate).toBe(0);
+  });
+});

--- a/utils/pipeline/index.js
+++ b/utils/pipeline/index.js
@@ -23,7 +23,8 @@ const { generate, assemblePrompt } = require('./generate');
 const { verify } = require('./verify');
 const { detectParallelExampleIntroduction } = require('../worksheetGuard');
 const { persist } = require('./persist');
-const { llmVerifyAnswer, pickProblemContext } = require('./llmVerifier');
+const { verifyWithEscalation, pickProblemContext } = require('./llmVerifier');
+const verifyMetrics = require('../verifyMetrics');
 const { buildSidecar, mergeLlmSignals, getSignalStats } = require('./sidecar');
 const { computeSessionMood, buildMoodDirective } = require('./sessionMood');
 const { generateSuggestions } = require('./suggestions');
@@ -123,20 +124,31 @@ async function runPipeline(message, ctx) {
       recentAssistantMessages.map(msg => ({ content: msg.content, problemInfo: msg.problemInfo || null }))
     );
     if (problemText) {
-      llmVerificationPromise = llmVerifyAnswer(problemText, observation.answer.value)
+      const verifyStart = Date.now();
+      llmVerificationPromise = verifyWithEscalation(problemText, observation.answer.value)
         .then(verdict => {
+          const tier = verdict.escalated ? `escalated→${verdict.tier}` : verdict.tier;
           if (verdict.isCorrect !== null) {
-            console.log(`[Pipeline] LLMVerify: ${verdict.isCorrect ? 'correct' : 'incorrect'} (confidence: ${verdict.confidence.toFixed(2)}, modelAnswer: ${verdict.modelAnswer})`);
+            console.log(`[Pipeline] LLMVerify: ${verdict.isCorrect ? 'correct' : 'incorrect'} (confidence: ${verdict.confidence.toFixed(2)}, modelAnswer: ${verdict.modelAnswer}, ${tier})`);
           } else if (verdict.error) {
-            console.log(`[Pipeline] LLMVerify: unverifiable (${verdict.error})`);
+            console.log(`[Pipeline] LLMVerify: unverifiable (${verdict.error}, ${tier})`);
           } else {
-            console.log(`[Pipeline] LLMVerify: low-confidence (${verdict.confidence.toFixed(2)}, modelAnswer: ${verdict.modelAnswer})`);
+            console.log(`[Pipeline] LLMVerify: low-confidence (${verdict.confidence.toFixed(2)}, modelAnswer: ${verdict.modelAnswer}, ${tier})`);
           }
+          verifyMetrics.recordVerification({
+            verdict,
+            escalated: verdict.escalated,
+            escalationResolved: verdict.escalationResolved,
+            tier: verdict.tier,
+            latencyMs: Date.now() - verifyStart,
+          });
           return verdict;
         })
         .catch(err => {
           console.error('[Pipeline] LLMVerify promise rejected:', err.message);
-          return { isCorrect: null, confidence: 0, modelAnswer: null, rationale: null, error: err.message };
+          const verdict = { isCorrect: null, confidence: 0, modelAnswer: null, rationale: null, error: err.message };
+          verifyMetrics.recordVerification({ verdict, latencyMs: Date.now() - verifyStart });
+          return verdict;
         });
     }
   }

--- a/utils/pipeline/index.js
+++ b/utils/pipeline/index.js
@@ -120,7 +120,7 @@ async function runPipeline(message, ctx) {
   let llmVerificationPromise = null;
   if (observation.messageType === MESSAGE_TYPES.ANSWER_ATTEMPT && observation.answer?.value) {
     const problemText = pickProblemContext(
-      recentAssistantMessages.map(msg => ({ content: msg.content }))
+      recentAssistantMessages.map(msg => ({ content: msg.content, problemInfo: msg.problemInfo || null }))
     );
     if (problemText) {
       llmVerificationPromise = llmVerifyAnswer(problemText, observation.answer.value)

--- a/utils/pipeline/llmVerifier.js
+++ b/utils/pipeline/llmVerifier.js
@@ -180,26 +180,46 @@ async function llmVerifyAnswer(problemText, studentAnswer, options = {}) {
 }
 
 /**
- * Choose the assistant message that posed the problem the student is answering.
- * Walks the recent assistant messages in reverse order; prefers messages with
- * stored problemInfo metadata, then falls back to the most recent message.
+ * Choose the assistant message that actually POSED the problem the student is
+ * answering — not merely the most recent message, which is frequently a
+ * pleasantry or follow-up ("Nice — ready for the next one?"). Verifying an
+ * answer against the wrong text produces spurious correct/incorrect verdicts,
+ * so we rank messages by how problem-like they are, newest-first within each
+ * tier, and take the first hit:
+ *
+ *   1. Carries stored problemInfo metadata — the persist stage recorded a posed
+ *      problem (with a correctAnswer) on this message. The most reliable signal.
+ *   2. Contains math-looking content — LaTeX delimiters/macros, or a digit next
+ *      to a math operator. A problem statement even without metadata.
+ *   3. Contains a question mark — a question, possibly the problem.
+ *   4. Fallback: the most recent non-empty message (the prior behavior, kept so
+ *      we never return null where we previously found something).
  *
  * Pure helper — safe to call from any stage.
  *
- * @param {Array} recentAssistantMessages - Ordered oldest → newest.
- * @returns {string|null} The problem text, or null if none found.
+ * @param {Array<{content?: string, problemInfo?: Object|null}>} recentAssistantMessages
+ *   Ordered oldest → newest.
+ * @returns {string|null} The chosen problem text, or null if none found.
  */
 function pickProblemContext(recentAssistantMessages) {
   if (!Array.isArray(recentAssistantMessages) || recentAssistantMessages.length === 0) {
     return null;
   }
-  // Prefer the most recent message that actually contains a question mark or
-  // math-looking content. Fall back to the most recent one.
-  for (let i = recentAssistantMessages.length - 1; i >= 0; i--) {
-    const msg = recentAssistantMessages[i];
-    const content = msg?.content;
-    if (typeof content === 'string' && content.trim().length > 0) {
-      return content;
+
+  const hasContent = (m) => typeof m?.content === 'string' && m.content.trim().length > 0;
+  const hasProblemInfo = (m) => hasContent(m) && m.problemInfo && m.problemInfo.correctAnswer != null;
+  const looksMathy = (m) => hasContent(m) && (
+    /\\\(|\\\[|\\frac|\$/.test(m.content) ||                 // LaTeX delimiters / macros
+    /\d\s*[+\-*/=×÷^]|[+\-*/=×÷^]\s*\d/.test(m.content)      // a digit adjacent to an operator
+  );
+  const hasQuestion = (m) => hasContent(m) && m.content.includes('?');
+
+  // Newest-first scan within each tier; first match wins.
+  for (const tier of [hasProblemInfo, looksMathy, hasQuestion, hasContent]) {
+    for (let i = recentAssistantMessages.length - 1; i >= 0; i--) {
+      if (tier(recentAssistantMessages[i])) {
+        return recentAssistantMessages[i].content;
+      }
     }
   }
   return null;

--- a/utils/pipeline/llmVerifier.js
+++ b/utils/pipeline/llmVerifier.js
@@ -38,6 +38,12 @@ const CONFIDENCE_THRESHOLD = 0.6;
 const MAX_PROBLEM_CHARS = 2000;
 const MAX_ANSWER_CHARS = 500;
 
+// Stronger judge for the minority of attempts the fast model can't resolve.
+// gpt-4o is already used for vision grading, so it stays within the OpenAI-only
+// contract. Escalation only fires on uncertain cases, so the cost/latency hit is
+// bounded to a small fraction of answer attempts.
+const ESCALATION_MODEL = 'gpt-4o';
+
 /**
  * Run two-step LLM verification on a student's answer.
  *
@@ -180,6 +186,53 @@ async function llmVerifyAnswer(problemText, studentAnswer, options = {}) {
 }
 
 /**
+ * Verify an answer with a fast model, escalating to a stronger judge when the
+ * fast model can't resolve it.
+ *
+ * Tier 1 (gpt-4o-mini) handles the common cases cheaply. When it returns no
+ * usable verdict — low confidence, a parse failure, or an upstream error — we
+ * escalate to Tier 2 (gpt-4o) rather than silently giving up, which is where the
+ * tutor would otherwise be left to judge correctness itself (the false
+ * affirm/reject risk). Missing-input cases never escalate (nothing to verify).
+ *
+ * Runs in parallel with the main tutor response, so the added latency lands
+ * inside the generate window for the small share of turns that escalate.
+ *
+ * @param {string} problemText
+ * @param {string} studentAnswer
+ * @param {Object} [options] - forwarded to llmVerifyAnswer (model, confidenceThreshold)
+ * @returns {Promise<Object>} verdict augmented with:
+ *   - tier {string}: the model that produced the final verdict
+ *   - escalated {boolean}: whether the stronger judge was invoked
+ *   - escalationResolved {boolean}: whether escalation produced a usable verdict
+ */
+async function verifyWithEscalation(problemText, studentAnswer, options = {}) {
+  const tier1Model = options.model || VERIFIER_MODEL;
+  const first = await llmVerifyAnswer(problemText, studentAnswer, options);
+
+  // Tier 1 resolved it — done.
+  if (first.isCorrect !== null) {
+    return { ...first, tier: tier1Model, escalated: false, escalationResolved: false };
+  }
+  // Nothing to verify — don't burn a stronger call on missing input.
+  if (first.error === 'missing_input') {
+    return { ...first, tier: tier1Model, escalated: false, escalationResolved: false };
+  }
+
+  // Tier 2: stronger judge for the hard/uncertain cases.
+  const second = await llmVerifyAnswer(problemText, studentAnswer, {
+    ...options,
+    model: ESCALATION_MODEL,
+  });
+  return {
+    ...second,
+    tier: ESCALATION_MODEL,
+    escalated: true,
+    escalationResolved: second.isCorrect !== null,
+  };
+}
+
+/**
  * Choose the assistant message that actually POSED the problem the student is
  * answering — not merely the most recent message, which is frequently a
  * pleasantry or follow-up ("Nice — ready for the next one?"). Verifying an
@@ -227,7 +280,9 @@ function pickProblemContext(recentAssistantMessages) {
 
 module.exports = {
   llmVerifyAnswer,
+  verifyWithEscalation,
   pickProblemContext,
   VERIFIER_MODEL,
+  ESCALATION_MODEL,
   CONFIDENCE_THRESHOLD,
 };

--- a/utils/verifyMetrics.js
+++ b/utils/verifyMetrics.js
@@ -1,0 +1,132 @@
+// utils/verifyMetrics.js
+// In-memory metrics for the LLM answer-verifier — the small, parallel "second
+// LLM call" that checks a student's answer in utils/pipeline/llmVerifier.js.
+//
+// Ring buffer, no Mongo, no new infra — mirrors utils/voiceMetrics.js and
+// utils/structuredTutorMetrics.js. Surfaced read-only on the admin metrics
+// endpoint. Every record is also emitted as a structured `llm_verify` log line
+// so Better Stack / Logtail can aggregate the unverifiable rate over time.
+
+const logger = require('./logger').child({ module: 'verifyMetrics' });
+
+const RING_SIZE = 1000;
+const ring = new Array(RING_SIZE);
+let cursor = 0;
+let total = 0;
+
+// Outcome taxonomy for one verification attempt.
+const OUTCOMES = [
+  'verified_correct',   // judge resolved: student answer is correct
+  'verified_incorrect', // judge resolved: student answer is wrong
+  'low_confidence',     // judge ran but below the confidence threshold (no usable verdict)
+  'unverifiable',       // could not compute/parse a verdict (not a missing-input case)
+  'error',              // missing input or upstream failure
+];
+
+/**
+ * Map a verifier verdict to a single outcome bucket.
+ * @param {{isCorrect:(boolean|null), error:(string|null)}} verdict
+ * @returns {string} one of OUTCOMES
+ */
+function classifyOutcome(verdict) {
+  if (!verdict) return 'error';
+  if (verdict.isCorrect === true) return 'verified_correct';
+  if (verdict.isCorrect === false) return 'verified_incorrect';
+  // isCorrect === null from here on.
+  if (verdict.error) {
+    return verdict.error === 'missing_input' ? 'error' : 'unverifiable';
+  }
+  // Judge ran, no error, but confidence was below threshold.
+  return 'low_confidence';
+}
+
+/**
+ * Record one verification attempt.
+ * @param {Object} args
+ * @param {Object} args.verdict - the (possibly escalated) verifier verdict
+ * @param {boolean} [args.escalated] - whether the stronger judge was invoked
+ * @param {boolean} [args.escalationResolved] - whether escalation produced a verdict
+ * @param {string|null} [args.tier] - the model that produced the final verdict
+ * @param {number|null} [args.latencyMs] - wall-clock of the verification
+ * @returns {Object} the stored record
+ */
+function recordVerification({ verdict, escalated = false, escalationResolved = false, tier = null, latencyMs = null } = {}) {
+  const outcome = classifyOutcome(verdict);
+  const rec = {
+    t: Date.now(),
+    outcome,
+    escalated: !!escalated,
+    escalationResolved: !!escalationResolved,
+    tier,
+    confidence: verdict && typeof verdict.confidence === 'number' ? verdict.confidence : null,
+    latencyMs,
+  };
+  ring[cursor] = rec;
+  cursor = (cursor + 1) % RING_SIZE;
+  total += 1;
+  // Structured log → Logtail/Better Stack. Cheap; one line per answer attempt.
+  logger.info('llm_verify', rec);
+  return rec;
+}
+
+/** Most-recent records, newest first. */
+function snapshot(limit = 100) {
+  const out = [];
+  const count = Math.min(total, RING_SIZE);
+  for (let i = 1; i <= count && out.length < limit; i++) {
+    const idx = (cursor - i + RING_SIZE) % RING_SIZE;
+    if (ring[idx]) out.push(ring[idx]);
+  }
+  return out;
+}
+
+/**
+ * Aggregate over the records currently in the ring. The headline number is
+ * `unverifiableRate` — the share of answer attempts the engine could not give
+ * a usable correct/incorrect verdict on, which is the gap escalation is meant
+ * to shrink.
+ */
+function aggregate() {
+  const records = snapshot(RING_SIZE);
+  const n = records.length;
+  const byOutcome = Object.fromEntries(OUTCOMES.map((o) => [o, 0]));
+  let escalated = 0;
+  let escalationResolved = 0;
+  for (const r of records) {
+    byOutcome[r.outcome] = (byOutcome[r.outcome] || 0) + 1;
+    if (r.escalated) escalated += 1;
+    if (r.escalated && r.escalationResolved) escalationResolved += 1;
+  }
+  const resolved = byOutcome.verified_correct + byOutcome.verified_incorrect;
+  const unresolved = byOutcome.low_confidence + byOutcome.unverifiable;
+  const rate = (x) => (n > 0 ? Number((x / n).toFixed(4)) : 0);
+  return {
+    sampleSize: n,
+    totalEver: total,
+    byOutcome,
+    resolvedRate: rate(resolved),
+    unverifiableRate: rate(unresolved),
+    errorRate: rate(byOutcome.error),
+    escalationRate: rate(escalated),
+    // Of the attempts we escalated, how often did the stronger judge resolve them?
+    escalationResolveRate: escalated > 0 ? Number((escalationResolved / escalated).toFixed(4)) : 0,
+    escalated,
+    escalationResolved,
+  };
+}
+
+/** Test/maintenance hook — clears the ring. */
+function reset() {
+  ring.fill(undefined);
+  cursor = 0;
+  total = 0;
+}
+
+module.exports = {
+  recordVerification,
+  classifyOutcome,
+  snapshot,
+  aggregate,
+  reset,
+  OUTCOMES,
+};


### PR DESCRIPTION
Deliverables from a full-codebase deep-dive, building on each other: a durable onboarding map, a safety regression net for the tutoring pipeline, and two accuracy fixes that net made safe to ship.

## 1. `CLAUDE.md` — root engineering guide
An index + mental model for the whole system (stack, boot/middleware order, 77-route API surface, 34-model data layer, the tutoring pipeline + `llmGateway` PII boundary, learning engines, frontend, security/compliance/billing, dev & ops, a "change X → start here" router, gotchas). Notes that `ANTHROPIC_API_KEY_*` is in `.env.example` but Claude is not wired in at runtime — OpenAI-only for the LLM today.

## 2. Golden-transcript test harness — `tests/golden/`
A data-driven regression net over the **deterministic** pipeline stages (`observe` → `decide`) + first-class **safety invariants** (`confirm_implies_correct`, `no_autoconfirm_unverified`, `giveup_no_reveal`). No LLM, no DB, <1s in CI. Fixtures in `transcripts.json` (add a case with no code; see `tests/golden/README.md`). `npm run test:golden`.

## 3. Fix: verify against the *posed problem*, not the last message
`pickProblemContext()` returned the most recent non-empty assistant message, so the verifier could check an answer against a trailing pleasantry instead of the problem. Now ranks messages by problem-likeness (stored `problemInfo` metadata → math content → question mark → fallback); `index.js` threads `problemInfo` through. Pinned by `problemContext` golden fixtures (incl. a case that fails on the old logic).

## 4. Tiered verification + instrumentation (the accuracy win underneath #3)
When the fast verifier (`gpt-4o-mini`) can't produce a usable verdict (low confidence / parse fail / error), it now **escalates to `gpt-4o`** instead of silently falling back to "unverifiable" — closing the false affirm/reject gap on the topics the deterministic solver can't cover. Escalation runs in parallel with the tutor response and only on the uncertain minority, so cost/latency is bounded; missing-input never escalates.

New `utils/verifyMetrics.js` (in-memory ring, same pattern as `voiceMetrics`/`structuredTutorMetrics`) records every verification's outcome/escalation/tier/latency, emits a structured `llm_verify` log for Logtail, and aggregates the headline **`unverifiableRate`** + escalation-resolve rate — surfaced on `GET /api/admin/structured-tutor-metrics`.

## Tests / scope
New: `tests/golden/*`, `tests/unit/llmVerifierEscalation.test.js`, `tests/unit/verifyMetrics.test.js`. All pass; 152 existing pipeline tests unchanged; lint clean (0 errors). Runtime changes are confined to `utils/pipeline/llmVerifier.js`, `utils/pipeline/index.js`, `utils/verifyMetrics.js`, and one admin read-endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)