### PR TITLE
First-try accuracy: count each problem once, not each attempt

### DIFF
--- a/models/conversation.js
+++ b/models/conversation.js
@@ -148,6 +148,17 @@ const conversationSchema = new Schema({
         type: Number,
         default: 0
     },
+    // First-try metric: counts each PROBLEM once, scored on the first attempt
+    // (retries of an in-progress problem don't open a new slot; skips are
+    // excluded). This is the honest accuracy denominator. Intentionally NO
+    // default — legacy conversations leave it undefined so the progress
+    // aggregation can fall back to problemsAttempted until they age out.
+    firstTryAttempted: {
+        type: Number
+    },
+    firstTryCorrect: {
+        type: Number
+    },
     strugglingWith: {
         type: String,
         default: null // e.g., "negative numbers", "isolating variables"

--- a/routes/student.js
+++ b/routes/student.js
@@ -357,13 +357,16 @@ router.get('/progress/summary', isAuthenticated, isStudent, async (req, res) => 
         const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
         const studentObjectId = new mongoose.Types.ObjectId(student._id);
 
+        // Prefer the first-try counters (one slot per problem, retries excluded).
+        // Legacy conversations predate these fields, so fall back to the older
+        // per-attempt counters until they age out of the 7-day window.
         const weeklyAgg = await Conversation.aggregate([
             { $match: { userId: studentObjectId, lastActivity: { $gte: oneWeekAgo } } },
             {
                 $group: {
                     _id: null,
-                    totalProblems: { $sum: { $ifNull: ['$problemsAttempted', 0] } },
-                    totalCorrect: { $sum: { $ifNull: ['$problemsCorrect', 0] } }
+                    totalProblems: { $sum: { $ifNull: ['$firstTryAttempted', { $ifNull: ['$problemsAttempted', 0] }] } },
+                    totalCorrect: { $sum: { $ifNull: ['$firstTryCorrect', { $ifNull: ['$problemsCorrect', 0] }] } }
                 }
             }
         ]);

--- a/tests/integration/studentProgressSummary.test.js
+++ b/tests/integration/studentProgressSummary.test.js
@@ -113,4 +113,17 @@ describe('GET /api/student/progress/summary — weekly accuracy', () => {
     const pipeline = GradingResult.aggregate.mock.calls[0][0];
     expect(pipeline[0].$match).toHaveProperty('previousAttemptId', null);
   });
+
+  test('chat aggregation prefers the first-try counter over per-attempt counters', async () => {
+    setSources({ conv: [{ totalProblems: 3, totalCorrect: 3 }], grade: [] });
+
+    await supertest(buildApp()).get('/api/student/progress/summary');
+
+    // The $group must read firstTryAttempted/firstTryCorrect (with a legacy
+    // fallback), not the raw per-attempt counters.
+    const pipeline = Conversation.aggregate.mock.calls[0][0];
+    const groupJson = JSON.stringify(pipeline.find(s => s.$group).$group);
+    expect(groupJson).toContain('firstTryAttempted');
+    expect(groupJson).toContain('firstTryCorrect');
+  });
 });

--- a/tests/unit/firstTryDedup.test.js
+++ b/tests/unit/firstTryDedup.test.js
@@ -1,0 +1,40 @@
+/**
+ * isSameProblemRetry UNIT TESTS
+ *
+ * Locks the retry-detection that powers the first-try accuracy metric: a
+ * miss-then-fix on the same problem must NOT open a second attempt slot, but a
+ * genuinely new problem must, even when a stale in-progress problem lingers.
+ */
+
+const { isSameProblemRetry } = require('../../utils/pipeline/persist');
+
+const diag = (content) => ({ problemInfo: content ? { content } : undefined });
+
+describe('isSameProblemRetry', () => {
+  test('first attempt (no in-progress problem) is not a retry', () => {
+    expect(isSameProblemRetry(null, diag('2 + 2'))).toBe(false);
+    expect(isSameProblemRetry(undefined, diag('2 + 2'))).toBe(false);
+  });
+
+  test('in-progress problem with no prior wrong attempt is not a retry', () => {
+    // e.g. multi-root partial: state exists but attemptCount is still 0
+    const state = { problemText: 'solve x^2 = 9', attemptCount: 0 };
+    expect(isSameProblemRetry(state, diag('solve x^2 = 9'))).toBe(false);
+  });
+
+  test('second try on the same problem is a retry', () => {
+    const state = { problemText: 'solve 3x + 6 = 12', attemptCount: 1 };
+    expect(isSameProblemRetry(state, diag('solve 3x + 6 = 12'))).toBe(true);
+  });
+
+  test('a new problem is not a retry even if a wrong problem is still in progress', () => {
+    // Student gave up on one problem (attemptCount 1) and moved to another.
+    const state = { problemText: 'factor x^2 - 9', attemptCount: 1 };
+    expect(isSameProblemRetry(state, diag('simplify 4/8'))).toBe(false);
+  });
+
+  test('when problem text cannot be compared, defer to the in-progress flag', () => {
+    const state = { problemText: '', attemptCount: 2 };
+    expect(isSameProblemRetry(state, diag(null))).toBe(true);
+  });
+});

--- a/utils/pipeline/persist.js
+++ b/utils/pipeline/persist.js
@@ -80,6 +80,33 @@ function extractCanonicalProblemText(problem) {
   }
 }
 
+/**
+ * Decide whether the current graded answer is a RETRY of the problem already in
+ * progress (so it should not be counted as a new first-try problem).
+ *
+ * lastProblemState holds the in-progress problem: attemptCount bumps on each
+ * wrong try and the state is cleared on a correct answer. A retry therefore
+ * requires a prior wrong attempt (attemptCount >= 1). To avoid mis-counting the
+ * case where a student abandons a wrong problem and moves to a new one (stale
+ * state), we also require the problem text to match when both are available;
+ * when it can't be compared, we defer to the in-progress flag.
+ *
+ * @param {Object|null} lastProblemState
+ * @param {Object} diagnosis
+ * @returns {boolean}
+ */
+function isSameProblemRetry(lastProblemState, diagnosis) {
+  if (!lastProblemState || (lastProblemState.attemptCount || 0) < 1) return false;
+  const prev = String(lastProblemState.problemText || '').trim().toLowerCase();
+  const curr = String(diagnosis?.problemInfo?.content || '').trim().toLowerCase();
+  if (prev && curr) {
+    const a = prev.slice(0, 60);
+    const b = curr.slice(0, 60);
+    return prev.includes(b) || curr.includes(a);
+  }
+  return true;
+}
+
 async function persist(params) {
   const {
     user, conversation, extracted, diagnosis, observation,
@@ -242,6 +269,19 @@ async function persist(params) {
     if (results.wasCorrect) {
       conversation.problemsCorrect = (conversation.problemsCorrect || 0) + 1;
     }
+
+    // First-try metric — the honest accuracy signal. Count each PROBLEM once,
+    // scored on the first attempt. lastProblemState still reflects the PRIOR
+    // turn here (it's updated below), so if it holds this same problem with a
+    // prior wrong attempt, this turn is a retry and must not open a new slot.
+    // Skips aren't a genuine attempt, so they're excluded entirely.
+    if (!results.wasSkipped && !isSameProblemRetry(conversation.lastProblemState, diagnosis)) {
+      conversation.firstTryAttempted = (conversation.firstTryAttempted || 0) + 1;
+      if (results.wasCorrect) {
+        conversation.firstTryCorrect = (conversation.firstTryCorrect || 0) + 1;
+      }
+    }
+
     const lastIdx = conversation.messages.length - 1;
     if (lastIdx >= 0) {
       conversation.messages[lastIdx].problemResult =
@@ -718,4 +758,5 @@ module.exports = {
   updateSkillMastery,
   processIepGoalUpdate,
   updateBadgeProgress,
+  isSameProblemRetry,
 };


### PR DESCRIPTION
The chat path counted every graded turn as its own attempt, so a miss-then-fix scored 0/2 (50%) on a problem the student actually learned — punishing exactly the productive-struggle the tutor is designed to create.

Persist now maintains first-try counters on the conversation: one slot per problem, scored on the first attempt. A retry of the in-progress problem (lastProblemState with a prior wrong attempt, same problem text) doesn't open a new slot; skips are excluded (not a genuine attempt). isSameProblemRetry guards the stale-state case where a student abandons a wrong problem and moves on.

The progress aggregation now prefers firstTryAttempted/firstTryCorrect, falling back to the legacy per-attempt counters for conversations that predate the fields (they age out of the 7-day window). This is the metric the redesigned card's "first-try wins" language needs.

QA: node --check on all three source files; new firstTryDedup unit suite (5) + updated integration assertion that the aggregation reads first-try counters; 81 pipeline/persist tests green; eslint 0 errors.