### PR TITLE
Avatar picker redesign: character-select lineup, retire the creature grid

### DIFF
--- a/public/css/avatar-picker.css
+++ b/public/css/avatar-picker.css
@@ -1,0 +1,90 @@
+/* avatar-picker.css — character-select layout for the student preset avatars.
+ * Full-body figures on clean light cards with a soft ground shadow (retires the
+ * cropped-circle creature look). Loaded after avatar-builder.css so these win.
+ */
+
+.avatar-selection-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: clamp(14px, 2vw, 24px);
+  width: 100%;
+  max-width: 1040px;
+  margin: 0 auto 2rem;
+  align-items: stretch;
+}
+@media (max-width: 900px) { .avatar-selection-grid { grid-template-columns: repeat(3, 1fr); } }
+@media (max-width: 560px) { .avatar-selection-grid { grid-template-columns: repeat(2, 1fr); } }
+
+/* ---- Student character card ---- */
+.avatar-card.student-avatar-card {
+  background: #fff;
+  border-radius: 18px;
+  box-shadow: 0 6px 20px rgba(15, 26, 36, 0.08);
+  border: 2px solid transparent;
+  padding: 14px 10px 14px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+.avatar-card.student-avatar-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 14px 34px rgba(15, 26, 36, 0.14);
+}
+.avatar-card.student-avatar-card.selected {
+  border-color: var(--clr-accent-hotpink, #ff3b7f);
+  box-shadow: 0 14px 34px rgba(255, 59, 127, 0.22);
+  transform: translateY(-6px);
+}
+
+/* Figure "standing in a space": full body, soft gradient floor, ground shadow. */
+.avatar-card.student-avatar-card .avatar-card-image {
+  position: relative;
+  width: 100%;
+  height: clamp(190px, 22vw, 250px);
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  border: none;
+  border-radius: 14px;
+  background: linear-gradient(180deg, #f7fafc 0%, #e9eef2 100%);
+  overflow: hidden;
+  margin: 0;
+}
+.avatar-card.student-avatar-card .avatar-card-image::after {
+  content: '';
+  position: absolute;
+  bottom: 12px;
+  width: 58%;
+  height: 14px;
+  background: radial-gradient(ellipse at center, rgba(15, 26, 36, 0.22), rgba(15, 26, 36, 0) 70%);
+  border-radius: 50%;
+  z-index: 0;
+}
+.avatar-card.student-avatar-card .avatar-card-image img {
+  position: relative;
+  z-index: 1;
+  height: 97%;
+  width: auto;
+  max-width: 94%;
+  object-fit: contain;
+  object-position: bottom center;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  filter: drop-shadow(0 6px 5px rgba(0, 0, 0, 0.16));
+}
+.avatar-card.student-avatar-card .avatar-card-name {
+  margin: 12px 0 0;
+  font-weight: 700;
+  color: var(--clr-text, #18202b);
+  font-size: clamp(0.85rem, 1.4vw, 1rem);
+  text-align: center;
+}
+
+/* Keep the "Create Your Own" card aligned in the same grid. */
+.avatar-selection-grid .avatar-card.create-custom {
+  border-radius: 18px;
+  justify-content: center;
+}

--- a/public/js/pick-avatar.js
+++ b/public/js/pick-avatar.js
@@ -99,40 +99,31 @@ document.addEventListener('DOMContentLoaded', () => {
     renderCatalogAvatars(esc);
   }
 
-  /* Render the selectable creature/character catalog with level gating. */
+  /* Render the human student preset avatars as a character-select lineup.
+     Creatures/characters/sports/styles are intentionally retired from the
+     picker — students get the polished full-body characters only. */
   function renderCatalogAvatars(esc) {
     const cfg = window.AVATAR_CONFIG || {};
-    const level = currentUser.level || 1;
-    const groupOrder = { student: 0, creature: 1, character: 2, sports: 3, style: 4 };
-    const items = Object.values(cfg).sort((a, b) =>
-      (groupOrder[a.group] - groupOrder[b.group]) ||
-      (a.unlockLevel - b.unlockLevel) ||
-      a.name.localeCompare(b.name)
-    );
+    const items = Object.values(cfg)
+      .filter(item => item.group === 'student')
+      .sort((a, b) => a.name.localeCompare(b.name));
 
     items.forEach(item => {
-      const unlocked = level >= item.unlockLevel;
       const card = document.createElement('div');
-      card.classList.add('avatar-card', unlocked ? 'unlocked' : 'locked');
+      card.classList.add('avatar-card', 'student-avatar-card', 'unlocked');
       card.dataset.avatarId = item.id;
       card.dataset.catalog = '1';
-      if (currentUser.selectedAvatarId === item.id && unlocked) {
+      if (currentUser.selectedAvatarId === item.id) {
         card.classList.add('selected');
         selectedAvatarId = item.id;
         completeSelectionBtn.disabled = false;
       }
-      const desc = unlocked
-        ? (item.rarity === 'common' ? 'Ready to wear' : esc(item.rarity))
-        : ('🔒 Unlocks at Level ' + item.unlockLevel);
-      // Absolute image paths (student presets under /images/students/) are used
-      // as-is; bare filenames resolve against the creature art dir.
+      // Student presets use absolute image paths (/images/students/…).
       const imgSrc = item.image.charAt(0) === '/' ? item.image : '/images/avatars/' + item.image;
       card.innerHTML =
         '<div class="avatar-card-image"><img src="' + esc(imgSrc) + '" alt="' + esc(item.name) + '" loading="lazy"></div>' +
-        '<h4 class="avatar-card-name">' + esc(item.name) + '</h4>' +
-        '<p class="avatar-card-description">' + desc + '</p>';
-      // Auto-hide a preset whose art file isn't in the repo yet (avoids broken
-      // image cards — relevant for the student presets pending art).
+        '<h4 class="avatar-card-name">' + esc(item.name) + '</h4>';
+      // Auto-hide a preset whose art file isn't present (defensive).
       const img = card.querySelector('img');
       if (img) img.addEventListener('error', () => card.remove());
       avatarSelectionGrid.appendChild(card);

--- a/public/pick-avatar.html
+++ b/public/pick-avatar.html
@@ -13,6 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <title>Choose Your Avatar! | M∆THM∆TIΧ AI</title>
   <link rel="stylesheet" href="/style.css" />
   <link rel="stylesheet" href="/css/avatar-builder.css" />
+  <link rel="stylesheet" href="/css/avatar-picker.css" />
   <link rel="stylesheet" href="/css/ux-enhancements.css" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" referrerpolicy="no-referrer" />
 </head>
@@ -50,7 +51,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- AVATAR SELECTION -->
     <section class="selection-section">
       <h1 class="section-title">Choose Your Avatar.</h1>
-      <p class="subtitle">Pick a cool creature to represent you! Unlock more as you level up!</p>
+      <p class="subtitle">Pick the character that's you — or create your own.</p>
 
       <div id="avatar-selection-grid" class="avatar-selection-grid">
         <p style="text-align: center; color: var(--clr-text-dim);">Loading avatars...</p>


### PR DESCRIPTION
## What

Reworks `pick-avatar.html` so the polished human characters aren't jammed into tiny circles next to the corny creature pixel art. Now it's a clean **character-select lineup**.

## Changes
- **Retire the creatures** from the picker — `pick-avatar.js` renders only the `student` group (creatures/sports/styles are hidden here; catalog data untouched, so still reversible).
- **Character-select cards** — `public/css/avatar-picker.css`: full-body figures on light cards with a soft gradient "floor" + ground shadow, hover lift, hot-pink selected state; responsive 4/3/2-column grid. Name-only under each figure.
- **Copy** — subtitle no longer says "creature."

## Notes
- The DiceBear **"Create Your Own"** card is kept (self-expression path).
- **Needs a visual pass** — I can't render a browser here. Card height, ground-shadow strength, floor gradient, and grid density are all easy to tune once you eyeball it.

## Not in this PR
The **tutor picker** still uses circular head-crops — a matching glow-up there is the natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017pbJuZYttti1qvqE5rsrHd)_