### PR TITLE
fix(math): one Unicode operator normalizer as the source of truth (stops the correct-answer rejections)

### DIFF
--- a/tests/unit/mathSolverUnicodeMinus.test.js
+++ b/tests/unit/mathSolverUnicodeMinus.test.js
@@ -1,0 +1,71 @@
+/**
+ * Regression tests for the Unicode MINUS SIGN (−, U+2212) in the math engine.
+ *
+ * THE BUG (from a real session): a student correctly solved 3(x-2)=2x-34 down to
+ * x - 6 = -34, then answered "-28" (x = -34 + 6 = -28). The tutor rejected it
+ * repeatedly — even reproducing "-28" while insisting it was wrong. Root cause:
+ * MathLive/LaTeX render subtraction and negatives with the Unicode MINUS SIGN
+ * (−, U+2212), NOT the ASCII hyphen. mathSolver never normalized it, so:
+ *   - processMathMessage("−34+6") dropped the leading minus and returned 40.
+ *   - the equation "3x−6=2x−34" was not detected as an equation at all (noMath).
+ *   - verifyAnswer("−28", "-28") stripped the U+2212 to a positive "28" and
+ *     graded the correct negative answer INCORRECT.
+ *
+ * THE FIX: normalize U+2212 (and the fullwidth/small hyphen-minus U+FF0D, U+FE63)
+ * to ASCII "-" in detection and in verifyAnswer/evalArithmeticString. En/em dashes
+ * (– —) are deliberately NOT normalized — they are prose punctuation.
+ */
+const { processMathMessage, verifyAnswer } = require('../../utils/mathSolver');
+
+const MINUS = '−'; // − MINUS SIGN
+
+describe('Unicode minus (U+2212) — arithmetic and equations', () => {
+  it('evaluates "−34+6" to -28 (not 40)', () => {
+    const r = processMathMessage(`${MINUS}34+6`);
+    expect(r.hasMath).toBe(true);
+    expect(String(r.solution.answer)).toBe('-28');
+  });
+
+  it('evaluates "−34 + 6" (spaced) to -28', () => {
+    expect(String(processMathMessage(`${MINUS}34 + 6`).solution.answer)).toBe('-28');
+  });
+
+  it('detects and solves the equation "3x−6=2x−34" → x = -28', () => {
+    const r = processMathMessage(`3x${MINUS}6=2x${MINUS}34`);
+    expect(r.hasMath).toBe(true);
+    expect(r.problem.type).toBe('general_linear');
+    expect(String(r.solution.answer)).toBe('-28');
+  });
+
+  it('detects and solves "x−6=−34" → x = -28', () => {
+    const r = processMathMessage(`x${MINUS}6=${MINUS}34`);
+    expect(r.hasMath).toBe(true);
+    expect(String(r.solution.answer)).toBe('-28');
+  });
+});
+
+describe('Unicode minus (U+2212) — verifyAnswer accepts the correct negative', () => {
+  it('accepts a student "−28" against a correct "-28"', () => {
+    expect(verifyAnswer(`${MINUS}28`, '-28').isCorrect).toBe(true);
+  });
+
+  it('accepts either side using U+2212', () => {
+    expect(verifyAnswer('-28', `${MINUS}28`).isCorrect).toBe(true);
+    expect(verifyAnswer(`${MINUS}28`, `${MINUS}28`).isCorrect).toBe(true);
+  });
+
+  it('still rejects a genuinely wrong sign or value', () => {
+    expect(verifyAnswer('28', '-28').isCorrect).toBe(false);      // wrong sign
+    expect(verifyAnswer(`${MINUS}40`, '-28').isCorrect).toBe(false); // wrong value
+  });
+});
+
+describe('en/em dashes are prose — NOT normalized as minus', () => {
+  it('leaves an em-dash in wrapper prose alone (limit detection still works)', () => {
+    const r = processMathMessage(
+      "Try this one: $\\lim_{x \\to 1} \\frac{x^2-1}{x-1}$ — what's your first move?"
+    );
+    expect(r.hasMath).toBe(true);
+    expect(String(r.solution.answer)).toBe('2');
+  });
+});

--- a/tests/unit/mathUnicodeNormalizer.test.js
+++ b/tests/unit/mathUnicodeNormalizer.test.js
@@ -1,4 +1,4 @@
-const { normalizeMathUnicode } = require('../../utils/mathUnicodeNormalizer');
+const { normalizeMathUnicode, normalizeMathOperators, OPERATOR_MAP } = require('../../utils/mathUnicodeNormalizer');
 
 describe('normalizeMathUnicode', () => {
   test('converts superscript digits to caret notation', () => {
@@ -54,5 +54,56 @@ describe('normalizeMathUnicode', () => {
 
   test('handles mixed Unicode and ASCII', () => {
     expect(normalizeMathUnicode('x² + x^3 − 1')).toBe('x^2 + x^3 - 1');
+  });
+});
+
+// ============================================================================
+// normalizeMathOperators — the operator/sign source of truth for the math engine
+// ============================================================================
+//
+// This is the layer the regex-based math engine (mathSolver) depends on. The
+// recurring class of "tutor rejected a correct answer" bugs all traced to a
+// Unicode operator/sign that wasn't mapped to ASCII (U+22C5 dot, U+2212 minus).
+// This suite enumerates the ENTIRE map so a new missing variant can never ship
+// silently, and pins the invariants mathSolver relies on.
+describe('normalizeMathOperators — exhaustive operator/sign coverage', () => {
+  test('EVERY entry in OPERATOR_MAP normalizes to its ASCII target in context', () => {
+    // Guarantee: whatever operators exist in the single source of truth, the
+    // focused normalizer applies all of them. Adding a glyph to OPERATOR_MAP
+    // automatically extends this guarantee to every mathSolver call site.
+    for (const [glyph, ascii] of Object.entries(OPERATOR_MAP)) {
+      expect(normalizeMathOperators(`3 ${glyph} 4`)).toBe(`3 ${ascii} 4`);
+    }
+  });
+
+  test('normalizes minus-sign family to ASCII "-" (NOT en/em dash)', () => {
+    expect(normalizeMathOperators('−34+6')).toBe('-34+6'); // U+2212
+    expect(normalizeMathOperators('－5')).toBe('-5');       // U+FF0D fullwidth
+    expect(normalizeMathOperators('﹣5')).toBe('-5');       // U+FE63 small
+  });
+
+  test('normalizes all multiplication and division glyphs', () => {
+    expect(normalizeMathOperators('2 × 3 ⋅ 4 ∙ 5 · 6 ∗ 7')).toBe('2 * 3 * 4 * 5 * 6 * 7');
+    expect(normalizeMathOperators('8 ÷ 2 ∕ 2 ／ 2')).toBe('8 / 2 / 2 / 2');
+  });
+
+  test('normalizes fullwidth plus and equals', () => {
+    expect(normalizeMathOperators('2＋3＝5')).toBe('2+3=5');
+  });
+
+  test('LEAVES en dash and em dash alone (prose, not math)', () => {
+    expect(normalizeMathOperators('pages 3–5')).toBe('pages 3–5');       // en dash
+    expect(normalizeMathOperators("$x$ — next step?")).toBe("$x$ — next step?"); // em dash
+  });
+
+  test('does NOT rewrite vulgar fractions or superscripts (mathSolver owns those)', () => {
+    expect(normalizeMathOperators('½ + ¼')).toBe('½ + ¼');
+    expect(normalizeMathOperators('x²')).toBe('x²');
+  });
+
+  test('is idempotent and safe on empty/nullish input', () => {
+    expect(normalizeMathOperators(normalizeMathOperators('−34+6'))).toBe('-34+6');
+    expect(normalizeMathOperators(null)).toBe('');
+    expect(normalizeMathOperators('')).toBe('');
   });
 });

--- a/utils/mathSolver.js
+++ b/utils/mathSolver.js
@@ -10,6 +10,8 @@
  * @module mathSolver
  */
 
+const { normalizeMathOperators } = require('./mathUnicodeNormalizer');
+
 /**
  * Detect if a message contains a math problem
  * @param {string} message - User message
@@ -20,30 +22,20 @@ function detectMathProblem(message) {
         return null;
     }
 
-    // Normalize Unicode superscripts/subscripts BEFORE any pattern matching.
-    // AI messages and MathLive input often use ² ³ ⁴ etc. instead of ^2 ^3 ^4.
-    // Without this, "3²" won't match the exponent pattern expecting "3^2".
-    let normalized = message
+    // Normalize BEFORE any pattern matching. Two concerns:
+    //  1. Unicode operators/signs (−, ×, ÷, ⋅, fullwidth forms, …) → ASCII, via the
+    //     shared normalizeMathOperators() — the single source of truth. MathLive/
+    //     LaTeX emit these glyphs, and a missing one silently corrupts detection or
+    //     grading (the U+2212 minus dropped a negative; the U+22C5 dot dropped a
+    //     factor). It deliberately leaves vulgar fractions (½) and superscripts
+    //     alone, which this engine handles its own way below.
+    //  2. Superscripts (² ³ ⁴ …) → ^2 ^3, so "3²" matches the exponent patterns.
+    let normalized = normalizeMathOperators(message)
         .replace(/⁰/g, '^0').replace(/¹/g, '^1').replace(/²/g, '^2')
         .replace(/³/g, '^3').replace(/⁴/g, '^4').replace(/⁵/g, '^5')
         .replace(/⁶/g, '^6').replace(/⁷/g, '^7').replace(/⁸/g, '^8')
         .replace(/⁹/g, '^9').replace(/⁻/g, '^-').replace(/⁺/g, '^+')
-        .replace(/ⁿ/g, '^n')
-        // Normalize multiplication dots — cdot (⋅, U+22C5), middot (·), bullet (∙ •) —
-        // to "*". These come from LaTeX \cdot rendering and MathLive input. Nothing
-        // downstream recognized them as operators, so "4 ⋅ 2" was treated as non-math
-        // and "16/4 ⋅ 2" lost its "⋅ 2" entirely (see arithmetic-chain detection below).
-        .replace(/[⋅·∙•]/g, '*')
-        // Normalize the Unicode MINUS SIGN (−, U+2212) and the fullwidth/small
-        // hyphen-minus (U+FF0D, U+FE63) to ASCII "-". MathLive/LaTeX render
-        // subtraction and negatives with U+2212, not the ASCII hyphen. Without this,
-        // "−34+6" parsed as "34+6" = 40 (dropping the negative) and "3x−6=2x−34" was
-        // not detected as an equation at all — so a correct negative answer got
-        // graded wrong. NOTE: deliberately excludes en/em dashes (– —) — those are
-        // PROSE punctuation, and rewriting them corrupts sentences like "$…$ — next?".
-        // (A shared normalizeMathUnicode() exists but also rewrites fractions/Greek;
-        // we keep a minimal inline pass for this regex pipeline.)
-        .replace(/[−－﹣]/g, '-');
+        .replace(/ⁿ/g, '^n');
 
     // Reassign so all downstream code (40+ regex matches and sub-function calls)
     // automatically operates on the normalized string.
@@ -473,7 +465,7 @@ function detectMathProblem(message) {
     // associativity (so 16/4*2 = (16/4)*2 = 8, NOT 16/(4*2) = 2). Placed AFTER the
     // two-operand and fraction-pair patterns so those keep their dedicated handling;
     // requires 2+ operators so it only ever catches genuine multi-operand chains.
-    const chainForm = message.replace(/\s+/g, '').replace(/×/g, '*').replace(/÷/g, '/');
+    const chainForm = message.replace(/\s+/g, ''); // operators already ASCII-normalized above
     if (/^-?\d+\.?\d*(?:[+\-*/^]\d+\.?\d*){2,}$/.test(chainForm)) {
         return { type: 'evaluation', expression: chainForm };
     }
@@ -2239,10 +2231,9 @@ function solveVolume(problem) {
 function solveEvaluation(problem) {
     const { expression } = problem;
 
-    // Clean the expression — convert word operators BEFORE stripping non-math chars
-    let cleaned = expression
-        .replace(/×/g, '*')
-        .replace(/÷/g, '/')
+    // Clean the expression — normalize Unicode operators (shared source of truth),
+    // then convert word operators BEFORE stripping non-math chars.
+    let cleaned = normalizeMathOperators(expression)
         // "x" between numbers with spaces = multiplication (e.g., "2.75 x 5")
         .replace(/(\d)\s+x\s+(\d)/gi, '$1*$2')
         .replace(/\btimes\b/gi, '*')
@@ -2312,11 +2303,9 @@ function greatestCommonDivisor(a, b) {
  */
 function evalArithmeticString(str) {
     if (typeof str !== 'string') return null;
-    let s = str
-        .replace(/[⋅·∙•×]/g, '*')   // multiplication dots / sign → *
-        .replace(/÷/g, '/')          // division sign → /
-        .replace(/[−－﹣]/g, '-')     // Unicode minus sign (U+2212) etc. → ASCII "-"
-        .replace(/\s+/g, '');
+    // Normalize Unicode operators/signs via the shared source of truth, then strip
+    // whitespace, so "16/4 ⋅ 2" and "−34+6" evaluate by value rather than as garbage.
+    let s = normalizeMathOperators(str).replace(/\s+/g, '');
     // Require at least one operator (so plain "8" stays on the caller's path)
     // and ONLY safe arithmetic characters (no letters, commas, currency, units).
     if (!/[+\-*/^]/.test(s)) return null;
@@ -2339,12 +2328,12 @@ function evalArithmeticString(str) {
  * @returns {Object} Verification result
  */
 function verifyAnswer(studentAnswer, correctAnswer, tolerance = 0.01) {
-    // Normalize answers. Convert the Unicode MINUS SIGN (−, U+2212) and dash
-    // variants to ASCII "-" so a student's "−28" (as MathLive/LaTeX renders it)
-    // is not stripped to a positive "28" and rejected against a correct "-28".
-    const normDash = (v) => String(v).trim().toLowerCase().replace(/[−－﹣]/g, '-');
-    const studentStr = normDash(studentAnswer);
-    const correctStr = normDash(correctAnswer);
+    // Normalize answers through the shared operator/sign map so a student's "−28"
+    // (Unicode minus, as MathLive/LaTeX render it) is not stripped to a positive
+    // "28" and rejected against a correct "-28" — and likewise for ×, ÷, dots, etc.
+    const norm = (v) => normalizeMathOperators(String(v).trim().toLowerCase());
+    const studentStr = norm(studentAnswer);
+    const correctStr = norm(correctAnswer);
 
     // Exact match
     if (studentStr === correctStr) {

--- a/utils/mathSolver.js
+++ b/utils/mathSolver.js
@@ -33,7 +33,17 @@ function detectMathProblem(message) {
         // to "*". These come from LaTeX \cdot rendering and MathLive input. Nothing
         // downstream recognized them as operators, so "4 ⋅ 2" was treated as non-math
         // and "16/4 ⋅ 2" lost its "⋅ 2" entirely (see arithmetic-chain detection below).
-        .replace(/[⋅·∙•]/g, '*');
+        .replace(/[⋅·∙•]/g, '*')
+        // Normalize the Unicode MINUS SIGN (−, U+2212) and the fullwidth/small
+        // hyphen-minus (U+FF0D, U+FE63) to ASCII "-". MathLive/LaTeX render
+        // subtraction and negatives with U+2212, not the ASCII hyphen. Without this,
+        // "−34+6" parsed as "34+6" = 40 (dropping the negative) and "3x−6=2x−34" was
+        // not detected as an equation at all — so a correct negative answer got
+        // graded wrong. NOTE: deliberately excludes en/em dashes (– —) — those are
+        // PROSE punctuation, and rewriting them corrupts sentences like "$…$ — next?".
+        // (A shared normalizeMathUnicode() exists but also rewrites fractions/Greek;
+        // we keep a minimal inline pass for this regex pipeline.)
+        .replace(/[−－﹣]/g, '-');
 
     // Reassign so all downstream code (40+ regex matches and sub-function calls)
     // automatically operates on the normalized string.
@@ -2305,6 +2315,7 @@ function evalArithmeticString(str) {
     let s = str
         .replace(/[⋅·∙•×]/g, '*')   // multiplication dots / sign → *
         .replace(/÷/g, '/')          // division sign → /
+        .replace(/[−－﹣]/g, '-')     // Unicode minus sign (U+2212) etc. → ASCII "-"
         .replace(/\s+/g, '');
     // Require at least one operator (so plain "8" stays on the caller's path)
     // and ONLY safe arithmetic characters (no letters, commas, currency, units).
@@ -2328,9 +2339,12 @@ function evalArithmeticString(str) {
  * @returns {Object} Verification result
  */
 function verifyAnswer(studentAnswer, correctAnswer, tolerance = 0.01) {
-    // Normalize answers
-    const studentStr = String(studentAnswer).trim().toLowerCase();
-    const correctStr = String(correctAnswer).trim().toLowerCase();
+    // Normalize answers. Convert the Unicode MINUS SIGN (−, U+2212) and dash
+    // variants to ASCII "-" so a student's "−28" (as MathLive/LaTeX renders it)
+    // is not stripped to a positive "28" and rejected against a correct "-28".
+    const normDash = (v) => String(v).trim().toLowerCase().replace(/[−－﹣]/g, '-');
+    const studentStr = normDash(studentAnswer);
+    const correctStr = normDash(correctAnswer);
 
     // Exact match
     if (studentStr === correctStr) {

--- a/utils/mathUnicodeNormalizer.js
+++ b/utils/mathUnicodeNormalizer.js
@@ -5,97 +5,145 @@
  * fractions, LaTeX commands) to their ASCII equivalents so downstream regex
  * patterns can match without per-site normalization.
  *
- * Used by visualCommandEnforcer, observe pipeline, and anywhere else that
- * extracts math expressions from AI/student text.
+ * Used by visualCommandEnforcer, mathSolver, the observe pipeline, and anywhere
+ * else that extracts or grades math expressions from AI/student text.
  *
  * @module mathUnicodeNormalizer
  */
 
 // ── Superscript digits ──
 const SUPERSCRIPT_MAP = {
-  '\u2070': '^0', // ⁰
-  '\u00B9': '^1', // ¹
-  '\u00B2': '^2', // ²
-  '\u00B3': '^3', // ³
-  '\u2074': '^4', // ⁴
-  '\u2075': '^5', // ⁵
-  '\u2076': '^6', // ⁶
-  '\u2077': '^7', // ⁷
-  '\u2078': '^8', // ⁸
-  '\u2079': '^9', // ⁹
-  '\u207B': '-',  // ⁻ (superscript minus)
-  '\u207A': '+',  // ⁺ (superscript plus)
-  '\u207F': '^n', // ⁿ
+  '⁰': '^0', // ⁰
+  '¹': '^1', // ¹
+  '²': '^2', // ²
+  '³': '^3', // ³
+  '⁴': '^4', // ⁴
+  '⁵': '^5', // ⁵
+  '⁶': '^6', // ⁶
+  '⁷': '^7', // ⁷
+  '⁸': '^8', // ⁸
+  '⁹': '^9', // ⁹
+  '⁻': '-',  // ⁻ (superscript minus)
+  '⁺': '+',  // ⁺ (superscript plus)
+  'ⁿ': '^n', // ⁿ
 };
 
 // ── Subscript digits ──
 const SUBSCRIPT_MAP = {
-  '\u2080': '0', // ₀
-  '\u2081': '1', // ₁
-  '\u2082': '2', // ₂
-  '\u2083': '3', // ₃
-  '\u2084': '4', // ₄
-  '\u2085': '5', // ₅
-  '\u2086': '6', // ₆
-  '\u2087': '7', // ₇
-  '\u2088': '8', // ₈
-  '\u2089': '9', // ₉
+  '₀': '0', // ₀
+  '₁': '1', // ₁
+  '₂': '2', // ₂
+  '₃': '3', // ₃
+  '₄': '4', // ₄
+  '₅': '5', // ₅
+  '₆': '6', // ₆
+  '₇': '7', // ₇
+  '₈': '8', // ₈
+  '₉': '9', // ₉
 };
 
-// ── Unicode operator replacements ──
+// ── Unicode operator/sign replacements ──
+// Single source of truth for mapping Unicode math operators and signs to their
+// ASCII equivalents. This is the map that has repeatedly bitten the regex-based
+// math engine: MathLive / LaTeX / mobile keyboards emit these glyphs instead of
+// ASCII, and any one that is MISSING here silently corrupts detection or grading
+// (the U+2212 minus dropped a negative sign; the U+22C5 dot dropped a whole
+// factor). Keep it EXHAUSTIVE — adding a variant here fixes every call site at once.
+//
+// Deliberately EXCLUDES the en dash (U+2013) and em dash (U+2014): those are
+// PROSE punctuation, not a math minus, and rewriting them corrupts sentences
+// like "$...$ — what's your next step?".
 const OPERATOR_MAP = {
-  '\u2212': '-',  // − (minus sign)
-  '\u00D7': '*',  // × (multiplication)
-  '\u00F7': '/',  // ÷ (division)
-  '\u22C5': '*',  // ⋅ (dot operator)
-  '\u2022': '*',  // • (bullet, sometimes used as multiplication)
-  '\u00B7': '*',  // · (middle dot)
-  '\u2264': '<=', // ≤
-  '\u2265': '>=', // ≥
-  '\u2260': '!=', // ≠
-  '\u2248': '~=', // ≈
-  '\u221A': 'sqrt', // √
+  // Minus / hyphen-minus
+  '−': '-',    // − minus sign
+  '－': '-',    // － fullwidth hyphen-minus
+  '﹣': '-',    // ﹣ small hyphen-minus
+  // Multiplication
+  '×': '*',    // × multiplication sign
+  '⋅': '*',    // ⋅ dot operator
+  '·': '*',    // · middle dot
+  '∙': '*',    // ∙ bullet operator
+  '•': '*',    // • bullet
+  '∗': '*',    // ∗ asterisk operator
+  '＊': '*',    // ＊ fullwidth asterisk
+  // Division
+  '÷': '/',    // ÷ division sign
+  '∕': '/',    // ∕ division slash
+  '⁄': '/',    // ⁄ fraction slash
+  '／': '/',    // ／ fullwidth solidus
+  // Plus / equals
+  '＋': '+',    // ＋ fullwidth plus
+  '＝': '=',    // ＝ fullwidth equals
+  // Comparison + roots
+  '≤': '<=',   // ≤
+  '≥': '>=',   // ≥
+  '≠': '!=',   // ≠
+  '≈': '~=',   // ≈
+  '√': 'sqrt', // √
 };
 
 // ── Unicode fraction replacements ──
 const FRACTION_MAP = {
-  '\u00BD': '(1/2)', // ½
-  '\u2153': '(1/3)', // ⅓
-  '\u2154': '(2/3)', // ⅔
-  '\u00BC': '(1/4)', // ¼
-  '\u00BE': '(3/4)', // ¾
-  '\u2155': '(1/5)', // ⅕
-  '\u2156': '(2/5)', // ⅖
-  '\u2157': '(3/5)', // ⅗
-  '\u2158': '(4/5)', // ⅘
-  '\u2159': '(1/6)', // ⅙
-  '\u215A': '(5/6)', // ⅚
-  '\u2150': '(1/7)', // ⅐
-  '\u215B': '(1/8)', // ⅛
-  '\u215C': '(3/8)', // ⅜
-  '\u215D': '(5/8)', // ⅝
-  '\u215E': '(7/8)', // ⅞
-  '\u2151': '(1/9)', // ⅑
-  '\u2152': '(1/10)', // ⅒
+  '½': '(1/2)', // ½
+  '⅓': '(1/3)', // ⅓
+  '⅔': '(2/3)', // ⅔
+  '¼': '(1/4)', // ¼
+  '¾': '(3/4)', // ¾
+  '⅕': '(1/5)', // ⅕
+  '⅖': '(2/5)', // ⅖
+  '⅗': '(3/5)', // ⅗
+  '⅘': '(4/5)', // ⅘
+  '⅙': '(1/6)', // ⅙
+  '⅚': '(5/6)', // ⅚
+  '⅐': '(1/7)', // ⅐
+  '⅛': '(1/8)', // ⅛
+  '⅜': '(3/8)', // ⅜
+  '⅝': '(5/8)', // ⅝
+  '⅞': '(7/8)', // ⅞
+  '⅑': '(1/9)', // ⅑
+  '⅒': '(1/10)', // ⅒
 };
 
 // ── Greek letters commonly used in math ──
 const GREEK_MAP = {
-  '\u03C0': 'pi',    // π
-  '\u03B8': 'theta', // θ
-  '\u03B1': 'alpha', // α
-  '\u03B2': 'beta',  // β
-  '\u03B3': 'gamma', // γ
-  '\u03B4': 'delta', // δ
-  '\u03BB': 'lambda', // λ
-  '\u03C3': 'sigma', // σ
-  '\u03C4': 'tau',   // τ
-  '\u221E': 'Infinity', // ∞
+  'π': 'pi',    // π
+  'θ': 'theta', // θ
+  'α': 'alpha', // α
+  'β': 'beta',  // β
+  'γ': 'gamma', // γ
+  'δ': 'delta', // δ
+  'λ': 'lambda', // λ
+  'σ': 'sigma', // σ
+  'τ': 'tau',   // τ
+  '∞': 'Infinity', // ∞
 };
 
 // Build a single regex that matches any character we need to replace
 const ALL_CHARS = Object.assign({}, SUPERSCRIPT_MAP, SUBSCRIPT_MAP, OPERATOR_MAP, FRACTION_MAP, GREEK_MAP);
 const UNICODE_REGEX = new RegExp('[' + Object.keys(ALL_CHARS).join('') + ']', 'g');
+
+// Operator-only regex, for callers (like the regex-based math engine) that want
+// to normalize operators/signs WITHOUT rewriting fractions/superscripts/Greek —
+// e.g. mathSolver handles vulgar fractions its own way and must not receive
+// "(1/2)" in place of "½".
+const OPERATOR_REGEX = new RegExp('[' + Object.keys(OPERATOR_MAP).join('') + ']', 'g');
+
+/**
+ * Normalize ONLY Unicode math operators and signs to ASCII (minus, ×, ÷, dots,
+ * comparison operators, √, and their fullwidth/variant forms). Leaves
+ * fractions, superscripts, Greek letters, and all other text untouched.
+ *
+ * This is the focused entry point for the regex-based math engine — apply it at
+ * every point that parses or grades an expression so no Unicode operator variant
+ * can slip through. Idempotent and safe on any string.
+ *
+ * @param {string} str
+ * @returns {string}
+ */
+function normalizeMathOperators(str) {
+  if (!str || typeof str !== 'string') return str || '';
+  return str.replace(OPERATOR_REGEX, ch => OPERATOR_MAP[ch] || ch);
+}
 
 /**
  * Normalize Unicode math characters to ASCII equivalents.
@@ -127,4 +175,4 @@ function normalizeMathUnicode(str) {
   return result;
 }
 
-module.exports = { normalizeMathUnicode };
+module.exports = { normalizeMathUnicode, normalizeMathOperators, OPERATOR_MAP };


### PR DESCRIPTION
## Why this exists

The tutor kept rejecting **correct** answers. Two sessions, two different triggers, one disease:
- `16/4 ⋅ 2` graded as `4` (the `⋅` U+22C5 dot was dropped) — shipped as #1077.
- `−34+6` graded as `40` and `−28` rejected against `-28` (the `−` U+2212 minus was dropped).

Both were the **same root cause**: `mathSolver.js` rolled its *own* partial Unicode normalization and kept missing glyphs one at a time. Patching each character as it surfaced is whack-a-mole. This PR fixes the disease.

## The solution

Make `mathUnicodeNormalizer` the **single source of truth** for operator/sign normalization, and have the math engine consume it everywhere.

**`utils/mathUnicodeNormalizer.js`**
- Expanded `OPERATOR_MAP` to the full arithmetic set: minus + fullwidth/small hyphen-minus (`− － ﹣`), multiplication (`× ⋅ · ∙ • ∗ ＊`), division (`÷ ∕ ⁄ ／`), fullwidth plus/equals (`＋ ＝`), comparisons (`≤ ≥ ≠ ≈`), `√`. **Deliberately excludes en/em dashes** — those are prose, not math minus.
- New `normalizeMathOperators()`: applies **only** the operator/sign map, leaving vulgar fractions (`½`) and superscripts (`²`) alone — so it's safe to apply broadly (the full `normalizeMathUnicode()` rewrites `½ → (1/2)`, which would break the engine's fraction patterns).

**`utils/mathSolver.js`**
- Wired to `normalizeMathOperators()` at **every** entry point — `detectMathProblem`, `solveEvaluation`, `evalArithmeticString`, `verifyAnswer` — and **deleted all inline `.replace()` calls.** Adding a new operator variant is now a one-line change in one map that every call site inherits.

## Why this is a solution, not a patch

Before: each site had its own partial character list; a new glyph silently broke grading until someone noticed and patched that one site.
After: one map, one function, four call sites that all read from it. The **exhaustive test iterates the entire `OPERATOR_MAP`** and asserts each glyph normalizes — so a missing variant can't ship silently — plus guards that en/em dashes, fractions, and superscripts are left untouched.

## Verification

- Reproductions fixed: `16/4 ⋅ 2 → 8`, `−34+6 → -28`, `3x−6=2x−34 → x=-28`, `verify("−28","-28") → true`; wrong sign/value still rejected; `1/2 + 1/4 → 3/4` (fractions preserved).
- **432 passing, 0 failing** across mathSolver + normalizer + parseCleanProblem + visualCommandEnforcer suites.
- Supersedes the targeted minus patch this branch opened with; keeps the integration tests (`mathSolverUnicodeMinus.test.js`) as regression coverage.

## Context

Related fixes from this run of tutor transcripts: #1077 (multi-operand arithmetic, merged), #1079 (elicit-first on bare drops, merged). This PR generalizes the verification-normalization root cause behind #1077 and the minus bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)