### PR TITLE
Fix desktop chat text resizing (pinch/Ctrl-scroll)

### DIFF
--- a/public/css/chat-redesign.css
+++ b/public/css/chat-redesign.css
@@ -577,7 +577,9 @@ body.cr-mode .message {
   max-width: min(72%, 640px);
   padding: 12px 16px;
   border-radius: 16px;
-  font-size: 14.5px;
+  /* Honor the pinch/Ctrl-scroll font scale on desktop too (mobile applies it
+     via mobile-poster-chat.css; this is the desktop equivalent). */
+  font-size: calc(14.5px * var(--chat-font-scale, 1));
   line-height: 1.55;
   border: 1px solid var(--cr-border);
   position: relative;

--- a/public/js/chat-pinch-zoom.js
+++ b/public/js/chat-pinch-zoom.js
@@ -202,16 +202,23 @@
             lastTap = currentTime;
         });
 
-        // Desktop: Ctrl + Scroll Wheel support
+        // Desktop: trackpad pinch + Ctrl/⌘ + scroll wheel.
+        // Both arrive as a wheel event with ctrlKey set (a macOS trackpad pinch
+        // is synthesized as ctrl+wheel). deltaY magnitude reflects pinch
+        // intensity on a trackpad — many small events — and notch size on a
+        // mouse — few large events. So scale BY the magnitude (continuous,
+        // tracks the fingers) instead of a fixed step, but clamp per event so a
+        // single mouse notch can't jump too far.
         chatContainer.addEventListener('wheel', function(e) {
             if (e.ctrlKey || e.metaKey) {
                 e.preventDefault();
 
-                // Calculate scale change
-                const delta = e.deltaY > 0 ? -0.1 : 0.1;
-                const newScale = currentScale + delta;
+                // Normalize line/page delta modes to roughly pixel scale.
+                const unit = e.deltaMode === 1 ? 16 : e.deltaMode === 2 ? 400 : 1;
+                const delta = Math.max(-30, Math.min(30, e.deltaY * unit));
 
-                applyFontScale(newScale);
+                // deltaY > 0 (pinch in / scroll down) shrinks text.
+                applyFontScale(currentScale - delta * 0.004);
             }
         }, { passive: false });
 


### PR DESCRIPTION
Desktop chat font scaling was a no-op while mobile worked. The font-scale gesture handlers (touch pinch + Ctrl/Cmd-scroll) update --chat-font-scale, but on desktop the message bubbles took a hard-coded `font-size: 14.5px` from `body.cr-mode .message` in chat-redesign.css, so the scale variable never reached the rendered text. Mobile only worked because mobile-poster- chat.css overrides it with an `!important` calc() inside a max-width media query.

- chat-redesign.css: make `body.cr-mode .message` font-size consume --chat-font-scale (calc(14.5px * var(...))); identical at scale 1.
- chat-pinch-zoom.js: scale the Ctrl/Cmd+wheel handler by deltaY magnitude (normalized across delta modes, clamped per event) instead of a fixed ±0.1 step, so trackpad pinch (synthesized as ctrl+wheel) tracks continuously rather than jumping.

Verified in-browser against the real stylesheets/script at desktop width: text now scales via trackpad pinch, touchscreen pinch, and Ctrl/Cmd+scroll, clamped to 0.8x-1.5x.