### PR TITLE
fix(verify): grade multi-root answers like "x=2 and x=3" as correct (+ harness scenario)

### DIFF
--- a/tests/eval/judges.js
+++ b/tests/eval/judges.js
@@ -24,7 +24,7 @@ const norm = (s) => String(s || '').toLowerCase();
 // The cardinal sin behind most of this session's transcripts: the student is
 // right and the tutor hedges/denies ("not quite", "almost", "you're close",
 // "let's double-check", "not correct"). Only a violation when the student WAS right.
-const REJECTION_MARKERS = /\b(not quite|almost(?!\s+there,\s+you'?re\s+right)|you'?re close|close,?\s+but|not (?:quite )?right|that'?s not (?:it|right|correct)|not correct|incorrect|try (?:that )?again|let'?s (?:double[-\s]?)?check|let'?s re[-\s]?check|hmm,?\s+not|isn'?t (?:quite )?right)\b/i;
+const REJECTION_MARKERS = /\b(not quite|almost(?!\s+there,\s+you'?re\s+right)|you'?re close|close,?\s+but|not (?:quite )?right|that'?s not (?:it|right|correct)|not correct|incorrect|try (?:that )?again|let'?s (?:double[-\s]?)?check|let'?s re[-\s]?check|hmm,?\s+not|isn'?t (?:quite )?right|(?:gone|went)\s+off\s+track|went\s+wrong|where\s+(?:things|it|we)\s+(?:went|might have gone)|pinpoint\s+where|where things might have gone)\b/i;
 function rejectedCorrectAnswer(reply, ctx = {}) {
   if (!ctx.studentWasCorrect) return { violated: false };
   const m = norm(reply).match(REJECTION_MARKERS);

--- a/tests/eval/scenarios.json
+++ b/tests/eval/scenarios.json
@@ -96,6 +96,21 @@
           "judge": ["rejectedCorrectAnswer"]
         }
       ]
+    },
+
+    {
+      "name": "multi-root answer 'x=2 and x=3' is correct, not doubted",
+      "focus": "(x-2)(x-3)=0",
+      "focusTerms": ["(x-2)(x-3)", "x^2-5x+6", "factor"],
+      "answer": "x = 2 or x = 3",
+      "turns": [
+        { "assistant": "Set each factor equal to zero. What are the solutions?" },
+        {
+          "student": "x=2 and x=3",
+          "ctx": { "studentWasCorrect": true, "hasFocus": true },
+          "judge": ["rejectedCorrectAnswer"]
+        }
+      ]
     }
   ]
 }

--- a/tests/eval/tutorEval.test.js
+++ b/tests/eval/tutorEval.test.js
@@ -32,6 +32,8 @@ const BAD_REPLIES = {
     'Hmm, that is not quite right. Let us double-check -34 + 6.',
   'self-check phrased as a question still gets verified':
     'Not quite, let us check that again.',
+  "multi-root answer 'x=2 and x=3' is correct, not doubted":
+    "I appreciate your effort! Let's take a closer look and pinpoint where things might have gone off track.",
 };
 
 // Clean replies that confirm correctly and stay on topic — must pass every judge.
@@ -48,6 +50,8 @@ const GOOD_REPLIES = {
     'Yes! -28 is correct. Nice work with the negatives.',
   'self-check phrased as a question still gets verified':
     'Yes, 5/12 is exactly right.',
+  "multi-root answer 'x=2 and x=3' is correct, not doubted":
+    'Exactly! x = 2 and x = 3 are both solutions. Nice factoring.',
 };
 
 describe('tutor eval — deterministic classification (no model)', () => {

--- a/tests/unit/mathSolverRootSet.test.js
+++ b/tests/unit/mathSolverRootSet.test.js
@@ -1,0 +1,55 @@
+/**
+ * Multi-root answer grading.
+ *
+ * Origin: a student factored x^2-5x+6=0 to (x-2)(x-3)=0 and answered "x=2 and x=3"
+ * — correct — and the tutor doubted it. Two defects:
+ *   1. "(x-2)(x-3)=0" was mis-detected as a linear equation, so it carried no roots
+ *      and the multi-root grading path couldn't fire off the form the student wrote.
+ *   2. verifyAnswer only exact-matched, so "x=2 and x=3" vs "x=2 or x=3" was false.
+ */
+const { processMathMessage, verifyAnswer } = require('../../utils/mathSolver');
+
+describe('factored equation → roots', () => {
+  it('detects "(x-2)(x-3)=0" as a factored equation with roots [2,3]', () => {
+    const r = processMathMessage('(x-2)(x-3)=0');
+    expect(r.hasMath).toBe(true);
+    expect(r.problem.type).toBe('factored_equation');
+    expect(r.solution.roots).toEqual([2, 3]);
+    expect(r.solution.answer).toBe('x = 2 or x = 3');
+  });
+
+  it('handles a leading coefficient: "(2x+1)(x-3)=0" → [-0.5, 3]', () => {
+    const r = processMathMessage('(2x+1)(x-3)=0');
+    expect(r.solution.roots).toEqual([-0.5, 3]);
+  });
+
+  it('still solves the standard form "x^2-5x+6=0" to the same roots', () => {
+    const r = processMathMessage('x^2-5x+6=0');
+    expect(r.solution.roots.slice().sort()).toEqual([2, 3]);
+  });
+});
+
+describe('verifyAnswer — root sets grade by membership', () => {
+  const t = (a, b, e) => expect(verifyAnswer(a, b).isCorrect).toBe(e);
+
+  it('accepts "and" vs "or" and any order', () => {
+    t('x=2 and x=3', 'x=2 or x=3', true);
+    t('x=2 and x=3', 'x = 3 or x = 2', true);
+    t('2 and 3', 'x = 3 or x = 2', true);
+  });
+
+  it('accepts fraction roots regardless of order', () => {
+    t('x = -7/3 or 1', 'x = 1 or x = -7/3', true);
+  });
+
+  it('rejects a wrong or incomplete set', () => {
+    t('x=2 and x=5', 'x=2 or x=3', false); // wrong second root
+    t('x=2', 'x=2 or x=3', false);          // only one of two roots
+  });
+
+  it('does not disturb single-value or fraction/decimal grading', () => {
+    t('5', '5', true);
+    t('3/4', '0.75', true);
+    t('8', '9', false);
+  });
+});

--- a/utils/mathSolver.js
+++ b/utils/mathSolver.js
@@ -109,6 +109,27 @@ function detectMathProblem(message) {
     const systemResult = detectSystem(message);
     if (systemResult) return systemResult;
 
+    // Pattern: Factored equation set to zero — "(x-2)(x-3)=0", "(2x+1)(x-3)=0".
+    // Each factor's root is where it equals zero (root = -constant/coeff). Detect
+    // BEFORE general_linear, which would otherwise mis-parse the product as a linear
+    // expression, lose the roots, and cause a correct answer like "x=2 and x=3" to be
+    // graded wrong.
+    {
+        const compact = message.replace(/\s+/g, '').replace(/−/g, '-');
+        if (/^(?:-?\d+)?(?:\(-?\d*x[+\-]\d+\)){2,}=0$/i.test(compact)) {
+            const parsed = parseFactoredForm(compact.replace(/=0$/, ''));
+            if (parsed && parsed.binomials.length >= 2) {
+                const roots = [];
+                for (const b of parsed.binomials) {
+                    if (b.coeff !== 0) roots.push(-b.constant / b.coeff);
+                }
+                if (roots.length >= 2) {
+                    return { type: 'factored_equation', roots };
+                }
+            }
+        }
+    }
+
     // Pattern: General linear equation — handles multi-step, distribution, and variables on both sides
     // Matches anything with "x" and "=" that isn't a quadratic (no x² / x^2)
     // Examples: "2x + 3 = 7", "3(x+2) - 5 = 16", "3x + 5 = x + 13", "-2(x-4) + 3x = 10"
@@ -592,6 +613,8 @@ function solveProblem(problem) {
                 return solveSystem(problem);
             case 'quadratic_equation':
                 return solveQuadratic(problem);
+            case 'factored_equation':
+                return solveFactoredEquation(problem);
             case 'slope':
                 return solveSlope(problem);
             case 'expand_polynomial':
@@ -1015,6 +1038,19 @@ function solveSlope(problem) {
             `slope = ${rise} / ${run}`,
             `slope = ${answer}`,
         ],
+    };
+}
+
+// Solve a factored equation like "(x-2)(x-3)=0" — roots are already computed in
+// detection. Output shape mirrors solveQuadratic (roots[] + "x = a or x = b").
+function solveFactoredEquation(problem) {
+    const roots = problem.roots.map((r) => (Number.isInteger(r) ? r : parseFloat(r.toFixed(4))));
+    const answer = 'x = ' + roots.join(' or x = ');
+    return {
+        success: true,
+        answer,
+        roots,
+        steps: roots.map((r) => `Set a factor equal to zero → x = ${r}`),
     };
 }
 
@@ -2344,6 +2380,17 @@ function verifyAnswer(studentAnswer, correctAnswer, tolerance = 0.01) {
     }
 
 
+    // Root-set answer: "x=2 and x=3" vs "x=2 or x=3" vs "x = 3, x = 2". A quadratic /
+    // factored solution names a SET of roots; grade by unordered set membership so the
+    // student isn't marked wrong for saying "and" vs "or", or a different order. Gated
+    // by a set shape (and / or / multiple "x=") so single values are never affected.
+    const studentRoots = parseRootSet(studentStr);
+    const correctRoots = parseRootSet(correctStr);
+    if (studentRoots && correctRoots && studentRoots.length === correctRoots.length &&
+        correctRoots.every((cr) => studentRoots.some((sr) => Math.abs(sr - cr) <= tolerance))) {
+        return { isCorrect: true, exact: false, equivalentForm: true };
+    }
+
     // System of equations answer: "x = 3, y = 2" vs "y = 2, x = 3"
     const studentVars = parseVariableAssignments(studentStr);
     const correctVars = parseVariableAssignments(correctStr);
@@ -2523,6 +2570,39 @@ function canonicalizePolynomial(terms) {
             if (!a.variable && b.variable) return 1;
             return (a.variable || '').localeCompare(b.variable || '');
         });
+}
+
+/**
+ * Parse a SET of roots from an answer like "x=2 and x=3", "x=2 or x=3",
+ * "x = 3, x = 2", "x = -7/3 or 1". Returns an array of distinct numeric roots,
+ * or null when the string isn't a root set (needs an "and"/"or" join or 2+ "x="
+ * so single values, points, and lone fractions are never treated as root sets).
+ */
+function parseRootSet(str) {
+    if (!str) return null;
+    const s = String(str).replace(/−/g, '-').toLowerCase();
+    const setShape = /\b(and|or)\b/.test(s) || /(x\s*=[^=]*){2,}/.test(s);
+    if (!setShape) return null;
+
+    const candidates = [];
+    const fracRegex = /(-?\d+)\s*\/\s*(\d+)/g;
+    let m;
+    while ((m = fracRegex.exec(s)) !== null) {
+        const den = parseFloat(m[2]);
+        if (den !== 0) candidates.push(parseFloat(m[1]) / den);
+    }
+    const stripped = s.replace(fracRegex, ' ');
+    const numRegex = /-?\d+\.?\d*/g;
+    while ((m = numRegex.exec(stripped)) !== null) {
+        const v = parseFloat(m[0]);
+        if (!isNaN(v)) candidates.push(v);
+    }
+
+    const distinct = [];
+    for (const c of candidates) {
+        if (!distinct.some((d) => Math.abs(d - c) <= 1e-9)) distinct.push(c);
+    }
+    return distinct.length >= 2 ? distinct : null;
 }
 
 /**


### PR DESCRIPTION
## The session

A student factored `x²-5x+6=0` to `(x-2)(x-3)=0` and answered **`x=2 and x=3`** — correct — and Ms. Maria doubted it: *"let's pinpoint where things might have gone off track."* The student had to ask "I got it wrong?" before she backpedaled. Same `rejectedCorrectAnswer` class, reached through a new door.

## Root cause — and why my recent fix did NOT cover it

You asked whether the recent fix would help. It didn't: #1103 handles a proposed answer *inside a question* (`"is it 5/12?"`); `"x=2 and x=3"` is a flat declarative answer. This is **two distinct defects**, both in the standalone (testable) math engine:

1. **`(x-2)(x-3)=0` was mis-detected as `general_linear`** (ans `2.5`, no roots) — so the multi-root grading path (`gradeRootSet` in `diagnose`) had nothing to grade against for the form the student actually wrote. (`x²-5x+6=0` correctly yields roots `[3,2]`; the factored form didn't.)
2. **`verifyAnswer` only exact-matched** — `"x=2 and x=3"` vs `"x=2 or x=3"` → `false`. Even a root-set answer that reached it was rejected.

## The fix (`utils/mathSolver.js`)

1. **Factored-equation detector** (before `general_linear`): reads each factor's root as `-constant/coeff` via the existing `parseFactoredForm`. `(x-2)(x-3)=0 → roots [2,3]`, answer `"x = 2 or x = 3"` — same shape as the quadratic solver.
2. **Root-set grading in `verifyAnswer`** (`parseRootSet` + set-membership): a root-set answer grades correct regardless of `and`/`or`, order, or fraction roots. Gated by a set shape (`and`/`or` or 2+ `x=`) so single values, points, and lone fractions are untouched.

## The harness earned its keep

I added this transcript as **eval scenario #7** — and its *real* failing line (`"pinpoint where things might have gone off track"`) slipped past the `rejectedCorrectAnswer` judge, so I strengthened that judge to cover "off track / went wrong / pinpoint where." **The harness catching a gap in my own detector is the loop working** — exactly the point of #1107.

## Verification

- `(x-2)(x-3)=0 → roots [2,3]`; `verifyAnswer("x=2 and x=3","x=2 or x=3") → true`; order/and-or/fraction variants pass; wrong/incomplete sets rejected; plain numbers & fraction/decimal grading unchanged.
- New `tests/unit/mathSolverRootSet.test.js`; **full mathSolver suite 458 passing**; eval harness validated with 7 scenarios; judge unit tests green.

Next: **#2** — the duplicate-greetings / stale-context weirdness in that same transcript (a separate session/regeneration investigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DffsjzSQTvBveT29DwtziR)_