### PR TITLE
Tutor picker: rebalance stage/panel widths

### DIFF
--- a/public/css/tutor-picker.css
+++ b/public/css/tutor-picker.css
@@ -46,7 +46,7 @@
   gap: clamp(16px, 2.5vw, 32px);
   align-items: stretch;
 }
-.tp-stage { flex: 1.85 1 0; min-width: 0; }
+.tp-stage { flex: 1.3 1 0; min-width: 0; }
 .tp-panel-wrap { flex: 1 1 0; min-width: 250px; }
 
 /* ---- Stage: full-body figures standing together as one crew ---- */


### PR DESCRIPTION
Narrow the figure stage (flex 1.85->1.3) so the grouped tutors fill it instead of stranding them in empty space, and widen the detail panel so bios fit in the 3-line clamp without truncating. Still fits above the fold.