### PR TITLE
CI coverage ratchet + 15 high-traffic pattern-skill definitions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,30 @@ jobs:
         env:
           NODE_ENV: test
 
+  coverage-critical:
+    # Per-file coverage ratchet on the highest-stakes logic (grading math, IRT,
+    # knowledge tracing, the tutoring pipeline's decide/diagnose/verify stages).
+    # Kept separate from `test` so it never perturbs the global coverage
+    # threshold. See jest.critical.config.js — raise floors as coverage improves,
+    # never lower them to make a red build green.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Critical-path coverage gate
+        run: npm run test:critical
+        env:
+          NODE_ENV: test
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/docs/PATTERN_SKILLS_IMPLEMENTATION.md
+++ b/docs/PATTERN_SKILLS_IMPLEMENTATION.md
@@ -126,6 +126,18 @@ console.log(skill2); // Should return the skill object
 
 ## Skill Coverage Analysis
 
+> **Update (2026-06):** Two distinct metrics are easy to conflate here —
+> *skill definitions* (catalog entries in `seeds/skills-pattern-based.json`) vs.
+> *skills with generated problems* (rows in the `Problem` collection). The
+> `59/204` figure below tracked an early snapshot. Current **definition**
+> coverage: the 8 patterns' 102 milestones reference **225** distinct skillIds,
+> of which **190 are defined** (35 still missing — almost all Tier-4
+> college-level: linear algebra, calculus, inferential statistics). The
+> remaining gap and the *problem*-generation pass (which needs MongoDB + OpenAI
+> via `scripts/generate-all-pattern-problems.js`) are tracked separately. The
+> seed is structurally guarded by `tests/unit/patternSkillsSeed.test.js`, which
+> ratchets the missing-definition count so it can only go down.
+
 ### Skills Now Available (59/204 = 29%)
 
 The 59 skills created cover the most critical early-tier concepts:

--- a/jest.critical.config.js
+++ b/jest.critical.config.js
@@ -1,0 +1,59 @@
+// jest.critical.config.js — coverage RATCHET for the highest-stakes logic.
+//
+// The main `npm test` keeps an intentionally low global coverage floor (~25%)
+// across the whole codebase. That floor can't protect the few modules where a
+// silent drop in coverage is genuinely dangerous: the answer-grading math
+// engine, the IRT placement math, knowledge tracing, and the tutoring pipeline's
+// decision/verification stages. A bug here mis-teaches or mis-grades students.
+//
+// This config runs ONLY the tests that exercise those modules, and measures
+// coverage ONLY on those modules, with per-file thresholds. Because the file set
+// and test set are fixed, the numbers are deterministic — no flakiness from the
+// rest of the suite. It runs as its own CI job (`npm run test:critical`) so it
+// never perturbs the global threshold in jest.config.js (Jest subtracts
+// path-scoped files from the global bucket, which we deliberately avoid here).
+//
+// RATCHET POLICY: thresholds are set just below current measured coverage. When
+// you add tests and coverage rises, raise the floor to lock the gain. Never lower
+// a floor to make a red build green — that's the regression this gate exists to
+// catch. Investigate the drop instead.
+
+module.exports = {
+  testEnvironment: 'node',
+  setupFilesAfterEnv: ['<rootDir>/tests/setup.js'],
+  clearMocks: true,
+  testMatch: [
+    '<rootDir>/tests/unit/pipeline.test.js',
+    '<rootDir>/tests/unit/pipelineIntegration.test.js',
+    '<rootDir>/tests/unit/llmVerifierEscalation.test.js',
+    '<rootDir>/tests/unit/verifyMetrics.test.js',
+    '<rootDir>/tests/unit/irt.test.js',
+    '<rootDir>/tests/unit/knowledgeTracer.test.js',
+    '<rootDir>/tests/unit/mathSolver*.test.js',
+    '<rootDir>/tests/golden/goldenTranscripts.test.js',
+  ],
+  collectCoverage: true,
+  collectCoverageFrom: [
+    'utils/mathSolver.js',
+    'utils/irt.js',
+    'utils/knowledgeTracer.js',
+    'utils/verifyMetrics.js',
+    'utils/pipeline/llmVerifier.js',
+    'utils/pipeline/observe.js',
+    'utils/pipeline/decide.js',
+    'utils/pipeline/diagnose.js',
+  ],
+  coverageReporters: ['text-summary', 'text'],
+  // Floors sit a few points below measured coverage to absorb cross-Node-version
+  // branch-counting drift. Tighten as coverage improves.
+  coverageThreshold: {
+    './utils/mathSolver.js': { statements: 73, branches: 63, functions: 84, lines: 76 },
+    './utils/irt.js': { statements: 90, branches: 82, functions: 95, lines: 90 },
+    './utils/knowledgeTracer.js': { statements: 83, branches: 78, functions: 95, lines: 83 },
+    './utils/verifyMetrics.js': { statements: 96, branches: 80, functions: 100, lines: 96 },
+    './utils/pipeline/llmVerifier.js': { statements: 88, branches: 75, functions: 100, lines: 88 },
+    './utils/pipeline/observe.js': { statements: 70, branches: 66, functions: 90, lines: 74 },
+    './utils/pipeline/decide.js': { statements: 44, branches: 42, functions: 62, lines: 45 },
+    './utils/pipeline/diagnose.js': { statements: 44, branches: 43, functions: 42, lines: 46 },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:unit": "jest --testPathPattern=tests/unit",
     "test:integration": "jest --testPathPattern=tests/integration",
     "test:golden": "jest --testPathPattern=tests/golden",
+    "test:critical": "jest --config jest.critical.config.js",
     "seed:test": "node scripts/seedTestData.js",
     "seed:playground": "node scripts/seedPlaygroundAccounts.js",
     "seed:playground:clear": "node scripts/seedPlaygroundAccounts.js --clear",

--- a/seeds/skills-pattern-based.json
+++ b/seeds/skills-pattern-based.json
@@ -7174,5 +7174,650 @@
       "fluencyType": "conceptual",
       "toleranceFactor": 4
     }
+  },
+  {
+    "skillId": "one-step-equations-addition",
+    "displayName": "One-Step Equations (Addition/Subtraction)",
+    "description": "Solve one-step equations using inverse addition or subtraction, e.g. x + 7 = 12",
+    "category": "equations",
+    "course": "Grade 6 Math",
+    "quarter": 2,
+    "unit": "Equivalence Pattern - Tier 2",
+    "prerequisites": [
+      "missing-addend"
+    ],
+    "enables": [
+      "one-step-equations-multiplication",
+      "two-step-equations"
+    ],
+    "standardsAlignment": [
+      "6.EE.7",
+      "6.EE.5"
+    ],
+    "teachingGuidance": {
+      "coreConcepts": [
+        "Inverse operations undo each other",
+        "Keep the equation balanced — do the same to both sides",
+        "Isolate the variable"
+      ],
+      "commonMistakes": [
+        "Operating on only one side",
+        "Adding instead of subtracting the constant",
+        "Sign errors"
+      ],
+      "teachingTips": [
+        "Use a balance-scale model",
+        "Check by substituting back",
+        "Annotate each step: '-7 on both sides'"
+      ]
+    },
+    "difficultyLevel": 4,
+    "fluencyMetadata": {
+      "baseFluencyTime": 45,
+      "fluencyType": "procedural",
+      "toleranceFactor": 3
+    }
+  },
+  {
+    "skillId": "one-step-equations-multiplication",
+    "displayName": "One-Step Equations (Multiplication/Division)",
+    "description": "Solve one-step equations using inverse multiplication or division, e.g. 3x = 12",
+    "category": "equations",
+    "course": "Grade 6 Math",
+    "quarter": 2,
+    "unit": "Equivalence Pattern - Tier 2",
+    "prerequisites": [
+      "one-step-equations-addition"
+    ],
+    "enables": [
+      "two-step-equations"
+    ],
+    "standardsAlignment": [
+      "6.EE.7"
+    ],
+    "teachingGuidance": {
+      "coreConcepts": [
+        "Divide both sides by the coefficient",
+        "Multiplication and division are inverses",
+        "Balance both sides"
+      ],
+      "commonMistakes": [
+        "Subtracting the coefficient instead of dividing",
+        "Dividing only one side",
+        "Slips with fractions or decimals"
+      ],
+      "teachingTips": [
+        "Think 'undo times-by with divide-by'",
+        "Check by substitution",
+        "Watch coefficients of 1 and negatives"
+      ]
+    },
+    "difficultyLevel": 4,
+    "fluencyMetadata": {
+      "baseFluencyTime": 45,
+      "fluencyType": "procedural",
+      "toleranceFactor": 3
+    }
+  },
+  {
+    "skillId": "unit-rates",
+    "displayName": "Unit Rates",
+    "description": "Compute and compare unit rates such as miles per hour or price per item",
+    "category": "ratios-proportions",
+    "course": "Grade 6-7 Math",
+    "quarter": 1,
+    "unit": "Scaling Pattern - Tier 2",
+    "prerequisites": [
+      "ratios"
+    ],
+    "enables": [
+      "proportions",
+      "slope-intercept-form"
+    ],
+    "standardsAlignment": [
+      "6.RP.2",
+      "6.RP.3b",
+      "7.RP.1"
+    ],
+    "teachingGuidance": {
+      "coreConcepts": [
+        "A unit rate has a denominator of 1",
+        "Divide to find the per-one amount",
+        "Compare rates by their unit values"
+      ],
+      "commonMistakes": [
+        "Inverting the rate",
+        "Dropping the units",
+        "Comparing rates that are not normalized"
+      ],
+      "teachingTips": [
+        "Ask 'how much for exactly one?'",
+        "Keep units attached throughout",
+        "Use a rate table"
+      ]
+    },
+    "difficultyLevel": 4,
+    "fluencyMetadata": {
+      "baseFluencyTime": 45,
+      "fluencyType": "procedural",
+      "toleranceFactor": 3
+    }
+  },
+  {
+    "skillId": "proportions",
+    "displayName": "Solving Proportions",
+    "description": "Set up and solve proportions a/b = c/d using cross-products or scaling",
+    "category": "ratios-proportions",
+    "course": "Grade 7 Math",
+    "quarter": 1,
+    "unit": "Scaling Pattern - Tier 2",
+    "prerequisites": [
+      "unit-rates"
+    ],
+    "enables": [
+      "percent-problems",
+      "similar-figures"
+    ],
+    "standardsAlignment": [
+      "7.RP.2",
+      "7.RP.3"
+    ],
+    "teachingGuidance": {
+      "coreConcepts": [
+        "A proportion states two ratios are equal",
+        "Cross-products of a true proportion are equal",
+        "A scale factor relates the two ratios"
+      ],
+      "commonMistakes": [
+        "Cross-multiplying incorrectly",
+        "Mismatching units across the two ratios",
+        "Adding instead of scaling"
+      ],
+      "teachingTips": [
+        "Label the units in each ratio",
+        "Set up the proportion before solving",
+        "Check the answer's reasonableness"
+      ]
+    },
+    "difficultyLevel": 5,
+    "fluencyMetadata": {
+      "baseFluencyTime": 60,
+      "fluencyType": "procedural",
+      "toleranceFactor": 3
+    }
+  },
+  {
+    "skillId": "percent-problems",
+    "displayName": "Percent Problems",
+    "description": "Find a percent of a number, the whole, or the percent using proportions or equations",
+    "category": "percent",
+    "course": "Grade 7 Math",
+    "quarter": 2,
+    "unit": "Scaling Pattern - Tier 2",
+    "prerequisites": [
+      "proportions"
+    ],
+    "enables": [
+      "percent-change",
+      "simple-interest"
+    ],
+    "standardsAlignment": [
+      "7.RP.3",
+      "6.RP.3c"
+    ],
+    "teachingGuidance": {
+      "coreConcepts": [
+        "Percent means per 100",
+        "part / whole = percent / 100",
+        "Translate the words into an equation"
+      ],
+      "commonMistakes": [
+        "Confusing the part and the whole",
+        "Forgetting to convert percent to a decimal",
+        "Mixing up percent-of and percent-change"
+      ],
+      "teachingTips": [
+        "Set up part/whole = %/100",
+        "Estimate with benchmarks (10%, 25%, 50%)",
+        "Check that the result is reasonable"
+      ]
+    },
+    "difficultyLevel": 5,
+    "fluencyMetadata": {
+      "baseFluencyTime": 60,
+      "fluencyType": "procedural",
+      "toleranceFactor": 3
+    }
+  },
+  {
+    "skillId": "order-of-operations",
+    "displayName": "Order of Operations",
+    "description": "Evaluate numerical expressions using the order-of-operations (PEMDAS/GEMDAS) conventions",
+    "category": "expressions",
+    "course": "Grade 5-6 Math",
+    "quarter": 1,
+    "unit": "Structure Pattern - Tier 2",
+    "prerequisites": [
+      "multiplication-division"
+    ],
+    "enables": [
+      "numerical-expressions-exponents",
+      "evaluate-expressions"
+    ],
+    "standardsAlignment": [
+      "5.OA.1",
+      "6.EE.1",
+      "6.EE.2c"
+    ],
+    "teachingGuidance": {
+      "coreConcepts": [
+        "Grouping symbols first, then exponents",
+        "Multiply/divide left to right, then add/subtract left to right",
+        "Operations of equal rank go left to right"
+      ],
+      "commonMistakes": [
+        "Always adding before multiplying",
+        "Working strictly left to right regardless of rank",
+        "Mishandling nested grouping symbols"
+      ],
+      "teachingTips": [
+        "Underline the next operation to perform",
+        "Rewrite the expression one step at a time",
+        "GEMDAS reminds you all grouping symbols come first"
+      ]
+    },
+    "difficultyLevel": 4,
+    "fluencyMetadata": {
+      "baseFluencyTime": 45,
+      "fluencyType": "procedural",
+      "toleranceFactor": 2
+    }
+  },
+  {
+    "skillId": "numerical-expressions-exponents",
+    "displayName": "Exponents in Numerical Expressions",
+    "description": "Evaluate numerical expressions that contain whole-number exponents",
+    "category": "expressions",
+    "course": "Grade 6 Math",
+    "quarter": 1,
+    "unit": "Structure Pattern - Tier 2",
+    "prerequisites": [
+      "order-of-operations"
+    ],
+    "enables": [
+      "properties-of-exponents"
+    ],
+    "standardsAlignment": [
+      "6.EE.1"
+    ],
+    "teachingGuidance": {
+      "coreConcepts": [
+        "An exponent is repeated multiplication",
+        "Evaluate powers before multiplication and division",
+        "Distinguish the base from the exponent"
+      ],
+      "commonMistakes": [
+        "Multiplying the base by the exponent (3^2 = 6)",
+        "Ignoring the priority of exponents",
+        "Confusing (-a)^n with -a^n"
+      ],
+      "teachingTips": [
+        "Expand the power while learning",
+        "Watch parentheses around negatives",
+        "Connect squares/cubes to area and volume"
+      ]
+    },
+    "difficultyLevel": 4,
+    "fluencyMetadata": {
+      "baseFluencyTime": 40,
+      "fluencyType": "procedural",
+      "toleranceFactor": 3
+    }
+  },
+  {
+    "skillId": "factoring-gcf",
+    "displayName": "Factoring Out the GCF",
+    "description": "Factor the greatest common factor from numerical and algebraic expressions",
+    "category": "expressions",
+    "course": "Grade 6 Math / Algebra 1",
+    "quarter": 3,
+    "unit": "Structure Pattern - Tier 2",
+    "prerequisites": [
+      "numerical-expressions-exponents"
+    ],
+    "enables": [
+      "factoring-trinomials",
+      "difference-of-squares"
+    ],
+    "standardsAlignment": [
+      "6.NS.4",
+      "A-SSE.3a"
+    ],
+    "teachingGuidance": {
+      "coreConcepts": [
+        "The GCF is the largest factor shared by every term",
+        "Divide each term by the GCF",
+        "Factoring out is the inverse of distributing"
+      ],
+      "commonMistakes": [
+        "Missing the variable part of the GCF",
+        "Taking a common factor that isn't the greatest",
+        "Sign errors when factoring out a negative"
+      ],
+      "teachingTips": [
+        "Use prime factorization to find the GCF",
+        "Check by re-distributing",
+        "Factor variables to their lowest shared power"
+      ]
+    },
+    "difficultyLevel": 5,
+    "fluencyMetadata": {
+      "baseFluencyTime": 60,
+      "fluencyType": "procedural",
+      "toleranceFactor": 3
+    }
+  },
+  {
+    "skillId": "slope-intercept-form",
+    "displayName": "Slope-Intercept Form",
+    "description": "Write, interpret, and use linear equations in y = mx + b form",
+    "category": "linear-functions",
+    "course": "Grade 8 Math / Algebra 1",
+    "quarter": 3,
+    "unit": "Change Pattern - Tier 2",
+    "prerequisites": [
+      "unit-rates"
+    ],
+    "enables": [
+      "graphing-linear-equations",
+      "systems-of-equations"
+    ],
+    "standardsAlignment": [
+      "8.EE.6",
+      "8.F.3",
+      "8.F.4"
+    ],
+    "teachingGuidance": {
+      "coreConcepts": [
+        "m is the slope (rate of change); b is the y-intercept",
+        "Slope = rise / run",
+        "b is the value of y when x = 0"
+      ],
+      "commonMistakes": [
+        "Swapping the slope and the intercept",
+        "Sign errors in the slope",
+        "Reading run/rise instead of rise/run"
+      ],
+      "teachingTips": [
+        "Plot b first, then step with the slope",
+        "Connect slope to a unit rate",
+        "Interpret m and b in the context of the problem"
+      ]
+    },
+    "difficultyLevel": 5,
+    "fluencyMetadata": {
+      "baseFluencyTime": 60,
+      "fluencyType": "conceptual",
+      "toleranceFactor": 3
+    }
+  },
+  {
+    "skillId": "graphing-linear-equations",
+    "displayName": "Graphing Linear Equations",
+    "description": "Graph lines from slope-intercept form, point-slope form, or a table of values",
+    "category": "graphing",
+    "course": "Grade 8 Math / Algebra 1",
+    "quarter": 3,
+    "unit": "Space Pattern - Tier 2",
+    "prerequisites": [
+      "slope-intercept-form"
+    ],
+    "enables": [
+      "systems-of-equations",
+      "graphing-inequalities"
+    ],
+    "standardsAlignment": [
+      "8.EE.5",
+      "8.F.3",
+      "A-REI.10"
+    ],
+    "teachingGuidance": {
+      "coreConcepts": [
+        "Every solution of the equation is a point on the line",
+        "Plot the intercept, then apply the slope",
+        "A table of values also generates points"
+      ],
+      "commonMistakes": [
+        "Plotting (y, x) instead of (x, y)",
+        "Miscounting the slope steps",
+        "Not extending or labeling the line"
+      ],
+      "teachingTips": [
+        "Plot at least three points",
+        "Use the intercept-plus-slope method",
+        "Verify a point by substitution"
+      ]
+    },
+    "difficultyLevel": 5,
+    "fluencyMetadata": {
+      "baseFluencyTime": 75,
+      "fluencyType": "procedural",
+      "toleranceFactor": 3
+    }
+  },
+  {
+    "skillId": "integer-addition",
+    "displayName": "Integer Addition",
+    "description": "Add positive and negative integers using number lines and the rules of signs",
+    "category": "number-sense",
+    "course": "Grade 7 Math",
+    "quarter": 1,
+    "unit": "Change Pattern - Tier 1",
+    "prerequisites": [
+      "addition"
+    ],
+    "enables": [
+      "integer-subtraction",
+      "rational-number-operations"
+    ],
+    "standardsAlignment": [
+      "7.NS.1",
+      "7.NS.1b"
+    ],
+    "teachingGuidance": {
+      "coreConcepts": [
+        "Same signs: add the magnitudes and keep the sign",
+        "Different signs: subtract and take the larger magnitude's sign",
+        "Model the sum as movement on a number line"
+      ],
+      "commonMistakes": [
+        "Ignoring the signs",
+        "Always subtracting",
+        "Sign of the final result"
+      ],
+      "teachingTips": [
+        "Use a number-line or two-color-chip model",
+        "Think in terms of gains and losses",
+        "Watch for double negatives"
+      ]
+    },
+    "difficultyLevel": 4,
+    "fluencyMetadata": {
+      "baseFluencyTime": 30,
+      "fluencyType": "procedural",
+      "toleranceFactor": 3
+    }
+  },
+  {
+    "skillId": "integer-subtraction",
+    "displayName": "Integer Subtraction",
+    "description": "Subtract integers by adding the opposite",
+    "category": "number-sense",
+    "course": "Grade 7 Math",
+    "quarter": 1,
+    "unit": "Change Pattern - Tier 1",
+    "prerequisites": [
+      "integer-addition"
+    ],
+    "enables": [
+      "rational-number-operations"
+    ],
+    "standardsAlignment": [
+      "7.NS.1",
+      "7.NS.1c"
+    ],
+    "teachingGuidance": {
+      "coreConcepts": [
+        "Subtracting is adding the opposite: a - b = a + (-b)",
+        "Keep-change-change",
+        "Subtraction is the distance between two numbers"
+      ],
+      "commonMistakes": [
+        "Changing only the operation or only the sign, not both",
+        "General sign confusion",
+        "Assuming a - b equals b - a"
+      ],
+      "teachingTips": [
+        "Rewrite the subtraction as addition first",
+        "Use a number line",
+        "Check with the gains-and-losses model"
+      ]
+    },
+    "difficultyLevel": 4,
+    "fluencyMetadata": {
+      "baseFluencyTime": 35,
+      "fluencyType": "procedural",
+      "toleranceFactor": 3
+    }
+  },
+  {
+    "skillId": "probability-basics",
+    "displayName": "Basic Probability",
+    "description": "Find the probability of a simple event as a fraction, decimal, or percent",
+    "category": "probability",
+    "course": "Grade 7 Math",
+    "quarter": 4,
+    "unit": "Uncertainty Pattern - Tier 1",
+    "prerequisites": [
+      "fractions"
+    ],
+    "enables": [
+      "compound-probability",
+      "experimental-probability"
+    ],
+    "standardsAlignment": [
+      "7.SP.5",
+      "7.SP.7"
+    ],
+    "teachingGuidance": {
+      "coreConcepts": [
+        "P(event) = favorable outcomes / total outcomes",
+        "Probabilities range from 0 to 1",
+        "In a fair model, outcomes are equally likely"
+      ],
+      "commonMistakes": [
+        "Counting the outcomes incorrectly",
+        "Reporting a probability greater than 1",
+        "Confusing favorable with total outcomes"
+      ],
+      "teachingTips": [
+        "List the sample space",
+        "Express the answer as a fraction, decimal, and percent",
+        "0 means impossible, 1 means certain"
+      ]
+    },
+    "difficultyLevel": 4,
+    "fluencyMetadata": {
+      "baseFluencyTime": 45,
+      "fluencyType": "conceptual",
+      "toleranceFactor": 3
+    }
+  },
+  {
+    "skillId": "statistics-probability",
+    "displayName": "Representing & Interpreting Data",
+    "description": "Organize and interpret data with tables and plots and describe likelihood",
+    "category": "statistics",
+    "course": "Grade 6 Math",
+    "quarter": 4,
+    "unit": "Uncertainty Pattern - Tier 1",
+    "prerequisites": [
+      "counting"
+    ],
+    "enables": [
+      "probability-basics",
+      "measures-of-center"
+    ],
+    "standardsAlignment": [
+      "6.SP.4",
+      "6.SP.5",
+      "3.MD.3"
+    ],
+    "teachingGuidance": {
+      "coreConcepts": [
+        "Data can be shown in tables, dot plots, and bar graphs",
+        "Read frequencies and compare categories",
+        "Likelihood words: certain, likely, unlikely, impossible"
+      ],
+      "commonMistakes": [
+        "Misreading the scale",
+        "Confusing a frequency with a data value",
+        "Ignoring the key or legend"
+      ],
+      "teachingTips": [
+        "Always read the axis labels and scale first",
+        "Compare bars or dots by height/count",
+        "Summarize in words what the data shows"
+      ]
+    },
+    "difficultyLevel": 3,
+    "fluencyMetadata": {
+      "baseFluencyTime": 45,
+      "fluencyType": "conceptual",
+      "toleranceFactor": 3
+    }
+  },
+  {
+    "skillId": "inverse-functions",
+    "displayName": "Inverse Functions",
+    "description": "Find and verify inverse functions and understand that inverses undo each other",
+    "category": "functions",
+    "course": "Algebra 2",
+    "quarter": 2,
+    "unit": "Structure Pattern - Tier 3",
+    "prerequisites": [
+      "functions"
+    ],
+    "enables": [
+      "logarithmic-functions",
+      "exponential-functions"
+    ],
+    "standardsAlignment": [
+      "F-BF.4",
+      "F-BF.4a"
+    ],
+    "teachingGuidance": {
+      "coreConcepts": [
+        "An inverse undoes what the original function does",
+        "Swap x and y, then solve for y",
+        "Composition check: f(f⁻¹(x)) = x"
+      ],
+      "commonMistakes": [
+        "Confusing the inverse with the reciprocal 1/f",
+        "Forgetting to swap x and y",
+        "Ignoring domain restrictions"
+      ],
+      "teachingTips": [
+        "Swap and solve for the inverse",
+        "Verify by composing the two functions",
+        "Reflect the graph over the line y = x"
+      ]
+    },
+    "difficultyLevel": 6,
+    "fluencyMetadata": {
+      "baseFluencyTime": 75,
+      "fluencyType": "conceptual",
+      "toleranceFactor": 3
+    }
   }
 ]

--- a/tests/unit/patternSkillsSeed.test.js
+++ b/tests/unit/patternSkillsSeed.test.js
@@ -1,0 +1,121 @@
+/**
+ * Structural validation + coverage ratchet for the pattern-skill seed
+ * (seeds/skills-pattern-based.json), which `npm run seed:skills` upserts into
+ * the Skill catalog. No DB/LLM — pure data checks, so it runs in CI.
+ *
+ * Guards two things:
+ *   1. Every seed entry is schema-valid (so a bad hand-edit can't reach the DB).
+ *   2. Coverage of the pattern-badge milestones only moves forward — the count
+ *      of milestone-referenced skillIds with no definition can't climb back up.
+ */
+
+const seed = require('../../seeds/skills-pattern-based.json');
+const { PATTERN_BADGES } = require('../../utils/patternBadges');
+
+// Mirrors the enum in models/skill.js (fluencyMetadata.fluencyType).
+const FLUENCY_TYPES = ['reflex', 'process', 'algorithm', 'conceptual', 'procedural', 'application'];
+
+// The high-traffic batch added in this change. These are held to the full rich
+// schema (quarter + fluencyMetadata + teachingGuidance), beyond the universal
+// baseline that all — including leaner legacy — entries must meet.
+const NEW_BATCH = new Set([
+  'one-step-equations-addition', 'one-step-equations-multiplication', 'unit-rates', 'proportions',
+  'percent-problems', 'order-of-operations', 'numerical-expressions-exponents', 'factoring-gcf',
+  'slope-intercept-form', 'graphing-linear-equations', 'integer-addition', 'integer-subtraction',
+  'probability-basics', 'statistics-probability', 'inverse-functions',
+]);
+
+const isNonEmptyString = (v) => typeof v === 'string' && v.trim().length > 0;
+const has3Arrays = (tg) => tg && Array.isArray(tg.coreConcepts) && Array.isArray(tg.commonMistakes) && Array.isArray(tg.teachingTips);
+
+// Ratchet: milestone-referenced skillIds still missing a definition. Lower this
+// as you add more skill defs; never raise it. (Was 50 before the high-traffic
+// batch; 35 after.)
+const MAX_MISSING_DEFINITIONS = 35;
+
+function referencedSkillIds() {
+  const ids = new Set();
+  const patterns = Array.isArray(PATTERN_BADGES) ? PATTERN_BADGES : Object.values(PATTERN_BADGES);
+  for (const p of patterns) {
+    for (const t of p.tiers || []) {
+      for (const m of t.milestones || []) {
+        for (const sid of m.skillIds || []) ids.add(sid);
+      }
+    }
+  }
+  return ids;
+}
+
+describe('pattern-skill seed: schema', () => {
+  test('every entry meets the universal baseline (and optional fields, when present, are well-formed)', () => {
+    const problems = [];
+    for (const s of seed) {
+      const id = s.skillId || '(missing skillId)';
+      // Universal baseline — true for all 190 entries.
+      for (const field of ['skillId', 'displayName', 'description', 'category', 'course', 'unit']) {
+        if (!isNonEmptyString(s[field])) problems.push(`${id}: bad ${field}`);
+      }
+      for (const field of ['prerequisites', 'enables', 'standardsAlignment']) {
+        if (!Array.isArray(s[field])) problems.push(`${id}: ${field} not an array`);
+      }
+      // Optional fields: if present they must be well-formed (so a bad edit fails).
+      if (s.teachingGuidance !== undefined && !has3Arrays(s.teachingGuidance)) {
+        problems.push(`${id}: malformed teachingGuidance`);
+      }
+      if (s.fluencyMetadata !== undefined) {
+        const fm = s.fluencyMetadata;
+        if (!Number.isFinite(fm.baseFluencyTime) || !Number.isFinite(fm.toleranceFactor)) {
+          problems.push(`${id}: malformed fluencyMetadata`);
+        }
+        if (fm.fluencyType && !FLUENCY_TYPES.includes(fm.fluencyType)) {
+          problems.push(`${id}: fluencyType "${fm.fluencyType}" not in enum`);
+        }
+      }
+    }
+    expect(problems).toEqual([]);
+  });
+
+  test('the new high-traffic batch meets the full rich schema', () => {
+    const problems = [];
+    for (const s of seed) {
+      if (!NEW_BATCH.has(s.skillId)) continue;
+      if (!Number.isFinite(s.quarter)) problems.push(`${s.skillId}: missing quarter`);
+      if (!has3Arrays(s.teachingGuidance)) problems.push(`${s.skillId}: missing rich teachingGuidance`);
+      const fm = s.fluencyMetadata;
+      if (!fm || !Number.isFinite(fm.baseFluencyTime) || !FLUENCY_TYPES.includes(fm.fluencyType) || !Number.isFinite(fm.toleranceFactor)) {
+        problems.push(`${s.skillId}: missing/invalid fluencyMetadata`);
+      }
+      if (!s.standardsAlignment.length) problems.push(`${s.skillId}: empty standardsAlignment`);
+    }
+    expect(problems).toEqual([]);
+  });
+
+  test('skillIds are unique', () => {
+    const counts = {};
+    for (const s of seed) counts[s.skillId] = (counts[s.skillId] || 0) + 1;
+    const dupes = Object.entries(counts).filter(([, n]) => n > 1).map(([id]) => id);
+    expect(dupes).toEqual([]);
+  });
+});
+
+describe('pattern-skill seed: milestone coverage ratchet', () => {
+  test('milestone-referenced skills without a definition stays at or below the cap', () => {
+    const seeded = new Set(seed.map((s) => s.skillId));
+    const missing = [...referencedSkillIds()].filter((id) => !seeded.has(id));
+    // If this fails after you ADDED skills, lower MAX_MISSING_DEFINITIONS to the
+    // new count to lock the gain. If it fails after a REMOVAL, that's the
+    // regression this guards — restore the definition.
+    expect(missing.length).toBeLessThanOrEqual(MAX_MISSING_DEFINITIONS);
+  });
+
+  test('the high-traffic batch is present', () => {
+    const seeded = new Set(seed.map((s) => s.skillId));
+    const expected = [
+      'one-step-equations-addition', 'one-step-equations-multiplication', 'unit-rates', 'proportions',
+      'percent-problems', 'order-of-operations', 'numerical-expressions-exponents', 'factoring-gcf',
+      'slope-intercept-form', 'graphing-linear-equations', 'integer-addition', 'integer-subtraction',
+      'probability-basics', 'statistics-probability', 'inverse-functions',
+    ];
+    expect(expected.filter((id) => !seeded.has(id))).toEqual([]);
+  });
+});


### PR DESCRIPTION
Two independent improvements on the `claude/stack-program-deep-dive-16popn` branch (happy to split into two PRs if you'd prefer to review/merge separately — say the word).

## A. Per-file coverage ratchet (CI)
The global ~25% floor can't protect the modules where a *silent* coverage drop mis-grades or mis-teaches students. Adds **`jest.critical.config.js`** + **`npm run test:critical`** + a dedicated **`coverage-critical` CI job** that enforces per-file floors on the grading math engine, IRT, knowledge tracing, and the pipeline's `observe`/`decide`/`diagnose`/`llmVerifier` stages. Kept separate from the main `test` job because Jest subtracts path-scoped files from the global bucket. Floors set just below measured coverage (margin for Node-version drift); verified the gate **fails** when a floor is unmet. 643 tests pass under it.

## B. 15 high-traffic pattern-skill definitions + seed guard
The 8 reasoning patterns' 102 milestones reference **225** distinct skillIds; the seed defined **175**, leaving 50 milestone-referenced skills with no catalog entry (a student routed to one hits "Skill not found"). This adds the **15 highest-traffic missing definitions** — the middle-school core: one-step equations (+/×), unit rates, proportions, percent problems, order of operations, exponents, factoring the GCF, slope-intercept form, graphing lines, integer add/subtract, basic probability, data representation, inverse functions. **Missing definitions: 50 → 35** (the rest are almost all Tier-4 college-level — linear algebra, calculus, inferential stats — low K-12 traffic).

- Entries mirror the existing seed schema (course/quarter/unit, prereq/enables graph, CCSS `standardsAlignment`, `teachingGuidance`, `fluencyMetadata`). **Append-only** — the existing 175 entries are byte-for-byte unchanged.
- New **`tests/unit/patternSkillsSeed.test.js`**: schema validation (universal baseline for all; full rich schema for the new batch) + a **coverage ratchet** capping milestone-referenced-but-undefined skills at 35 (can only go down).
- These are skill *definitions*. Generating *problems* for them needs your MongoDB + OpenAI (`scripts/generate-all-pattern-problems.js`) — that's the follow-up pass, not runnable in CI. Doc note added to disambiguate the two metrics.

> Pedagogical metadata (standards codes, teaching guidance) is drafted for your review — the math is standard middle-school, but give the CCSS alignment a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)