### PR TITLE
XP surfacing: combo meter + identity chip (+ system overview doc)

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -68,6 +68,7 @@ const { router: memoryRouter } = require('../routes/memory');
 const guidedLessonRoutes = require('../routes/guidedLesson');
 const summaryGeneratorRouter = require('../routes/summary_generator');
 const avatarRoutes = require('../routes/avatar');
+const cosmeticsRoutes = require('../routes/cosmetics');
 const curriculumRoutes = require('../routes/curriculum');
 const assessmentRoutes = require('../routes/assessment');
 const screenerRoutes = require('../routes/screener');
@@ -206,6 +207,7 @@ function registerRoutes(app, { authLimiter, signupLimiter }) {
   app.use('/api/summary', isAuthenticated, summaryGeneratorRouter);
   app.use('/api/avatars', isAuthenticated, avatarRoutes);
   app.use('/api/avatar', isAuthenticated, avatarRoutes);
+  app.use('/api/cosmetics', isAuthenticated, cosmeticsRoutes);
 
   // Public API routes (no auth required)
   app.use('/api/waitlist', waitlistRoutes);

--- a/docs/COSMETICS_SHOP_DESIGN.md
+++ b/docs/COSMETICS_SHOP_DESIGN.md
@@ -1,0 +1,263 @@
+# "Build Your Own Mathmatix" — Cosmetics Shop Design
+
+> Design spec for a student-facing cosmetics economy: earn a soft currency by
+> doing math, spend it on UI customization (themes, board skins, calculator
+> skins, header patterns — cheetah print, hot pink, camo, seasonal, etc.).
+>
+> Status: **proposal / design sign-off pending**. No code written yet. Grounded
+> against the current codebase; assumed defaults are called out and can change.
+>
+> Assumed defaults (change these and the rest follows):
+> 1. **Currency = earned "Coins,"** not XP and not real money.
+> 2. **Cosmetic-only** — zero effect on tutoring, grading, XP, or progression.
+> 3. **Accessibility is a hard gate**, not a polish item.
+
+---
+
+## 1. Why this fits the codebase (already-present scaffolding)
+
+| Need | Already exists |
+|---|---|
+| Themeable UI | Full `--cr-*` design-token layer (`design-system.css`, `chat-redesign.css`): `--cr-accent`, `--cr-bg-0/1/2`, `--cr-bubble-*`, `--cr-panel-grad-*`, radii, shadows. A theme = a bundle of overrides to these. |
+| Full alternate skin precedent | `dark-mode.css` + `user.theme` enum (`light`/`dark`/`high-contrast`) — a theme toggled by a body attribute. |
+| Owned-items storage precedent | `user.unlockedItems[]` (tutor unlocks) and `user.avatarGallery` (up to 3 saved avatars). |
+| A customization front door | The Avatar Builder (unlocks at Level 2, `user.avatarBuilderUnlocked`). Becomes the shell for a "My Mathmatix" studio. |
+| Purchase/unlock celebration | `showTutorUnlockCelebration` / confetti infra in `public/js/modules/gamification.js`. |
+| Server-authoritative economy discipline | XP caps (`maxTier2PerTurn`, `maxTier3PerTurn`) and the "never client-assert XP" rule already establish the pattern. |
+
+**Net:** cheetah board / hot-pink calculator / camo header = scoped skin classes on
+those components + a token bundle. Low structural risk; the risk is *economy and
+accessibility*, not rendering.
+
+---
+
+## 2. Currency model — "Coins" (earned soft currency)
+
+A **separate** currency from XP. Rationale for not reusing XP:
+
+- XP drives `level`, tutor unlocks, and the leaderboard. If XP were spendable,
+  a student would face "level up **or** buy a skin," and spending would corrupt
+  the leaderboard/level signal. Keep XP as the pure progression track.
+- Real money is deliberately excluded from v1 (see §11) — COPPA/consent burden,
+  classroom equity, and direct conflict with the mission *"An Affordable Math
+  Tutor for Every Child."*
+
+### Earning Coins
+Coins drip from the **same learning events that already exist**, as a parallel,
+capped reward — never inflating XP:
+
+| Source | Suggested Coins | Notes |
+|---|---|---|
+| Daily quest complete | 10–25 | Scales with quest tier; reuse `routes/dailyQuests.js` completion hook. |
+| Weekly challenge complete | 50–100 | Reuse `routes/weeklyChallenges.js`. |
+| Mastery badge earned | 100 | Reuse `routes/mastery.js` badge award. |
+| Level-up | 20 × new level | A reason to celebrate a level beyond the ceremony. |
+| Streak milestone (7/30/100 days) | 25/100/500 | Ties Coins to consistency. |
+
+All amounts are **server-computed and capped per period** (mirror the XP-cap
+discipline). No client path ever asserts a balance.
+
+> Deliberately **not** awarding Coins per-turn: that would recreate the "grind for
+> currency" failure mode and pressure the tutor turn loop. Coins reward
+> *completion and consistency*, not message volume.
+
+---
+
+## 3. Data model additions (`models/user.js`)
+
+```js
+// Cosmetics economy
+wallet: {
+  coins: { type: Number, default: 0, min: 0 },
+  lifetimeEarned: { type: Number, default: 0 },  // analytics / never spent-down
+},
+ownedCosmetics: [{ type: String }],   // catalog item ids, e.g. 'board.cheetah'
+equippedCosmetics: {
+  theme:      { type: String, default: 'default' },  // full token bundle
+  board:      { type: String, default: 'default' },  // whiteboard/inline-card frame
+  calculator: { type: String, default: 'default' },
+  header:     { type: String, default: 'default' },
+  // future slots: bubbleStyle, cursor, soundpack, avatarFrame …
+},
+```
+
+- `ownedCosmetics` follows the exact `unlockedItems[]` pattern (string ids,
+  `markModified` on push).
+- `equippedCosmetics` is the currently-worn loadout — one item per slot.
+- Keep `user.theme` (light/dark/high-contrast) as the **base mode**; cosmetic
+  `theme` layers *on top* and must respect it (see §6).
+
+---
+
+## 4. Catalog schema (config, like `tutorConfig.js` / `brand.js`)
+
+A single source-of-truth catalog (`utils/cosmeticsCatalog.js`, mirrored to the
+client the same way `rankTitles.js` mirrors `brand.js`):
+
+```js
+{
+  'board.cheetah': {
+    slot: 'board',
+    name: 'Cheetah Print Board',
+    price: 250,
+    rarity: 'rare',
+    previewImg: '/images/cosmetics/board-cheetah.png',
+    // Cosmetic application: a scoped skin class + optional token overrides.
+    skinClass: 'skin-board-cheetah',
+    tokenBundle: { '--cr-panel-grad-from': '#…', '--cr-panel-grad-to': '#…' },
+    // Accessibility contract (enforced at equip time — see §6):
+    a11y: { patternOnChromeOnly: true, minTextContrast: 4.5 },
+    unlockLevel: 0,          // optional level gate in addition to price
+    season: null,            // e.g. 'winter-2026' for limited items
+  },
+  'calc.hotpink': { slot: 'calculator', name: 'Hot Pink Calculator', price: 150, … },
+  'header.camo':  { slot: 'header',     name: 'Camo Header',          price: 200, … },
+  'theme.neon':   { slot: 'theme',      name: 'Neon Night',           price: 400, … },
+}
+```
+
+Slots (v1): **theme, board, calculator, header.** Extensible.
+
+---
+
+## 5. Theming implementation
+
+Two mechanisms, composed:
+
+1. **Token bundles** (whole-vibe themes): set a body attribute
+   `document.body.dataset.theme = 'neon'` and ship a CSS block
+   `body[data-theme="neon"] { --cr-accent: …; --cr-bg-1: …; }`. This is exactly
+   the `dark-mode.css` pattern, so themes inherit every already-tokenized
+   component for free.
+2. **Component skin classes** (per-slot patterns): e.g.
+   `body[data-skin-board="cheetah"] .board-frame { … }`. Patterns are painted on
+   **chrome only** (frames, headers, borders, calculator body), never behind
+   math text.
+
+Equipping = write `equippedCosmetics` server-side, then on load apply
+`data-theme` / `data-skin-*` attributes from the user payload (same place
+`applyAgeTier` / `user.theme` are applied today). Live preview in the studio
+toggles the attributes without persisting until "Equip."
+
+A single `public/css/cosmetics.css` (linked like `gamification-surfacing.css`)
+holds all skin/theme blocks; item art lives in `/images/cosmetics/`.
+
+---
+
+## 6. Accessibility guardrails (HARD requirements)
+
+Given the IEP/accessibility focus, cosmetics must never degrade learning:
+
+1. **Patterns on chrome, never behind text.** Cheetah/camo/etc. render on
+   headers, frames, borders, calculator bodies — not behind chat text, math, or
+   input fields. Enforced by the catalog `a11y.patternOnChromeOnly` contract.
+2. **Contrast floor.** Every theme ships with a guaranteed text/background
+   contrast ≥ 4.5:1; a build-time or equip-time validator rejects bundles that
+   don't meet it (reuse the spirit of the dataviz contrast rule).
+3. **Force-plain overrides win.** If the student is in `high-contrast` mode, has
+   IEP `reducedDistraction`, or `prefers-reduced-motion`, the base mode overrides
+   any equipped cosmetic (animated/busy skins fall back to a plain variant).
+   These CSS rules load *after* cosmetics so they cascade-win.
+4. **Math legibility is sacred.** KaTeX/MathLive rendering surfaces keep a
+   neutral, high-contrast backing regardless of theme.
+
+---
+
+## 7. Shop + studio UI
+
+Extend the Avatar Builder into a **"My Mathmatix" studio** (tabbed):
+
+- **Avatar** (existing) · **Themes** · **Board** · **Calculator** · **Header** · **Shop**.
+- Each slot tab: a grid of items with **live preview** (apply attributes on
+  hover/click, revert on leave), an owned/locked state, price, and Equip / Buy.
+- **Coin balance** shown in the header (a small wallet chip, sibling to the
+  streak/identity chips in `.cr-header-extras`).
+- Buying reuses the confetti/celebration path; a "new item" reveal like the
+  tutor-unlock screen.
+
+---
+
+## 8. Purchase flow (server-authoritative)
+
+`POST /api/cosmetics/purchase { itemId }`:
+
+1. Load catalog item; 404 if unknown.
+2. Reject if already owned, if `wallet.coins < price`, or if `unlockLevel` unmet.
+3. Debit `wallet.coins`, push to `ownedCosmetics`, save. Idempotent per item
+   (owning is terminal). Return new balance + owned list.
+
+`POST /api/cosmetics/equip { slot, itemId }`: validate ownership (or `default`),
+write `equippedCosmetics[slot]`, return. Never trust client balance/ownership.
+
+Earning uses a shared `awardCoins(user, amount, reason)` helper (parallel to
+`xpEngine.applyXpToUser`) called from the existing quest/challenge/mastery hooks,
+with per-period caps.
+
+---
+
+## 9. Economy tuning
+
+- **Cosmetic-only ⇒ no pay-to-win.** Nothing purchasable affects tutoring,
+  grading, XP, or leaderboard. This sidesteps the fairness problems paid power
+  would create.
+- Price bands: common 100 / rare 250 / epic 400 / seasonal 500+. Tune so a
+  regular student can afford ~1 item every 1–2 weeks from quests+challenges.
+- Anti-grind: because Coins come from *completion* (capped) not volume, there's
+  no per-message farming vector.
+- Watch metric: median days-to-first-purchase and Coin sink/faucet ratio.
+
+---
+
+## 10. Teacher controls & classroom equity
+
+- **Focus mode:** a class/session setting (hooks into the existing browser-lock /
+  IEP `reducedDistraction` machinery) that force-plains cosmetics during
+  instruction.
+- **Self-facing by default:** a student's theme is their own. If equipped accents
+  ever appear on classmate-visible surfaces (leaderboard rows, Showdown cards),
+  they run through `hasOptedOutOfDirectoryInfo` like everything else, and we keep
+  it subtle to avoid have/have-not shaming.
+
+---
+
+## 11. Non-goals / explicitly avoided
+
+- **Loot boxes / randomized paid packs.** Gambling-adjacent mechanics aimed at
+  minors are a legal and ethical no-go. Purchases are **direct** (you see exactly
+  what you buy).
+- **Real-money microtransactions (v1).** Deferred; if ever added, gated behind a
+  **parent account** with explicit consent, never a child-facing checkout, and
+  never for power/progression.
+- **Trading / marketplace between students.** Out of scope (moderation +
+  safety burden).
+- **Any progression or grading effect.** Cosmetics are purely visual, forever.
+
+---
+
+## 12. Open decisions (need a call before building)
+
+1. **Currency name** — "Coins," "Gems," "Pi-Coins," "Sparks"? (Pi-Coins ties to
+   the existing Pi Day motif.)
+2. **Coin visibility to parents/teachers** — surface balance in dashboards?
+3. **Launch item set** — how many slots and items in the first drop (suggest ~3
+   themes + 2 boards + 2 calculators + 2 headers to feel like a real shop).
+4. **Level gating** — should some items require both Coins *and* a level, or
+   Coins only?
+5. **Seasonal/limited items** — do we want time-limited drops (drives return
+   visits) from day one, or add later?
+
+---
+
+## 13. Suggested rollout sequencing
+
+1. **Wallet + earning** — add `wallet`, `awardCoins`, wire into existing
+   quest/challenge/mastery/level hooks, show the balance chip. (No shop yet —
+   let balances accrue first.)
+2. **Catalog + theming engine** — `cosmeticsCatalog.js`, `cosmetics.css`, the
+   `data-theme`/`data-skin-*` application layer + accessibility overrides.
+3. **One vertical slice** — buy + equip **one** theme end-to-end (e.g. Hot Pink),
+   server-authoritative, to prove the pattern.
+4. **The studio UI** — build out the tabbed "My Mathmatix" hub and the full item
+   set.
+5. **Teacher focus mode + polish** — classroom controls, celebrations, seasonal
+   drops.

--- a/docs/ENGAGEMENT_NORTH_STAR.md
+++ b/docs/ENGAGEMENT_NORTH_STAR.md
@@ -1,0 +1,145 @@
+# Engagement North-Star — Making Progress Feel Alive
+
+> Where the gamification vision is going and why. Captures the "layered
+> progression" thesis (six layers + anticipation + tutor relationship + mastery
+> reputation) and, crucially, tags each idea **Exists / Dormant / Net-new**
+> against the *actual* codebase — so this is a buildable roadmap, not a manifesto.
+>
+> Companion docs: `XP_LEVELING_SYSTEM_OVERVIEW.md` (current economy),
+> `COSMETICS_SHOP_DESIGN.md` (Coins + shop).
+
+---
+
+## The core thesis
+
+A student didn't ask "what is XP?" — they asked **"why should I care?"** The
+diagnosis: Mathmatix has **progress** but not **anticipation**. Good games hook
+on *uncertainty and "what's next,"* not points. The fix is not "more math
+excitement" — it's **making the progress we already track visible, personal, and
+forward-looking.**
+
+The single feeling to optimize for: **"just one more problem."** Every mechanic
+below is judged by whether it serves that without compromising the teaching.
+
+**The under-appreciated fact:** we already own most of the substrate. The work is
+mostly *surfacing and connecting* existing systems, not inventing new ones.
+
+---
+
+## The six layers — tagged against reality
+
+### 1. Tutor relationship (proud-of-you) — **Net-new, highest ROI**
+Students build a *relationship*, not just a level. Milestone- and history-aware,
+persona-specific dialogue: "Yesterday you struggled with distribution — today I
+think you're ready."
+- **Substrate exists:** `tutorPlan` is literally "the tutor's persistent mental
+  model of a student"; each persona has distinct `humanBehaviors`; the status
+  card already renders a persona line.
+- **Net-new:** milestone triggers + a tutorPlan-backed "what should the tutor
+  notice today" message. This is the most on-brand idea ("the tutor that won't
+  let you fake it") and cheap relative to impact.
+
+### 2. Collections — **Exists, unsurfaced**
+- **Exists:** `badges`, `strategyBadges`, `habitBadges`, `metaBadges`,
+  `patternBadges`, mastery badges. That *is* a collection system.
+- **Work:** present it as a **case/shelf to complete** (progress toward sets),
+  not a scattered list. Pure UI + a completion metric.
+
+### 3. Random drops — **Net-new, guardrails required**
+Small chance of a delightful cosmetic on a *verified* win.
+- **Guardrails (non-negotiable):** earned-only, **never paid randomization**
+  (loot boxes for minors = gambling; a hard No-Go). Drops key off
+  **verified-correct + genuine behavior** (same gate as the combo meter / Tier-3
+  XP), **never problem volume** — otherwise it fights `antiGaming`/`worksheetGuard`.
+- **Substrate:** the app already uses variable-ratio (tutor unlock rolls,
+  `showUnlockProximityTeaser`) and now has the Coins/cosmetics economy to drop into.
+
+### 4. Daily quests — **Exists, now surfaced**
+- **Exists & shipped:** `routes/dailyQuests.js` (3/day, streakKeeper, Pi Day
+  3.14×). The Personal Status Card now surfaces them prominently (they were
+  buried in an unreachable drawer).
+- **Work:** richer quest variety ("help Maya teach Bob," "beat yesterday's
+  streak") + visibility in more entry points.
+
+### 5. Visible skill trees — **Data exists, no visualization**
+- **Exists:** `skill.js` has a prereq/enables graph; `masteryEngine` scores it.
+- **Net-new:** the *visualization* — a tree that lights up as skills are
+  mastered. Parents and teachers value this too. Rendering job, not a modeling job.
+
+### 6. Unlocking personality / deeper tutors — **Partially exists / Dormant**
+Tutors deepen over levels (stories → jokes → roasts → custom celebrations).
+- **Dormant:** the tutor *unlock* engine is fully built but all unlockable tutors
+  are `active:false` (see `XP_LEVELING_SYSTEM_OVERVIEW.md`).
+- **Net-new:** level-gated *dialogue* layers per persona (distinct from
+  unlocking new tutors).
+
+---
+
+## The two finishers (both cheaper than they look)
+
+### Anticipation / surprise — **Partially exists**
+"Before today's lesson… I found something" → a chest → a rare cosmetic.
+- **Exists:** `showUnlockProximityTeaser` already does "something's about to
+  unlock." Extend into session-open surprise moments, powered by the drop system.
+
+### Mastery Reputation (Learning → Confident → Proven) — **Already built, needs renaming/surfacing**
+> This is the big one, and it's **already your core differentiator.**
+- The `masteryEngine` has a **4-pillar model (accuracy / independence / transfer
+  / retention)** with tiers. "Proven = demonstrate later, in a new context,
+  without prompting" is **literally the transfer pillar + FSRS retention**, and
+  `transfer` is already one of the six Tier-3 behaviors the tutor awards.
+- **Work:** surface the existing tiers as **Learning → Confident → Proven** and
+  gate "Proven" on unprompted transfer. Mostly renaming + a status display over
+  an engine that already exists — and it aligns reward with *real* mastery, not
+  shallow repetition. This should be the **top of the progression stack**, above
+  "Level N."
+
+---
+
+## XP economy → Coins (already underway)
+"XP should buy things" — resolved in `COSMETICS_SHOP_DESIGN.md`: a separate
+**earned Coins** currency (not XP, not real money), cosmetic-only, no pay-to-win.
+**Shipped:** the wallet spine + earning on level-up and quest/challenge
+completion. **Next:** the shop/catalog + spend endpoints, then cosmetics and
+avatar unlocks.
+
+## Seasons — **Extend an existing pattern**
+Pi Day already works (3.14× event). A seasonal *framework* (Halloween, Back to
+School, Summer Camp) with exclusive quests/cosmetics/badges is generalizing one
+proven mechanic.
+
+---
+
+## Guardrails (duty of care — apply to everything above)
+1. **No loot boxes / no paid randomization** for minors. Direct purchases only.
+2. **Rewards tie to verified learning**, never volume — protects the teaching and
+   the anti-gaming systems.
+3. **Nothing educational is ever locked.** Everything is earnable. Keeps faith
+   with *"an affordable math tutor for every child."*
+4. **Accessibility is a gate** (contrast, math legibility, reduced-motion,
+   IEP force-plain) — see the cosmetics spec.
+5. **Attention budget.** Don't ship six meters at once; surface layers
+   sequentially, each showing something real.
+
+---
+
+## Sequenced roadmap (by ROI, lowest risk first)
+
+| # | Move | Status of substrate | Effort |
+|---|---|---|---|
+| 1 | ✅ Surface quests + status card + combo/identity chips | done | shipped |
+| 2 | ✅ Coins wallet + earning | done | shipped |
+| 3 | **Mastery Reputation (Learning/Confident/Proven)** surfacing | engine exists | low–med |
+| 4 | **Tutor "proud of you" milestone messages** | tutorPlan exists | low–med |
+| 5 | **Collections shelf** (badges as completable sets) | badges exist | low |
+| 6 | **Cosmetics shop + spend** (Coins sink) | wallet exists | med |
+| 7 | **Skill-tree visualization** | graph exists | med |
+| 8 | **Student avatar glow-up** (revive 54 orphaned PNGs, gate by level/Coins) | art + schema exist | med |
+| 9 | **Earned random drops + session-open surprise** | variable-ratio + Coins exist | med (guardrails) |
+| 10 | **Tutor personality layers** + reactivate dormant tutor unlocks | unlock engine exists (dormant) | med |
+| 11 | **Seasonal framework** | Pi Day exists | med |
+
+**Throughline:** you have the telemetry (mastery pillars, badges, tutorPlan,
+tier-3 behaviors, skill graph). Almost none of it is *shown back* to the student
+as anticipation. Close that gap and Mathmatix stops feeling like school pretending
+to be a game and starts feeling like a tutor you *want* to come back to.

--- a/docs/XP_LEVELING_SYSTEM_OVERVIEW.md
+++ b/docs/XP_LEVELING_SYSTEM_OVERVIEW.md
@@ -1,0 +1,259 @@
+# XP, Leveling, Tutor Unlock & Leaderboard — System Overview
+
+> Status report of the gamification/progression system **as it currently exists in code**
+> (verified against source, not design docs). Where the code and the intended design diverge,
+> that divergence is called out explicitly.
+
+---
+
+## 1. The big picture
+
+XP is a **pure engagement + behavior-reinforcement currency**. There is **no spend/store
+mechanic** — you cannot buy anything with XP. XP does exactly three things:
+
+1. Accumulates on `user.xp` and drives `user.level` up a mildly increasing curve.
+2. Levels gate a small set of unlocks (Avatar Builder, tutor characters) and scale quest/challenge difficulty.
+3. XP + level determine **leaderboard ranking**.
+
+The system is deliberately built on **variable-ratio reinforcement** ("keep them guessing")
+— XP amounts, unlock timing, and teaser messaging are all designed around a dopamine loop.
+
+**Key files**
+
+| Concern | File |
+|---|---|
+| Per-turn XP calc + level-up + unlock application | `utils/pipeline/xpEngine.js` |
+| Config: XP amounts, level curve, boost | `utils/brand.js` (lines 74–205) |
+| Tutor unlock logic (variable ratio) | `utils/unlockTutors.js` |
+| Tutor definitions + unlock gates | `utils/tutorConfig.js` |
+| New-user boost factor | `utils/promptCompressor.js:174–205` |
+| Pipeline wiring (where XP is applied each turn) | `utils/pipeline/persist.js:348–360` |
+| Leaderboard API | `routes/leaderboard.js` |
+| Frontend display, celebrations, teasers | `public/js/modules/gamification.js` |
+| Storage | `models/user.js` (`xp`, `level`, `xpLadderStats`, `unlockedItems`, `avatarBuilderUnlocked`) |
+| Bulk XP sources | `routes/dailyQuests.js`, `routes/weeklyChallenges.js`, `routes/mastery.js` |
+
+---
+
+## 2. How XP is earned per chat turn — the three-tier "XP ladder"
+
+Every student turn runs `computeXpBreakdown()` (`xpEngine.js:27–66`), driven by
+`BRAND_CONFIG.xpLadder` (`brand.js:85–124`). It produces up to three tiers:
+
+### Tier 1 — Turn XP (engagement)
+- **+2 XP on every single turn**, unconditionally (`brand.js:87–92`, engine line 32).
+- **Silent** — no UI notification. Pure "showing up" reinforcement.
+
+### Tier 2 — Performance XP (correct answers only)
+Awarded only when `wasCorrect` is true (engine lines 35–41):
+- **+10 XP ("clean")** — correct without asking for help.
+- **+5 XP ("correct")** — correct, but the student asked for a hint in the last ~6 messages.
+- Hint detection: regex `/\b(hint|help|stuck|don'?t know|idk|confused)\b/i` over recent **user** messages (engine line 14).
+- Hard cap: `maxTier2PerTurn = 10`.
+
+### Tier 3 — Core Behavior XP (the ceremonial reward)
+The tutor LLM emits a `<CORE_BEHAVIOR_XP:amount,behavior>` tag, extracted upstream and passed
+in as `extracted.coreBehaviorXp` (engine lines 44–49). Amounts (`brand.js:105–109`):
+- **25 (small)** — good reasoning shown.
+- **50 (medium)** — caught own error / strategy selection.
+- **100 (large)** — transfer / persistence through struggle.
+
+Six recognized trigger behaviors (`brand.js:110–117`):
+`explained_reasoning`, `caught_own_error`, `strategy_selection`, `persistence`, `transfer`, `taught_back`.
+
+Cap: `maxTier3PerTurn = 100` (scaled by boost — see below).
+
+**Legacy fallback:** older model outputs emitting `legacyXp` are routed into Tier 2, capped at 10 (engine lines 50–54).
+
+### Turn total & course boost
+`total = tier1 + tier2 + tier3`. If the turn is inside a structured course session
+(`user.activeCourseSessionId`), the **entire total is multiplied by 1.5×** (engine lines 59–63).
+
+---
+
+## 3. New-user boost (first 15 levels)
+
+`calculateXpBoostFactor(level)` (`promptCompressor.js:174–205`) multiplies **Tier 3 only**:
+
+- **Levels 1–5:** flat **2.0×** (both the award *and* the Tier-3 cap are scaled — engine lines 45–48). Prompt guidance set to `'high'` (AI actively hunts for XP-worthy behaviors).
+- **Levels 6–14:** fades linearly from 2.0× down toward 1.0×
+  (`factor = 2.0 - fadeProgress*(1.0)`, where `fadeProgress = (level-6)/9`).
+- **Level 15+:** **1.0×** (no boost).
+
+Config lives in `brand.js:129–151` (`newUserBoost`). The intent is early momentum that
+tapers as the student matures.
+
+---
+
+## 4. Applying XP + leveling up
+
+`applyXpToUser(user, breakdown)` (`xpEngine.js:77–128`) mutates the user doc (caller saves):
+
+1. `user.xp += breakdown.total`.
+2. Accumulates lifetime analytics in `user.xpLadderStats` (`lifetimeTier1/2/3` and a
+   per-behavior `tier3Behaviors[]` with counts + `lastEarned`). These behavior counts feed
+   tutor unlocks (§6).
+3. **Level-up loop** (lines 104–108): bumps `user.level` while
+   `user.xp >= cumulativeXpForLevel(level+1)`.
+4. Runs tutor-unlock check (§6) and Avatar Builder unlock (§5).
+
+Wired into the pipeline at `persist.js:349–360` (main chat) and mirrored in the standalone
+course path — both call the same shared engine, by design.
+
+### The level curve (`brand.js:166–183`)
+- `xpPerLevel = 100`, `xpScalingFactor = 0.1` (each level costs 10% more than the previous).
+- **XP to go from level L → L+1:** `round(100 * (1 + 0.1*(L-1)))`
+  - Level 1→2 = **100**, 5→6 = **140**, 10→11 = **190**, 20→21 = **290**.
+- `cumulativeXpForLevel(L)` sums the per-level costs to get total XP to *reach* level L.
+
+---
+
+## 5. Avatar Builder unlock
+
+- Unlocks at **Level 2** (`xpEngine.js:121–125`), sets `user.avatarBuilderUnlocked = true`.
+- Only fires on a level-up transition, one time.
+
+---
+
+## 6. Tutor unlock system (`utils/unlockTutors.js`)
+
+This is the **primary intended reward** for leveling. Each unlockable tutor in `tutorConfig.js`
+has: `unlockLevel` (minimum), `unlockLevelMax` (guaranteed by), `unlockTrigger` (a Tier-3
+behavior), and `unlockTriggerCount`.
+
+`getTutorsToUnlock(level, unlockedItems, behaviorStats)` unlocks a tutor when **all** hold:
+1. `level >= unlockLevel`, and the tutor isn't already unlocked, and is not `active:false`.
+2. **One of:**
+   - **Behavior trigger:** the linked behavior has been demonstrated `>= unlockTriggerCount` times.
+   - **Guaranteed:** `level >= unlockLevelMax`.
+   - **Variable-ratio roll:** probability ramps from **15% at `unlockLevel` → ~70% near `unlockLevelMax`**
+     (`0.15 + 0.55*(progress/range)`, lines 57–68). The roll is *deterministic per (tutorId, level)*
+     via a string hash, so it doesn't flip-flop between requests within the same level.
+
+### The configured tutor gates (`tutorConfig.js`)
+
+| Tutor | unlockLevel–Max | Behavior trigger (×count) | Narrative |
+|---|---|---|---|
+| Ms. Rashida | 5–7 | `persistence` ×1 | "unlocks because you didn't give up" |
+| Mr. Sierawski | 8–12 | `persistence` ×3 | wrestling coach — grit |
+| Prof. Davies | 13–17 | `explained_reasoning` ×2 | intellectual curiosity |
+| Ms. Alex | 18–22 | `strategy_selection` ×2 | thought before solving |
+| Mr. Lee | 22–27 | `caught_own_error` ×3 | precision / self-correction |
+| Dr. G | 27–32 | `transfer` ×2 | strength spans domains |
+| Mr. Wiggles | 32–37 | `taught_back` ×2 | taught it back |
+
+### ⚠️ Current state: tutor unlock is DORMANT
+**All seven unlockable tutors are currently `active: false`** in `tutorConfig.js`
+(the "INACTIVE TUTORS" block, lines 66+). `getTutorsToUnlock` filters out any tutor with
+`active === false` (`unlockTutors.js:35`). The four starting tutors (**Bob, Maya, Ms. Maria,
+Mr. Nappier**) are `unlocked: true` with no `unlockLevel`, so they're skipped too.
+
+**Net effect: `getTutorsToUnlock` returns nothing today — no tutor can actually be unlocked
+via XP right now.** The entire mechanic (level gates, behavior triggers, variable-ratio rolls,
+the "Mortal Kombat" reveal UI) is fully built and wired, but gated off behind the `active`
+flags. Per the code comment, any tutor can be reactivated later by removing its `active:false`
+flag (voices, personas, and unlock config are all intact).
+
+---
+
+## 7. Other XP sources (bulk XP)
+
+Beyond per-turn XP, three systems award larger chunks (numbers per the route files):
+
+- **Daily Quests** (`routes/dailyQuests.js`): 3 quests/day (`streakKeeper` always included).
+  Rewards range **25–100 XP** (streakKeeper 25; problemSolver/explorer 50; speedster 60;
+  skillBuilder/accuracyAce 75; masteryHunter/perfectionist 100), added directly to `user.xp`
+  on completion. **Pi Day (Mar 14)** swaps in a special quest set with a **3.14× multiplier**.
+  Quest target counts scale with level: `floor(level/5)`.
+- **Weekly Challenges** (`routes/weeklyChallenges.js`): 3/week, **300–750 XP** each plus a
+  `specialReward` (badges, "2× XP Weekend Pass", etc.). Difficulty scales `floor(level/10)`.
+- **Mastery-mode badges** (`routes/mastery.js`): each badge earned grants a flat **+500 XP** bonus.
+
+---
+
+## 8. Streaks
+
+Two parallel streak notions:
+- **Daily-quest streak** (`user.dailyQuests.currentStreak/longestStreak`), bumped by
+  `bumpDailyStreak()` (`utils/gamificationEvents.js`) on every substantive turn
+  (`persist.js:377`). Consecutive-day logic; a **weekly streak freeze** absorbs a single
+  1-day gap; a gap > 1 day resets the streak to 1.
+- **Paper-progress streak** fields on the user doc (separate feature).
+
+⚠️ **Display-only multiplier:** `routes/dailyQuests.js` exposes
+`streakMultiplier = 1 + min(streak*0.01, 0.5)` (up to 1.5×) in the stats endpoint, but **no
+code path actually applies it to earned XP**. Streaks currently drive the `streakKeeper` quest
+and UI only — not a real XP multiplier.
+
+---
+
+## 9. Leaderboard (`routes/leaderboard.js`)
+
+- `GET /api/leaderboard`, guarded by `isAuthorizedForLeaderboard`.
+- Returns **top 10 students**, sorted by **`level` desc, then `xp` desc**.
+- **Scope by role:**
+  - Teacher → only their own students (`teacherId == req.user._id`).
+  - Student → classmates sharing their `teacherId`; if the student has no teacher, a **global**
+    leaderboard.
+  - Admin → all students.
+  - Demo/clone accounts excluded.
+- **FERPA:** names formatted "First L."; students who opted out of directory info via
+  `hasOptedOutOfDirectoryInfo()` are redacted to `"Student"` with `level` hidden (XP still returned).
+
+---
+
+## 10. Frontend display & celebrations (`public/js/modules/gamification.js`)
+
+The server sends the client `xpForCurrentLevel` (XP within the current level) and
+`xpForNextLevel` (= `xpRequiredForLevel(level)`), computed in `routes/chat.js` (~lines 286,
+411–419, 466–474, 1503–1510) and `routes/courseChat.js`.
+
+- **Sidebar** (`updateGamificationDisplay`): shows level, an `X / Y XP` label, and a progress
+  bar filled to `xpForCurrentLevel / xpForNextLevel`.
+- **Floating XP animation** (`triggerXpAnimation`): pops "+N XP" text over the chat; a
+  `special-xp` style for larger awards.
+- **Level-up celebration** (`showLevelUpCelebration` + `triggerXpAnimation` level-up branch):
+  brand-colored confetti; an in-place "tutor comes to life" hero overlay, falling back to a
+  fullscreen modal video. Every **5th level** is a milestone → bigger `LEVEL N!` treatment.
+  Only tutors in `TUTORS_WITH_CELEBRATION_VIDEO` (bob, maya, mr-nappier, ms-maria) get the video modal.
+- **Tutor unlock reveal** (`showTutorUnlockCelebration`): a "Mortal Kombat"-style full-screen
+  reveal, cycling through each newly unlocked tutor (image, catchphrase, specialties).
+  *(Currently never triggers — see §6.)*
+- **Proximity teaser** (`showUnlockProximityTeaser`): when within **3 levels** of an upcoming
+  unlock, shows a deliberately vague toast ("Something's about to unlock… keep going!") — it
+  hard-codes the unlock ladder (Avatar Builder @2, tutors @5/8/13/18/22/27/32) but hides exact
+  levels to preserve the variable-ratio mystery.
+- **Quest/challenge completion** (`processGamificationEvents`): toasts with earned XP + confetti.
+- **Badge award** (`processBadgeAward`): full modal with tier + `+N XP`.
+
+---
+
+## 11. Data model (`models/user.js`)
+
+| Field | Meaning |
+|---|---|
+| `xp` (default 0) | Total lifetime XP |
+| `level` (default 1) | Current level |
+| `xpLadderStats` | `{ lifetimeTier1, lifetimeTier2, lifetimeTier3, tier3Behaviors:[{behavior,count,lastEarned}] }` |
+| `unlockedItems[]` | Unlocked tutor IDs (empty in practice today — §6) |
+| `avatarBuilderUnlocked` | Set true at level 2 |
+| `dailyQuests.currentStreak / longestStreak` | Daily streak state |
+
+---
+
+## 12. Summary of "what currently exists vs. dormant"
+
+**Fully live today:**
+- 3-tier per-turn XP (2 / 5–10 / 25–100), course 1.5× boost, new-user 2×→1× Tier-3 boost.
+- Leveling on the scaling curve; level-up confetti + celebration modal.
+- Avatar Builder unlock at level 2.
+- Daily quests, weekly challenges, mastery-badge XP.
+- Daily streaks (with weekly freeze).
+- Leaderboard (role-scoped, FERPA-aware).
+- Full sidebar/animation/teaser UI.
+
+**Built but currently inactive:**
+- **Tutor unlocking** — the entire variable-ratio + behavior-trigger engine and reveal UI are
+  wired, but every unlockable tutor is `active:false`, so no unlocks fire. Reactivating is a
+  one-line flag flip per tutor.
+- **Streak XP multiplier** — computed and surfaced, but not applied to earned XP.

--- a/models/user.js
+++ b/models/user.js
@@ -630,6 +630,16 @@ const userSchema = new Schema({
     }]
   },
 
+  /* Cosmetics economy — Coins are an EARNED soft currency (never real money,
+     never XP). Spent only on cosmetics; zero effect on tutoring/grading/XP.
+     Server-authoritative: only utils/coinEngine.awardCoins mutates this. */
+  wallet: {
+    coins:          { type: Number, default: 0, min: 0 },  // spendable balance
+    lifetimeEarned: { type: Number, default: 0 },          // analytics; never spent down
+    dailyEarned:    { type: Number, default: 0 },          // anti-abuse daily cap counter
+    lastCoinReset:  { type: Date, default: Date.now }       // anchors the daily reset
+  },
+
   totalActiveTutoringMinutes:  { type: Number, default: 0 },
   weeklyActiveTutoringMinutes: { type: Number, default: 0 },
   // Precise time tracking in seconds (minutes are derived from these)

--- a/models/user.js
+++ b/models/user.js
@@ -640,6 +640,16 @@ const userSchema = new Schema({
     lastCoinReset:  { type: Date, default: Date.now }       // anchors the daily reset
   },
 
+  /* Cosmetics ownership + equipped loadout (see utils/cosmeticsCatalog.js).
+     Purely visual; nothing here affects tutoring/grading/XP. */
+  ownedCosmetics:    { type: [String], default: [] },       // catalog item ids owned
+  equippedCosmetics: {
+    theme:      { type: String, default: 'default' },
+    board:      { type: String, default: 'default' },
+    calculator: { type: String, default: 'default' },
+    header:     { type: String, default: 'default' }
+  },
+
   totalActiveTutoringMinutes:  { type: Number, default: 0 },
   weeklyActiveTutoringMinutes: { type: Number, default: 0 },
   // Precise time tracking in seconds (minutes are derived from these)

--- a/public/chat.html
+++ b/public/chat.html
@@ -58,6 +58,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <link rel="stylesheet" href="/css/design-system.css" />
   <!-- Redesigned chat shell (opt-in via body.cr-mode) -->
   <link rel="stylesheet" href="/css/chat-redesign.css" />
+  <!-- Gamification surfacing: combo meter + identity chip -->
+  <link rel="stylesheet" href="/css/gamification-surfacing.css" />
   <!-- Interactive math workspace (chat right slot) -->
   <link rel="stylesheet" href="/css/workspace.css" />
   <!-- Voice mode (layout mode of the chat stage) -->

--- a/public/chat.html
+++ b/public/chat.html
@@ -60,6 +60,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <link rel="stylesheet" href="/css/chat-redesign.css" />
   <!-- Gamification surfacing: combo meter + identity chip -->
   <link rel="stylesheet" href="/css/gamification-surfacing.css" />
+  <!-- Personal status card modal (Progress button) -->
+  <link rel="stylesheet" href="/css/status-card.css" />
   <!-- Interactive math workspace (chat right slot) -->
   <link rel="stylesheet" href="/css/workspace.css" />
   <!-- Voice mode (layout mode of the chat stage) -->

--- a/public/css/gamification-surfacing.css
+++ b/public/css/gamification-surfacing.css
@@ -1,0 +1,243 @@
+/* gamification-surfacing.css
+ * Feature A (Combo Meter) + Feature B (Identity Chip) — surfacing the XP economy
+ * where students live (chat.html). Brand tokens: teal #12B3B3, hot pink #FF3B7F,
+ * gold #FFC24B, success green #16C86D.
+ */
+
+/* ============================================================
+ * Feature A — Combo Meter
+ * ============================================================ */
+
+/* Edge glow on the chat container. Intensity 0..1 drives shadow strength; the
+ * ~600ms transition means the glow eases DOWN on a cool (never a hard break). */
+#chat-container {
+  --combo-intensity: 0;
+  transition: box-shadow 600ms ease;
+  box-shadow:
+    inset 0 0 0 2px rgba(255, 59, 127, var(--combo-intensity)),
+    inset 0 0 42px rgba(255, 59, 127, calc(var(--combo-intensity) * 0.45));
+}
+
+/* Combo counter chip near the input bar. Appears at rung 2+. */
+.combo-chip {
+  position: fixed;
+  bottom: 96px;
+  right: 24px;
+  z-index: 850;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-family: Inter, sans-serif;
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: #fff;
+  background: linear-gradient(135deg, #ff3b7f 0%, #ff7a3b 100%);
+  box-shadow: 0 4px 14px rgba(255, 59, 127, 0.4);
+  pointer-events: none;
+  user-select: none;
+}
+.combo-chip[hidden] { display: none; }
+.combo-chip .combo-flame { font-size: 1.05rem; line-height: 1; }
+.combo-chip .combo-count { letter-spacing: 0.02em; }
+
+@keyframes combo-pop {
+  0% { transform: scale(1); }
+  40% { transform: scale(1.22); }
+  100% { transform: scale(1); }
+}
+.combo-chip.combo-pop { animation: combo-pop 260ms ease; }
+
+/* Reduced motion: counter only, no glow animation, no pop. */
+@media (prefers-reduced-motion: reduce) {
+  #chat-container { transition: none; box-shadow: none; }
+  .combo-chip.combo-pop { animation: none; }
+}
+.combo-chip.combo-reduced { box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15); }
+
+@media (max-width: 480px) {
+  .combo-chip { bottom: 84px; right: 12px; font-size: 0.85rem; padding: 5px 10px; }
+}
+
+/* ============================================================
+ * Feature B — Identity Chip (level ring + rank title)
+ * ============================================================ */
+
+.cr-identity-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 10px 2px 2px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  border-radius: 999px;
+  font-family: Inter, sans-serif;
+  transition: background 150ms ease;
+}
+.cr-identity-chip:hover { background: rgba(18, 179, 179, 0.1); }
+
+.identity-ring-wrap {
+  position: relative;
+  width: 40px;
+  height: 40px;
+  flex: 0 0 40px;
+}
+.identity-ring { position: absolute; inset: 0; width: 40px; height: 40px; }
+.identity-ring-track {
+  fill: none;
+  stroke: rgba(18, 179, 179, 0.2);
+  stroke-width: 3;
+}
+.identity-ring-fill {
+  fill: none;
+  stroke: #12b3b3;
+  stroke-width: 3;
+  stroke-linecap: round;
+  transition: stroke-dashoffset 600ms ease;
+}
+
+.identity-avatar {
+  position: absolute;
+  top: 5px; left: 5px;
+  width: 30px; height: 30px;
+  border-radius: 50%;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+}
+.identity-avatar-img { width: 100%; height: 100%; object-fit: cover; }
+.identity-avatar-initial { color: #fff; font-weight: 700; font-size: 0.9rem; }
+
+.identity-level {
+  position: absolute;
+  bottom: -2px; right: -2px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 3px;
+  border-radius: 999px;
+  background: #ff3b7f;
+  color: #fff;
+  font-size: 0.62rem;
+  font-weight: 800;
+  line-height: 16px;
+  text-align: center;
+  box-shadow: 0 0 0 2px #fff;
+}
+
+.identity-title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: #12b3b3;
+  white-space: nowrap;
+  max-width: 140px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.identity-title[hidden] { display: none; }
+
+@keyframes identity-pulse {
+  0% { transform: scale(1); }
+  45% { transform: scale(1.12); }
+  100% { transform: scale(1); }
+}
+.cr-identity-chip.identity-pulse .identity-ring-wrap { animation: identity-pulse 500ms ease; }
+
+/* On narrow screens the header is crowded (streak pill + progress + voice
+ * toggle inject here). Hide the inline title; it's reachable via tap-to-reveal. */
+@media (max-width: 640px) {
+  .identity-title { display: none; }
+  .cr-identity-chip { padding: 2px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .identity-ring-fill { transition: none; }
+  .cr-identity-chip.identity-pulse .identity-ring-wrap { animation: none; }
+}
+
+/* Title picker popover */
+.cr-title-popover {
+  position: fixed;
+  z-index: 1200;
+  min-width: 200px;
+  max-width: 260px;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.18);
+  padding: 8px;
+  font-family: Inter, sans-serif;
+}
+.cr-title-head {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #5b6876;
+  padding: 4px 8px 6px;
+}
+.cr-title-empty { font-size: 0.82rem; color: #5b6876; padding: 8px; line-height: 1.4; }
+.cr-title-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  background: transparent;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.88rem;
+  color: #18202b;
+}
+.cr-title-option:hover { background: rgba(18, 179, 179, 0.1); }
+.cr-title-option.is-active { background: rgba(18, 179, 179, 0.15); }
+.cr-title-name { font-weight: 700; }
+.cr-title-meta { font-size: 0.72rem; color: #5b6876; }
+
+/* Title-earn ceremony card */
+.title-card-celebration {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(15, 26, 36, 0.55);
+  opacity: 0;
+  transition: opacity 400ms ease;
+  cursor: pointer;
+}
+.title-card-celebration.show { opacity: 1; }
+.title-card-inner {
+  text-align: center;
+  padding: 32px 44px;
+  border-radius: 20px;
+  background: linear-gradient(135deg, #12b3b3 0%, #0f8a8a 100%);
+  color: #fff;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+  transform: scale(0.9);
+  transition: transform 400ms cubic-bezier(0.2, 0.9, 0.3, 1.2);
+}
+.title-card-celebration.show .title-card-inner { transform: scale(1); }
+.title-card-eyebrow {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  opacity: 0.85;
+}
+.title-card-name {
+  font-size: 2rem;
+  font-weight: 800;
+  margin: 8px 0 4px;
+}
+.title-card-sub { font-size: 0.95rem; opacity: 0.9; }
+
+@media (prefers-reduced-motion: reduce) {
+  .title-card-celebration,
+  .title-card-inner { transition: none; }
+  .title-card-inner { transform: none; }
+}

--- a/public/css/status-card.css
+++ b/public/css/status-card.css
@@ -1,0 +1,116 @@
+/* status-card.css — Personal Status Card modal.
+ * Opens from the header Progress button on all viewports (replaces the dead
+ * mobile-drawer hack). Brand tokens: teal #12B3B3, hot pink #FF3B7F, gold #FFC24B.
+ */
+
+.sc-modal { position: fixed; inset: 0; z-index: 3000; }
+.sc-modal[hidden] { display: none; }
+
+.sc-backdrop {
+  position: absolute; inset: 0;
+  background: rgba(15, 26, 36, 0.55);
+  opacity: 0; transition: opacity 200ms ease;
+}
+.sc-modal.sc-open .sc-backdrop { opacity: 1; }
+
+.sc-card {
+  position: absolute;
+  top: 50%; left: 50%;
+  transform: translate(-50%, -48%) scale(0.96);
+  opacity: 0;
+  width: min(440px, calc(100vw - 32px));
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
+  background: #fff;
+  border-radius: 20px;
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.35);
+  padding: 22px;
+  font-family: Inter, sans-serif;
+  transition: transform 220ms cubic-bezier(0.2, 0.9, 0.3, 1.1), opacity 200ms ease;
+}
+.sc-modal.sc-open .sc-card { transform: translate(-50%, -50%) scale(1); opacity: 1; }
+
+.sc-close {
+  position: absolute; top: 12px; right: 14px;
+  border: none; background: transparent;
+  font-size: 1.6rem; line-height: 1; color: #5b6876; cursor: pointer;
+}
+.sc-close:hover { color: #18202b; }
+
+/* Hero: avatar ring + identity */
+.sc-hero { display: flex; align-items: center; gap: 16px; }
+.sc-avatar-wrap { position: relative; width: 60px; height: 60px; flex: 0 0 60px; }
+.sc-ring { position: absolute; inset: 0; width: 60px; height: 60px; }
+.sc-ring-track { fill: none; stroke: rgba(18, 179, 179, 0.18); stroke-width: 4; }
+.sc-ring-fill { fill: none; stroke: #12b3b3; stroke-width: 4; stroke-linecap: round; transition: stroke-dashoffset 500ms ease; }
+.sc-avatar {
+  position: absolute; top: 7px; left: 7px; width: 46px; height: 46px;
+  border-radius: 50%; overflow: hidden; display: flex; align-items: center; justify-content: center;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+}
+.sc-avatar-img { width: 100%; height: 100%; object-fit: cover; }
+.sc-avatar-initial { color: #fff; font-weight: 700; font-size: 1.3rem; }
+.sc-level-badge {
+  position: absolute; bottom: -3px; right: -3px;
+  min-width: 22px; height: 22px; padding: 0 5px;
+  border-radius: 999px; background: #ff3b7f; color: #fff;
+  font-size: 0.72rem; font-weight: 800; line-height: 22px; text-align: center;
+  box-shadow: 0 0 0 2px #fff;
+}
+.sc-identity { flex: 1; min-width: 0; }
+.sc-name { font-size: 1.15rem; font-weight: 800; color: #18202b; }
+.sc-rank { font-size: 0.85rem; font-weight: 700; color: #12b3b3; margin-top: 1px; }
+.sc-lab-cta {
+  display: inline-block; margin-top: 6px;
+  font-size: 0.78rem; font-weight: 700; color: #ff3b7f; text-decoration: none;
+}
+.sc-lab-cta:hover { text-decoration: underline; }
+
+/* Stat row */
+.sc-stats {
+  display: flex; gap: 8px; margin: 18px 0 10px;
+}
+.sc-stat {
+  flex: 1; text-align: center;
+  background: #f5f8fa; border-radius: 12px; padding: 10px 6px;
+}
+.sc-stat-val { display: block; font-size: 1.15rem; font-weight: 800; color: #18202b; }
+.sc-stat-label { display: block; font-size: 0.68rem; color: #5b6876; margin-top: 2px; }
+
+.sc-progress-row { margin-bottom: 16px; }
+.sc-progress-bar { height: 8px; border-radius: 999px; background: rgba(18, 179, 179, 0.15); overflow: hidden; }
+.sc-progress-fill { height: 100%; border-radius: 999px; background: linear-gradient(90deg, #12b3b3, #16c86d); transition: width 500ms ease; }
+
+/* Tutor message */
+.sc-tutor {
+  display: flex; align-items: center; gap: 10px;
+  background: linear-gradient(135deg, rgba(18,179,179,0.08), rgba(255,59,127,0.06));
+  border-radius: 14px; padding: 10px 12px; margin-bottom: 16px;
+}
+.sc-tutor[hidden] { display: none; }
+.sc-tutor-img { width: 40px; height: 40px; border-radius: 50%; object-fit: cover; flex: 0 0 40px; background: #e6eef0; }
+.sc-tutor-bubble { font-size: 0.85rem; line-height: 1.35; }
+.sc-tutor-name { font-weight: 800; color: #12b3b3; margin-right: 6px; }
+.sc-tutor-text { color: #18202b; }
+
+/* Quests */
+.sc-quests-head { font-size: 0.9rem; font-weight: 800; color: #18202b; margin-bottom: 8px; }
+.sc-quests { display: flex; flex-direction: column; gap: 10px; }
+.sc-quest { background: #f5f8fa; border-radius: 12px; padding: 10px 12px; }
+.sc-quest.is-complete { background: rgba(22, 200, 109, 0.12); }
+.sc-quest-top { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; }
+.sc-quest-name { font-size: 0.86rem; font-weight: 700; color: #18202b; }
+.sc-quest-reward { font-size: 0.74rem; font-weight: 800; color: #12b3b3; white-space: nowrap; }
+.sc-quest-bar { height: 6px; border-radius: 999px; background: rgba(0,0,0,0.06); overflow: hidden; margin: 6px 0 3px; }
+.sc-quest-fill { height: 100%; border-radius: 999px; background: linear-gradient(90deg, #12b3b3, #16c86d); }
+.sc-quest-count { font-size: 0.72rem; color: #5b6876; text-align: right; }
+.sc-quests-empty { font-size: 0.82rem; color: #5b6876; text-align: center; padding: 12px; }
+
+@media (prefers-reduced-motion: reduce) {
+  .sc-backdrop, .sc-card, .sc-ring-fill, .sc-progress-fill { transition: none; }
+}
+
+@media (max-width: 480px) {
+  .sc-card { padding: 18px; border-radius: 16px; }
+  .sc-stat-val { font-size: 1rem; }
+}

--- a/public/js/chat-redesign.js
+++ b/public/js/chat-redesign.js
@@ -414,8 +414,13 @@
     const btn = document.getElementById('cr-progress-btn');
     if (!btn) return;
     btn.addEventListener('click', function () {
-      // Open the existing right drawer (Progress & Profile)
-      document.getElementById('right-drawer-toggle')?.click();
+      // Open the Personal Status Card modal (works on all viewports). Falls back
+      // to the legacy mobile drawer if the module hasn't loaded yet.
+      if (typeof window.openStatusCard === 'function') {
+        window.openStatusCard();
+      } else {
+        document.getElementById('right-drawer-toggle')?.click();
+      }
     });
   }
 

--- a/public/js/modules/comboMeter.js
+++ b/public/js/modules/comboMeter.js
@@ -1,0 +1,143 @@
+// modules/comboMeter.js
+// Feature A — Combo Meter (chat, client-side v1). Surfaces answer momentum in
+// the chat surface where students actually live. NO XP is attached in v1 (see
+// spec Non-Goals); this is pure feedback juice keyed off the per-turn payload.
+//
+// Pedagogy constraint (non-negotiable): in tutor mode the combo COOLS on a wrong
+// answer (rung −1), it never "shatters." Wrongness must stay safe here — a
+// dramatic combo-break would punish the exact behavior Tier-3 XP rewards
+// (catching your own error). Full break/shatter effects belong to Showdown and
+// Fact Fluency Blaster, where speed/accuracy competition is the explicit frame.
+
+const MOUNT_ID = 'combo-chip';
+const GLOW_TARGET_ID = 'chat-container';
+const MAX_GLOW_RUNG = 5; // visual escalation caps here; the counter keeps counting
+
+// Ascending pentatonic solve-sound ladder (C5 D5 E5 G5 A5). Index by rung,
+// sustaining the top pitch past rung 5.
+const PITCH_LADDER = [523.25, 587.33, 659.25, 783.99, 880.0];
+
+let rung = 0;
+let audioCtx = null;
+
+function prefersReducedMotion() {
+    return window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+function soundEnabled() {
+    // Respect an explicit opt-out; default on. Mirrors the conservative pattern
+    // used by other client sound (notifications.js).
+    if (window.MM_SOUND_ENABLED === false) return false;
+    try {
+        if (localStorage.getItem('mm_sound_enabled') === 'false') return false;
+    } catch { /* localStorage may be unavailable */ }
+    return true;
+}
+
+function ensureChip() {
+    let chip = document.getElementById(MOUNT_ID);
+    if (chip) return chip;
+    chip = document.createElement('div');
+    chip.id = MOUNT_ID;
+    chip.className = 'combo-chip';
+    chip.setAttribute('role', 'status');
+    chip.setAttribute('aria-live', 'polite');
+    chip.hidden = true;
+    chip.innerHTML = '<span class="combo-flame" aria-hidden="true">🔥</span><span class="combo-count"></span>';
+    // Mounted on body: the chip is position:fixed, so a parent with overflow or
+    // a transform (containing block) would otherwise clip it.
+    document.body.appendChild(chip);
+    return chip;
+}
+
+function renderChip() {
+    const chip = ensureChip();
+    if (!chip) return;
+    if (rung >= 2) {
+        // A "combo of 1" is noise — only surface at 2+.
+        chip.querySelector('.combo-count').textContent = `x${rung}`;
+        chip.hidden = false;
+        chip.classList.toggle('combo-reduced', prefersReducedMotion());
+        // Re-trigger the tick pop animation on each change.
+        chip.classList.remove('combo-pop');
+        void chip.offsetWidth;
+        if (!prefersReducedMotion()) chip.classList.add('combo-pop');
+    } else {
+        chip.hidden = true;
+    }
+}
+
+function renderGlow() {
+    const host = document.getElementById(GLOW_TARGET_ID);
+    if (!host) return;
+    // Rungs 2/3/4/5 → 0.25/0.5/0.75/1.0. Below 2 → 0 (glow eases out via the CSS
+    // transition on --combo-intensity, ~600ms).
+    let intensity = 0;
+    if (rung >= 2) {
+        const capped = Math.min(rung, MAX_GLOW_RUNG);
+        intensity = (capped - 1) / (MAX_GLOW_RUNG - 1); // rung2→0.25 … rung5→1.0
+    }
+    host.style.setProperty('--combo-intensity', prefersReducedMotion() ? '0' : String(intensity));
+    host.classList.toggle('combo-active', rung >= 2 && !prefersReducedMotion());
+}
+
+function playRungSound() {
+    if (!soundEnabled()) return;
+    try {
+        const Ctx = window.AudioContext || window.webkitAudioContext;
+        if (!Ctx) return;
+        if (!audioCtx) audioCtx = new Ctx();
+        if (audioCtx.state === 'suspended') audioCtx.resume();
+        const idx = Math.min(rung, PITCH_LADDER.length) - 1; // rung 1..5 → 0..4, sustain top
+        const freq = PITCH_LADDER[Math.max(0, idx)];
+        const now = audioCtx.currentTime;
+        const osc = audioCtx.createOscillator();
+        const gain = audioCtx.createGain();
+        osc.type = 'sine';
+        osc.frequency.setValueAtTime(freq, now);
+        gain.gain.setValueAtTime(0.0001, now);
+        gain.gain.exponentialRampToValueAtTime(0.12, now + 0.02);
+        gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.22);
+        osc.connect(gain).connect(audioCtx.destination);
+        osc.start(now);
+        osc.stop(now + 0.24);
+    } catch { /* audio is best-effort; never block the turn */ }
+}
+
+/**
+ * Advance the combo based on a chat turn's verified problem result.
+ * @param {'correct'|'incorrect'|null|undefined} problemResult
+ *   From the chat response (D1: reliable, null on neutral/discussion turns).
+ */
+export function registerTurn(problemResult) {
+    if (problemResult === 'correct') {
+        rung += 1;
+        renderChip();
+        renderGlow();
+        playRungSound(); // sound only on rung-up
+    } else if (problemResult === 'incorrect') {
+        // Cool, don't shatter.
+        rung = Math.max(0, rung - 1);
+        renderChip();
+        renderGlow(); // glow eases down via CSS transition; no negative sound, no red
+    }
+    // Neutral turns (null): hold — no change.
+}
+
+/** Reset the combo (session end / conversation switch). */
+export function resetCombo() {
+    rung = 0;
+    renderChip();
+    renderGlow();
+}
+
+/** Current rung — exposed for instrumentation (combo rung distribution metric). */
+export function getComboRung() {
+    return rung;
+}
+
+// Also expose on window so non-module callers (e.g. conversation-switch hook in
+// script.js) can reset without an import cycle.
+if (typeof window !== 'undefined') {
+    window.comboMeter = { registerTurn, resetCombo, getComboRung };
+}

--- a/public/js/modules/identityChip.js
+++ b/public/js/modules/identityChip.js
@@ -1,0 +1,226 @@
+// modules/identityChip.js
+// Feature B — Identity Chip (level ring + rank title). A persistent identity /
+// goal-gradient display in the chat header: the student's avatar wrapped in a
+// level-progress ring, their level, and their highest-earned rank title.
+//
+// Data sources (all already on the client — no new endpoint, see D2):
+//   • currentUser.xpForCurrentLevel / xpForNextLevel  (ring fill)
+//   • currentUser.level                                (badge)
+//   • currentUser.xpLadderStats.tier3Behaviors         (rank titles)
+//   • currentUser.avatar.dicebearUrl                   (portrait)
+//
+// FERPA: this chip is the student's OWN header view, so no directory-info
+// redaction is needed here. Classmate-visible rank surfaces (leaderboard rows,
+// Showdown cards) ship in Feature C and MUST run through hasOptedOutOfDirectoryInfo.
+
+import { triggerConfetti } from './helpers.js';
+import { computeEarnedTitles, highestTitle } from './rankTitles.js';
+
+const RING_R = 16;
+const RING_C = 2 * Math.PI * RING_R; // circumference
+
+const SELECTED_KEY = 'mm_selected_title';   // behavior the student chose to display
+const LAST_SEEN_KEY = 'mm_last_rank_title';  // for one-time earn ceremony
+
+let lastProgress = null;
+
+function lsGet(k) { try { return localStorage.getItem(k); } catch { return null; } }
+function lsSet(k, v) { try { localStorage.setItem(k, v); } catch { /* ignore */ } }
+
+function avatarMarkup(user) {
+    const url = user?.avatar?.dicebearUrl;
+    if (url) return `<img class="identity-avatar-img" src="${url}" alt="My avatar" />`;
+    const initial = (user?.firstName || '?').charAt(0);
+    return `<span class="identity-avatar-initial" aria-hidden="true">${initial}</span>`;
+}
+
+function buildChip() {
+    const host = document.querySelector('.cr-header-extras');
+    if (!host) return null;
+    let chip = document.getElementById('cr-identity-chip');
+    if (chip) return chip;
+
+    chip = document.createElement('button');
+    chip.type = 'button';
+    chip.id = 'cr-identity-chip';
+    chip.className = 'cr-identity-chip';
+    chip.setAttribute('aria-label', 'Your level and rank');
+    chip.innerHTML = `
+      <span class="identity-ring-wrap">
+        <svg class="identity-ring" viewBox="0 0 40 40" aria-hidden="true">
+          <circle class="identity-ring-track" cx="20" cy="20" r="${RING_R}" />
+          <circle class="identity-ring-fill" cx="20" cy="20" r="${RING_R}"
+                  stroke-dasharray="${RING_C.toFixed(2)}" stroke-dashoffset="${RING_C.toFixed(2)}"
+                  transform="rotate(-90 20 20)" />
+        </svg>
+        <span class="identity-avatar">${avatarMarkup(null)}</span>
+        <span class="identity-level" id="cr-identity-level">1</span>
+      </span>
+      <span class="identity-title" id="cr-identity-title" hidden></span>
+    `;
+    // Insert to the LEFT of the streak pill.
+    const streak = document.getElementById('cr-streak-pill');
+    if (streak && streak.parentElement === host) host.insertBefore(chip, streak);
+    else host.insertBefore(chip, host.firstChild);
+
+    chip.addEventListener('click', toggleTitlePopover);
+    return chip;
+}
+
+/** The title to display: the student's chosen one if still earned, else highest. */
+function resolveDisplayTitle(user) {
+    const behaviors = user?.xpLadderStats?.tier3Behaviors;
+    const earned = computeEarnedTitles(behaviors);
+    if (!earned.length) return null;
+    const chosen = lsGet(SELECTED_KEY);
+    if (chosen) {
+        const match = earned.find(e => e.behavior === chosen);
+        if (match) return match;
+    }
+    return earned[0]; // highest
+}
+
+function toggleTitlePopover(evt) {
+    if (evt) evt.stopPropagation();
+    const existing = document.getElementById('cr-title-popover');
+    if (existing) { existing.remove(); return; }
+
+    const user = window.currentUser;
+    const earned = computeEarnedTitles(user?.xpLadderStats?.tier3Behaviors);
+    const chip = document.getElementById('cr-identity-chip');
+    if (!chip) return;
+
+    const pop = document.createElement('div');
+    pop.id = 'cr-title-popover';
+    pop.className = 'cr-title-popover';
+    pop.setAttribute('role', 'menu');
+
+    if (!earned.length) {
+        pop.innerHTML = `<div class="cr-title-empty">Earn rank titles by showing your thinking —
+          catch your own mistakes, explain your reasoning, stick with hard problems.</div>`;
+    } else {
+        const current = resolveDisplayTitle(user);
+        pop.innerHTML = `<div class="cr-title-head">Choose your title</div>` +
+            earned.map(e => `
+              <button type="button" class="cr-title-option${current && e.behavior === current.behavior ? ' is-active' : ''}"
+                      data-behavior="${e.behavior}" role="menuitemradio">
+                <span class="cr-title-name">${e.title}</span>
+                <span class="cr-title-meta">${e.count}×</span>
+              </button>`).join('');
+    }
+
+    document.body.appendChild(pop);
+    const r = chip.getBoundingClientRect();
+    pop.style.top = `${r.bottom + 8}px`;
+    pop.style.left = `${Math.max(8, r.left)}px`;
+
+    pop.querySelectorAll('.cr-title-option').forEach(btn => {
+        btn.addEventListener('click', () => {
+            lsSet(SELECTED_KEY, btn.dataset.behavior);
+            pop.remove();
+            updateIdentityChip(window.currentUser);
+        });
+    });
+
+    // Dismiss on outside click.
+    setTimeout(() => {
+        const onDoc = (e) => {
+            if (!pop.contains(e.target) && e.target !== chip) {
+                pop.remove();
+                document.removeEventListener('click', onDoc);
+            }
+        };
+        document.addEventListener('click', onDoc);
+    }, 0);
+}
+
+function fireTitleCeremony(title) {
+    try { triggerConfetti(); } catch { /* optional */ }
+    const card = document.createElement('div');
+    card.className = 'title-card-celebration';
+    card.setAttribute('role', 'status');
+    card.innerHTML = `
+      <div class="title-card-inner">
+        <div class="title-card-eyebrow">New Title Earned</div>
+        <div class="title-card-name">${title}</div>
+        <div class="title-card-sub">This is who you're becoming.</div>
+      </div>`;
+    document.body.appendChild(card);
+    void card.offsetWidth;
+    card.classList.add('show');
+    const dismiss = () => {
+        card.classList.remove('show');
+        setTimeout(() => card.remove(), 400);
+    };
+    card.addEventListener('click', dismiss);
+    setTimeout(dismiss, 4500);
+}
+
+/**
+ * Update the chip from the current user object. Safe to call every turn.
+ * @param {Object} user
+ * @param {{celebrate?: boolean}} [opts] celebrate=false seeds the baseline
+ *   without firing the earn ceremony (used on initial load).
+ */
+export function updateIdentityChip(user, opts = {}) {
+    const { celebrate = true } = opts;
+    if (!user) return;
+    const chip = buildChip();
+    if (!chip) return;
+
+    // Avatar (may have changed via Avatar Builder).
+    const avatarSlot = chip.querySelector('.identity-avatar');
+    if (avatarSlot) avatarSlot.innerHTML = avatarMarkup(user);
+
+    // Level badge.
+    const levelEl = chip.querySelector('#cr-identity-level');
+    if (levelEl && user.level != null) levelEl.textContent = String(user.level);
+
+    // Ring progress toward next level.
+    const cur = Number(user.xpForCurrentLevel);
+    const need = Number(user.xpForNextLevel);
+    const progress = (need > 0 && Number.isFinite(cur)) ? Math.max(0, Math.min(1, cur / need)) : 0;
+    const fill = chip.querySelector('.identity-ring-fill');
+    if (fill) {
+        fill.style.strokeDashoffset = String(RING_C * (1 - progress));
+        // Pulse when the ring grows (goal-gradient reinforcement).
+        if (lastProgress !== null && progress > lastProgress) {
+            chip.classList.remove('identity-pulse');
+            void chip.offsetWidth;
+            chip.classList.add('identity-pulse');
+        }
+    }
+    lastProgress = progress;
+
+    // Rank title.
+    const titleEl = chip.querySelector('#cr-identity-title');
+    const display = resolveDisplayTitle(user);
+    if (titleEl) {
+        if (display) {
+            titleEl.textContent = display.title;
+            titleEl.hidden = false;
+        } else {
+            titleEl.textContent = '';
+            titleEl.hidden = true;
+        }
+    }
+
+    // One-time earn ceremony when the student's HIGHEST title advances.
+    // Baseline is seeded on first sight (or the init call) so we never fire
+    // retroactively for titles the student already had — only genuine advances.
+    const top = highestTitle(user.xpLadderStats?.tier3Behaviors);
+    const currentKey = top ? `${top.behavior}:${top.tier}` : 'none';
+    const stored = lsGet(LAST_SEEN_KEY);
+    if (stored === null) {
+        lsSet(LAST_SEEN_KEY, currentKey); // seed baseline, no ceremony
+    } else if (stored !== currentKey) {
+        lsSet(LAST_SEEN_KEY, currentKey);
+        if (top && celebrate) fireTitleCeremony(top.title);
+    }
+}
+
+/** Initialize on page load. Seeds the title baseline without a ceremony. */
+export function initIdentityChip(user) {
+    buildChip();
+    updateIdentityChip(user, { celebrate: false });
+}

--- a/public/js/modules/rankTitles.js
+++ b/public/js/modules/rankTitles.js
@@ -1,0 +1,73 @@
+// modules/rankTitles.js
+// Rank title ladder (identity layer) — CLIENT MIRROR of utils/brand.js
+// `rankTitleLadder`. Titles are derived from cumulative Tier-3 behavior counts
+// (user.xpLadderStats.tier3Behaviors: [{ behavior, count, lastEarned }]).
+//
+// ⚠️ Keep this in sync with utils/brand.js. The server config is canonical;
+// this mirror exists because brand.js is CommonJS and cannot be imported by the
+// ES-module client bundle. D2 verified the raw tier3Behaviors array already
+// reaches the client on the GET /user payload, so titles compute client-side.
+
+export const RANK_THRESHOLDS = [5, 15, 40]; // counts for tier 1 / 2 / 3
+
+export const RANK_TITLE_LADDER = {
+    caught_own_error:    ['Error Spotter', 'Error Hunter', 'Error Hunter II'],
+    explained_reasoning: ['Explainer', 'Reasoner', 'Master Reasoner'],
+    persistence:         ['Grinder', 'Unshakeable', 'Relentless'],
+    taught_back:         ['Study Buddy', 'Tutor-in-Training', 'The Professor'],
+    strategy_selection:  ['Planner', 'Strategist', 'Grandmaster'],
+    transfer:            ['Connector', 'Pattern Seer', 'Polymath'],
+};
+
+/**
+ * Given a behavior's cumulative count, return the earned tier index
+ * (0-based: 0 = first title … 2 = top title) or -1 if none earned yet.
+ */
+function tierForCount(count) {
+    let tier = -1;
+    for (let i = 0; i < RANK_THRESHOLDS.length; i++) {
+        if (count >= RANK_THRESHOLDS[i]) tier = i;
+    }
+    return tier;
+}
+
+/**
+ * Normalize the tier3Behaviors array (from user.xpLadderStats) into a count map.
+ * Tolerates a missing/!array input.
+ */
+function toCountMap(tier3Behaviors) {
+    const map = {};
+    if (Array.isArray(tier3Behaviors)) {
+        for (const entry of tier3Behaviors) {
+            if (entry && entry.behavior) map[entry.behavior] = entry.count || 0;
+        }
+    }
+    return map;
+}
+
+/**
+ * Compute the highest earned title per behavior.
+ * @returns {Array<{behavior, tier, title, count}>} one entry per behavior that
+ *          has earned at least tier 0, sorted best-first (tier desc, count desc).
+ */
+export function computeEarnedTitles(tier3Behaviors) {
+    const counts = toCountMap(tier3Behaviors);
+    const earned = [];
+    for (const [behavior, titles] of Object.entries(RANK_TITLE_LADDER)) {
+        const count = counts[behavior] || 0;
+        const tier = tierForCount(count);
+        if (tier >= 0) {
+            earned.push({ behavior, tier, title: titles[tier], count });
+        }
+    }
+    earned.sort((a, b) => (b.tier - a.tier) || (b.count - a.count));
+    return earned;
+}
+
+/**
+ * The single most impressive earned title (or null if none earned yet).
+ */
+export function highestTitle(tier3Behaviors) {
+    const earned = computeEarnedTitles(tier3Behaviors);
+    return earned.length ? earned[0] : null;
+}

--- a/public/js/modules/statusCard.js
+++ b/public/js/modules/statusCard.js
@@ -1,0 +1,201 @@
+// modules/statusCard.js
+// Personal Status Card — the "who am I in Mathmatix" surface. Replaces the dead
+// Progress button (which used to click a mobile-only drawer that has no desktop
+// presentation) with a proper centered modal that works on every viewport AND
+// surfaces daily quests, which were previously buried in that unreachable drawer.
+//
+// Everything is built from data already on the client (window.currentUser) plus
+// the existing /api/daily-quests endpoint — no new server work.
+//
+// Forward slots (light up when those systems ship, hidden until then):
+//   • Coins        — shown only if currentUser.wallet.coins is present.
+//   • Full-body avatar — today shows the DiceBear portrait; the "Creation Lab"
+//     CTA deep-links to the existing avatar builder.
+
+import { highestTitle } from './rankTitles.js';
+
+const MODAL_ID = 'status-card-modal';
+
+function ringDash(progress) {
+    const r = 26, c = 2 * Math.PI * r;
+    return { c, offset: c * (1 - Math.max(0, Math.min(1, progress))) };
+}
+
+function avatarMarkup(user) {
+    const url = user?.avatar?.dicebearUrl;
+    if (url) return `<img class="sc-avatar-img" src="${url}" alt="Your avatar" />`;
+    const initial = (user?.firstName || '?').charAt(0);
+    return `<span class="sc-avatar-initial" aria-hidden="true">${initial}</span>`;
+}
+
+function tutorMessage(user) {
+    // Persona-authentic line from the selected tutor. Real data (their catchphrase),
+    // not fabricated praise. A richer, history-aware message can replace this once
+    // a tutorPlan-backed endpoint exists.
+    const cfg = window.TUTOR_CONFIG || {};
+    const tutor = cfg[user?.selectedTutorId];
+    if (!tutor) return null;
+    return { name: tutor.name, image: tutor.image, text: tutor.catchphrase || '' };
+}
+
+function questRowHTML(q) {
+    const pct = q.targetCount > 0 ? Math.min((q.progress / q.targetCount) * 100, 100) : 0;
+    return `
+      <div class="sc-quest ${q.completed ? 'is-complete' : ''}">
+        <div class="sc-quest-top">
+          <span class="sc-quest-name">${q.completed ? '✅ ' : ''}${q.name || q.title || q.type || 'Quest'}</span>
+          <span class="sc-quest-reward">+${q.xpReward || 50} XP</span>
+        </div>
+        <div class="sc-quest-bar"><div class="sc-quest-fill" style="width:${pct}%"></div></div>
+        <div class="sc-quest-count">${q.progress || 0}/${q.targetCount || 0}</div>
+      </div>`;
+}
+
+async function loadQuests(mount) {
+    try {
+        const res = await fetch('/api/daily-quests', { credentials: 'include' });
+        if (!res.ok) throw new Error(`quests ${res.status}`);
+        const data = await res.json();
+        const quests = data?.quests || [];
+        if (!quests.length) {
+            mount.innerHTML = `<div class="sc-quests-empty">No quests right now — check back tomorrow!</div>`;
+            return;
+        }
+        mount.innerHTML = quests.map(questRowHTML).join('');
+    } catch (e) {
+        mount.innerHTML = `<div class="sc-quests-empty">Couldn't load quests. Try again in a bit.</div>`;
+        console.warn('Status card quests failed', e);
+    }
+}
+
+function buildModal() {
+    let modal = document.getElementById(MODAL_ID);
+    if (modal) return modal;
+
+    modal = document.createElement('div');
+    modal.id = MODAL_ID;
+    modal.className = 'sc-modal';
+    modal.setAttribute('role', 'dialog');
+    modal.setAttribute('aria-modal', 'true');
+    modal.setAttribute('aria-label', 'Your status card');
+    modal.hidden = true;
+    modal.innerHTML = `
+      <div class="sc-backdrop" data-sc-close></div>
+      <div class="sc-card" role="document">
+        <button class="sc-close" type="button" aria-label="Close" data-sc-close>&times;</button>
+
+        <div class="sc-hero">
+          <div class="sc-avatar-wrap">
+            <svg class="sc-ring" viewBox="0 0 60 60" aria-hidden="true">
+              <circle class="sc-ring-track" cx="30" cy="30" r="26" />
+              <circle class="sc-ring-fill" cx="30" cy="30" r="26" transform="rotate(-90 30 30)" />
+            </svg>
+            <span class="sc-avatar"></span>
+            <span class="sc-level-badge"><span class="sc-level-num">1</span></span>
+          </div>
+          <div class="sc-identity">
+            <div class="sc-name"></div>
+            <div class="sc-rank"></div>
+            <a class="sc-lab-cta" href="/avatar-builder.html">🎨 Design in the Creation Lab</a>
+          </div>
+        </div>
+
+        <div class="sc-stats">
+          <div class="sc-stat"><span class="sc-stat-val sc-xp">0 / 100</span><span class="sc-stat-label">XP to next level</span></div>
+          <div class="sc-stat"><span class="sc-stat-val sc-total-xp">0</span><span class="sc-stat-label">Total XP</span></div>
+          <div class="sc-stat sc-coins-stat" hidden><span class="sc-stat-val sc-coins">0</span><span class="sc-stat-label">Coins</span></div>
+          <div class="sc-stat"><span class="sc-stat-val sc-streak">0</span><span class="sc-stat-label">Day streak</span></div>
+        </div>
+
+        <div class="sc-progress-row">
+          <div class="sc-progress-bar"><div class="sc-progress-fill"></div></div>
+        </div>
+
+        <div class="sc-tutor" hidden>
+          <img class="sc-tutor-img" alt="" />
+          <div class="sc-tutor-bubble"><span class="sc-tutor-name"></span><span class="sc-tutor-text"></span></div>
+        </div>
+
+        <div class="sc-quests-block">
+          <div class="sc-quests-head">🎯 Today's Quests</div>
+          <div class="sc-quests" id="sc-quests-mount"><div class="sc-quests-empty">Loading…</div></div>
+        </div>
+      </div>`;
+
+    document.body.appendChild(modal);
+    modal.querySelectorAll('[data-sc-close]').forEach(el =>
+        el.addEventListener('click', closeStatusCard));
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && !modal.hidden) closeStatusCard();
+    });
+    return modal;
+}
+
+function populate(modal, user) {
+    if (!user) return;
+    const q = (sel) => modal.querySelector(sel);
+
+    q('.sc-avatar').innerHTML = avatarMarkup(user);
+    q('.sc-name').textContent = user.firstName || 'Mathematician';
+    q('.sc-level-num').textContent = String(user.level || 1);
+
+    // Rank title (identity layer).
+    const rank = highestTitle(user.xpLadderStats?.tier3Behaviors);
+    q('.sc-rank').textContent = rank ? rank.title : 'Rising Mathematician';
+
+    // XP + progress ring/bar.
+    const cur = Number(user.xpForCurrentLevel) || 0;
+    const need = Number(user.xpForNextLevel) || 100;
+    const progress = need > 0 ? cur / need : 0;
+    q('.sc-xp').textContent = `${cur} / ${need}`;
+    q('.sc-total-xp').textContent = String(user.xp ?? 0);
+    q('.sc-streak').textContent = String(user.dailyQuests?.currentStreak ?? 0);
+
+    const { c, offset } = ringDash(progress);
+    const fill = q('.sc-ring-fill');
+    fill.setAttribute('stroke-dasharray', c.toFixed(2));
+    fill.setAttribute('stroke-dashoffset', offset.toFixed(2));
+    q('.sc-progress-fill').style.width = `${Math.min(100, progress * 100)}%`;
+
+    // Coins — forward slot, only shown once a wallet exists.
+    const coins = user.wallet?.coins;
+    if (coins != null) {
+        q('.sc-coins').textContent = String(coins);
+        q('.sc-coins-stat').hidden = false;
+    }
+
+    // Tutor message.
+    const msg = tutorMessage(user);
+    const tutorEl = q('.sc-tutor');
+    if (msg && msg.text) {
+        q('.sc-tutor-img').src = `/images/tutor_avatars/${msg.image}`;
+        q('.sc-tutor-img').alt = msg.name;
+        q('.sc-tutor-name').textContent = msg.name;
+        q('.sc-tutor-text').textContent = msg.text;
+        tutorEl.hidden = false;
+    } else {
+        tutorEl.hidden = true;
+    }
+}
+
+export function openStatusCard() {
+    const user = window.currentUser;
+    const modal = buildModal();
+    populate(modal, user);
+    loadQuests(modal.querySelector('#sc-quests-mount'));
+    modal.hidden = false;
+    void modal.offsetWidth; // reflow so the open transition runs
+    modal.classList.add('sc-open');
+}
+
+export function closeStatusCard() {
+    const modal = document.getElementById(MODAL_ID);
+    if (!modal) return;
+    modal.classList.remove('sc-open');
+    setTimeout(() => { modal.hidden = true; }, 200);
+}
+
+if (typeof window !== 'undefined') {
+    window.openStatusCard = openStatusCard;
+    window.closeStatusCard = closeStatusCard;
+}

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -8,6 +8,7 @@ import { sessionTracker, initSessionTracking, getActiveSeconds, sendTimeHeartbea
 import { showLevelUpCelebration, triggerXpAnimation as _triggerXpAnimation, updateGamificationDisplay as _updateGamificationDisplay, fetchAndDisplayLeaderboard, loadQuestsAndChallenges, showTutorUnlockCelebration, showUnlockProximityTeaser, processGamificationEvents, processBadgeAward, showNextActionSuggestion } from './modules/gamification.js';
 import { registerTurn as comboRegisterTurn, resetCombo } from './modules/comboMeter.js';
 import { initIdentityChip, updateIdentityChip } from './modules/identityChip.js';
+import './modules/statusCard.js'; // registers window.openStatusCard (Progress button)
 import { checkBillingStatus, updateFreeTimeIndicator, showUpgradePrompt, initiateUpgrade, showManageSubscription } from './modules/billing.js';
 import { audioState, audioQueue, playAudio, processAudioQueue, pauseAudio, resumeAudio, restartAudio, stopAudio, changePlaybackSpeed, resetAudioState, updateAudioControls } from './modules/audio.js';
 import { createIepSystem } from './modules/iep.js';

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -6,6 +6,8 @@ console.log("LOG: Mâˆ†THMâˆ†TIÎ§ AI Initialized");
 import { sleep, getGraphColor, generateSpeakableText, showToast, escapeHtml as escapeHtmlHelper, triggerConfetti } from './modules/helpers.js';
 import { sessionTracker, initSessionTracking, getActiveSeconds, sendTimeHeartbeat } from './modules/session.js';
 import { showLevelUpCelebration, triggerXpAnimation as _triggerXpAnimation, updateGamificationDisplay as _updateGamificationDisplay, fetchAndDisplayLeaderboard, loadQuestsAndChallenges, showTutorUnlockCelebration, showUnlockProximityTeaser, processGamificationEvents, processBadgeAward, showNextActionSuggestion } from './modules/gamification.js';
+import { registerTurn as comboRegisterTurn, resetCombo } from './modules/comboMeter.js';
+import { initIdentityChip, updateIdentityChip } from './modules/identityChip.js';
 import { checkBillingStatus, updateFreeTimeIndicator, showUpgradePrompt, initiateUpgrade, showManageSubscription } from './modules/billing.js';
 import { audioState, audioQueue, playAudio, processAudioQueue, pauseAudio, resumeAudio, restartAudio, stopAudio, changePlaybackSpeed, resetAudioState, updateAudioControls } from './modules/audio.js';
 import { createIepSystem } from './modules/iep.js';
@@ -135,7 +137,7 @@ document.addEventListener("DOMContentLoaded", () => {
             _speechSilenceTimer = setTimeout(() => {
                 // No new speech for 3s — auto-stop and keep text
                 if (isRecognizing) {
-                    try { recognition.stop(); } catch (_) {}
+                    try { recognition.stop(); } catch {}
                 }
             }, SPEECH_AUTO_STOP_MS);
 
@@ -396,6 +398,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
     function setupChatUI() {
         updateGamificationDisplay();
+        // Identity chip (level ring + rank title) in the chat header.
+        try { initIdentityChip(currentUser); } catch (e) { console.warn('Identity chip init failed', e); }
     }
 
     
@@ -2621,7 +2625,7 @@ document.addEventListener("DOMContentLoaded", () => {
             // Auto-detect the user's IANA timezone so the streak day-boundary
             // math respects the student's local day, not server UTC.
             let clientTimezone = null;
-            try { clientTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone; } catch (_) {}
+            try { clientTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone; } catch {}
 
             // Bound the request with an AbortController so a silently-dead
             // SSE connection (proxy closed the socket mid-stream) can't park
@@ -2759,7 +2763,7 @@ document.addEventListener("DOMContentLoaded", () => {
                     if (!streamAbort) return;
                     streamIdleTimer = setTimeout(() => {
                         console.warn(`[Stream] No bytes received in ${STREAM_IDLE_MS}ms — aborting`);
-                        try { streamAbort.abort(); } catch (_) { /* already aborted */ }
+                        try { streamAbort.abort(); } catch { /* already aborted */ }
                     }, STREAM_IDLE_MS);
                 }
                 resetStreamIdleTimer();
@@ -3076,17 +3080,36 @@ document.addEventListener("DOMContentLoaded", () => {
                 }, 2000); // Delay so it doesn't overlap with level-up celebration
             }
 
+            // Reconcile the Tier-3 behavior earned this turn into the local user
+            // so the identity chip's rank title advances live (the /user payload
+            // won't refresh until reload). Mirrors the server increment in
+            // xpEngine.applyXpToUser → xpLadderStats.tier3Behaviors.
+            if (data.xpLadder?.tier3 > 0 && data.xpLadder.tier3Behavior) {
+                if (!currentUser.xpLadderStats) currentUser.xpLadderStats = { tier3Behaviors: [] };
+                if (!Array.isArray(currentUser.xpLadderStats.tier3Behaviors)) currentUser.xpLadderStats.tier3Behaviors = [];
+                const behaviors = currentUser.xpLadderStats.tier3Behaviors;
+                const existing = behaviors.find(b => b.behavior === data.xpLadder.tier3Behavior);
+                if (existing) existing.count = (existing.count || 0) + 1;
+                else behaviors.push({ behavior: data.xpLadder.tier3Behavior, count: 1 });
+            }
+
             if (data.userXp !== undefined) {
                 currentUser.level = data.userLevel;
                 currentUser.xpForCurrentLevel = Math.max(0, data.userXp);
                 currentUser.xpForNextLevel = data.xpNeeded;
                 updateGamificationDisplay();
+                // Identity chip: refresh level ring + rank title from the fresh XP state.
+                try { updateIdentityChip(currentUser); } catch (e) { console.warn('Identity chip update failed', e); }
 
                 // Show unlock proximity teaser (after level-up or when close)
                 if (data.xpLadder?.leveledUp) {
                     setTimeout(() => showUnlockProximityTeaser(currentUser), 5000);
                 }
             }
+
+            // Combo meter: advance/cool off the verified problem result (D1).
+            // null on neutral turns → the combo holds. No XP is attached (v1).
+            try { comboRegisterTurn(data.problemResult); } catch (e) { console.warn('Combo meter failed', e); }
 
             // Session stats tracker update
             if (data.problemResult && typeof window.trackProblemAttempt === 'function') {
@@ -3676,7 +3699,7 @@ document.addEventListener("DOMContentLoaded", () => {
             parent.removeChild(textNode);
 
             if (typeof renderMathInElement === 'function') {
-                try { renderMathInElement(mathSpan); } catch (_) {}
+                try { renderMathInElement(mathSpan); } catch {}
             }
 
             // Restore cursor just after the trigger character
@@ -3984,7 +4007,7 @@ document.addEventListener("DOMContentLoaded", () => {
             // Install our custom MathLive layouts (advanced structures).
             installMathLiveLayouts();
             if (window.mathVirtualKeyboard) {
-                try { window.mathVirtualKeyboard.visible = true; } catch (_) {}
+                try { window.mathVirtualKeyboard.visible = true; } catch {}
             }
         } else if (isMobileView()) {
             // Legacy mobile bottom-sheet path (kept as fallback).
@@ -4155,7 +4178,7 @@ document.addEventListener("DOMContentLoaded", () => {
         }
         // Hide MathLive's virtual keyboard (it was opened by fullscreen mode)
         if (window.mathVirtualKeyboard) {
-            try { window.mathVirtualKeyboard.visible = false; } catch (_) {}
+            try { window.mathVirtualKeyboard.visible = false; } catch {}
         }
         // Tear down fullscreen state on close
         if (inlineEquationPalette && inlineEquationPalette.classList.contains('eq-fullscreen')) {
@@ -5213,6 +5236,9 @@ document.addEventListener("DOMContentLoaded", () => {
             messageIndexCounter = 0; // Reset message counter
             updateChatWatermark(); // Mark chat as empty for watermark
         }
+
+        // Combo meter resets on conversation switch (session boundary).
+        try { resetCombo(); } catch { /* non-blocking */ }
 
         // Display session header if it's a topic-based conversation
         if (conversation.conversationType === 'topic' && conversation.topic) {

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -3108,6 +3108,13 @@ document.addEventListener("DOMContentLoaded", () => {
                 }
             }
 
+            // Coins wallet: reflect the server balance locally so the status
+            // card's Coins slot shows live without a reload.
+            if (data.coins !== undefined) {
+                if (!currentUser.wallet) currentUser.wallet = {};
+                currentUser.wallet.coins = data.coins;
+            }
+
             // Combo meter: advance/cool off the verified problem result (D1).
             // null on neutral turns → the combo holds. No XP is attached (v1).
             try { comboRegisterTurn(data.problemResult); } catch (e) { console.warn('Combo meter failed', e); }

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -1531,6 +1531,8 @@ router.post('/', isAuthenticated, promptInjectionFilter, conditionalUpload, cond
                 ...pipelineResult.xpBreakdown,
                 leveledUp: pipelineResult.leveledUp,
             },
+            coins: user.wallet?.coins ?? 0,
+            coinsAwarded: pipelineResult.coinsAwarded || 0,
             aiTimeUsed: pipelineResult.aiTimeUsed,
             freeWeeklySecondsRemaining: pipelineResult.freeWeeklySecondsRemaining,
             courseProgress: courseProgressUpdate || null,

--- a/routes/cosmetics.js
+++ b/routes/cosmetics.js
@@ -1,0 +1,71 @@
+// routes/cosmetics.js
+// Cosmetics shop — server-authoritative purchase/equip over the earned Coins
+// currency. All validation + mutation lives in utils/cosmeticsCatalog.js; this
+// is a thin HTTP wrapper. Mounted at /api/cosmetics (see config/routes.js).
+const express = require('express');
+const router = express.Router();
+const User = require('../models/user');
+const {
+    CATALOG,
+    DEFAULT_LOADOUT,
+    applyPurchase,
+    applyEquip,
+} = require('../utils/cosmeticsCatalog');
+
+// GET /api/cosmetics/catalog — catalog + this user's balance/owned/equipped.
+router.get('/catalog', async (req, res) => {
+    try {
+        const user = await User.findById(req.user._id).select('wallet ownedCosmetics equippedCosmetics').lean();
+        if (!user) return res.status(401).json({ success: false, error: 'Not authenticated' });
+        res.json({
+            success: true,
+            catalog: CATALOG,
+            coins: user.wallet?.coins ?? 0,
+            owned: user.ownedCosmetics || [],
+            equipped: { ...DEFAULT_LOADOUT, ...(user.equippedCosmetics || {}) },
+        });
+    } catch (err) {
+        console.error('[cosmetics] catalog error:', err.message);
+        res.status(500).json({ success: false, error: 'Could not load catalog' });
+    }
+});
+
+// POST /api/cosmetics/purchase { itemId }
+router.post('/purchase', async (req, res) => {
+    try {
+        const { itemId } = req.body || {};
+        if (!itemId) return res.status(400).json({ success: false, error: 'Missing itemId' });
+        const user = await User.findById(req.user._id);
+        if (!user) return res.status(401).json({ success: false, error: 'Not authenticated' });
+
+        const result = applyPurchase(user, itemId);
+        if (!result.ok) {
+            return res.status(400).json({ success: false, error: result.reason, coins: result.coins });
+        }
+        await user.save();
+        res.json({ success: true, coins: result.coins, owned: result.owned });
+    } catch (err) {
+        console.error('[cosmetics] purchase error:', err.message);
+        res.status(500).json({ success: false, error: 'Purchase failed' });
+    }
+});
+
+// POST /api/cosmetics/equip { slot, itemId }  (itemId 'default' unequips)
+router.post('/equip', async (req, res) => {
+    try {
+        const { slot, itemId } = req.body || {};
+        if (!slot) return res.status(400).json({ success: false, error: 'Missing slot' });
+        const user = await User.findById(req.user._id);
+        if (!user) return res.status(401).json({ success: false, error: 'Not authenticated' });
+
+        const result = applyEquip(user, slot, itemId);
+        if (!result.ok) return res.status(400).json({ success: false, error: result.reason });
+        await user.save();
+        res.json({ success: true, equipped: result.equipped });
+    } catch (err) {
+        console.error('[cosmetics] equip error:', err.message);
+        res.status(500).json({ success: false, error: 'Equip failed' });
+    }
+});
+
+module.exports = router;

--- a/routes/dailyQuests.js
+++ b/routes/dailyQuests.js
@@ -448,9 +448,22 @@ router.post('/daily-quests/update', isAuthenticated, async (req, res) => {
         const xpEarned = Math.round(quest.xpReward * quest.bonusMultiplier);
         user.xp = (user.xp || 0) + xpEarned;
 
+        // Award Coins (earned soft currency; server-authoritative, daily-capped).
+        // Non-blocking — a coin failure must never break quest completion.
+        let coinsEarned = 0;
+        try {
+          const { awardCoins } = require('../utils/coinEngine');
+          const BRAND = require('../utils/brand');
+          const perQuest = (BRAND.coinRewards && BRAND.coinRewards.questComplete) || 0;
+          coinsEarned = awardCoins(user, perQuest, 'quest_complete').awarded;
+        } catch (coinErr) {
+          console.error('[dailyQuests] coin award failed:', coinErr.message);
+        }
+
         completedQuests.push({
           ...quest,
-          xpEarned
+          xpEarned,
+          coinsEarned
         });
       }
     });

--- a/routes/weeklyChallenges.js
+++ b/routes/weeklyChallenges.js
@@ -353,9 +353,22 @@ router.post('/weekly-challenges/update', isAuthenticated, async (req, res) => {
         // Award XP
         user.xp = (user.xp || 0) + challenge.xpReward;
 
+        // Award Coins (earned soft currency; server-authoritative, daily-capped).
+        // Non-blocking — a coin failure must never break challenge completion.
+        let coinsEarned = 0;
+        try {
+          const { awardCoins } = require('../utils/coinEngine');
+          const BRAND = require('../utils/brand');
+          const perChallenge = (BRAND.coinRewards && BRAND.coinRewards.challengeComplete) || 0;
+          coinsEarned = awardCoins(user, perChallenge, 'challenge_complete').awarded;
+        } catch (coinErr) {
+          console.error('[weeklyChallenges] coin award failed:', coinErr.message);
+        }
+
         completedChallenges.push({
           ...challenge,
-          xpEarned: challenge.xpReward
+          xpEarned: challenge.xpReward,
+          coinsEarned
         });
       }
     });

--- a/utils/brand.js
+++ b/utils/brand.js
@@ -150,6 +150,24 @@ const BRAND_CONFIG = {
         ]
     },
 
+    // 11. Rank Title Ladder (identity layer)
+    // Human-readable titles derived from cumulative Tier-3 behavior counts
+    // (user.xpLadderStats.tier3Behaviors). Each behavior has three aspirational
+    // tiers unlocked at the thresholds below. This is the CANONICAL source of
+    // truth; the client mirrors it in public/js/modules/rankTitles.js — keep the
+    // two in sync if you edit either.
+    rankTitleLadder: {
+        thresholds: [5, 15, 40], // counts required for tier 1 / 2 / 3
+        behaviors: {
+            caught_own_error:    ['Error Spotter', 'Error Hunter', 'Error Hunter II'],
+            explained_reasoning: ['Explainer', 'Reasoner', 'Master Reasoner'],
+            persistence:         ['Grinder', 'Unshakeable', 'Relentless'],
+            taught_back:         ['Study Buddy', 'Tutor-in-Training', 'The Professor'],
+            strategy_selection:  ['Planner', 'Strategist', 'Grandmaster'],
+            transfer:            ['Connector', 'Pattern Seer', 'Polymath'],
+        },
+    },
+
     digestEmailSchedule: "Sunday 7 AM ET", //
     digestEmailProvider: "SendGrid", //
 

--- a/utils/brand.js
+++ b/utils/brand.js
@@ -168,6 +168,18 @@ const BRAND_CONFIG = {
         },
     },
 
+    // 12. Coin Economy (earned soft currency for cosmetics)
+    // Coins drip from completion + consistency events (NOT per-turn, to avoid a
+    // grind vector). All awards route through utils/coinEngine.awardCoins, which
+    // enforces the daily cap. See docs/COSMETICS_SHOP_DESIGN.md.
+    coinRewards: {
+        dailyCap: 500,            // max coins earnable per UTC day (anti-abuse)
+        levelUp: 20,              // per level gained
+        questComplete: 15,        // per daily quest completed
+        challengeComplete: 75,    // per weekly challenge completed (wiring TBD)
+        masteryBadge: 100         // per mastery badge earned (wiring TBD)
+    },
+
     digestEmailSchedule: "Sunday 7 AM ET", //
     digestEmailProvider: "SendGrid", //
 

--- a/utils/coinEngine.js
+++ b/utils/coinEngine.js
@@ -1,0 +1,67 @@
+/**
+ * COIN ENGINE — the single server-authoritative entry point for awarding Coins.
+ *
+ * Coins are an EARNED soft currency for cosmetics only. This module is the ONLY
+ * place that should mutate `user.wallet`. It enforces a per-UTC-day cap so no
+ * event path (or bug) can mint unbounded currency, mirroring the XP-cap
+ * discipline in utils/pipeline/xpEngine.js.
+ *
+ * Pure and defensive: accepts a Mongoose doc or a plain object, never throws on
+ * bad input, and only calls markModified when available. Callers are
+ * responsible for user.save().
+ *
+ * @module coinEngine
+ */
+
+const BRAND_CONFIG = require('./brand');
+
+/** Start-of-day in UTC for a given date (matches the app's UTC streak logic). */
+function startOfUtcDay(d) {
+    const x = new Date(d);
+    x.setUTCHours(0, 0, 0, 0);
+    return x;
+}
+
+/**
+ * Award coins to a user, honoring the daily cap.
+ *
+ * @param {Object} user - Mongoose user doc or plain object (mutated in place)
+ * @param {number} amount - Coins to award (floored to a non-negative integer)
+ * @param {string} [reason] - Audit label (e.g. 'level_up', 'quest_complete')
+ * @returns {{awarded:number, coins:number, capped:boolean, reason:(string|null)}}
+ */
+function awardCoins(user, amount, reason) {
+    const cap = (BRAND_CONFIG.coinRewards && BRAND_CONFIG.coinRewards.dailyCap) || 500;
+    const out = { awarded: 0, coins: 0, capped: false, reason: reason || null };
+    if (!user) return out;
+
+    if (!user.wallet) {
+        user.wallet = { coins: 0, lifetimeEarned: 0, dailyEarned: 0, lastCoinReset: new Date() };
+    }
+    const w = user.wallet;
+
+    // Roll over the daily counter when we've crossed into a new UTC day.
+    const now = new Date();
+    const last = w.lastCoinReset ? new Date(w.lastCoinReset) : null;
+    if (!last || startOfUtcDay(last).getTime() < startOfUtcDay(now).getTime()) {
+        w.dailyEarned = 0;
+        w.lastCoinReset = now;
+    }
+
+    const amt = Math.max(0, Math.floor(Number(amount) || 0));
+    if (amt > 0) {
+        const remaining = Math.max(0, cap - (w.dailyEarned || 0));
+        const awarded = Math.min(amt, remaining);
+        w.coins = (w.coins || 0) + awarded;
+        w.lifetimeEarned = (w.lifetimeEarned || 0) + awarded;
+        w.dailyEarned = (w.dailyEarned || 0) + awarded;
+        out.awarded = awarded;
+        out.capped = awarded < amt;
+        if (typeof user.markModified === 'function') user.markModified('wallet');
+    }
+
+    out.coins = w.coins || 0;
+    return out;
+}
+
+module.exports = { awardCoins, startOfUtcDay };

--- a/utils/cosmeticsCatalog.js
+++ b/utils/cosmeticsCatalog.js
@@ -1,0 +1,109 @@
+/**
+ * COSMETICS CATALOG + purchase/equip logic (server-authoritative).
+ *
+ * Cosmetics are bought with earned Coins (utils/coinEngine.js) and are purely
+ * visual — zero effect on tutoring, grading, XP, or progression. This module is
+ * the single source of truth for the catalog and the ONLY place that debits
+ * coins / mutates ownership + loadout. Logic is pure and testable; routes are a
+ * thin wrapper. Callers are responsible for user.save().
+ *
+ * See docs/COSMETICS_SHOP_DESIGN.md.
+ *
+ * @module cosmeticsCatalog
+ */
+
+const SLOTS = ['theme', 'board', 'calculator', 'header'];
+
+// v1 starter catalog. Token-based themes work with no new art; pattern skins
+// (cheetah/camo/etc.) reference art that ships with the shop UI later.
+const CATALOG = {
+    'theme.sunset':   { slot: 'theme',      name: 'Sunset',              price: 250, rarity: 'rare',   skinClass: 'theme-sunset' },
+    'theme.neon':     { slot: 'theme',      name: 'Neon Night',          price: 400, rarity: 'epic',   skinClass: 'theme-neon' },
+    'board.cheetah':  { slot: 'board',      name: 'Cheetah Print Board', price: 250, rarity: 'rare',   skinClass: 'skin-board-cheetah' },
+    'calc.hotpink':   { slot: 'calculator', name: 'Hot Pink Calculator', price: 150, rarity: 'common', skinClass: 'skin-calc-hotpink' },
+    'header.camo':    { slot: 'header',      name: 'Camo Header',         price: 200, rarity: 'common', skinClass: 'skin-header-camo' },
+};
+
+const DEFAULT_LOADOUT = { theme: 'default', board: 'default', calculator: 'default', header: 'default' };
+
+function getItem(itemId) {
+    return CATALOG[itemId] || null;
+}
+
+/**
+ * Can this user buy this item? Pure check, no mutation.
+ * @returns {{ok:boolean, reason?:string}}
+ */
+function canPurchase(user, itemId) {
+    const item = getItem(itemId);
+    if (!item) return { ok: false, reason: 'unknown_item' };
+    if (!user) return { ok: false, reason: 'no_user' };
+    const owned = user.ownedCosmetics || [];
+    if (owned.includes(itemId)) return { ok: false, reason: 'already_owned' };
+    if (item.unlockLevel && (user.level || 1) < item.unlockLevel) {
+        return { ok: false, reason: 'level_locked' };
+    }
+    const coins = (user.wallet && user.wallet.coins) || 0;
+    if (coins < item.price) return { ok: false, reason: 'insufficient_coins' };
+    return { ok: true };
+}
+
+/**
+ * Debit coins and grant ownership. Validates first; no-op on failure.
+ * @returns {{ok:boolean, reason?:string, coins:number, owned?:string[]}}
+ */
+function applyPurchase(user, itemId) {
+    const check = canPurchase(user, itemId);
+    if (!check.ok) return { ok: false, reason: check.reason, coins: (user && user.wallet && user.wallet.coins) || 0 };
+
+    const item = getItem(itemId);
+    if (!user.wallet) user.wallet = { coins: 0, lifetimeEarned: 0, dailyEarned: 0 };
+    user.wallet.coins = Math.max(0, (user.wallet.coins || 0) - item.price);
+    if (!Array.isArray(user.ownedCosmetics)) user.ownedCosmetics = [];
+    user.ownedCosmetics.push(itemId);
+
+    if (typeof user.markModified === 'function') {
+        user.markModified('wallet');
+        user.markModified('ownedCosmetics');
+    }
+    return { ok: true, coins: user.wallet.coins, owned: user.ownedCosmetics };
+}
+
+/**
+ * Can this user equip itemId in slot? 'default' (unequip) is always allowed.
+ * @returns {{ok:boolean, reason?:string}}
+ */
+function canEquip(user, slot, itemId) {
+    if (!SLOTS.includes(slot)) return { ok: false, reason: 'unknown_slot' };
+    if (itemId === 'default' || itemId == null) return { ok: true };
+    const item = getItem(itemId);
+    if (!item) return { ok: false, reason: 'unknown_item' };
+    if (item.slot !== slot) return { ok: false, reason: 'wrong_slot' };
+    const owned = (user && user.ownedCosmetics) || [];
+    if (!owned.includes(itemId)) return { ok: false, reason: 'not_owned' };
+    return { ok: true };
+}
+
+/**
+ * Set the equipped item for a slot. Validates first; no-op on failure.
+ * @returns {{ok:boolean, reason?:string, equipped?:object}}
+ */
+function applyEquip(user, slot, itemId) {
+    const check = canEquip(user, slot, itemId);
+    if (!check.ok) return { ok: false, reason: check.reason };
+    if (!user.equippedCosmetics) user.equippedCosmetics = { ...DEFAULT_LOADOUT };
+    user.equippedCosmetics[slot] = itemId || 'default';
+    if (typeof user.markModified === 'function') user.markModified('equippedCosmetics');
+    return { ok: true, equipped: user.equippedCosmetics };
+}
+
+module.exports = {
+    SLOTS,
+    CATALOG,
+    DEFAULT_LOADOUT,
+    getItem,
+    canPurchase,
+    applyPurchase,
+    canEquip,
+    applyEquip,
+};

--- a/utils/pipeline/persist.js
+++ b/utils/pipeline/persist.js
@@ -358,6 +358,7 @@ async function persist(params) {
   results.leveledUp = xpResult.leveledUp;
   results.tutorsUnlocked = xpResult.tutorsUnlocked;
   results.avatarBuilderUnlocked = xpResult.avatarBuilderUnlocked;
+  results.coinsAwarded = xpResult.coinsAwarded || 0;
 
   // Badge progress + mastery completion check
   if (user.masteryProgress?.activeBadge && results.problemAnswered) {

--- a/utils/pipeline/xpEngine.js
+++ b/utils/pipeline/xpEngine.js
@@ -102,9 +102,24 @@ function applyXpToUser(user, breakdown) {
 
   // Level up check
   let leveledUp = false;
+  let levelsGained = 0;
   while (user.xp >= BRAND_CONFIG.cumulativeXpForLevel((user.level || 1) + 1)) {
     user.level += 1;
     leveledUp = true;
+    levelsGained += 1;
+  }
+
+  // Coins for leveling up (earned soft currency; server-authoritative, capped).
+  let coinsAwarded = 0;
+  if (levelsGained > 0) {
+    try {
+      const { awardCoins } = require('../coinEngine');
+      const perLevel = (BRAND_CONFIG.coinRewards && BRAND_CONFIG.coinRewards.levelUp) || 0;
+      coinsAwarded = awardCoins(user, perLevel * levelsGained, 'level_up').awarded;
+    } catch (err) {
+      // Non-blocking: coin failures must never break XP/leveling.
+      console.error('[xpEngine] coin award failed:', err.message);
+    }
   }
 
   // Tutor unlocks (variable ratio with behavior triggers)
@@ -124,7 +139,7 @@ function applyXpToUser(user, breakdown) {
     avatarBuilderUnlocked = true;
   }
 
-  return { leveledUp, tutorsUnlocked, avatarBuilderUnlocked };
+  return { leveledUp, tutorsUnlocked, avatarBuilderUnlocked, coinsAwarded };
 }
 
 module.exports = { computeXpBreakdown, applyXpToUser, HINT_REGEX };


### PR DESCRIPTION
## What

Two things on this branch:

1. **`docs/XP_LEVELING_SYSTEM_OVERVIEW.md`** — a source-verified reference for the existing XP / leveling / tutor-unlock / leaderboard system.
2. **Gamification-surfacing phase 1** — surface the (well-designed but invisible) XP economy where students actually live, in `chat.html`. Client-heavy, minimal economy risk; both features key off data **already on the per-turn chat payload** — no new server round-trips.

## Feature A — Combo Meter (`public/js/modules/comboMeter.js`)

- State machine off `problemResult`: **+1 on verified correct**, **cools −1 on verified incorrect** (never "shatters" — wrongness stays safe in tutor mode, consistent with paying Tier-3 XP for `caught_own_error`), **holds** on neutral turns, **resets** on conversation switch.
- Combo chip near the input (appears at rung 2+), escalating edge glow via `--combo-intensity` (rungs 2–5 → 0.25–1.0), synthesized **5-pitch ascending solve-sound ladder** (Web Audio — no SFX assets existed), ~600ms glow ease-down on cool, `prefers-reduced-motion` → counter only.
- **No XP attached** (v1). Combo bonuses are explicitly deferred and would route server-side through `xpEngine.js` if ever added.

## Feature B — Identity Chip (`public/js/modules/identityChip.js`)

- Avatar wrapped in an **SVG level-progress ring** + level badge in the chat header, pulsing when the ring grows (goal-gradient).
- **Rank titles** derived from `xpLadderStats.tier3Behaviors` (`public/js/modules/rankTitles.js` mirrors the canonical ladder added to `utils/brand.js`). Highest earned shown by default; tap the chip to pick any earned title. One-time **earn ceremony** on genuine advancement (baseline seeded on load, so no retroactive fire).
- Tier-3 behavior earned each turn is reconciled into the local user so the title advances live before the next `/user` refresh.
- **FERPA:** the header chip is the student's own view (no redaction). Classmate-visible rank surfaces are Feature C (not in this PR) and will run through `hasOptedOutOfDirectoryInfo`.

## Integration facts (verified against `main` before building)

`xpLadder` payload (chat.js:1530), `problemResult === 'incorrect'` as the verified-wrong signal (D1), `.cr-header-extras` header anchor, and `GET /user` already shipping `tier3Behaviors` to the client (D2) — all confirmed in source.

## Verification

- Vite build passes; eslint clean on the new modules (0 errors/warnings).
- Combo state machine and rank-title tiering covered by standalone logic tests (transitions, floor-at-0, hold-on-neutral, tier/threshold/tiebreak).

## Scope / Non-Goals

No changes to XP amounts, the level curve, or the dormant tutor-unlock engine. No XP wagers. Showdown-in-chat (Feature C), the sandbagging fix, and challenge guardrails are deferred to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)