### PR TITLE
fix(chat): stop injecting duplicate greetings into an in-progress session

### DIFF
--- a/routes/chat.js
+++ b/routes/chat.js
@@ -2109,6 +2109,17 @@ router.get('/resume-context', isAuthenticated, async (req, res) => {
     }
 });
 
+// A conversation is an IN-PROGRESS session (not a fresh visit) once the student
+// has sent at least one message in it. A greeting request against such a
+// conversation is a re-mount/refocus within the session, not a new arrival, so
+// the tutor should continue rather than inject a duplicate greeting. Pure +
+// exported for unit testing.
+function isInProgressSession(conversation) {
+    return !!(conversation
+        && Array.isArray(conversation.messages)
+        && conversation.messages.some(m => m && m.role === 'user'));
+}
+
 // ========== GREETING HANDLER: AI-initiated conversation ==========
 // Builds a context-rich "ghost message" the user doesn't see,
 // but the AI responds to naturally - creating the illusion of AI initiating
@@ -2204,6 +2215,54 @@ async function handleGreetingRequest(req, res, userId) {
                     xpNeeded: BRAND_CONFIG.xpRequiredForLevel(user.level || 1)
                 });
             }
+        }
+
+        // In-progress session: if this reused conversation already has a real
+        // student↔tutor exchange, a greeting request is a page re-mount / tab
+        // refocus / navigation WITHIN the same session — not a new visit. The
+        // 2-minute replay guard below only covers the case where the greeting is
+        // still the last message; between 2 and 30 minutes (the reuse window), or
+        // once the student has replied, a fresh greeting would be generated and
+        // appended into the MIDDLE of the live thread — the duplicate "Hey Jason!"
+        // (and stale prior context) seen in production. Continue instead: replay
+        // the recent messages, no new greeting. A genuinely new session is a fresh
+        // conversation with no user messages (the 30-min reuse window rolls to one
+        // after a gap), so first greetings are unaffected.
+        if (isInProgressSession(activeConversation)) {
+            const contTutorKey = user.selectedTutorId && TUTOR_CONFIG[user.selectedTutorId] ? user.selectedTutorId : "default";
+            const contTutor = TUTOR_CONFIG[contTutorKey];
+            await Conversation.findByIdAndUpdate(activeConversation._id, { lastActivity: new Date() });
+
+            const visibleMessages = activeConversation.messages
+                .slice(-50)
+                .filter(m => !(
+                    m.role === 'assistant'
+                    && typeof m.content === 'string'
+                    && m.content.startsWith('[Voice session')
+                ))
+                .map(m => ({ role: m.role, content: m.content, workCheckId: m.workCheckId || null }));
+
+            const useStreaming = req.query.stream === 'true';
+            if (useStreaming) {
+                res.setHeader('Content-Type', 'text/event-stream');
+                res.setHeader('Cache-Control', 'no-cache');
+                res.setHeader('Connection', 'keep-alive');
+                res.setHeader('X-Accel-Buffering', 'no');
+                res.flushHeaders();
+                res.write(`data: ${JSON.stringify({ done: true, voiceId: contTutor.voiceId, isGreeting: true, continued: true, conversationId: activeConversation._id, messages: visibleMessages })}\n\n`);
+                return res.end();
+            }
+            return res.json({
+                text: '',
+                continued: true,
+                conversationId: activeConversation._id,
+                messages: visibleMessages,
+                voiceId: contTutor.voiceId,
+                isGreeting: true,
+                userXp: user.xp || 0,
+                userLevel: user.level || 1,
+                xpNeeded: BRAND_CONFIG.xpRequiredForLevel(user.level || 1)
+            });
         }
 
         // Replay the just-sent greeting on a quick page refresh so the same
@@ -2789,3 +2848,5 @@ The student has an overdue Growth Check (${timingPhrase} since their last one). 
 }
 
 module.exports = router;
+// Exported for unit testing the duplicate-greeting guard.
+module.exports.isInProgressSession = isInProgressSession;

--- a/tests/unit/greetingIdempotency.test.js
+++ b/tests/unit/greetingIdempotency.test.js
@@ -1,0 +1,50 @@
+/**
+ * Guard against duplicate greetings mid-session.
+ *
+ * Origin: a transcript with ~4 back-to-back "Hey Jason!" greetings interleaved
+ * with the student's turns, plus stale context from a prior session. Root cause:
+ * the greeting handler reuses a conversation for 30 minutes, but its only
+ * anti-duplicate guards were voice-continuation and a 2-minute replay. Between 2
+ * and 30 minutes — or once the student has replied — a greeting re-request (page
+ * re-mount / tab refocus) fell through and appended a fresh greeting into the live
+ * thread. isInProgressSession() is the predicate that now short-circuits that:
+ * a conversation the student has already spoken in is a continuation, not a new
+ * visit, so it must not be re-greeted.
+ */
+const { isInProgressSession } = require('../../routes/chat');
+
+describe('isInProgressSession — the duplicate-greeting guard', () => {
+  test('a brand-new conversation is NOT in-progress (greet normally)', () => {
+    expect(isInProgressSession({ messages: [] })).toBe(false);
+  });
+
+  test('a greeting-only conversation (no student reply yet) is NOT in-progress', () => {
+    // Handled by the 2-minute replay path, not this guard.
+    expect(isInProgressSession({ messages: [{ role: 'assistant', content: 'Hey Jason!' }] })).toBe(false);
+  });
+
+  test('once the student has replied, it IS in-progress (continue, do not re-greet)', () => {
+    expect(isInProgressSession({
+      messages: [
+        { role: 'assistant', content: 'Hey Jason!' },
+        { role: 'user', content: 'hi' },
+      ],
+    })).toBe(true);
+  });
+
+  test('a real exchange is in-progress', () => {
+    expect(isInProgressSession({
+      messages: [
+        { role: 'user', content: 'x=2 and x=3' },
+        { role: 'assistant', content: 'Exactly!' },
+      ],
+    })).toBe(true);
+  });
+
+  test('null / missing / malformed conversations are not in-progress (safe default)', () => {
+    expect(isInProgressSession(null)).toBe(false);
+    expect(isInProgressSession(undefined)).toBe(false);
+    expect(isInProgressSession({})).toBe(false);
+    expect(isInProgressSession({ messages: null })).toBe(false);
+  });
+});


### PR DESCRIPTION
## The session (#2 from the last transcript)

That transcript had ~4 back-to-back `Hey Jason!` / `¡Hola, Jason!` greetings **interleaved with the student's turns**, and stale context (`"it also increases and decreases"`) from a prior session riding along.

## Root cause

`handleGreetingRequest` reuses a conversation for **30 minutes** (`REUSE_WINDOW_MS`), but its only anti-duplicate guards are:
- the **voice-continuation** marker, and
- a **2-minute** greeting replay (fires only when the greeting is still the last message).

So in the gap — **between 2 and 30 minutes, or once the student has already replied** — a greeting re-request (page re-mount, tab refocus, navigation) falls through both guards, generates a **fresh** greeting, and appends it into the middle of the live thread. Repeat on each re-mount → the duplicate greetings, each dragging the reused conversation's old messages.

## The fix

Add an **in-progress-session guard** mirroring the existing voice-continuation branch: if the reused conversation already contains a student message, treat the greeting request as a **continuation** — replay the recent messages, emit no new greeting.

- First greetings are unaffected — a genuinely new session is a fresh conversation with **no user messages**, and the 30-min reuse window rolls to a new conversation after a real gap.
- The 2-minute replay path still handles "quick refresh before the student types."

`isInProgressSession()` is a **pure predicate**, exported and unit-tested (`tests/unit/greetingIdempotency.test.js`): empty / greeting-only / null → not in-progress; any student message → in-progress.

## ⚠️ Verification caveat

This is a **route / session-lifecycle change I could not run end-to-end in the sandbox** (no DB / app). The predicate is unit-tested and the handler wiring mirrors the adjacent voice-continuation branch, but **it needs a manual or integration check before merge** — specifically: open chat, send a message, refresh after ~3 min, confirm no second greeting is injected; and confirm a first visit still greets.

## One behavior choice for you

On a re-mount mid-session it now **continues silently** (replays messages, no text). If you'd rather it say a brief "welcome back" on return within the window, that's a one-line change — tell me which you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DffsjzSQTvBveT29DwtziR)_