### PR TITLE
refactor(math): one exact-rational engine for all numeric evaluation

### DIFF
--- a/tests/unit/parseCleanProblem.test.js
+++ b/tests/unit/parseCleanProblem.test.js
@@ -61,16 +61,18 @@ describe('parseCleanProblem — prose-wrapped tutor poses (the Bug B regression)
     expect(String(r.solution.answer)).toBe('7');
   });
 
-  test('the same prose-wrapped text via raw processMathMessage returns the bogus 331 (regression-guard control)', () => {
-    // This is the bug behavior parseCleanProblem exists to fix.
-    // If this stops being 331, mathSolver's matcher changed and the
-    // parseCleanProblem guard may not be needed anymore.
+  test('raw processMathMessage no longer fabricates a bogus answer from prose (exact engine refuses)', () => {
+    // HISTORY: the old Function()-based evaluation catch-all stripped the letters
+    // out of "Here's another equation for you to solve: Solve 4x+3=27." and
+    // evaluated the leftover digits to a bogus "331", which then poisoned grading.
+    // The exact-rational engine refuses to evaluate a prose-laden string (it can't
+    // tokenize letters), so no fake answer is produced. parseCleanProblem is still
+    // the right front door — this just confirms the raw path is no longer a hazard.
     const r = processMathMessage(
       "Here's another equation for you to solve: Solve 4x+3=27."
     );
-    expect(r.hasMath).toBe(true);
-    expect(r.problem.type).toBe('evaluation');
-    expect(String(r.solution.answer)).toBe('331');
+    const fabricated = r.hasMath && r.solution && r.solution.success && r.solution.answer === '331';
+    expect(fabricated).toBe(false);
   });
 });
 

--- a/tests/unit/rationalEvaluator.test.js
+++ b/tests/unit/rationalEvaluator.test.js
@@ -1,0 +1,82 @@
+/**
+ * The exact-rational evaluator — the single numeric engine that replaced the five
+ * hand-rolled evaluators in mathSolver. These tests pin the core contract: exact
+ * arithmetic (no floating-point drift), domain-aware formatting, and a clean null
+ * for anything that isn't a pure numeric expression.
+ */
+const { evalExpression, expressionValue } = require('../../utils/rationalEvaluator');
+
+const ans = (expr, mode) => { const r = evalExpression(expr, mode); return r ? r.answer : null; };
+
+describe('rationalEvaluator — exact arithmetic', () => {
+  test('integers and precedence', () => {
+    expect(ans('15 + 27')).toBe('42');
+    expect(ans('2+3*4')).toBe('14');
+    expect(ans('(2+3)*4')).toBe('20');
+    expect(ans('100 - 10 - 5')).toBe('85');
+    expect(ans('2^3 * 4')).toBe('32');
+    expect(ans('-34+6')).toBe('-28');
+  });
+
+  test('no floating-point error (the reason for BigInt rationals)', () => {
+    expect(ans('0.1 + 0.2')).toBe('0.3');          // not 0.30000000000000004
+    expect(ans('1/3 + 1/3 + 1/3')).toBe('1');       // not 0.9999...
+  });
+
+  test('fraction domain keeps exact fractions', () => {
+    expect(ans('1/2 + 1/4')).toBe('3/4');
+    expect(ans('3/4 * 2')).toBe('3/2');
+    expect(ans('1/2 - 3/4')).toBe('-1/4');
+    expect(ans('16/4')).toBe('4');
+  });
+
+  test('mixed-number domain', () => {
+    expect(ans('12 2/3 - 4 1/4')).toBe('8 5/12');
+    expect(ans('12⅔ - 4¼')).toBe('8 5/12');
+    expect(ans('2 1/2 + 3')).toBe('5 1/2');
+    expect(ans('1½ + 2¼')).toBe('3 3/4');
+    expect(ans('2 1/4 - 3 1/2')).toBe('-1 1/4');
+    expect(ans('1 1/2 + 1 1/2')).toBe('3');
+  });
+
+  test('decimal domain', () => {
+    expect(ans('2.75 * 5')).toBe('13.75');
+    expect(ans('2.5 + 1.5')).toBe('4');
+  });
+
+  test('mode override forces representation', () => {
+    expect(ans('7/2', 'decimal')).toBe('3.5');
+    expect(ans('7/2', 'fraction')).toBe('7/2');
+    expect(ans('5/4', 'mixed')).toBe('1 1/4');
+  });
+
+  test('Unicode operators normalize through the engine', () => {
+    expect(ans('16/4 ⋅ 2')).toBe('8');   // U+22C5 dot
+    expect(ans('16 ÷ 4 × 2')).toBe('8');
+    expect(ans('−34 + 6')).toBe('-28');  // U+2212 minus
+  });
+
+  test('returns null for non-numeric / malformed input (no fabrication)', () => {
+    expect(evalExpression('x + 1')).toBeNull();
+    expect(evalExpression('Solve 4x+3=27')).toBeNull();
+    expect(evalExpression('(1+2')).toBeNull();
+    expect(evalExpression('1/0')).toBeNull();
+    expect(evalExpression('')).toBeNull();
+    expect(evalExpression(null)).toBeNull();
+  });
+});
+
+describe('expressionValue — numeric value for grading', () => {
+  test('equivalent forms share a value', () => {
+    expect(expressionValue('8 5/12')).toBeCloseTo(101 / 12, 6);
+    expect(expressionValue('101/12')).toBeCloseTo(101 / 12, 6);
+    expect(expressionValue('8.4167')).toBeCloseTo(8.4167, 4);
+    expect(expressionValue('16/4 ⋅ 2')).toBe(8);
+    expect(expressionValue('−28')).toBe(-28);
+  });
+
+  test('null for algebra or non-numeric', () => {
+    expect(expressionValue('2x')).toBeNull();
+    expect(expressionValue('hello')).toBeNull();
+  });
+});

--- a/utils/mathSolver.js
+++ b/utils/mathSolver.js
@@ -11,6 +11,7 @@
  */
 
 const { normalizeMathOperators } = require('./mathUnicodeNormalizer');
+const { evalExpression, expressionValue } = require('./rationalEvaluator');
 
 /**
  * Detect if a message contains a math problem
@@ -467,18 +468,20 @@ function detectMathProblem(message) {
         };
     }
 
-    // Pattern: Multi-operation arithmetic CHAIN like "16/4*2", "2+3*4", "16 ÷ 4 ⋅ 2".
-    // These have 3+ operands (2+ operators). Both the single-pair arithmeticPattern
-    // above AND the last-resort embeddedArithmeticPattern below capture only the FIRST
-    // operator pair ("16/4" → 4), producing a confidently WRONG answer that then poisons
-    // answer grading: the bogus 4 gets pinned as the problem's correctAnswer, so a
-    // student's correct final "8" is graded INCORRECT against it. Route the WHOLE
-    // expression to solveEvaluation, which honors operator precedence and left-to-right
-    // associativity (so 16/4*2 = (16/4)*2 = 8, NOT 16/(4*2) = 2). Placed AFTER the
-    // two-operand and fraction-pair patterns so those keep their dedicated handling;
-    // requires 2+ operators so it only ever catches genuine multi-operand chains.
+    // Pattern: any WHOLE pure-numeric expression — multi-operand chains ("16/4*2",
+    // "2+3*4", "16 ÷ 4 ⋅ 2") and parenthesised expressions ("(2+3)*4"). The
+    // single-pair arithmeticPattern above and the last-resort embeddedArithmeticPattern
+    // below would capture only the FIRST operator pair ("16/4" → 4 / "2+3" → 5),
+    // producing a confidently WRONG answer that then poisons grading. Hand the whole
+    // thing to the exact-rational engine (correct precedence + parentheses, no
+    // floating drift). Placed AFTER the two-operand and fraction-pair patterns so those
+    // keep their dedicated types; fires only when the expression has parentheses OR
+    // 2+ operators, so simple two-operand arithmetic is left alone.
     const chainForm = message.replace(/\s+/g, ''); // operators already ASCII-normalized above
-    if (/^-?\d+\.?\d*(?:[+\-*/^]\d+\.?\d*){2,}$/.test(chainForm)) {
+    const isPureNumericExpr = /^[\d.+\-*/^()]+$/.test(chainForm) && /[+\-*/^]/.test(chainForm);
+    const hasParens = /[()]/.test(chainForm);
+    const hasTwoPlusOps = /^-?\d+\.?\d*(?:[+\-*/^]\d+\.?\d*){2,}$/.test(chainForm);
+    if (isPureNumericExpr && (hasParens || hasTwoPlusOps) && evalExpression(chainForm) !== null) {
         return { type: 'evaluation', expression: chainForm };
     }
 
@@ -648,36 +651,18 @@ function solveProblem(problem) {
 /**
  * Solve basic arithmetic
  */
+// Thin adapter over the single exact-rational engine. Two-operand arithmetic is
+// decimal-domain (7/2 → "3.5"), matching the original formatNumber behavior.
 function solveArithmetic(problem) {
     const { left, operator, right } = problem;
-    let answer;
-
-    switch (operator) {
-        case '+':
-            answer = left + right;
-            break;
-        case '-':
-            answer = left - right;
-            break;
-        case '*':
-        case '×':
-            answer = left * right;
-            break;
-        case '/':
-        case '÷':
-            if (right === 0) {
-                return { success: false, error: 'Division by zero' };
-            }
-            answer = left / right;
-            break;
-        default:
-            return { success: false, error: 'Unknown operator' };
-    }
-
+    const op = operator === '×' ? '*' : operator === '÷' ? '/' : operator;
+    if ((op === '/') && Number(right) === 0) return { success: false, error: 'Division by zero' };
+    const r = evalExpression(`${left} ${op} ${right}`, 'decimal');
+    if (!r) return { success: false, error: 'Unknown operator' };
     return {
         success: true,
-        answer: formatNumber(answer),
-        steps: [`${left} ${operator} ${right} = ${formatNumber(answer)}`]
+        answer: r.answer,
+        steps: [`${left} ${operator} ${right} = ${r.answer}`],
     };
 }
 
@@ -1348,64 +1333,22 @@ function formatBinomialProduct(a, p, b, q) {
     return `${formatTerm(a, p)}${formatTerm(b, q)}`;
 }
 
-// ── Mixed-number support ────────────────────────────────────────────────────
-// Vulgar-fraction glyph → [numerator, denominator]. mathSolver keeps its own map
-// (the shared operator normalizer deliberately leaves vulgar fractions alone so the
-// engine can treat "12⅔" as an operand rather than a "(2/3)" substring).
-const VULGAR_FRACTIONS = {
-    '½': [1, 2], '⅓': [1, 3], '⅔': [2, 3], '¼': [1, 4], '¾': [3, 4],
-    '⅕': [1, 5], '⅖': [2, 5], '⅗': [3, 5], '⅘': [4, 5], '⅙': [1, 6],
-    '⅚': [5, 6], '⅐': [1, 7], '⅛': [1, 8], '⅜': [3, 8], '⅝': [5, 8],
-    '⅞': [7, 8], '⅑': [1, 9], '⅒': [1, 10],
-};
-const VULGAR_CLASS = Object.keys(VULGAR_FRACTIONS).join('');
+// ── Mixed-number support (detection only — the exact-rational engine does the math) ──
+const VULGAR_CLASS = '½⅓⅔¼¾⅕⅖⅗⅘⅙⅚⅐⅛⅜⅝⅞⅑⅒';
 
-/**
- * Parse a single operand into an improper fraction {num, den} (den > 0), or null.
- * Handles "12 2/3" (mixed), "12⅔"/"⅔" (vulgar), "2/3" (fraction), "5" (integer),
- * each with an optional leading "-".
- */
-function parseOperandToImproper(tok) {
-    if (tok == null) return null;
-    let t = String(tok).trim();
-    if (!t) return null;
-    let sign = 1;
-    if (t[0] === '-') { sign = -1; t = t.slice(1).trim(); }
-    let m;
-    if ((m = t.match(new RegExp(`^(\\d+)\\s*([${VULGAR_CLASS}])$`)))) {         // "12⅔"
-        const [n, d] = VULGAR_FRACTIONS[m[2]];
-        return { num: sign * (parseInt(m[1], 10) * d + n), den: d };
-    }
-    if ((m = t.match(new RegExp(`^([${VULGAR_CLASS}])$`)))) {                    // "⅔"
-        const [n, d] = VULGAR_FRACTIONS[m[1]];
-        return { num: sign * n, den: d };
-    }
-    if ((m = t.match(/^(\d+)\s+(\d+)\s*\/\s*(\d+)$/))) {                         // "12 2/3"
-        const d = parseInt(m[3], 10); if (!d) return null;
-        return { num: sign * (parseInt(m[1], 10) * d + parseInt(m[2], 10)), den: d };
-    }
-    if ((m = t.match(/^(\d+)\s*\/\s*(\d+)$/))) {                                 // "2/3"
-        const d = parseInt(m[2], 10); if (!d) return null;
-        return { num: sign * parseInt(m[1], 10), den: d };
-    }
-    if ((m = t.match(/^(\d+)$/))) {                                             // "5"
-        return { num: sign * parseInt(m[1], 10), den: 1 };
-    }
-    return null;
-}
-
-// Genuine mixed number ("12 2/3") or a vulgar fraction ("⅔") — used to gate
-// detection so plain fraction/integer arithmetic keeps its dedicated handlers.
+// Genuine mixed number ("12 2/3") or a vulgar fraction ("⅔") — gates detection so
+// plain fraction/integer arithmetic keeps its own handlers.
 function isMixedOrVulgar(tok) {
     const t = String(tok);
     return /\d+\s+\d+\s*\/\s*\d+/.test(t) || new RegExp(`[${VULGAR_CLASS}]`).test(t);
 }
 
 /**
- * Detect a two-operand mixed-number expression: "12 2/3 - 4 1/4", "12⅔ - 4¼",
- * "2 1/2 + 3". Returns a problem object or null. Requires at least one operand to
- * be a genuine mixed number / vulgar fraction so proper-fraction and integer
- * arithmetic defer to their own handlers.
+ * Detect a two-operand mixed-number expression ("12 2/3 - 4 1/4", "12⅔ - 4¼",
+ * "2 1/2 + 3"). Returns a problem carrying the raw expression (the exact-rational
+ * engine evaluates it), or null. Requires at least one operand to be a genuine
+ * mixed number / vulgar fraction so proper-fraction and integer arithmetic defer
+ * to their own handlers.
  */
 function detectMixedNumberArithmetic(text) {
     if (!text || typeof text !== 'string') return null;
@@ -1413,120 +1356,30 @@ function detectMixedNumberArithmetic(text) {
     const OP = `\\d+\\s+\\d+\\s*/\\s*\\d+|\\d*\\s*[${VULGAR_CLASS}]|\\d+\\s*/\\s*\\d+|\\d+`;
     const m = t.match(new RegExp(`^(${OP})\\s*([+\\-*/])\\s*(${OP})\\s*$`));
     if (!m) return null;
-    const [, leftRaw, operator, rightRaw] = m;
-    if (!isMixedOrVulgar(leftRaw) && !isMixedOrVulgar(rightRaw)) return null;
-    const left = parseOperandToImproper(leftRaw);
-    const right = parseOperandToImproper(rightRaw);
-    if (!left || !right) return null;
-    return { type: 'mixed_number_arithmetic', left, operator, right, raw: t };
+    if (!isMixedOrVulgar(m[1]) && !isMixedOrVulgar(m[3])) return null;
+    return { type: 'mixed_number_arithmetic', expression: t };
 }
 
-/**
- * Format an improper fraction as a simplified string: whole number, proper
- * fraction, or mixed number (e.g. 101/12 → "8 5/12", -101/12 → "-8 5/12").
- */
-function formatRational(num, den) {
-    if (den === 0) return 'undefined';
-    const g = greatestCommonDivisor(Math.abs(num), Math.abs(den)) || 1;
-    num /= g; den /= g;
-    if (den < 0) { num = -num; den = -den; }
-    if (den === 1) return `${num}`;
-    if (Math.abs(num) < den) return `${num}/${den}`;
-    const sign = num < 0 ? '-' : '';
-    const whole = Math.floor(Math.abs(num) / den);
-    const rem = Math.abs(num) % den;
-    return rem === 0 ? `${sign}${whole}` : `${sign}${whole} ${rem}/${den}`;
-}
-
-/**
- * Numeric value of a mixed number / fraction / vulgar fraction / decimal string,
- * or null. Used by verifyAnswer so "8 5/12", "101/12", and "8.4167" grade equal.
- */
-function rationalOrDecimalValue(str) {
-    if (typeof str !== 'string') return null;
-    const t = str.trim();
-    if (!t || /[a-z]/i.test(t)) return null;
-    const frac = parseOperandToImproper(t);
-    if (frac && frac.den) return frac.num / frac.den;
-    if (/^-?\d+(\.\d+)?$/.test(t)) return parseFloat(t);
-    return null;
-}
-
-/**
- * Solve mixed-number arithmetic by converting both operands to improper fractions.
- */
+// Mixed-number arithmetic → exact-rational engine, formatted as a mixed number.
 function solveMixedNumberArithmetic(problem) {
-    const { left, operator, right } = problem;
-    let num, den;
-    switch (operator) {
-        case '+': num = left.num * right.den + right.num * left.den; den = left.den * right.den; break;
-        case '-': num = left.num * right.den - right.num * left.den; den = left.den * right.den; break;
-        case '*': num = left.num * right.num; den = left.den * right.den; break;
-        case '/':
-            if (right.num === 0) return { success: false, error: 'Division by zero' };
-            num = left.num * right.den; den = left.den * right.num; break;
-        default: return { success: false, error: 'Unknown operator' };
-    }
-    const answer = formatRational(num, den);
-    return {
-        success: true,
-        answer,
-        steps: [
-            `${formatRational(left.num, left.den)} ${operator} ${formatRational(right.num, right.den)}`,
-            `= ${answer}`,
-        ],
-    };
+    const r = evalExpression(problem.expression, 'mixed');
+    if (!r) return { success: false, error: 'Could not evaluate' };
+    return { success: true, answer: r.answer, steps: [`${problem.expression} = ${r.answer}`] };
 }
 
 /**
  * Solve fraction arithmetic
  */
+// Thin adapter over the exact-rational engine; fraction domain (result kept as a
+// reduced proper/improper fraction, e.g. "3/4", "3/2", or a whole number).
 function solveFractionArithmetic(problem) {
     const { leftNum, leftDen, operator, rightNum, rightDen } = problem;
-
-    let resultNum, resultDen;
-
-    switch (operator) {
-        case '+':
-            resultNum = leftNum * rightDen + rightNum * leftDen;
-            resultDen = leftDen * rightDen;
-            break;
-        case '-':
-            resultNum = leftNum * rightDen - rightNum * leftDen;
-            resultDen = leftDen * rightDen;
-            break;
-        case '*':
-            resultNum = leftNum * rightNum;
-            resultDen = leftDen * rightDen;
-            break;
-        case '/':
-            resultNum = leftNum * rightDen;
-            resultDen = leftDen * rightNum;
-            break;
-        default:
-            return { success: false, error: 'Unknown operator' };
-    }
-
-    // Simplify fraction
-    const gcd = greatestCommonDivisor(Math.abs(resultNum), Math.abs(resultDen));
-    resultNum = resultNum / gcd;
-    resultDen = resultDen / gcd;
-
-    // Handle negative denominator
-    if (resultDen < 0) {
-        resultNum = -resultNum;
-        resultDen = -resultDen;
-    }
-
-    const answer = resultDen === 1 ? `${resultNum}` : `${resultNum}/${resultDen}`;
-
+    const r = evalExpression(`(${leftNum}/${leftDen}) ${operator} (${rightNum}/${rightDen})`, 'fraction');
+    if (!r) return { success: false, error: 'Unknown operator' };
     return {
         success: true,
-        answer,
-        steps: [
-            `${leftNum}/${leftDen} ${operator} ${rightNum}/${rightDen}`,
-            `= ${answer}`
-        ]
+        answer: r.answer,
+        steps: [`${leftNum}/${leftDen} ${operator} ${rightNum}/${rightDen}`, `= ${r.answer}`],
     };
 }
 
@@ -2373,45 +2226,28 @@ function solveVolume(problem) {
 }
 
 function solveEvaluation(problem) {
-    const { expression } = problem;
+    const { expression, evalMode } = problem;
 
-    // Clean the expression — normalize Unicode operators (shared source of truth),
-    // then convert word operators BEFORE stripping non-math chars.
-    let cleaned = normalizeMathOperators(expression)
-        // "x" between numbers with spaces = multiplication (e.g., "2.75 x 5")
+    // Convert word operators and "2.75 x 5" style, then hand the whole expression
+    // to the single exact-rational engine (which normalizes Unicode operators,
+    // honors precedence/parentheses, and keeps exact fractions — no Function()/eval,
+    // no floating-point drift). Domain (decimal/fraction/mixed) is auto-detected
+    // unless the caller pins evalMode.
+    const worded = String(expression)
         .replace(/(\d)\s+x\s+(\d)/gi, '$1*$2')
         .replace(/\btimes\b/gi, '*')
         .replace(/\bmultiplied\s+by\b/gi, '*')
         .replace(/\bdivided\s+by\b/gi, '/')
         .replace(/\bplus\b/gi, '+')
-        .replace(/\bminus\b/gi, '-')
-        .replace(/\s+/g, '')
-        .replace(/[^\d+\-*/().^]/g, '');
+        .replace(/\bminus\b/gi, '-');
 
-    // Handle exponents
-    cleaned = cleaned.replace(/(\d+\.?\d*)\^(\d+\.?\d*)/g, 'Math.pow($1,$2)');
-
-    // Safety check - only allow numbers and operators
-    if (!/^[\d+\-*/().Math,pow\s]+$/.test(cleaned)) {
-        return { success: false, error: 'Expression contains invalid characters' };
-    }
-
-    try {
-        // Using Function instead of eval for slightly better safety
-        const result = Function('"use strict"; return (' + cleaned + ')')();
-
-        if (typeof result !== 'number' || !isFinite(result)) {
-            return { success: false, error: 'Invalid result' };
-        }
-
-        return {
-            success: true,
-            answer: formatNumber(result),
-            steps: [`${expression} = ${formatNumber(result)}`]
-        };
-    } catch (error) {
-        return { success: false, error: 'Could not evaluate expression' };
-    }
+    const r = evalExpression(worded, evalMode);
+    if (!r) return { success: false, error: 'Could not evaluate expression' };
+    return {
+        success: true,
+        answer: r.answer,
+        steps: [`${expression} = ${r.answer}`],
+    };
 }
 
 /**
@@ -2440,31 +2276,6 @@ function greatestCommonDivisor(a, b) {
 }
 
 /**
- * Safely evaluate a pure-arithmetic string to a number, honoring operator
- * precedence (so "16/4*2" = 8, not 1642). Returns null for anything that
- * isn't a clean numeric expression with at least one operator — plain
- * numbers, units, commas, or algebra fall back to the caller's own parsing.
- */
-function evalArithmeticString(str) {
-    if (typeof str !== 'string') return null;
-    // Normalize Unicode operators/signs via the shared source of truth, then strip
-    // whitespace, so "16/4 ⋅ 2" and "−34+6" evaluate by value rather than as garbage.
-    let s = normalizeMathOperators(str).replace(/\s+/g, '');
-    // Require at least one operator (so plain "8" stays on the caller's path)
-    // and ONLY safe arithmetic characters (no letters, commas, currency, units).
-    if (!/[+\-*/^]/.test(s)) return null;
-    if (!/^[-+*/^().\d]+$/.test(s)) return null;
-    s = s.replace(/(\d+\.?\d*)\^(\d+\.?\d*)/g, 'Math.pow($1,$2)');
-    if (!/^[\d+\-*/().,Mathpow]+$/.test(s)) return null;
-    try {
-        const r = Function('"use strict"; return (' + s + ')')();
-        return (typeof r === 'number' && isFinite(r)) ? r : null;
-    } catch (e) {
-        return null;
-    }
-}
-
-/**
  * Verify if a student's answer matches the correct answer
  * @param {string|number} studentAnswer - Student's provided answer
  * @param {string|number} correctAnswer - Correct answer from solver
@@ -2490,12 +2301,13 @@ function verifyAnswer(studentAnswer, correctAnswer, tolerance = 0.01) {
     // falsely matches "3x^2-3" stripped to "32-3" → 32.
     const hasLetters = /[a-zA-Z]/.test(studentStr) || /[a-zA-Z]/.test(correctStr);
     if (!hasLetters) {
-        // Evaluate each side as an arithmetic expression FIRST so an expression-form
-        // answer ("16/4 ⋅ 2") is compared by its value (8), not by its stripped digits
-        // ("1642"). Falls back to digit-strip parsing for plain numbers that carry
+        // Evaluate each side through the single exact-rational engine, so any
+        // equivalent numeric form grades equal by VALUE: expressions ("16/4 ⋅ 2" = 8),
+        // fractions, mixed numbers ("8 5/12" == "101/12" == "8.4167"), and decimals.
+        // Falls back to digit-strip parsing for plain numbers that carry
         // units/commas/currency ("1,000", "$8").
-        const studentEval = evalArithmeticString(studentStr);
-        const correctEval = evalArithmeticString(correctStr);
+        const studentEval = expressionValue(studentStr);
+        const correctEval = expressionValue(correctStr);
         const studentNum = studentEval !== null ? studentEval : parseFloat(studentStr.replace(/[^\d.\-]/g, ''));
         const correctNum = correctEval !== null ? correctEval : parseFloat(correctStr.replace(/[^\d.\-]/g, ''));
 
@@ -2531,15 +2343,6 @@ function verifyAnswer(studentAnswer, correctAnswer, tolerance = 0.01) {
         }
     }
 
-    // Mixed-number equivalence: "8 5/12" == "101/12" == "8.4167" all grade equal,
-    // so a student who leaves the answer improper (or as a decimal) still gets credit.
-    if (!hasLetters) {
-        const sVal = rationalOrDecimalValue(studentStr);
-        const cVal = rationalOrDecimalValue(correctStr);
-        if (sVal !== null && cVal !== null && Math.abs(sVal - cVal) <= tolerance) {
-            return { isCorrect: true, exact: false, equivalentForm: true };
-        }
-    }
 
     // System of equations answer: "x = 3, y = 2" vs "y = 2, x = 3"
     const studentVars = parseVariableAssignments(studentStr);

--- a/utils/rationalEvaluator.js
+++ b/utils/rationalEvaluator.js
@@ -1,0 +1,174 @@
+/**
+ * Exact-rational expression evaluator — the single numeric engine for mathSolver.
+ *
+ * WHY: the math engine historically had five separate hand-rolled evaluators
+ * (two-operand arithmetic, fraction arithmetic, a Function()-based multi-operand
+ * chain, a bespoke mixed-number solver, and an embedded last-resort regex). Each
+ * had its own parser, its own bugs, and its own answer format — and every
+ * "tutor rejected a correct answer" incident traced to one of them mis-computing
+ * (16/4*2 → 4, −34+6 → 40, mixed numbers unsupported).
+ *
+ * This replaces all of that with ONE correct core: parse to exact rationals
+ * (BigInt numerator/denominator, so 0.1 + 0.2 = 0.3 and 38/3 - 17/4 = 101/12 with
+ * no floating-point error), then format per domain (decimal / fraction / mixed).
+ * Mixed numbers, vulgar fractions, operator precedence, parentheses, and Unicode
+ * operators all fall out of the same engine.
+ *
+ * @module rationalEvaluator
+ */
+
+const { normalizeMathOperators } = require('./mathUnicodeNormalizer');
+
+// ── Exact rational: { n: BigInt, d: BigInt }, d > 0, reduced ──
+function bgcd(a, b) { a = a < 0n ? -a : a; b = b < 0n ? -b : b; while (b) { [a, b] = [b, a % b]; } return a; }
+function rat(n, d = 1n) {
+  n = BigInt(n); d = BigInt(d);
+  if (d === 0n) return null;
+  if (d < 0n) { n = -n; d = -d; }
+  const g = bgcd(n < 0n ? -n : n, d) || 1n;
+  return { n: n / g, d: d / g };
+}
+const rAdd = (a, b) => rat(a.n * b.d + b.n * a.d, a.d * b.d);
+const rSub = (a, b) => rat(a.n * b.d - b.n * a.d, a.d * b.d);
+const rMul = (a, b) => rat(a.n * b.n, a.d * b.d);
+const rDiv = (a, b) => (b.n === 0n ? null : rat(a.n * b.d, a.d * b.n));
+function rPow(a, b) {
+  if (b.d !== 1n) return null; // only integer exponents (no radicals here)
+  let e = b.n;
+  const neg = e < 0n; if (neg) e = -e;
+  let acc = rat(1n);
+  for (let i = 0n; i < e; i++) acc = rMul(acc, a);
+  return neg ? rDiv(rat(1n), acc) : acc;
+}
+
+// ── Vulgar fraction glyph → [num, den] ──
+const VULGAR = {
+  '½': [1, 2], '⅓': [1, 3], '⅔': [2, 3], '¼': [1, 4], '¾': [3, 4],
+  '⅕': [1, 5], '⅖': [2, 5], '⅗': [3, 5], '⅘': [4, 5], '⅙': [1, 6],
+  '⅚': [5, 6], '⅐': [1, 7], '⅛': [1, 8], '⅜': [3, 8], '⅝': [5, 8],
+  '⅞': [7, 8], '⅑': [1, 9], '⅒': [1, 10],
+};
+const VC = Object.keys(VULGAR).join('');
+
+// Rewrite mixed numbers and vulgar fractions as explicit parenthesised rationals:
+//   "12 2/3" → "(12+2/3)"   "12⅔" → "(12+2/3)"   "⅔" → "(2/3)"
+function preprocess(expr) {
+  return expr
+    .replace(new RegExp(`(\\d+)\\s*([${VC}])`, 'g'), (_, w, g) => { const [n, d] = VULGAR[g]; return `(${w}+${n}/${d})`; })
+    .replace(new RegExp(`[${VC}]`, 'g'), (g) => { const [n, d] = VULGAR[g]; return `(${n}/${d})`; })
+    .replace(/(\d+)\s+(\d+\s*\/\s*\d+)/g, '($1+$2)');
+}
+
+function tokenize(s) {
+  const toks = []; let i = 0;
+  while (i < s.length) {
+    const c = s[i];
+    if (c === ' ') { i++; continue; }
+    if ('+-*/^()'.includes(c)) { toks.push(c); i++; continue; }
+    if ((c >= '0' && c <= '9') || c === '.') {
+      let j = i; while (j < s.length && ((s[j] >= '0' && s[j] <= '9') || s[j] === '.')) j++;
+      const num = s.slice(i, j);
+      if ((num.match(/\./g) || []).length > 1) return null; // "1.2.3"
+      toks.push(num); i = j; continue;
+    }
+    return null; // letters or anything non-numeric
+  }
+  return toks;
+}
+function numToRat(num) {
+  if (!num.includes('.')) return rat(num);
+  const [intp, frac] = num.split('.');
+  return rat(BigInt((intp || '0') + frac), 10n ** BigInt(frac.length));
+}
+
+// Recursive descent: expr(+ -) → term(* /) → pow(^) → unary(±) → atom(number|parens)
+function evaluate(exprRaw) {
+  const toks = tokenize(exprRaw);
+  if (!toks || toks.length === 0) return null;
+  let pos = 0, failed = false;
+  const peek = () => toks[pos];
+  const next = () => toks[pos++];
+
+  function parseExpr() {
+    let left = parseTerm(); if (left === null) return null;
+    while (peek() === '+' || peek() === '-') { const op = next(); const r = parseTerm(); if (r === null) return null; left = op === '+' ? rAdd(left, r) : rSub(left, r); }
+    return left;
+  }
+  function parseTerm() {
+    let left = parsePow(); if (left === null) return null;
+    while (peek() === '*' || peek() === '/') { const op = next(); const r = parsePow(); if (r === null) return null; left = op === '*' ? rMul(left, r) : rDiv(left, r); if (left === null) return null; }
+    return left;
+  }
+  function parsePow() {
+    const base = parseUnary(); if (base === null) return null;
+    if (peek() === '^') { next(); const exp = parsePow(); if (exp === null) return null; return rPow(base, exp); }
+    return base;
+  }
+  function parseUnary() {
+    if (peek() === '-') { next(); const v = parseUnary(); return v === null ? null : rat(-v.n, v.d); }
+    if (peek() === '+') { next(); return parseUnary(); }
+    return parseAtom();
+  }
+  function parseAtom() {
+    const t = peek();
+    if (t === '(') { next(); const v = parseExpr(); if (v === null) return null; if (peek() !== ')') { failed = true; return null; } next(); return v; }
+    if (t !== undefined && /^[\d.]+$/.test(t)) { next(); return numToRat(t); }
+    failed = true; return null;
+  }
+  const result = parseExpr();
+  if (failed || pos !== toks.length || result === null) return null;
+  return result;
+}
+
+// Format an exact rational per domain mode: 'decimal' | 'fraction' | 'mixed'.
+function formatRat(r, mode) {
+  if (!r) return null;
+  if (mode === 'decimal') {
+    const val = Number(r.n) / Number(r.d);
+    return Number.isInteger(val) ? String(val) : String(parseFloat(val.toFixed(4)));
+  }
+  if (r.d === 1n) return String(r.n);
+  const neg = r.n < 0n, an = neg ? -r.n : r.n, sgn = neg ? '-' : '';
+  if (mode === 'mixed' && an >= r.d) {
+    const whole = an / r.d, rem = an % r.d;
+    return rem === 0n ? `${sgn}${whole}` : `${sgn}${whole} ${rem}/${r.d}`;
+  }
+  return `${sgn}${an}/${r.d}`; // proper or improper fraction
+}
+
+// Which representation does this expression call for?
+function detectMode(originalExpr) {
+  if (/\d\s+\d+\s*\/\s*\d+/.test(originalExpr) || new RegExp(`\\d\\s*[${VC}]`).test(originalExpr)) return 'mixed';
+  if (/\d\.\d/.test(originalExpr)) return 'decimal';
+  if (/\//.test(originalExpr) || new RegExp(`[${VC}]`).test(originalExpr)) return 'fraction';
+  return 'decimal';
+}
+
+/**
+ * Evaluate a numeric expression exactly. Returns { rat, answer, mode } or null
+ * if the string isn't a pure numeric expression (letters, malformed, /0).
+ * @param {string} originalExpr
+ * @param {string} [modeOverride] - force 'decimal' | 'fraction' | 'mixed'
+ */
+function evalExpression(originalExpr, modeOverride) {
+  if (typeof originalExpr !== 'string') return null;
+  const normalized = normalizeMathOperators(originalExpr);
+  const r = evaluate(preprocess(normalized));
+  if (r === null) return null;
+  const mode = modeOverride || detectMode(normalized);
+  return { rat: r, answer: formatRat(r, mode), mode };
+}
+
+/**
+ * Numeric value of a mixed number / fraction / decimal / expression, or null.
+ * Used by verifyAnswer to grade "8 5/12", "101/12", and "8.4167" as equal.
+ */
+function expressionValue(str) {
+  if (typeof str !== 'string') return null;
+  const t = normalizeMathOperators(str).trim();
+  if (!t || /[a-z]/i.test(t)) return null;
+  const r = evaluate(preprocess(t));
+  return r ? Number(r.n) / Number(r.d) : null;
+}
+
+module.exports = { evalExpression, expressionValue, evaluate, preprocess, formatRat, detectMode, rat };


### PR DESCRIPTION
## The disease, not the symptom

Every "tutor rejected a correct answer" bug we've chased — `16/4 ⋅ 2 → 4`, `−34+6 → 40`, mixed numbers unsupported, `(2+3)*4` truncated — lived in one of **five separate hand-rolled numeric evaluators** in `mathSolver.js`: two-operand arithmetic, fraction arithmetic, a `Function()`-based multi-operand chain, a bespoke mixed-number solver, and an embedded last-resort regex. Each had its own parser, its own bugs, its own answer format. Every fix so far patched one of them. The mixed-number PR added a sixth.

This replaces all of them with **one correct core.**

## The solution — `utils/rationalEvaluator.js`

A single exact-rational expression evaluator:
- **Recursive-descent parser** over exact rationals (BigInt numerator/denominator), so there's no floating-point drift: `0.1 + 0.2 = 0.3`, `1/3 + 1/3 + 1/3 = 1`, `38/3 − 17/4 = 101/12` — exactly.
- **Domain-aware formatting**: decimal (`13.75`), fraction (`3/4`), or mixed (`8 5/12`), auto-detected or pinned via a mode override.
- Mixed numbers, vulgar fractions (`½`), operator precedence, **parentheses**, and Unicode operators all fall out of the same engine.

## `mathSolver.js` now delegates

- `solveArithmetic` / `solveFractionArithmetic` / `solveMixedNumberArithmetic` / `solveEvaluation` become **thin adapters** that call the engine with the right domain.
- Detection routes any whole pure-numeric expression — chains **and parenthesised** — to the engine, so `(2+3)*4 → 20` instead of the embedded pattern's `5`.
- `verifyAnswer` grades by exact value, so mixed / improper / decimal forms all match.
- Deleted `parseOperandToImproper`, `formatRational`, `rationalOrDecimalValue`, and the `Function()`-based `evalArithmeticString`. **`mathSolver.js` drops ~325 lines** (net −269 including the adapters).

## Bonus safety

A prose string like `"Solve 4x+3=27."` no longer fabricates a bogus `331` — the exact engine refuses non-numeric input rather than stripping letters and evaluating the leftover digits (the old catch-all's exact failure mode, which #1077's `parseCleanProblem` guard was built to work around). Updated the regression-guard control test to lock in the improvement.

## Verification

- New `tests/unit/rationalEvaluator.test.js` — engine contract: exactness, all four domains, mode override, Unicode operators, and null-on-garbage.
- Existing behavior preserved: `15+27 → 42`, `7/2 → 3.5`, `16/4 → 4`, `1/2 + 1/4 → 3/4`.
- All prior repros fixed: `16/4 ⋅ 2 → 8`, `−34+6 → -28`, `3x−6=2x−34 → x=-28`, `12⅔ - 4¼ → 8 5/12`.
- **Full suite: 458 passing, 0 failing.**

## Context

This supersedes the incremental fixes (#1077 chain, #1097 Unicode normalizer, #1100 mixed-number) with the single engine they were all approximating. Those normalization/detection fixes remain valid front-doors; this makes the evaluation core correct by construction so the class can't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DffsjzSQTvBveT29DwtziR)_