### PR TITLE
fix(tutor): elicit-first on bare arithmetic/fraction problem drops (don't solve them)

### DIFF
--- a/tests/unit/bareProblemDrop.test.js
+++ b/tests/unit/bareProblemDrop.test.js
@@ -134,6 +134,47 @@ describe('detectBareProblemDrop', () => {
     expect(detectBareProblemDrop('4x-5=22', typeGeneralMath, noAnswer, [])).toBe(true);
     expect(detectBareProblemDrop('4x-5=22', typeGeneralMath, noAnswer, undefined)).toBe(true);
   });
+
+  // ── Bare ARITHMETIC / fraction computation drops ──
+  // Origin: a session where a student dropped "12⅔ - 4¼" with no attempt and the
+  // tutor solved it (converted both mixed numbers to improper fractions). Only
+  // equations / variables / \frac LaTeX counted as math signals, so a Unicode or
+  // ASCII fraction computation slipped past the gate.
+
+  test('flags "12⅔ - 4¼" — bare mixed-number subtraction (Unicode vulgar fractions)', () => {
+    expect(detectBareProblemDrop('12⅔ - 4¼', typeGeneralMath, noAnswer)).toBe(true);
+  });
+
+  test('flags "12 2/3 - 4 1/4" — bare mixed-number subtraction (ASCII)', () => {
+    expect(detectBareProblemDrop('12 2/3 - 4 1/4', typeGeneralMath, noAnswer)).toBe(true);
+  });
+
+  test('flags "1/2 + 1/4" — bare fraction addition', () => {
+    expect(detectBareProblemDrop('1/2 + 1/4', typeGeneralMath, noAnswer)).toBe(true);
+  });
+
+  test('flags "16/4 - 2" and "3.5 × 4" — bare multi-operand arithmetic', () => {
+    expect(detectBareProblemDrop('16/4 - 2', typeGeneralMath, noAnswer)).toBe(true);
+    expect(detectBareProblemDrop('3.5 × 4', typeGeneralMath, noAnswer)).toBe(true);
+  });
+
+  test('does NOT flag a lone fraction/number value — it is an answer, not a drop', () => {
+    // A single "/" denotes one fraction value (e.g. a conversion result), not an
+    // operation to carry out — these must stay un-flagged so student answers work.
+    expect(detectBareProblemDrop('3/4', typeGeneralMath, noAnswer)).toBe(false);
+    expect(detectBareProblemDrop('38/3', typeGeneralMath, noAnswer)).toBe(false);
+    expect(detectBareProblemDrop('⅔', typeGeneralMath, noAnswer)).toBe(false);
+  });
+
+  test('does NOT flag an arithmetic expression that carries reasoning or a stuck indicator', () => {
+    expect(detectBareProblemDrop('I got 1/2 + 1/4 = 3/4', typeGeneralMath, noAnswer)).toBe(false);
+    expect(detectBareProblemDrop("I'm stuck on 16/4 - 2", typeGeneralMath, noAnswer)).toBe(false);
+  });
+
+  test('does NOT flag a fraction reply when the tutor just asked for the next step', () => {
+    const recent = [{ content: "What's the first step you want to take?" }];
+    expect(detectBareProblemDrop('1/2 + 1/4', typeGeneralMath, noAnswer, recent)).toBe(false);
+  });
 });
 
 // ============================================================================

--- a/utils/pipeline/observe.js
+++ b/utils/pipeline/observe.js
@@ -436,7 +436,23 @@ function detectBareProblemDrop(text, messageType, hasAnswer, recentAssistantMess
   const hasUnicodeMath = /[²³⁴√∫Σπ]/.test(t);
   const hasSolveVerb = /^(solve|factor|simplify|evaluate|compute|graph|find)\s+/i.test(t);
 
-  const hasMathSignals = hasEquation || hasLatexMath || hasVariableTerms || hasUnicodeMath || hasSolveVerb;
+  // Bare arithmetic / fraction COMPUTATION drops — a student handing over a
+  // numeric problem to carry out, with no attempt: "12⅔ - 4¼", "1/2 + 1/4",
+  // "16/4 - 2", "3.5 × 4". Without this, only equations (=), variable terms,
+  // \frac LaTeX, or the limited [²³⁴√∫Σπ] set counted — so a Unicode or ASCII
+  // fraction drop slipped through and the tutor solved it end-to-end.
+  // A lone value/answer ("3/4", "38/3", "8") is NOT a drop, so we require an
+  // explicit +, -, ×, ÷, ·, or * operator between terms (a single "/" denotes
+  // one fraction value, not an operation to perform).
+  const hasVulgarFraction = /[¼-¾⅐-⅞]/.test(t); // ¼ ½ ¾ ⅓ ⅔ ⅕ …
+  const hasArithmeticOp =
+    /\d\s*[-+×÷⋅·*]\s*[\d(¼-¾⅐-⅞]/.test(t) ||   // 4 - 2, 16 ÷ 4, 1/2 + 1/4
+    /[¼-¾⅐-⅞]\s*[-+×÷⋅·*/]\s*\d/.test(t);        // ⅔ - 4  (mixed-number op)
+  const hasArithmeticComputation =
+    hasArithmeticOp || (hasVulgarFraction && /[-+×÷⋅·*/]/.test(t));
+
+  const hasMathSignals = hasEquation || hasLatexMath || hasVariableTerms ||
+    hasUnicodeMath || hasSolveVerb || hasArithmeticComputation;
   if (!hasMathSignals) return false;
 
   // Attempt / reasoning / stuck indicators disqualify — the student has engaged.


### PR DESCRIPTION
## The session that started this

A student dropped `12⅔ - 4¼` with no attempt, and the tutor **solved it for them** — converting both mixed numbers to improper fractions (`38/3`, `17/4`) end-to-end — before asking a single question. That violates RULE 1 / one-concept-per-message / anti-cheat: it should ask *"how would you convert `12⅔` first?"* and wait.

## Root cause (reproduced)

The pipeline already has a `detectBareProblemDrop` gate (`observe.js`) that routes a no-attempt problem drop to `ACTIONS.ELICIT_FIRST` with anti-leak directives — but its math-signal check was **equation/variable-centric**:

```js
hasEquation     = /=/                      // no '=' in "12⅔ - 4¼"
hasLatexMath    = /\\frac|\\sqrt|.../      // matches LaTeX, not Unicode
hasVariableTerms= /…[a-z]…/                // no letters
hasUnicodeMath  = /[²³⁴√∫Σπ]/              // excludes ⅔ ¼ ½ ÷ ×
hasSolveVerb    = /^(solve|factor|…)/      // none
```

So whether a bare **arithmetic/fraction** drop is caught depended entirely on encoding. Verified with `observe()`:

| input | `isBareProblemDrop` (before) |
|---|---|
| `12\frac{2}{3} - 4\frac{1}{4}` (LaTeX) | ✅ true |
| `12⅔ - 4¼` (MathLive/Unicode) | ❌ **false** |
| `12 2/3 - 4 1/4` (ASCII) | ❌ **false** |
| `1/2 + 1/4`, `16/4 - 2` | ❌ **false** |

The transcript's Unicode form slipped through → no `ELICIT_FIRST` → the LLM defaulted to solving. Same bug class the team already fixed for bare *equations*, never extended to *computation* drops.

## The fix

Extend `detectBareProblemDrop`'s math-signal gate to recognize bare arithmetic/fraction computation drops (`observe.js`):
- Vulgar-fraction Unicode (`¼ ½ ¾ ⅓ ⅔ ⅕ …`) and multi-operand numeric expressions.
- **Conservative**: require an explicit `+ - × ÷ · *` operator between terms. A single `/` denotes one fraction *value*, so a lone `3/4`, `38/3`, or `8` is **not** flagged — student answers keep working.
- Existing guards intact: reasoning ("I got…"), stuck ("I'm stuck on…"), step-reply (tutor just asked for the next step), and `ANSWER_ATTEMPT` classification all still suppress the flag.

No `decide` change needed — once `observe` flags the drop, `decide` already routes it to `ELICIT_FIRST`.

## Verification

- E2E: `observe("12⅔ - 4¼")` → `isBareProblemDrop=true` → `decide` → `ELICIT_FIRST` with a `do not solve` directive.
- `tests/unit/bareProblemDrop.test.js`: **38 passing** (+7 new — Unicode/ASCII/fraction drops flagged; lone values, reasoning, stuck, and step-replies not flagged).
- `parroting` (29) and `progressReport` (10) suites unaffected; `node --check` clean.

## Scope note

This is the **pedagogical** half of the two issues surfaced from these sessions. The **answer-rejection / verification** half (multi-operand arithmetic mis-evaluated, poisoning grading) shipped separately in #1077 (merged). This PR does not touch the verify path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DffsjzSQTvBveT29DwtziR)_