### PR TITLE
Lifecycle progress card: mastery-first, effort-framed, one CTA

### DIFF
--- a/public/css/resume-card.css
+++ b/public/css/resume-card.css
@@ -357,3 +357,113 @@
     font-size: 0.85rem;
   }
 }
+
+/* ── Lifecycle hero — mastery-first, effort-framed, one clear next step ── */
+.rc-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 14px;
+}
+
+.rc-hero-label {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.rc-hero-skill {
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: #fff;
+}
+
+.rc-hero-track {
+  height: 10px;
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 99px;
+  overflow: hidden;
+}
+
+.rc-hero-fill {
+  height: 100%;
+  background: #2dd4bf;
+  border-radius: 99px;
+  transition: width 0.4s ease;
+}
+
+.rc-hero-progrow {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.rc-hero-copy {
+  font-size: 0.82rem;
+  color: rgba(255, 255, 255, 0.72);
+  line-height: 1.5;
+}
+
+.rc-hero-week,
+.rc-hero-effort {
+  font-size: 0.82rem;
+  color: rgba(255, 255, 255, 0.88);
+  background: rgba(45, 212, 191, 0.12);
+  border-radius: 10px;
+  padding: 9px 11px;
+}
+
+.rc-hero-week strong,
+.rc-hero-effort strong {
+  color: #2dd4bf;
+  font-weight: 600;
+}
+
+.rc-hero-badge {
+  font-size: 0.82rem;
+  color: #2dd4bf;
+  font-weight: 600;
+}
+
+.rc-hero-cta {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  background: #2dd4bf;
+  color: #04302b;
+  border: none;
+  border-radius: 12px;
+  padding: 12px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.rc-hero-cta:hover {
+  background: #5eead4;
+}
+
+.rc-hero-alt {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.75);
+  border: none;
+  padding: 8px;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.rc-hero-alt:hover {
+  color: #fff;
+}
+
+.rc-hero-arrow {
+  font-weight: 700;
+}

--- a/public/js/resume-card.js
+++ b/public/js/resume-card.js
@@ -67,57 +67,97 @@
       </div>`;
   }
 
-  // Build weekly stats strip
-  function weeklyStatsHTML(stats) {
-    if (!stats) return '';
-    const items = [];
-    if (stats.problemsSolved != null && stats.problemsSolved > 0) {
-      items.push(`<div class="rc-stat"><span class="rc-stat-val">${stats.problemsSolved}</span><span class="rc-stat-label">problems</span></div>`);
-    }
-    if (stats.accuracy != null) {
-      // Enough attempts for a percentage to be meaningful.
-      items.push(`<div class="rc-stat"><span class="rc-stat-val">${stats.accuracy}%</span><span class="rc-stat-label">accuracy</span></div>`);
-    } else if (stats.problemsCorrect != null && stats.problemsSolved > 0) {
-      // Small sample: a % here would be noise, so show the raw fraction instead.
-      items.push(`<div class="rc-stat"><span class="rc-stat-val">${stats.problemsCorrect}/${stats.problemsSolved}</span><span class="rc-stat-label">correct</span></div>`);
-    }
-    if (stats.xpEarned != null && stats.xpEarned > 0) {
-      items.push(`<div class="rc-stat"><span class="rc-stat-val">+${stats.xpEarned}</span><span class="rc-stat-label">XP this week</span></div>`);
-    }
-    if (stats.skillsMastered != null && stats.skillsMastered > 0) {
-      items.push(`<div class="rc-stat"><span class="rc-stat-val">${stats.skillsMastered}</span><span class="rc-stat-label">mastered</span></div>`);
-    }
-    if (items.length === 0) return '';
-    return `<div class="rc-stats-strip">${items.join('')}</div>`;
+  // Escape text going into innerHTML
+  function esc(s) {
+    return String(s == null ? '' : s).replace(/[&<>"']/g, (c) => (
+      { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+    ));
   }
 
-  // Build learning progress section
-  function learningHTML(summary) {
+  // A CTA that types a prompt to the tutor and sends it (wired in wireCtaClicks)
+  function ctaButton(label, prompt, kind) {
+    const cls = kind === 'alt' ? 'rc-hero-alt' : 'rc-hero-cta';
+    const arrow = kind === 'alt' ? '' : '<span class="rc-hero-arrow">→</span>';
+    return `<button class="${cls}" data-rc-prompt="${esc(prompt)}">${esc(label)}${arrow}</button>`;
+  }
+
+  // Progress bar toward mastery of a skill
+  function masteryBar(displayName, pct, labelText) {
+    const p = Math.max(0, Math.min(100, Math.round(pct || 0)));
+    const state = p >= 100 ? 'mastered' : (p >= 50 ? 'halfway to mastery' : 'building it up');
+    return `
+      <div class="rc-hero-label">${esc(labelText || 'Working toward mastery')}</div>
+      <div class="rc-hero-skill">${esc(displayName)}</div>
+      <div class="rc-hero-track"><div class="rc-hero-fill" style="width: ${p}%"></div></div>
+      <div class="rc-hero-progrow"><span>${state}</span><span>${p}%</span></div>`;
+  }
+
+  // State-aware hero — leads with the ONE thing that matters and ends with a
+  // single next step. Framing is honest per lifecycle state: effort and growth,
+  // never a verdict number. Driven by summary.cardState from the server.
+  function heroHTML(summary) {
     if (!summary) return '';
+    const learning = summary.currentLearning;
+    const stats = summary.weeklyStats || {};
+    const reviewDue = summary.reviewDue || 0;
+
+    // FIRST SESSION — an invitation, never a wall of zeros.
+    if (summary.cardState === 'first_session') {
+      return `
+        <div class="rc-hero">
+          <div class="rc-hero-label">Your journey starts here</div>
+          <div class="rc-hero-skill">A quick warm-up</div>
+          <div class="rc-hero-copy">A few short problems so we can find the right place to start. No grades, no pressure.</div>
+          ${ctaButton('Start the warm-up', "I'm ready for a warm-up.")}
+        </div>`;
+    }
+
+    // MASTERY — celebrate, then open the next door.
+    if (summary.cardState === 'mastery') {
+      const mastered = summary.recentMastery;
+      const next = summary.nextReady;
+      return `
+        <div class="rc-hero">
+          <div class="rc-hero-badge">★ skill mastered</div>
+          ${masteryBar(mastered ? mastered.displayName : 'Your skill', 100, 'You just mastered')}
+          <div class="rc-hero-copy">Ready for something new.</div>
+          ${next
+            ? ctaButton(`Start ${next.displayName}`, `I'm ready to start ${next.displayName}.`)
+            : ctaButton('Start something new', 'What should I work on next?')}
+        </div>`;
+    }
+
+    // STRUGGLING — name the persistence, no percentage, gentler on-ramp.
+    if (summary.cardState === 'struggling') {
+      const solved = stats.problemsSolved || 0;
+      return `
+        <div class="rc-hero">
+          ${learning ? masteryBar(learning.displayName, learning.progress, 'Working toward mastery') : ''}
+          <div class="rc-hero-effort">You worked through <strong>${solved} tricky problem${solved === 1 ? '' : 's'}</strong> and didn't quit.</div>
+          ${ctaButton('Review the tricky part together', 'Can we review the part I keep getting stuck on?')}
+          ${ctaButton('or try an easier warm-up', 'Can we try an easier warm-up first?', 'alt')}
+        </div>`;
+    }
+
+    // PROGRESS (default) — mastery bar + honest week + continue.
+    const wins = stats.problemsCorrect || 0;
+    const practiced = stats.problemsSolved || 0;
+    const weekBlock = practiced > 0
+      ? `<div class="rc-hero-week"><strong>${wins} first-try win${wins === 1 ? '' : 's'}</strong> · ${practiced} practiced this week</div>`
+      : '';
     const parts = [];
-
-    if (summary.currentLearning) {
-      const pct = summary.currentLearning.progress || 0;
-      parts.push(`
-        <div class="rc-learning-item">
-          <div class="rc-learning-header">
-            <span class="rc-learning-status">📖 Currently learning</span>
-            <span class="rc-learning-pct">${pct}%</span>
-          </div>
-          <div class="rc-learning-name">${summary.currentLearning.displayName}</div>
-          <div class="rc-learning-track"><div class="rc-learning-fill" style="width: ${pct}%"></div></div>
-        </div>`);
+    if (learning) {
+      parts.push(masteryBar(learning.displayName, learning.progress, 'Working toward mastery'));
+      parts.push(weekBlock);
+      parts.push(ctaButton(`Continue ${learning.displayName}`, `Let's keep working on ${learning.displayName}.`));
+    } else {
+      parts.push(weekBlock);
+      parts.push(ctaButton('Keep practicing', "Let's practice."));
     }
-
-    if (summary.recentMastery) {
-      parts.push(`
-        <div class="rc-learning-item rc-mastery-item">
-          <span class="rc-mastery-badge">⭐</span>
-          <span>Recently mastered <strong>${summary.recentMastery.displayName}</strong></span>
-        </div>`);
+    if (reviewDue > 0) {
+      parts.push(ctaButton(`${reviewDue} skill${reviewDue === 1 ? '' : 's'} ready to review`, "Let's review what I've learned.", 'alt'));
     }
-
-    return parts.length > 0 ? `<div class="rc-learning">${parts.join('')}</div>` : '';
+    return `<div class="rc-hero">${parts.join('')}</div>`;
   }
 
   // Build recent session buttons
@@ -169,13 +209,13 @@
     const firstName = user?.firstName || user?.name?.split(' ')[0] || '';
     const greeting = `${getTimeGreeting()}${firstName ? ', ' + firstName : ''}!`;
 
-    // Only show card if there's meaningful content
-    const hasStreak = summary?.streak > 0;
+    // Show the card whenever we have a lifecycle hero to render (any assessed
+    // student — including the brand-new, no-activity first-session state), or
+    // when there are sessions to resume.
+    const hasHero = !!summary?.cardState;
     const hasSessions = returning?.isReturningUser && (returning.courses?.length > 0 || returning.recentSessions?.length > 0);
-    const hasLearning = summary?.currentLearning || summary?.recentMastery;
-    const hasStats = summary?.weeklyStats && (summary.weeklyStats.problemsSolved > 0 || summary.weeklyStats.xpEarned > 0);
 
-    if (!hasSessions && !hasLearning && !hasStats && !hasStreak) return null;
+    if (!hasHero && !hasSessions) return null;
 
     const html = `
       <div id="${CARD_ID}" class="rc-card" role="region" aria-label="Welcome back">
@@ -184,12 +224,11 @@
           <button class="rc-dismiss" id="rc-dismiss-btn" aria-label="Dismiss">&times;</button>
         </div>
         <div class="rc-body">
+          ${heroHTML(summary)}
           <div class="rc-top-row">
             ${streakHTML(summary?.streak)}
             ${xpBarHTML(user)}
           </div>
-          ${weeklyStatsHTML(summary?.weeklyStats)}
-          ${learningHTML(summary)}
           ${sessionsHTML(returning)}
         </div>
       </div>`;
@@ -254,6 +293,7 @@
       const dismissBtn = document.getElementById('rc-dismiss-btn');
       if (dismissBtn) dismissBtn.addEventListener('click', dismissCard);
       wireSessionClicks();
+      wireCtaClicks();
 
       // Card stays until the user dismisses it or taps a session.
       // No auto-dismiss — let them read at their own pace.
@@ -263,6 +303,31 @@
     }
   }
 
+  // A CTA types its prompt into the chat and sends it, as if the student typed
+  // it — reusing the chat's own input + send button (no private API).
+  function wireCtaClicks() {
+    const card = document.getElementById(CARD_ID);
+    if (!card) return;
+    card.querySelectorAll('[data-rc-prompt]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const prompt = btn.getAttribute('data-rc-prompt') || '';
+        dismissCard();
+        const input = document.getElementById('user-input');
+        if (input) {
+          input.textContent = prompt;
+          input.dispatchEvent(new Event('input', { bubbles: true }));
+        }
+        const sendBtn = document.getElementById('send-button');
+        if (sendBtn && !sendBtn.disabled) sendBtn.click();
+      });
+    });
+  }
+
   // Expose globally so initializeApp can call it
-  window.showResumeCard = showResumeCard;
+  if (typeof window !== 'undefined') window.showResumeCard = showResumeCard;
+
+  // Testable surface (no-op in the browser)
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { heroHTML };
+  }
 })();

--- a/tests/unit/resumeCardHero.test.js
+++ b/tests/unit/resumeCardHero.test.js
@@ -1,0 +1,84 @@
+/**
+ * resume-card heroHTML RENDER TESTS
+ *
+ * Locks the lifecycle framing at the render layer: the right content per state,
+ * a single primary CTA carrying a promptable action, and — the governing rule —
+ * no punishing accuracy percentage anywhere.
+ *
+ * heroHTML is pure string-building; the module guards its window/document use, so
+ * it loads in the default node test environment (no jsdom dependency needed).
+ */
+
+const { heroHTML } = require('../../public/js/resume-card');
+
+describe('heroHTML', () => {
+  test('first_session renders an invitation with a warm-up CTA, no zeros', () => {
+    const html = heroHTML({ cardState: 'first_session', weeklyStats: { problemsSolved: 0, problemsCorrect: 0 } });
+    expect(html).toContain('Your journey starts here');
+    expect(html).toContain('Start the warm-up');
+    expect(html).toContain('data-rc-prompt');
+    expect(html).not.toContain('0%');
+  });
+
+  test('progress leads with the mastery bar and an honest week, ends with continue', () => {
+    const html = heroHTML({
+      cardState: 'progress',
+      currentLearning: { displayName: 'Fractions', progress: 50 },
+      weeklyStats: { problemsSolved: 9, problemsCorrect: 3, accuracy: null },
+      reviewDue: 2,
+    });
+    expect(html).toContain('Fractions');
+    expect(html).toContain('width: 50%');
+    expect(html).toContain('3 first-try wins');
+    expect(html).toContain('Continue Fractions');
+    expect(html).toContain('2 skills ready to review'); // FSRS alt CTA
+    // The governing rule: never a verdict percentage.
+    expect(html).not.toContain('accuracy');
+    expect(html).not.toContain('33%');
+  });
+
+  test('struggling names persistence and offers a gentler on-ramp, no percentage', () => {
+    const html = heroHTML({
+      cardState: 'struggling',
+      currentLearning: { displayName: 'Order of operations', progress: 35 },
+      weeklyStats: { problemsSolved: 8, problemsCorrect: 1 },
+    });
+    expect(html).toContain("didn't quit");
+    expect(html).toContain('8 tricky problems');
+    expect(html).toContain('Review the tricky part together');
+    expect(html).toContain('easier warm-up');
+    expect(html).not.toContain('12%'); // 1/8 must never surface as a verdict
+    expect(html).not.toContain('accuracy');
+  });
+
+  test('mastery celebrates and opens the next skill', () => {
+    const html = heroHTML({
+      cardState: 'mastery',
+      recentMastery: { displayName: 'Order of operations' },
+      nextReady: { displayName: 'Combining like terms' },
+    });
+    expect(html).toContain('skill mastered');
+    expect(html).toContain('width: 100%');
+    expect(html).toContain('Start Combining like terms');
+  });
+
+  test('progress with no active skill still gives a next step', () => {
+    const html = heroHTML({
+      cardState: 'progress',
+      currentLearning: null,
+      weeklyStats: { problemsSolved: 6, problemsCorrect: 4 },
+    });
+    expect(html).toContain('Keep practicing');
+    expect(html).toContain('4 first-try wins');
+  });
+
+  test('escapes text interpolated into markup', () => {
+    const html = heroHTML({
+      cardState: 'progress',
+      currentLearning: { displayName: '<img src=x>', progress: 10 },
+      weeklyStats: { problemsSolved: 1, problemsCorrect: 0 },
+    });
+    expect(html).not.toContain('<img src=x>');
+    expect(html).toContain('&lt;img');
+  });
+});


### PR DESCRIPTION
Rewrites the Resume Card hero to be state-aware (driven by summary.cardState), replacing the four competing numbers + verdict accuracy % with a single honest hero per lifecycle state:

- first_session: an invitation ("start the warm-up"), never a wall of zeros.
- progress: current-skill mastery bar + honest week ("N first-try wins · practiced") + one "Continue <skill>" CTA + FSRS "N skills ready to review".
- struggling: names persistence ("worked through N tricky problems and didn't quit"), NO percentage, gentler on-ramp (review / easier warm-up).
- mastery: celebrate + open the next skill.

CTAs type their prompt into the chat and send it via the existing input/send button (no private API). Streak/XP demoted to a quiet momentum row; the sessions list is unchanged. Hero styles added to resume-card.css in the existing dark card aesthetic (teal accent). heroHTML is exported (guarded) and unit-tested per state, including the governing rule: no verdict percentage anywhere.

QA: node --check + eslint clean; resumeCardHero suite (6) + full accuracy/card set (35 across 6 suites) green. Verified all four states render correctly via a static preview screenshot (can't drive the live app: no seeded DB + student auth locally) — framing and styling confirmed.