### PR TITLE
Progress card data layer: cardState + reviewDue on /progress/summary

### DIFF
--- a/routes/student.js
+++ b/routes/student.js
@@ -12,6 +12,8 @@ const { isAuthenticated, isStudent } = require('../middleware/auth'); // Import 
 const crypto = require('crypto'); // Node.js built-in module for cryptography
 const mongoose = require('mongoose');
 const { computeWeeklyAccuracy } = require('../utils/weeklyAccuracy');
+const { deriveProgressCardState } = require('../utils/progressCardState');
+const { getReviewSummary } = require('../utils/smartReviewQueue');
 
 // Helper function to generate a unique short code for student-to-parent linking
 async function generateUniqueStudentLinkCode() {
@@ -410,6 +412,13 @@ router.get('/progress/summary', isAuthenticated, isStudent, async (req, res) => 
             skillsMastered: skillsMasteredThisWeek
         };
 
+        // Review-due count (FSRS) powers the card's "N skills ready to review" CTA.
+        const reviewDue = getReviewSummary(student).dueNow;
+
+        // Server-derived lifecycle state so the card's framing stays honest and
+        // the client stays dumb (see utils/progressCardState.js).
+        const cardState = deriveProgressCardState({ currentLearning, recentMastery, weeklyStats });
+
         res.json({
             assessmentCompleted: true,
             recentMastery,
@@ -418,6 +427,8 @@ router.get('/progress/summary', isAuthenticated, isStudent, async (req, res) => 
             streak,
             dailyQuests,
             weeklyStats,
+            reviewDue,
+            cardState,
             recentWins: recentWins.map(w => ({
                 description: w.description,
                 date: w.date

--- a/tests/integration/studentProgressSummary.test.js
+++ b/tests/integration/studentProgressSummary.test.js
@@ -114,6 +114,17 @@ describe('GET /api/student/progress/summary — weekly accuracy', () => {
     expect(pipeline[0].$match).toHaveProperty('previousAttemptId', null);
   });
 
+  test('returns a lifecycle cardState and a review-due count', async () => {
+    setSources({ conv: [], grade: [] }); // no activity
+
+    const res = await supertest(buildApp()).get('/api/student/progress/summary');
+
+    expect(res.status).toBe(200);
+    // No skill in progress and nothing done → the first-session invitation state.
+    expect(res.body.cardState).toBe('first_session');
+    expect(res.body.reviewDue).toBe(0);
+  });
+
   test('chat aggregation prefers the first-try counter over per-attempt counters', async () => {
     setSources({ conv: [{ totalProblems: 3, totalCorrect: 3 }], grade: [] });
 

--- a/tests/unit/progressCardState.test.js
+++ b/tests/unit/progressCardState.test.js
@@ -1,0 +1,81 @@
+/**
+ * deriveProgressCardState UNIT TESTS
+ *
+ * Locks the lifecycle-state decision that drives the progress card's framing.
+ */
+
+const { deriveProgressCardState } = require('../../utils/progressCardState');
+
+const NOW = 1_700_000_000_000; // fixed epoch for deterministic recency checks
+
+describe('deriveProgressCardState', () => {
+  test('first_session when nothing is in progress and nothing done yet', () => {
+    const state = deriveProgressCardState({
+      currentLearning: null,
+      recentMastery: null,
+      weeklyStats: { problemsSolved: 0, problemsCorrect: 0 },
+      now: NOW,
+    });
+    expect(state).toBe('first_session');
+  });
+
+  test('mastery when a skill was mastered within the last day', () => {
+    const state = deriveProgressCardState({
+      currentLearning: { skillId: 'x', progress: 100 },
+      recentMastery: { date: new Date(NOW - 2 * 60 * 60 * 1000) }, // 2h ago
+      weeklyStats: { problemsSolved: 6, problemsCorrect: 5 },
+      now: NOW,
+    });
+    expect(state).toBe('mastery');
+  });
+
+  test('mastery outranks struggling', () => {
+    const state = deriveProgressCardState({
+      currentLearning: { skillId: 'x' },
+      recentMastery: { date: new Date(NOW - 1000) },
+      weeklyStats: { problemsSolved: 8, problemsCorrect: 1 }, // would be struggling
+      now: NOW,
+    });
+    expect(state).toBe('mastery');
+  });
+
+  test('a stale mastery does not trigger the celebration', () => {
+    const state = deriveProgressCardState({
+      currentLearning: { skillId: 'x', progress: 40 },
+      recentMastery: { date: new Date(NOW - 3 * 24 * 60 * 60 * 1000) }, // 3 days ago
+      weeklyStats: { problemsSolved: 4, problemsCorrect: 3 },
+      now: NOW,
+    });
+    expect(state).toBe('progress');
+  });
+
+  test('struggling when there is real effort but few first-try wins', () => {
+    const state = deriveProgressCardState({
+      currentLearning: { skillId: 'x', progress: 35 },
+      recentMastery: null,
+      weeklyStats: { problemsSolved: 8, problemsCorrect: 1 }, // 12.5%
+      now: NOW,
+    });
+    expect(state).toBe('struggling');
+  });
+
+  test('progress is the normal in-progress default', () => {
+    const state = deriveProgressCardState({
+      currentLearning: { skillId: 'x', progress: 50 },
+      recentMastery: null,
+      weeklyStats: { problemsSolved: 6, problemsCorrect: 4 },
+      now: NOW,
+    });
+    expect(state).toBe('progress');
+  });
+
+  test('a couple of misses is not enough to call it struggling', () => {
+    const state = deriveProgressCardState({
+      currentLearning: { skillId: 'x', progress: 20 },
+      recentMastery: null,
+      weeklyStats: { problemsSolved: 2, problemsCorrect: 0 }, // below minStruggleAttempts
+      now: NOW,
+    });
+    expect(state).toBe('progress');
+  });
+});

--- a/utils/progressCardState.js
+++ b/utils/progressCardState.js
@@ -1,0 +1,57 @@
+// utils/progressCardState.js
+//
+// Decides which lifecycle state the student progress card should render. Kept
+// pure and server-side so the client stays dumb and the rule is testable.
+//
+// Governing principle (see the card redesign): never show a number that reads as
+// a verdict — always name the effort and offer a next step. The state drives the
+// framing:
+//   first_session  — no skill in progress and no activity yet → an invitation.
+//   mastery        — just mastered a skill → celebrate + open the next door.
+//   struggling     — recent effort with low first-try success → supportive, no %.
+//   progress       — the normal in-progress state.
+//
+// The handler already early-returns for students who haven't completed the
+// assessment, so this only runs for assessed students.
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * @param {Object} args
+ * @param {Object|null} args.currentLearning   skill in progress, or null
+ * @param {Object|null} args.recentMastery     { date } of the most recent mastery, or null
+ * @param {Object} [args.weeklyStats]          { problemsSolved, problemsCorrect }
+ * @param {number} [args.now]                  epoch ms (injectable for tests)
+ * @param {number} [args.masteryWindowMs]      how recent a mastery still counts as "just now"
+ * @param {number} [args.minStruggleAttempts]  min attempts before we'll call it struggling
+ * @param {number} [args.struggleThreshold]    first-try ratio below which it's struggling
+ * @returns {'first_session'|'mastery'|'struggling'|'progress'}
+ */
+function deriveProgressCardState({
+  currentLearning = null,
+  recentMastery = null,
+  weeklyStats = {},
+  now = Date.now(),
+  masteryWindowMs = DAY_MS,
+  minStruggleAttempts = 3,
+  struggleThreshold = 0.4,
+} = {}) {
+  const solved = weeklyStats.problemsSolved || 0;
+  const correct = weeklyStats.problemsCorrect || 0;
+
+  // Celebrate a fresh mastery first — it outranks everything.
+  if (recentMastery && recentMastery.date) {
+    const ageMs = now - new Date(recentMastery.date).getTime();
+    if (ageMs >= 0 && ageMs <= masteryWindowMs) return 'mastery';
+  }
+
+  // Brand-new: nothing in progress and nothing done yet → an invitation, not a 0%.
+  if (!currentLearning && solved === 0) return 'first_session';
+
+  // Enough recent effort but few first-try wins → supportive framing, never a %.
+  if (solved >= minStruggleAttempts && correct / solved < struggleThreshold) return 'struggling';
+
+  return 'progress';
+}
+
+module.exports = { deriveProgressCardState };


### PR DESCRIPTION
Adds the two signals the lifecycle progress card needs beyond what the endpoint already returned (mastery %, first-try counts, streak, XP):

- cardState: server-derived lifecycle state (first_session | mastery | struggling | progress) via utils/progressCardState.js, so the card's framing stays honest and the client stays dumb.
- reviewDue: FSRS due-now count (getReviewSummary) for the review CTA.

QA: node --check + eslint clean; deriveProgressCardState unit suite (7) + integration assertions that the endpoint returns cardState/reviewDue.