### PR TITLE
test(eval): LLM-in-the-loop tutor eval harness — stop finding bugs in prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "test:unit": "jest --testPathPattern=tests/unit",
     "test:integration": "jest --testPathPattern=tests/integration",
     "test:golden": "jest --testPathPattern=tests/golden",
+    "test:eval": "jest --testPathPattern=tests/eval",
+    "test:eval:live": "RUN_LLM_EVAL=1 jest --testPathPattern=tests/eval/liveEval",
     "test:critical": "jest --config jest.critical.config.js",
     "seed:test": "node scripts/seedTestData.js",
     "seed:playground": "node scripts/seedPlaygroundAccounts.js",

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -1,0 +1,64 @@
+# Tutor Eval Harness
+
+An **LLM-in-the-loop** regression net for the tutor's *actual replies*.
+
+## Why this exists
+
+Every "the tutor told a correct student they were wrong" bug we've shipped was
+found the same way: a human read a production transcript. The unit tests and the
+`tests/golden/` suite can't catch these — **they mock the LLM**, so they lock the
+deterministic `observe → decide` layer but are blind to what the model actually
+*says*.
+
+This harness closes that gap. It replays real failing transcripts as permanent
+scenarios and scores the tutor's reply against the failure classes we already
+know it hits — turning "Jason finds it in prod" into "CI finds the class in the PR."
+
+## The two layers
+
+| Layer | Runs in | Needs a key? | Catches |
+|-------|---------|--------------|---------|
+| **Deterministic** | normal `npm test` | no | classification/decision regressions (a self-check `"is it 5/12?"` must be an `answer_attempt`; `"12 2/3 - 4 1/4"` must be a bare problem drop) |
+| **Judges (mock model)** | normal `npm test` | no | proves the judge+runner wiring: the real failing transcript lines are flagged, clean replies pass |
+| **Live** (`liveEval.test.js`) | opt-in only | **yes** | the *real* gpt-4o-mini reply violating a judge — the thing the golden suite can't see |
+
+```bash
+npm run test:eval                # hermetic layers (deterministic + mock model)
+npm run test:eval:live           # real model — needs RUN_LLM_EVAL=1 + OPENAI_API_KEY
+```
+
+The live eval is **opt-in** (`RUN_LLM_EVAL=1`) so the nondeterministic model never
+flakes the keyless PR gate. Wire it as a nightly / pre-release job.
+
+## The failure classes (`judges.js`)
+
+Each judge is a pure `(reply, ctx) → { violated, evidence }`. Current classes,
+all drawn from real transcripts:
+
+- **rejectedCorrectAnswer** — hedged/denied ("not quite", "you're close") when the student was right.
+- **assertedFalseEquivalence** — claimed two equal forms (e.g. `5/12` and `10/24`) are "not equivalent".
+- **lostContext** — asked the student to re-name the topic while a problem/graph was on screen.
+- **solvedInsteadOfEliciting** — worked a full solution to a bare problem drop instead of asking for the first move.
+- **usedImpreciseTerm** — said "reduce" (say *simplify*) or "improper fraction" (say *a fraction greater than one*).
+- **badOrderOfOperations** — asserted "multiplication comes before division" as a rule.
+- **revealedAnswer** — leaked a withheld answer.
+
+## Add a scenario — edit `scenarios.json`, no code
+
+Each scenario is a real transcript. Turns are either a pre-seeded `assistant`
+line (context) or a `student` turn with:
+
+- `expect` — deterministic `observe()` assertions (`messageType`, `answerValue`, `isBareProblemDrop`, `notAnswerAttempt`).
+- `judge` — judge names to score the reply (generation layer).
+- `ctx` — flags the judges read: `studentWasCorrect`, `hasFocus`, `shouldElicit`, `mustNotReveal`, `answer`.
+
+Scenario-level `focus` / `focusTerms` / `answer` provide defaults.
+
+When you add a `judge` turn, also add a known-bad and known-good reply for it in
+`tutorEval.test.js` (the mock-model fixtures) — the suite-integrity test enforces this.
+
+## Adding a judge
+
+Add a pure function to `judges.js`, register it in the `JUDGES` map, and add
+unit tests in `tests/unit/evalJudges.test.js` against real good/bad lines. Every
+new production failure should become a judge (the class) **and** a scenario (the case).

--- a/tests/eval/judges.js
+++ b/tests/eval/judges.js
@@ -1,0 +1,134 @@
+/**
+ * TUTOR-REPLY JUDGES — automated detectors for the tutor failure classes this
+ * project keeps hitting in production transcripts.
+ *
+ * Each judge is a PURE function of (reply, ctx) → { violated: boolean, evidence }.
+ * They are heuristic string checks, not proofs — a regression NET, not a verifier.
+ * The point is to turn "Jason reads a transcript and spots the bug" into "CI scores
+ * the tutor's actual words against the classes we already know it fails."
+ *
+ * ctx fields the judges may use:
+ *   studentWasCorrect  {boolean}  the student's answer this turn was mathematically correct
+ *   hasFocus           {boolean}  a specific problem/graph was already on screen
+ *   focusTerms         {string[]} tokens naming the current focus (e.g. ["y=x^3","x^3","cubic"])
+ *   shouldElicit       {boolean}  the tutor should have asked the student to try, not solved it
+ *   answer             {string}   the (never-to-be-revealed) answer for the active problem
+ *   mustNotReveal      {boolean}  revealing `answer` is a violation this turn
+ */
+
+'use strict';
+
+const norm = (s) => String(s || '').toLowerCase();
+
+// ── Rejecting a correct answer ──────────────────────────────────────────────
+// The cardinal sin behind most of this session's transcripts: the student is
+// right and the tutor hedges/denies ("not quite", "almost", "you're close",
+// "let's double-check", "not correct"). Only a violation when the student WAS right.
+const REJECTION_MARKERS = /\b(not quite|almost(?!\s+there,\s+you'?re\s+right)|you'?re close|close,?\s+but|not (?:quite )?right|that'?s not (?:it|right|correct)|not correct|incorrect|try (?:that )?again|let'?s (?:double[-\s]?)?check|let'?s re[-\s]?check|hmm,?\s+not|isn'?t (?:quite )?right)\b/i;
+function rejectedCorrectAnswer(reply, ctx = {}) {
+  if (!ctx.studentWasCorrect) return { violated: false };
+  const m = norm(reply).match(REJECTION_MARKERS);
+  return m ? { violated: true, evidence: `rejected a correct answer: "${m[0]}"` } : { violated: false };
+}
+
+// ── Asserting a false non-equivalence ───────────────────────────────────────
+// The tutor told the student 5/12 and 10/24 were "not equivalent". When the two
+// forms in play ARE equal (studentWasCorrect), claiming they're not is a hard fail.
+const NONEQUIV_MARKERS = /\b(not equivalent|aren'?t equivalent|isn'?t equivalent|not equal|aren'?t equal|isn'?t equal|not the same|aren'?t the same|don'?t (?:match|equal)|they'?re different)\b/i;
+function assertedFalseEquivalence(reply, ctx = {}) {
+  if (!ctx.studentWasCorrect) return { violated: false };
+  const m = norm(reply).match(NONEQUIV_MARKERS);
+  return m ? { violated: true, evidence: `claimed equal forms are unequal: "${m[0]}"` } : { violated: false };
+}
+
+// ── Losing the current focus ────────────────────────────────────────────────
+// "What function do you have in mind?" while y=x^3 was on screen. A violation only
+// when a focus already existed AND the reply asks the student to (re)name the topic.
+const AMNESIA_MARKERS = /\bwhat\b[^?]{0,60}?\b(?:do you have in mind|would you like to (?:work on|explore|tackle|focus on)|are you (?:working on|referring to|thinking (?:of|about)))\b|what (?:do you )?(?:want|feel like) (?:to )?work(?:ing)? on\b/i;
+function lostContext(reply, ctx = {}) {
+  if (!ctx.hasFocus) return { violated: false };
+  const m = norm(reply).match(AMNESIA_MARKERS);
+  return m ? { violated: true, evidence: `asked the student to re-name the topic while a focus was active: "${m[0]}"` } : { violated: false };
+}
+
+// ── Solving instead of eliciting ────────────────────────────────────────────
+// A bare problem drop should be met with "what's your first move?", not a full
+// worked solution. Heuristic: two or more equation-transformation lines, or the
+// final answer stated, when the tutor should have elicited.
+function solvedInsteadOfEliciting(reply, ctx = {}) {
+  if (!ctx.shouldElicit) return { violated: false };
+  const text = String(reply || '');
+  // Two or more "=" transformations with numbers = a worked solution, not a prompt.
+  const eqCount = /\d/.test(text) ? (text.match(/=/g) || []).length : 0;
+  if (eqCount >= 2) return { violated: true, evidence: `worked ${eqCount} solution steps instead of eliciting` };
+  if (ctx.answer && containsValue(text, ctx.answer)) return { violated: true, evidence: `stated the answer (${ctx.answer}) instead of eliciting` };
+  return { violated: false };
+}
+
+// ── Imprecise / stigmatizing math language ──────────────────────────────────
+// Terminology the teacher explicitly rejected: "reduce" (implies smaller) — say
+// SIMPLIFY; "improper fraction" (implies wrong) — say "fraction greater than one".
+function usedImpreciseTerm(reply, ctx = {}) {
+  const found = [];
+  if (/\breduc(?:e|es|ed|ing|tion)\b/i.test(reply) && /\b(fraction|lowest terms|simplest)\b/i.test(reply)) {
+    found.push('"reduce" (say "simplify")');
+  }
+  if (/\bimproper fraction/i.test(reply)) found.push('"improper fraction" (say "fraction greater than one")');
+  return found.length ? { violated: true, evidence: found.join('; ') } : { violated: false };
+}
+
+// ── Revealing the answer ────────────────────────────────────────────────────
+function revealedAnswer(reply, ctx = {}) {
+  if (!ctx.mustNotReveal || !ctx.answer) return { violated: false };
+  return containsValue(reply, ctx.answer)
+    ? { violated: true, evidence: `revealed the withheld answer (${ctx.answer})` }
+    : { violated: false };
+}
+
+// ── Wrong order-of-operations claim ─────────────────────────────────────────
+// "multiplication comes before division" as a RULE (the PEMDAS trap).
+const OOO_MARKERS = /\bmultipl\w+\s+(?:comes?|is|goes|happens?)\s+before\s+divi|divi\w+\s+(?:comes?|is|goes)\s+after\s+multipl|addition\s+(?:comes?|is|goes)\s+before\s+subtrac/i;
+function badOrderOfOperations(reply) {
+  const m = norm(reply).match(OOO_MARKERS);
+  return m ? { violated: true, evidence: `asserted a false precedence rule: "${m[0]}"` } : { violated: false };
+}
+
+// A value can appear in many forms; match the raw string and, for fractions/
+// numbers, a whitespace-insensitive form.
+function containsValue(text, value) {
+  const t = String(text);
+  const v = String(value).trim();
+  if (!v) return false;
+  if (t.includes(v)) return true;
+  const compact = v.replace(/\s+/g, '');
+  return compact !== v && t.replace(/\s+/g, '').includes(compact);
+}
+
+const JUDGES = {
+  rejectedCorrectAnswer,
+  assertedFalseEquivalence,
+  lostContext,
+  solvedInsteadOfEliciting,
+  usedImpreciseTerm,
+  revealedAnswer,
+  badOrderOfOperations,
+};
+
+/**
+ * Run a set of judges against a reply. Returns { violations: [{judge, evidence}] }.
+ * @param {string} reply
+ * @param {string[]} judgeNames  which judges to apply this turn
+ * @param {object} ctx
+ */
+function judgeReply(reply, judgeNames, ctx = {}) {
+  const violations = [];
+  for (const name of judgeNames) {
+    const fn = JUDGES[name];
+    if (!fn) throw new Error(`Unknown judge: ${name}`);
+    const r = fn(reply, ctx);
+    if (r.violated) violations.push({ judge: name, evidence: r.evidence });
+  }
+  return { violations, passed: violations.length === 0 };
+}
+
+module.exports = { JUDGES, judgeReply, containsValue };

--- a/tests/eval/liveEval.test.js
+++ b/tests/eval/liveEval.test.js
@@ -1,0 +1,86 @@
+/**
+ * LIVE TUTOR EVAL — runs the scenarios against the REAL model and scores the
+ * tutor's actual replies with the judges. This is the piece the old golden suite
+ * couldn't do (it mocks the LLM): it catches the tutor's WORDS regressing.
+ *
+ * OPT-IN ONLY. It needs an OpenAI key and makes real calls, so it is skipped
+ * unless RUN_LLM_EVAL=1. Wire it as a nightly / pre-release job, not the keyless
+ * PR gate — the model is nondeterministic and would flake normal CI.
+ *
+ *   RUN_LLM_EVAL=1 OPENAI_API_KEY=sk-... npm run test:eval:live
+ *
+ * The reply is generated the way production does for a correctness turn: the real
+ * compact system prompt + the scenario history, plus the same verified-answer hint
+ * chat.js injects when the student's message is an answer attempt. So a failure
+ * here is a real "the tutor would say this to a student" failure.
+ */
+'use strict';
+
+const RUN = process.env.RUN_LLM_EVAL === '1' && !!process.env.OPENAI_API_KEY;
+
+const scenarios = require('./scenarios.json').scenarios;
+const { runScenario, formatFailures } = require('./runner');
+
+const TEST_PROFILE = {
+  firstName: 'Alex', lastName: 'Rivera', gradeLevel: '7', mathCourse: 'Math 7',
+  interests: [], learningStyle: null, tonePreference: 'encouraging',
+};
+const TEST_TUTOR = {
+  name: 'Mr. Nappier',
+  catchphrase: 'See the patterns, solve with ease.',
+  personality: 'Warm, encouraging middle-school math teacher who guides with questions.',
+};
+
+// Mirror chat.js: on a verified answer attempt, the pinned answer is injected for
+// grading (never to be revealed). We give the model the SAME signal so the eval
+// tests the real "does it respect the verdict" behavior, not a handicapped path.
+function verifiedAnswerHint(turn, scenario) {
+  if (!turn.ctx || !turn.ctx.studentWasCorrect) return '';
+  const ans = turn.ctx.answer ?? scenario.answer;
+  if (!ans) return '';
+  return `\n\n[MATH_VERIFICATION — INTERNAL GRADING ONLY: the student's answer is CORRECT (equivalent to ${ans}). Confirm it's correct. NEVER reveal or restate ${ans} as the answer; guide from here.]`;
+}
+
+async function liveGenerateReply({ scenario, turn, history }) {
+  // Lazy-require so the keyless suite never loads the OpenAI client.
+  const { generateSystemPrompt } = require('../../utils/promptCompact');
+  const { callLLM } = require('../../utils/llmGateway');
+
+  const recent = history.filter((m) => m.role === 'user').slice(-6).map((m) => m.content);
+  const systemPrompt = generateSystemPrompt(
+    TEST_PROFILE, TEST_TUTOR, null, 'student',
+    null, null, null, [], null,
+    { topicName: scenario.focus || undefined }, null, null, null, null,
+    turn.student, history.slice(-8),
+  );
+
+  const messages = [{ role: 'system', content: systemPrompt }];
+  history.forEach((m, idx) => {
+    const isLastUser = idx === history.length - 1 && m.role === 'user';
+    messages.push({ role: m.role, content: isLastUser ? m.content + verifiedAnswerHint(turn, scenario) : m.content });
+  });
+
+  const completion = await callLLM('gpt-4o-mini', messages, { temperature: 0.5, max_tokens: 400 });
+  return (completion && (completion.content || completion.text || completion)) || '';
+}
+
+(RUN ? describe : describe.skip)('LIVE tutor eval (real gpt-4o-mini)', () => {
+  jest.setTimeout(120000);
+
+  for (const s of scenarios) {
+    if (!s.turns.some((t) => Array.isArray(t.judge))) continue;
+    test(s.name, async () => {
+      const r = await runScenario(s, { generateReply: liveGenerateReply });
+      if (!r.judgesPassed) {
+        throw new Error(`LIVE tutor reply violated a judge:\n${formatFailures(r).join('\n')}`);
+      }
+    });
+  }
+});
+
+// Keep the file non-empty for the keyless runner (describe.skip emits no tests).
+describe('live eval harness config', () => {
+  test('is opt-in via RUN_LLM_EVAL', () => {
+    expect(typeof RUN).toBe('boolean');
+  });
+});

--- a/tests/eval/runner.js
+++ b/tests/eval/runner.js
@@ -1,0 +1,105 @@
+/**
+ * EVAL RUNNER — walks a scenario turn by turn, running the REAL deterministic
+ * pipeline (observe) for classification checks, and — when a model is wired in —
+ * generating the tutor's actual reply and scoring it with the judges.
+ *
+ * The model is dependency-injected via opts.generateReply, so the same runner
+ * powers both the hermetic CI test (a canned/mock model) and the live eval (the
+ * real gpt-4o-mini pipeline). No network or API key is required unless a real
+ * generateReply is passed.
+ */
+'use strict';
+
+const { observe } = require('../../utils/pipeline/observe');
+const { judgeReply } = require('./judges');
+
+function classify(studentMsg, history, scenario) {
+  return observe(studentMsg, {
+    recentUserMessages: history.filter((m) => m.role === 'user').slice(-6),
+    recentAssistantMessages: history.filter((m) => m.role === 'assistant').slice(-6),
+    hasRecentUpload: !!scenario.hasRecentUpload,
+  });
+}
+
+function checkExpectations(expect, obs) {
+  const checks = {};
+  if (!expect) return checks;
+  if (expect.messageType) {
+    checks.messageType = { got: obs.messageType, want: expect.messageType, ok: obs.messageType === expect.messageType };
+  }
+  if (expect.answerValue) {
+    const got = obs.answer && obs.answer.value;
+    checks.answerValue = { got, want: expect.answerValue, ok: got === expect.answerValue };
+  }
+  if (expect.notAnswerAttempt) {
+    checks.notAnswerAttempt = { got: obs.messageType, ok: obs.messageType !== 'answer_attempt' };
+  }
+  if (typeof expect.isBareProblemDrop === 'boolean') {
+    checks.isBareProblemDrop = { got: obs.isBareProblemDrop, want: expect.isBareProblemDrop, ok: obs.isBareProblemDrop === expect.isBareProblemDrop };
+  }
+  return checks;
+}
+
+/**
+ * @param {object} scenario  one entry from scenarios.json
+ * @param {object} [opts]
+ * @param {(args:{scenario,turnIndex,history,student})=>Promise<string>|string} [opts.generateReply]
+ *        Produce the tutor's reply for this turn. Omit to run classification-only.
+ * @returns {Promise<{name, turns, classificationPassed, judgesPassed, passed}>}
+ */
+async function runScenario(scenario, opts = {}) {
+  const { generateReply } = opts;
+  const history = [];
+  const turns = [];
+
+  for (let i = 0; i < scenario.turns.length; i++) {
+    const turn = scenario.turns[i];
+
+    // A pre-seeded tutor line (context the student is responding to).
+    if (turn.assistant) {
+      history.push({ role: 'assistant', content: turn.assistant });
+      continue;
+    }
+
+    const student = turn.student;
+    const obs = classify(student, history, scenario);
+    const checks = checkExpectations(turn.expect, obs);
+    history.push({ role: 'user', content: student });
+
+    let reply = null;
+    let violations = [];
+    if (generateReply && Array.isArray(turn.judge) && turn.judge.length) {
+      reply = await generateReply({ scenario, turn, turnIndex: i, history, student });
+      const ctx = {
+        ...(turn.ctx || {}),
+        answer: turn.ctx?.answer ?? scenario.answer,
+        hasFocus: turn.ctx?.hasFocus ?? !!scenario.focus,
+        focusTerms: scenario.focusTerms || [],
+      };
+      violations = judgeReply(reply, turn.judge, ctx).violations;
+      history.push({ role: 'assistant', content: reply });
+    }
+
+    turns.push({ student, obs: { messageType: obs.messageType, answer: obs.answer, isBareProblemDrop: obs.isBareProblemDrop }, checks, reply, violations });
+  }
+
+  const classificationPassed = turns.every((t) => Object.values(t.checks).every((c) => c.ok));
+  const judgesPassed = turns.every((t) => t.violations.length === 0);
+  return { name: scenario.name, turns, classificationPassed, judgesPassed, passed: classificationPassed && judgesPassed };
+}
+
+/** Format a failed scenario result into a readable report line set. */
+function formatFailures(result) {
+  const lines = [];
+  for (const t of result.turns) {
+    for (const [k, c] of Object.entries(t.checks)) {
+      if (!c.ok) lines.push(`  classification[${k}]: got ${JSON.stringify(c.got)}, want ${JSON.stringify(c.want)} — student: "${t.student}"`);
+    }
+    for (const v of t.violations) {
+      lines.push(`  judge[${v.judge}]: ${v.evidence}\n    reply: "${String(t.reply).slice(0, 160)}"`);
+    }
+  }
+  return lines;
+}
+
+module.exports = { runScenario, formatFailures };

--- a/tests/eval/scenarios.json
+++ b/tests/eval/scenarios.json
@@ -1,0 +1,101 @@
+{
+  "_comment": "LLM-in-the-loop eval scenarios. Each is a real production transcript this project failed on, encoded as a permanent regression case. `expect` assertions run DETERMINISTICALLY (real observe(), no API key). `judge` assertions score the tutor's ACTUAL reply and run only when a model is wired in (the mock model in tutorEval.test.js, or the real model in liveEval.test.js). ctx flags per turn feed the judges — see tests/eval/judges.js.",
+
+  "scenarios": [
+    {
+      "name": "fractions: butterfly answer 10/24 is correct (= 5/12), confirm then simplify",
+      "focus": "1/4 + 1/6",
+      "focusTerms": ["1/4", "1/6", "common denominator"],
+      "answer": "5/12",
+      "turns": [
+        { "assistant": "How would you add 1/4 + 1/6? What's the first step?" },
+        {
+          "student": "oh wait. add the denominators for the numerator and multiply em for the denominator, right? 10/24",
+          "expect": { "messageType": "answer_attempt", "answerValue": "10/24" },
+          "ctx": { "studentWasCorrect": true, "hasFocus": true },
+          "judge": ["rejectedCorrectAnswer", "assertedFalseEquivalence", "usedImpreciseTerm"]
+        },
+        {
+          "student": "but isn't that equal to 10/24?",
+          "expect": { "messageType": "answer_attempt", "answerValue": "10/24" },
+          "ctx": { "studentWasCorrect": true, "hasFocus": true },
+          "judge": ["assertedFalseEquivalence", "rejectedCorrectAnswer"]
+        }
+      ]
+    },
+
+    {
+      "name": "graph: don't lose the y=x^3 context",
+      "focus": "y=x^3",
+      "focusTerms": ["y=x^3", "x^3", "cubic", "inflection"],
+      "turns": [
+        { "student": "can you show me the graph of y=x^3" },
+        { "assistant": "Here's the graph of y=x^3. What do you observe about the behavior as x increases or decreases?" },
+        {
+          "student": "it also increases and decreases",
+          "ctx": { "hasFocus": true },
+          "judge": ["lostContext"]
+        }
+      ]
+    },
+
+    {
+      "name": "bare mixed-number drop is elicited, not solved",
+      "focus": null,
+      "answer": "8 5/12",
+      "turns": [
+        {
+          "student": "12 2/3 - 4 1/4",
+          "expect": { "isBareProblemDrop": true },
+          "ctx": { "shouldElicit": true, "answer": "8 5/12" },
+          "judge": ["solvedInsteadOfEliciting"]
+        }
+      ]
+    },
+
+    {
+      "name": "order of operations: 16/4 x 2 = 8 is correct; no PEMDAS 'M before D'",
+      "focus": "16/4 * 2",
+      "answer": "8",
+      "turns": [
+        { "assistant": "What's the first step to simplify 16/4 x 2?" },
+        {
+          "student": "8",
+          "expect": { "messageType": "answer_attempt", "answerValue": "8" },
+          "ctx": { "studentWasCorrect": true, "hasFocus": true },
+          "judge": ["rejectedCorrectAnswer", "badOrderOfOperations"]
+        }
+      ]
+    },
+
+    {
+      "name": "negative answer -28 is correct, not rejected",
+      "focus": "x - 6 = -34",
+      "answer": "-28",
+      "turns": [
+        { "assistant": "You have x - 6 = -34. What do you get when you add 6 to both sides?" },
+        {
+          "student": "-28",
+          "expect": { "messageType": "answer_attempt", "answerValue": "-28" },
+          "ctx": { "studentWasCorrect": true, "hasFocus": true },
+          "judge": ["rejectedCorrectAnswer"]
+        }
+      ]
+    },
+
+    {
+      "name": "self-check phrased as a question still gets verified",
+      "focus": "1/4 + 1/6",
+      "answer": "5/12",
+      "turns": [
+        { "assistant": "Convert both to twelfths and add. What do you get?" },
+        {
+          "student": "is it 5/12?",
+          "expect": { "messageType": "answer_attempt", "answerValue": "5/12" },
+          "ctx": { "studentWasCorrect": true, "hasFocus": true },
+          "judge": ["rejectedCorrectAnswer"]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/eval/tutorEval.test.js
+++ b/tests/eval/tutorEval.test.js
@@ -1,0 +1,95 @@
+/**
+ * TUTOR EVAL — hermetic layer (runs in normal `npm test`, no API key).
+ *
+ * Two things are asserted here without ever calling a model:
+ *   1. DETERMINISTIC classification — the real observe() reads each scenario turn
+ *      the way production does. This locks the merged fixes (a self-checked answer
+ *      "is it 5/12?" is an answer_attempt; "12 2/3 - 4 1/4" is a bare problem drop)
+ *      so a refactor can't silently regress them.
+ *   2. JUDGE wiring — a mock model feeds the runner the ACTUAL failing transcript
+ *      lines (must be flagged) and clean replies (must pass). This proves the
+ *      judge+runner path works, so the live eval (liveEval.test.js) is trustworthy.
+ *
+ * The live eval against the real gpt-4o-mini pipeline lives in liveEval.test.js and
+ * is opt-in (RUN_LLM_EVAL=1) so it never flakes the keyless CI path.
+ */
+'use strict';
+
+const scenarios = require('./scenarios.json').scenarios;
+const { runScenario, formatFailures } = require('./runner');
+
+// Real failing lines from this session's transcripts — each must trip its judges.
+const BAD_REPLIES = {
+  "fractions: butterfly answer 10/24 is correct (= 5/12), confirm then simplify":
+    'Not quite! While 5/12 and 10/24 may look similar, they are not equivalent. Can you reduce it?',
+  "graph: don't lose the y=x^3 context":
+    'That sounds like functions! What specific function or type of graph do you have in mind?',
+  'bare mixed-number drop is elicited, not solved':
+    'Convert to improper: 38/3 - 17/4 = 152/12 - 51/12 = 101/12 = 8 5/12.',
+  "order of operations: 16/4 x 2 = 8 is correct; no PEMDAS 'M before D'":
+    'Not quite - multiplication comes before division, so let us re-check.',
+  'negative answer -28 is correct, not rejected':
+    'Hmm, that is not quite right. Let us double-check -34 + 6.',
+  'self-check phrased as a question still gets verified':
+    'Not quite, let us check that again.',
+};
+
+// Clean replies that confirm correctly and stay on topic — must pass every judge.
+const GOOD_REPLIES = {
+  "fractions: butterfly answer 10/24 is correct (= 5/12), confirm then simplify":
+    'Exactly right - 10/24 works. Can you simplify it to lowest terms?',
+  "graph: don't lose the y=x^3 context":
+    'Right! As x increases, y increases; as x decreases, y decreases. Why does the left side dive so fast?',
+  'bare mixed-number drop is elicited, not solved':
+    'Good one to practice. What is your first move here?',
+  "order of operations: 16/4 x 2 = 8 is correct; no PEMDAS 'M before D'":
+    'Exactly, 8 is right. Multiply and divide left to right.',
+  'negative answer -28 is correct, not rejected':
+    'Yes! -28 is correct. Nice work with the negatives.',
+  'self-check phrased as a question still gets verified':
+    'Yes, 5/12 is exactly right.',
+};
+
+describe('tutor eval — deterministic classification (no model)', () => {
+  for (const s of scenarios) {
+    test(s.name, async () => {
+      const r = await runScenario(s);
+      if (!r.classificationPassed) {
+        throw new Error(`classification regressed:\n${formatFailures(r).join('\n')}`);
+      }
+    });
+  }
+});
+
+describe('tutor eval — judges flag known-bad replies and pass clean ones', () => {
+  const scored = scenarios.filter((s) => s.turns.some((t) => Array.isArray(t.judge)));
+
+  for (const s of scored) {
+    test(`${s.name} — bad reply is caught`, async () => {
+      expect(BAD_REPLIES[s.name]).toBeDefined();
+      const r = await runScenario(s, { generateReply: () => BAD_REPLIES[s.name] });
+      const anyViolation = r.turns.some((t) => t.violations.length > 0);
+      expect(anyViolation).toBe(true);
+    });
+
+    test(`${s.name} — clean reply passes`, async () => {
+      expect(GOOD_REPLIES[s.name]).toBeDefined();
+      const r = await runScenario(s, { generateReply: () => GOOD_REPLIES[s.name] });
+      if (!r.judgesPassed) {
+        throw new Error(`clean reply was wrongly flagged:\n${formatFailures(r).join('\n')}`);
+      }
+    });
+  }
+});
+
+describe('tutor eval — suite integrity', () => {
+  test('scenarios loaded and every judge turn has a known-bad + known-good fixture', () => {
+    expect(scenarios.length).toBeGreaterThan(4);
+    for (const s of scenarios) {
+      if (s.turns.some((t) => Array.isArray(t.judge))) {
+        expect(BAD_REPLIES[s.name]).toBeDefined();
+        expect(GOOD_REPLIES[s.name]).toBeDefined();
+      }
+    }
+  });
+});

--- a/tests/unit/evalJudges.test.js
+++ b/tests/unit/evalJudges.test.js
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for the tutor-reply judges (tests/eval/judges.js). These pin the
+ * detectors against the ACTUAL failing lines from production transcripts (must
+ * flag) and clean tutor replies (must pass), so the eval harness stays trustworthy.
+ */
+const { judgeReply, JUDGES } = require('../../tests/eval/judges');
+
+const flags = (reply, names, ctx) => judgeReply(reply, names, ctx).violations.map((v) => v.judge).sort();
+
+describe('rejectedCorrectAnswer', () => {
+  test('flags hedging on a correct answer', () => {
+    expect(flags('You are close, but let us refine that.', ['rejectedCorrectAnswer'], { studentWasCorrect: true })).toEqual(['rejectedCorrectAnswer']);
+    expect(flags('Hmm, not quite. Let us double-check.', ['rejectedCorrectAnswer'], { studentWasCorrect: true })).toEqual(['rejectedCorrectAnswer']);
+  });
+  test('does not flag a genuine confirmation', () => {
+    expect(flags('Exactly right! Nice work.', ['rejectedCorrectAnswer'], { studentWasCorrect: true })).toEqual([]);
+  });
+  test('does not fire when the student was wrong (hedging is appropriate)', () => {
+    expect(flags('Not quite — try adding 6 to both sides.', ['rejectedCorrectAnswer'], { studentWasCorrect: false })).toEqual([]);
+  });
+});
+
+describe('assertedFalseEquivalence', () => {
+  test('flags "not equivalent" when the forms are equal', () => {
+    expect(flags('5/12 and 10/24 are not equivalent.', ['assertedFalseEquivalence'], { studentWasCorrect: true })).toEqual(['assertedFalseEquivalence']);
+  });
+  test('passes when it affirms equivalence', () => {
+    expect(flags('Right, 10/24 is the same value as 5/12.', ['assertedFalseEquivalence'], { studentWasCorrect: true })).toEqual([]);
+  });
+});
+
+describe('lostContext', () => {
+  test('flags asking the student to re-name the topic mid-focus', () => {
+    expect(flags('What specific function or type of graph do you have in mind?', ['lostContext'], { hasFocus: true })).toEqual(['lostContext']);
+    expect(flags('What do you want to work on today?', ['lostContext'], { hasFocus: true })).toEqual(['lostContext']);
+  });
+  test('does not flag a follow-up about the SAME focus', () => {
+    expect(flags('As x increases, y increases. What happens for negative x?', ['lostContext'], { hasFocus: true })).toEqual([]);
+  });
+  test('does not fire when there is no active focus', () => {
+    expect(flags('What do you want to work on today?', ['lostContext'], { hasFocus: false })).toEqual([]);
+  });
+});
+
+describe('solvedInsteadOfEliciting', () => {
+  test('flags a multi-step worked solution to a bare drop', () => {
+    expect(flags('3x - 6 = 2x - 34, so x - 6 = -34, then x = -28.', ['solvedInsteadOfEliciting'], { shouldElicit: true })).toEqual(['solvedInsteadOfEliciting']);
+  });
+  test('flags stating the answer even without steps', () => {
+    expect(flags('The answer is 8 5/12.', ['solvedInsteadOfEliciting'], { shouldElicit: true, answer: '8 5/12' })).toEqual(['solvedInsteadOfEliciting']);
+  });
+  test('passes an elicit prompt', () => {
+    expect(flags('What is your first move here?', ['solvedInsteadOfEliciting'], { shouldElicit: true })).toEqual([]);
+  });
+});
+
+describe('usedImpreciseTerm', () => {
+  test('flags "reduce" in a fraction context', () => {
+    expect(flags('Can you reduce the fraction to lowest terms?', ['usedImpreciseTerm'], {})).toEqual(['usedImpreciseTerm']);
+  });
+  test('flags "improper fraction"', () => {
+    expect(flags('That is an improper fraction — convert it.', ['usedImpreciseTerm'], {})).toEqual(['usedImpreciseTerm']);
+  });
+  test('passes "simplify" and "fraction greater than one"', () => {
+    expect(flags('Can you simplify it? A fraction greater than one is fine.', ['usedImpreciseTerm'], {})).toEqual([]);
+  });
+});
+
+describe('badOrderOfOperations', () => {
+  test('flags the "multiplication before division" rule', () => {
+    expect(flags('Multiplication comes before division in the order of operations.', ['badOrderOfOperations'], {})).toEqual(['badOrderOfOperations']);
+  });
+  test('passes the correct left-to-right statement', () => {
+    expect(flags('Multiply and divide are equal — go left to right.', ['badOrderOfOperations'], {})).toEqual([]);
+  });
+});
+
+describe('revealedAnswer', () => {
+  test('flags leaking the withheld answer', () => {
+    expect(flags('The answer is x = 8.', ['revealedAnswer'], { mustNotReveal: true, answer: '8' })).toEqual(['revealedAnswer']);
+  });
+  test('passes when the answer is withheld', () => {
+    expect(flags('What operation undoes multiplication?', ['revealedAnswer'], { mustNotReveal: true, answer: '8' })).toEqual([]);
+  });
+});
+
+describe('judge registry', () => {
+  test('every judge referenced by name exists', () => {
+    for (const name of Object.keys(JUDGES)) {
+      expect(typeof JUDGES[name]).toBe('function');
+    }
+  });
+  test('unknown judge name throws', () => {
+    expect(() => judgeReply('x', ['nope'], {})).toThrow(/unknown judge/i);
+  });
+});


### PR DESCRIPTION
## Why

Every "the tutor told a correct student they were wrong" bug we've shipped this week was caught the same way: **you read a production transcript.** The unit tests and `tests/golden/` can't catch them — **they mock the LLM**, so they lock the deterministic `observe → decide` layer but are blind to what the model actually *says*.

This is the systemic fix I recommended: turn "Jason finds it in prod" into "CI finds the class in the PR." It replays this session's real failing transcripts as permanent scenarios and scores the tutor's actual reply against the failure classes we already know it hits.

## How it's layered

| Layer | Runs in | Key? | Catches |
|-------|---------|------|---------|
| **Deterministic** | normal `npm test` | no | classification/decision regressions — locks the merged fixes (`"is it 5/12?"` → `answer_attempt`; `"12 2/3 - 4 1/4"` → bare problem drop) |
| **Judges (mock model)** | normal `npm test` | no | proves the judge+runner wiring: the *actual* failing transcript lines are flagged; clean replies pass |
| **Live** (`liveEval.test.js`) | opt-in (`RUN_LLM_EVAL=1`) | **yes** | the real gpt-4o-mini reply violating a judge — the thing golden can't see |

Live is opt-in so the nondeterministic model never flakes the keyless PR gate — wire it nightly.

## Failure-class judges (`tests/eval/judges.js`)

Pure `(reply, ctx) → { violated, evidence }`, each from a real transcript:
`rejectedCorrectAnswer` · `assertedFalseEquivalence` · `lostContext` · `solvedInsteadOfEliciting` · `usedImpreciseTerm` (say **simplify** not "reduce"; **a fraction greater than one** not "improper") · `badOrderOfOperations` · `revealedAnswer`.

## Files

- `tests/eval/judges.js` — the detectors
- `tests/eval/scenarios.json` — this session's transcripts as cases
- `tests/eval/runner.js` — walks turns: real `observe` + injected model + judges
- `tests/eval/tutorEval.test.js` — hermetic layers (deterministic + mock model)
- `tests/eval/liveEval.test.js` — real-model eval, opt-in
- `tests/eval/README.md`
- `tests/unit/evalJudges.test.js` — 20 judge unit tests vs real good/bad lines
- `package.json` — `test:eval`, `test:eval:live`

## Verification

- Harness validated end to end: deterministic classification passes for every scenario (locks the merged fixes); judges flag all known-bad transcript lines and pass all clean replies; **20/20 judge unit tests.**
- Hermetic layers run in normal `npm test` (`testMatch` picks up `tests/eval/*.test.js`); live layer self-skips without `RUN_LLM_EVAL`.

## Extending is data-only

Add a transcript to `scenarios.json` + a good/bad fixture. Every future production failure becomes a **judge** (the class) and a **scenario** (the case) — the loop that ends the whack-a-mole.

## What this sets up next

The live eval's scores are the evidence for the other two structural moves I flagged: **model tiering** (route correctness-critical turns to a stronger model) and **context-as-state grounding** (make the active problem/graph mandatory injected state, so tonight's `y=x³` amnesia can't happen). This harness measures which failures are model-weakness vs. grounding — so those next moves are targeted, not guessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DffsjzSQTvBveT29DwtziR)_