### PR TITLE
Fix chat math renderer collapsing prose into one KaTeX block

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -2266,6 +2266,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <script src="/js/impersonationBanner.js"></script>
   <script src="/js/storage-utils.js"></script>
   <script src="/js/sanitize-util.js"></script>
+  <!-- LaTeX delimiter scanner (sets window.MathDelimiters) — must load before script.js -->
+  <script src="/js/mathDelimiters.js"></script>
   <script src="/js/logout.js"></script>
   <script src="/js/role-switcher.js"></script>
   <script src="/js/auto-logout.js"></script>

--- a/public/js/mathDelimiters.js
+++ b/public/js/mathDelimiters.js
@@ -1,0 +1,74 @@
+// public/js/mathDelimiters.js
+//
+// Pure, dependency-free LaTeX-delimiter protection for the chat renderer.
+//
+// WHY THIS EXISTS
+// The tutor LLM occasionally emits an UNBALANCED math delimiter — e.g. it
+// opens `\[` for a display equation but forgets the closing `\]`. A naive
+// non-greedy scan (`/\\\[([\s\S]*?)\\\]/`) then bridges from that stray `\[`
+// all the way to the NEXT `\]` several paragraphs later, swallowing the whole
+// explanation into a single KaTeX block. KaTeX discards whitespace, so the
+// student sees prose collapsed into one space-stripped wall:
+//   "y=Asin(B(x−C))+DHere'swhateachpartmeans:−Aistheamplitude..."
+// (the bullet dashes "- A" even become math minus signs "−A").
+//
+// THE RULE
+// A math block can never span a paragraph break (a blank line). Real math —
+// even multi-line `aligned` / `cases` / `matrix` environments — never contains
+// a blank line, so terminating a block at the first blank line is safe and
+// bounds the blast radius of one missing delimiter to *nothing*: the stray
+// opener simply closes itself at the paragraph break and the prose after it is
+// left alone for markdown to render normally.
+//
+// Loaded as a classic <script> (sets window.MathDelimiters) AND require()-able
+// in Node for unit tests — same UMD pattern as graphTitleSync.js.
+
+(function (root, factory) {
+  const api = factory();
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  if (root) root.MathDelimiters = api;
+})(typeof window !== 'undefined'
+  ? window
+  : (typeof globalThis !== 'undefined' ? globalThis : this), function () {
+
+  // Open the delimiter, then lazily capture until the FIRST of:
+  //   - the matching close delimiter (consumed), OR
+  //   - a paragraph break / blank line  (NOT consumed — block auto-closes), OR
+  //   - end of string.
+  // The lazy quantifier + alternation makes the earliest terminator win, so a
+  // well-formed block still closes at its real `\]` / `\)` while a stray opener
+  // can never reach past a blank line.
+  const DISPLAY_RE = /\\\[([\s\S]*?)(?:\\\]|(?=\n[ \t]*\n)|$)/g;
+  const INLINE_RE  = /\\\(([\s\S]*?)(?:\\\)|(?=\n[ \t]*\n)|$)/g;
+
+  /**
+   * Replace LaTeX delimiters with placeholders so markdown can be parsed
+   * without mangling the math. Display blocks are extracted before inline ones
+   * so a `\[ ... \]` region is never re-scanned for `\( ... \)`.
+   *
+   * @param {string} text                    raw message text
+   * @param {(index:number)=>string} placeholder  builds the sentinel, e.g.
+   *                                          `i => '@@LATEX_BLOCK_' + i + '@@'`
+   * @returns {{ text: string, blocks: Array<{math:string, display:boolean}> }}
+   */
+  function protectMathBlocks(text, placeholder) {
+    const blocks = [];
+    let out = (text == null) ? '' : String(text);
+
+    out = out.replace(DISPLAY_RE, (_match, math) => {
+      const i = blocks.length;
+      blocks.push({ math: math.trim(), display: true });
+      return placeholder(i);
+    });
+
+    out = out.replace(INLINE_RE, (_match, math) => {
+      const i = blocks.length;
+      blocks.push({ math: math.trim(), display: false });
+      return placeholder(i);
+    });
+
+    return { text: out, blocks };
+  }
+
+  return { protectMathBlocks };
+});

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -725,13 +725,22 @@ document.addEventListener("DOMContentLoaded", () => {
         const _marked = window.marked;
         const _DOMPurify = window.DOMPurify;
 
+        // Protect LaTeX from markdown using the shared delimiter scanner.
+        // It auto-closes a stray/unbalanced delimiter at the next paragraph
+        // break, so one missing `\]` can never swallow an entire explanation
+        // into a single space-stripped KaTeX block. See mathDelimiters.js.
+        const _protect = window.MathDelimiters && window.MathDelimiters.protectMathBlocks;
+
         if (!_marked || !_marked.parse) {
             console.warn('[renderMarkdownMath] marked not available, falling back to plain text');
             // Even without markdown, try to render KaTeX math
             let fallback = text;
-            if (window.katex) {
-                fallback = fallback.replace(/\\\[([\s\S]*?)\\\]/g, (_, math) => renderKatex(math, true));
-                fallback = fallback.replace(/\\\(([\s\S]*?)\\\)/g, (_, math) => renderKatex(math, false));
+            if (window.katex && _protect) {
+                const { text: protectedText, blocks } = _protect(fallback, (i) => `@@LATEX_BLOCK_${i}@@`);
+                fallback = protectedText;
+                blocks.forEach((block, index) => {
+                    fallback = fallback.replace(`@@LATEX_BLOCK_${index}@@`, renderKatex(block.math, block.display));
+                });
             }
             return _DOMPurify ? _DOMPurify.sanitize(fallback) : fallback;
         }
@@ -739,21 +748,14 @@ document.addEventListener("DOMContentLoaded", () => {
         let processedText = text;
 
         // Protect LaTeX blocks from markdown parsing
-        const latexBlocks = [];
-
-        // Display math \[...\]
-        processedText = processedText.replace(/\\\[([\s\S]*?)\\\]/g, (match, math) => {
-            const index = latexBlocks.length;
-            latexBlocks.push({ math, display: true });
-            return `@@LATEX_BLOCK_${index}@@`;
-        });
-
-        // Inline math \(...\)
-        processedText = processedText.replace(/\\\(([\s\S]*?)\\\)/g, (match, math) => {
-            const index = latexBlocks.length;
-            latexBlocks.push({ math, display: false });
-            return `@@LATEX_BLOCK_${index}@@`;
-        });
+        let latexBlocks = [];
+        if (_protect) {
+            const result = _protect(processedText, (i) => `@@LATEX_BLOCK_${i}@@`);
+            processedText = result.text;
+            latexBlocks = result.blocks;
+        } else {
+            console.warn('[renderMarkdownMath] MathDelimiters not loaded — math left unrendered');
+        }
 
         // Protect inline visual HTML (SVG containers from inlineChatVisuals)
         // Uses div-depth counting to reliably match the full container,

--- a/tests/unit/mathDelimiters.test.js
+++ b/tests/unit/mathDelimiters.test.js
@@ -1,0 +1,124 @@
+/**
+ * mathDelimiters — LaTeX delimiter protection for the chat renderer.
+ *
+ * The bug this guards against (real transcript, Mr. Nappier teaching sine
+ * waves): the tutor omitted a single closing `\]`, so the old non-greedy
+ * scan bridged from the first `\[` to the NEXT `\]` two paragraphs later and
+ * fed the entire explanation to KaTeX as one block. KaTeX strips whitespace,
+ * so the student saw:
+ *   "y=Asin(B(x−C))+DHere'swhateachpartmeans:−Aistheamplitude..."
+ *
+ * The fix: a math block can never cross a blank line, so a stray opener
+ * auto-closes at the paragraph break and the prose is left for markdown.
+ */
+
+const { protectMathBlocks } = require('../../public/js/mathDelimiters');
+
+const PH = (i) => `@@LATEX_BLOCK_${i}@@`;
+
+describe('protectMathBlocks — well-formed math', () => {
+  test('captures a balanced display block', () => {
+    const { text, blocks } = protectMathBlocks('See \\[ x^2 - 4 \\] here', PH);
+    expect(blocks).toEqual([{ math: 'x^2 - 4', display: true }]);
+    expect(text).toBe('See @@LATEX_BLOCK_0@@ here');
+  });
+
+  test('captures a balanced inline block', () => {
+    const { text, blocks } = protectMathBlocks('So \\( x = 1 \\) then', PH);
+    expect(blocks).toEqual([{ math: 'x = 1', display: false }]);
+    expect(text).toBe('So @@LATEX_BLOCK_0@@ then');
+  });
+
+  test('display blocks are indexed before inline blocks', () => {
+    const { blocks } = protectMathBlocks('\\( a \\) and \\[ b \\]', PH);
+    // display pass runs first → \[ b \] becomes block 0
+    expect(blocks[0]).toEqual({ math: 'b', display: true });
+    expect(blocks[1]).toEqual({ math: 'a', display: false });
+  });
+
+  test('multiple display blocks across paragraphs are captured separately', () => {
+    const input = '\\[ x = 1 \\]\n\n\\[ y = 2 \\]';
+    const { blocks } = protectMathBlocks(input, PH);
+    expect(blocks).toEqual([
+      { math: 'x = 1', display: true },
+      { math: 'y = 2', display: true },
+    ]);
+  });
+
+  test('multi-line aligned environment (no blank line) stays intact', () => {
+    const aligned = '\\[\\begin{aligned} a &= b \\\\ c &= d \\end{aligned}\\]';
+    const { blocks } = protectMathBlocks(aligned, PH);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].display).toBe(true);
+    expect(blocks[0].math).toContain('\\begin{aligned}');
+    expect(blocks[0].math).toContain('\\end{aligned}');
+  });
+});
+
+describe('protectMathBlocks — the over-capture regression', () => {
+  // Exactly the failure mode: opening \[ with NO closing \], prose in between,
+  // then a *later* well-formed display block at the end.
+  const buggy = [
+    '\\[ y = A\\sin(B(x - C)) + D',          // <-- missing closing \]
+    '',
+    "Here's what each part means:",
+    '- A is the amplitude (how tall the wave is).',
+    '- B affects the frequency.',
+    '',
+    'If we set A=1, B=2, C=0, and D=0, we get:',
+    '',
+    '\\[ y = \\sin(2x) \\]',
+  ].join('\n');
+
+  test('the stray opener auto-closes at the paragraph break', () => {
+    const { blocks } = protectMathBlocks(buggy, PH);
+    // First block is JUST the first formula — not the whole message.
+    expect(blocks[0]).toEqual({ math: 'y = A\\sin(B(x - C)) + D', display: true });
+  });
+
+  test('prose is NOT swallowed into a math block', () => {
+    const { text, blocks } = protectMathBlocks(buggy, PH);
+    // The explanation survives as ordinary text for markdown to render.
+    expect(text).toContain("Here's what each part means:");
+    expect(text).toContain('- A is the amplitude (how tall the wave is).');
+    expect(text).toContain('If we set A=1, B=2, C=0, and D=0, we get:');
+    // No block contains the prose.
+    for (const b of blocks) {
+      expect(b.math).not.toContain('amplitude');
+      expect(b.math).not.toContain('Here');
+    }
+  });
+
+  test('the trailing well-formed formula is still captured on its own', () => {
+    const { blocks } = protectMathBlocks(buggy, PH);
+    expect(blocks).toContainEqual({ math: 'y = \\sin(2x)', display: true });
+  });
+});
+
+describe('protectMathBlocks — unclosed at edges', () => {
+  test('unclosed inline auto-closes at a blank line, sparing the next paragraph', () => {
+    const input = 'Try \\( x = 5\n\nNew paragraph.';
+    const { text, blocks } = protectMathBlocks(input, PH);
+    expect(blocks).toEqual([{ math: 'x = 5', display: false }]);
+    expect(text).toContain('New paragraph.');
+  });
+
+  test('unclosed display at end-of-string closes at EOF', () => {
+    const { blocks } = protectMathBlocks('Final: \\[ x = 5', PH);
+    expect(blocks).toEqual([{ math: 'x = 5', display: true }]);
+  });
+});
+
+describe('protectMathBlocks — edge inputs', () => {
+  test('null/undefined/empty are safe', () => {
+    expect(protectMathBlocks(null, PH)).toEqual({ text: '', blocks: [] });
+    expect(protectMathBlocks(undefined, PH)).toEqual({ text: '', blocks: [] });
+    expect(protectMathBlocks('', PH)).toEqual({ text: '', blocks: [] });
+  });
+
+  test('plain text with no math is untouched', () => {
+    const { text, blocks } = protectMathBlocks('just words here', PH);
+    expect(text).toBe('just words here');
+    expect(blocks).toEqual([]);
+  });
+});


### PR DESCRIPTION
When the tutor LLM omits a closing `\]`, the old non-greedy delimiter scan bridged from the stray `\[` to the NEXT `\]` paragraphs later, feeding an entire explanation to KaTeX as a single block. KaTeX strips whitespace, so the student saw the formula, intro, bullets, and final equation collapsed into one space-stripped wall:
"y=Asin(B(x−C))+DHere'swhateachpartmeans:−Aistheamplitude...".

Extract delimiter protection into public/js/mathDelimiters.js (UMD, so it's require()-able for tests and exposed as window.MathDelimiters). A math block now auto-closes at the first paragraph break — real math, including multi-line aligned/cases environments, never contains a blank line — so one missing delimiter can no longer swallow prose. script.js (main + marked-less fallback paths) routes through it; chat.html loads it before the ESM entry.

Adds tests/unit/mathDelimiters.test.js (12 tests) covering the exact regression plus balanced/aligned/edge cases.