### PR TITLE
Unhide the visual math board panel

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -27,7 +27,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
        with the tutor's work mirrored inline as cards. To bring the board back,
        set boardPanel: true (or delete this block). -->
   <script>
-    window.MM_FEATURES = Object.assign({ boardPanel: false }, window.MM_FEATURES || {});
+    window.MM_FEATURES = Object.assign({ boardPanel: true }, window.MM_FEATURES || {});
     if (window.MM_FEATURES.boardPanel === false) {
       document.documentElement.classList.add('mm-board-hidden');
     }


### PR DESCRIPTION
Flip MM_FEATURES.boardPanel from false to true so the right-column workspace (whiteboard, graph/tiles/calc tools) renders again instead of applying the mm-board-hidden class. Reverses the shelving of the board; tutor work no longer restricted to inline chat cards.