### PR TITLE
Board: fix prose/image defects + add reasoning juice

### DIFF
--- a/public/css/workspace.css
+++ b/public/css/workspace.css
@@ -531,6 +531,26 @@
   }
 }
 
+/* Attention pulse — a gentle accent halo drawing the eye to a card (e.g. the
+   current line the tutor is talking through). Added/removed by
+   MathWorkspace.boardHighlight; accent-purple, distinct from the gold
+   clean-solution pulse so the two never read as the same event. */
+.cr-ws-board-card--attention {
+  animation: cr-ws-attention-pulse 1.4s var(--cr-ease, ease-out) 1;
+}
+@keyframes cr-ws-attention-pulse {
+  0%   { box-shadow: 0 0 0 0 rgba(139, 123, 255, 0.0),
+                     0 8px 22px rgba(0, 0, 0, 0.30); }
+  35%  { box-shadow: 0 0 0 10px rgba(139, 123, 255, 0.0),
+                     0 0 22px 3px rgba(139, 123, 255, 0.50),
+                     0 8px 22px rgba(0, 0, 0, 0.30); }
+  100% { box-shadow: 0 0 0 0 rgba(139, 123, 255, 0.0),
+                     0 8px 22px rgba(0, 0, 0, 0.30); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .cr-ws-board-card--attention { animation: none; }
+}
+
 /* Scaffold — a hint card: the next step's structure with empty \boxed{}
    slots for the student to fill. Dashed amber presence + a "your turn"
    eyebrow so it reads as an invitation, not a finished step. The blanks

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -3349,6 +3349,21 @@ document.addEventListener("DOMContentLoaded", () => {
                     }
                 }
 
+                // Thinking Streak — consecutive turns that earned reasoning (tier-3
+                // behavior) XP. Rewards SUSTAINED REASONING, not correctness: a
+                // tier-2-only (correct, no reasoning credit) turn is neutral, while a
+                // turn that earns no performance/behavior XP breaks the streak. No XP
+                // number is shown here — the streak is a callout only, so the display
+                // never diverges from the server-authoritative XP totals.
+                if (xp.tier3 > 0) {
+                    window.__thinkingStreak = (window.__thinkingStreak || 0) + 1;
+                    if (window.__thinkingStreak >= 2) {
+                        triggerXpAnimation(`🔥 Thinking Streak x${window.__thinkingStreak}`, false, true);
+                    }
+                } else if (xp.tier2 === 0) {
+                    window.__thinkingStreak = 0;
+                }
+
                 // Inline XP attribution chip — show "+N XP — reason" in the chat message
                 if (xp.total > 0) {
                     const messageElements = document.querySelectorAll('.message.ai');

--- a/public/js/workspace.js
+++ b/public/js/workspace.js
@@ -45,11 +45,28 @@
     return !(window.MM_FEATURES && window.MM_FEATURES.boardPanel === false);
   }
 
+  // A board expression is meant to be math (LaTeX). Occasionally the tutor emits
+  // a plain-English sentence (e.g. a word-problem prompt) where a LaTeX string is
+  // expected; KaTeX then renders every letter as an italic variable and drops the
+  // spaces ("Iftwotriangleshave..."). Detect obvious prose so we render it as
+  // readable text instead. Conservative on purpose: a real LaTeX command, or fewer
+  // than three English words, keeps the string on the math path (so "2x + 4 = 20"
+  // and "y = mx + b" still render as math).
+  function looksLikeProse(s) {
+    s = String(s || '');
+    if (/\\[a-zA-Z]+/.test(s)) return false;      // has a LaTeX command -> math
+    var words = s.match(/[A-Za-z]{2,}/g) || [];    // 2+ letter word tokens
+    return words.length >= 3;                       // a sentence, not an expression
+  }
+
   // KaTeX renderer with a safe text fallback if KaTeX hasn't loaded yet
   // (very early in page life) or the expression doesn't parse.
   function renderTex(target, tex) {
     if (!target) return;
     var s = String(tex || '');
+    // Prose (a word-problem statement, not an expression) -> render as text so the
+    // words and spaces survive instead of KaTeX mangling them into run-on italics.
+    if (looksLikeProse(s)) { target.textContent = s; return; }
     if (window.katex && typeof window.katex.render === 'function') {
       try {
         window.katex.render(s, target, {
@@ -460,18 +477,25 @@
           }
           imgHost.innerHTML = '';
           var img = el('img', 'cr-ws-board-card-image-img');
-          // Prefer the cached thumbnail (e.g. Google's gstatic copy / Wikimedia
-          // thumb): it loads reliably cross-origin, whereas the source `url`
-          // frequently hotlink-blocks and renders as a broken-image glyph.
-          img.src = first.thumbnail || first.url;
+          // Route remote images through our same-origin proxy: third-party hosts
+          // frequently hotlink-block a bare <img> and render as a broken glyph.
+          // Local concept images (/images/...) are already same-origin — serve
+          // them as-is.
+          function srcFor(u) {
+            return /^https?:\/\//i.test(u)
+              ? '/api/images/proxy?url=' + encodeURIComponent(u)
+              : u;
+          }
+          // Prefer the cached thumbnail (Google gstatic / Wikimedia thumb); fall
+          // back to the source url, then degrade to text instead of a broken image.
+          var triedUrl = false;
+          img.src = srcFor(first.thumbnail || first.url);
           img.alt = first.title || step.query;
           img.loading = 'lazy';
-          // If even the chosen source fails, try the other one, then degrade to
-          // text instead of a broken image.
           img.onerror = function () {
-            if (first.url && img.src !== first.url) {
-              img.onerror = function () { imgHost.textContent = 'Couldn’t load that diagram.'; };
-              img.src = first.url;
+            if (!triedUrl && first.url && first.url !== (first.thumbnail || first.url)) {
+              triedUrl = true;
+              img.src = srcFor(first.url);
             } else {
               imgHost.textContent = 'Couldn’t load that diagram.';
             }
@@ -906,6 +930,31 @@
     // student has stated.
 
     /**
+     * Briefly pulse a board card to direct the student's attention (e.g. as the
+     * tutor starts talking through the current line). Presentational only — it
+     * highlights an EXISTING card and reveals nothing new, so it's safe on the
+     * student's own problem. Token-level "circle the 2" attention is a follow-up
+     * that needs the term-addressable canvas. No-op when the board isn't visible.
+     * @param {object} [opts] { index } — which card (default: the most recent).
+     * @returns {boolean} whether a card was pulsed.
+     */
+    boardHighlight: function (opts) {
+      if (!WS.body) return false;
+      var stack = WS.body.querySelector('.cr-ws-board-stack');
+      if (!stack) return false;
+      var cards = stack.querySelectorAll('.cr-ws-board-card');
+      if (!cards.length) return false;
+      var i = (opts && typeof opts.index === 'number') ? opts.index : cards.length - 1;
+      var card = cards[i];
+      if (!card) return false;
+      card.classList.remove('cr-ws-board-card--attention'); // restart if already pulsing
+      void card.offsetWidth;                                 // reflow so re-adding re-triggers
+      card.classList.add('cr-ws-board-card--attention');
+      setTimeout(function () { card.classList.remove('cr-ws-board-card--attention'); }, 1500);
+      return true;
+    },
+
+    /**
      * Render the starting problem as the top card.
      * @param {string} tex  LaTeX expression, e.g. "2x + 4 = 20"
      * @param {object} [opts] reserved for future caption/parallel marks
@@ -920,6 +969,13 @@
         this.showTool('board');
       }
       pushBoardStep({ type: 'pose', tex: tex, opts: opts || null });
+      // Direct the eye to the problem first (vision: "the board softly
+      // highlights"). One gentle pulse after the enter animation settles;
+      // no-op on mobile (drawer) and under prefers-reduced-motion.
+      if (!isMobileChat()) {
+        var self = this;
+        setTimeout(function () { self.boardHighlight(); }, 420);
+      }
       return true;
     },
 

--- a/routes/imageSearch.js
+++ b/routes/imageSearch.js
@@ -4,13 +4,15 @@
 // ============================================
 
 const express = require('express');
+const axios = require('axios');
 const router = express.Router();
 const rateLimit = require('express-rate-limit');
 const {
   searchEducationalImages,
   sanitizeQuery,
   getStaticConceptImage,
-  isValidCategory
+  isValidCategory,
+  isProxyableImageUrl
 } = require('../utils/safeImageSearch');
 
 // ── Strict rate limiter: 10 image searches per student per 15 minutes ──
@@ -126,6 +128,62 @@ router.get('/concept/:concept', (req, res) => {
   }
 
   return res.status(404).json({ error: 'No image available for this concept' });
+});
+
+// ── Image proxy limiter: generous vs search (one hit per board diagram) ──
+const imageProxyLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 60,
+  keyGenerator: (req) => req.user?._id?.toString() || req.ip,
+  message: { error: 'Too many image requests. Try again in a few minutes.' },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+/**
+ * GET /api/images/proxy?url=<encoded>
+ *
+ * Streams a whitelisted educational image from our own origin. Third-party
+ * hosts frequently hotlink-block a browser <img> (no matching Referer) so board
+ * diagrams render as a broken glyph; fetching server-side with a browser-like
+ * User-Agent and re-serving same-origin fixes that. SSRF is contained by
+ * isProxyableImageUrl (host allowlist + internal-host block) and no redirects.
+ */
+router.get('/proxy', imageProxyLimiter, async (req, res) => {
+  const url = req.query.url;
+  if (!url || typeof url !== 'string') {
+    return res.status(400).json({ error: 'Image url is required' });
+  }
+  if (!isProxyableImageUrl(url)) {
+    return res.status(400).json({ error: 'Image url not allowed' });
+  }
+
+  try {
+    const upstream = await axios.get(url, {
+      responseType: 'arraybuffer',
+      timeout: 8000,
+      maxContentLength: 8 * 1024 * 1024, // 8MB cap
+      maxRedirects: 0,                   // allowlisted hosts serve directly; blocks redirect-to-internal SSRF
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; MathmatixBot/1.0; +https://www.mathmatix.ai)',
+        'Accept': 'image/avif,image/webp,image/png,image/jpeg,image/*;q=0.8',
+      },
+      validateStatus: (s) => s >= 200 && s < 300,
+    });
+
+    const type = String(upstream.headers['content-type'] || '');
+    if (!type.startsWith('image/')) {
+      return res.status(415).json({ error: 'Not an image' });
+    }
+
+    res.set('Content-Type', type);
+    res.set('Cache-Control', 'public, max-age=86400'); // diagrams are stable; cache a day
+    res.set('Cross-Origin-Resource-Policy', 'same-origin');
+    return res.send(Buffer.from(upstream.data));
+  } catch (error) {
+    console.error('[ImageProxy] fetch failed:', error.message);
+    return res.status(502).json({ error: 'Image unavailable' });
+  }
 });
 
 module.exports = router;

--- a/tests/unit/safeImageSearch.test.js
+++ b/tests/unit/safeImageSearch.test.js
@@ -5,6 +5,7 @@ const {
   sanitizeQuery,
   isValidCategory,
   getStaticConceptImage,
+  isProxyableImageUrl,
   ALLOWED_DOMAINS,
   VALID_CATEGORIES
 } = require('../../utils/safeImageSearch');
@@ -136,5 +137,35 @@ describe('ALLOWED_DOMAINS', () => {
     expect(ALLOWED_DOMAINS).not.toContain('facebook.com');
     expect(ALLOWED_DOMAINS).not.toContain('youtube.com');
     expect(ALLOWED_DOMAINS).not.toContain('twitter.com');
+  });
+});
+
+describe('isProxyableImageUrl (SSRF guard for the image proxy)', () => {
+  test('allows whitelisted educational + thumbnail hosts', () => {
+    expect(isProxyableImageUrl('https://encrypted-tbn0.gstatic.com/images?q=tbn:abc')).toBe(true);
+    expect(isProxyableImageUrl('https://upload.wikimedia.org/wikipedia/commons/a/b/tri.png')).toBe(true);
+    expect(isProxyableImageUrl('https://en.wikipedia.org/x.png')).toBe(true);
+    expect(isProxyableImageUrl('https://khanacademy.org/img.png')).toBe(true);
+  });
+
+  test('blocks internal/metadata hosts (SSRF)', () => {
+    expect(isProxyableImageUrl('http://169.254.169.254/latest/meta-data/')).toBe(false);
+    expect(isProxyableImageUrl('http://localhost:3000/x.png')).toBe(false);
+    expect(isProxyableImageUrl('http://127.0.0.1/x.png')).toBe(false);
+    expect(isProxyableImageUrl('http://10.0.0.5/x.png')).toBe(false);
+    expect(isProxyableImageUrl('http://192.168.1.1/x.png')).toBe(false);
+  });
+
+  test('blocks non-http(s) schemes and off-allowlist hosts', () => {
+    expect(isProxyableImageUrl('file:///etc/passwd')).toBe(false);
+    expect(isProxyableImageUrl('https://evil.com/x.png')).toBe(false);
+    // subdomain-suffix spoof: gstatic.com is allowed, gstatic.com.evil.com is NOT
+    expect(isProxyableImageUrl('https://gstatic.com.evil.com/x')).toBe(false);
+  });
+
+  test('rejects relative/local URLs (served directly, never proxied)', () => {
+    expect(isProxyableImageUrl('/images/concepts/triangle-types.png')).toBe(false);
+    expect(isProxyableImageUrl('')).toBe(false);
+    expect(isProxyableImageUrl(null)).toBe(false);
   });
 });

--- a/utils/safeImageSearch.js
+++ b/utils/safeImageSearch.js
@@ -384,12 +384,37 @@ function getStaticConceptImage(concept) {
   return null;
 }
 
+// Hosts we'll proxy image BYTES from (see the /proxy route in routes/imageSearch.js).
+// Superset of ALLOWED_DOMAINS plus the thumbnail CDNs the search results point at
+// (Google CSE thumbnails live on gstatic; some cached copies on googleusercontent).
+const PROXYABLE_IMAGE_HOSTS = ALLOWED_DOMAINS.concat(['gstatic.com', 'googleusercontent.com']);
+
+/**
+ * Whether a URL is safe for the server-side image proxy to fetch. Defends the
+ * proxy against SSRF: only http(s), never an obvious internal host, and the
+ * hostname must match (or be a subdomain of) a known educational / thumbnail
+ * host. Relative URLs (our own /images/...) return false — the client serves
+ * those directly and never needs the proxy.
+ * @param {string} raw
+ * @returns {boolean}
+ */
+function isProxyableImageUrl(raw) {
+  let u;
+  try { u = new URL(String(raw)); } catch (_) { return false; }
+  if (u.protocol !== 'https:' && u.protocol !== 'http:') return false;
+  const host = u.hostname.toLowerCase();
+  // Belt-and-suspenders against the allowlist below: refuse obvious internal names.
+  if (/^(localhost$|127\.|10\.|192\.168\.|169\.254\.|0\.|::1|\[)/.test(host)) return false;
+  return PROXYABLE_IMAGE_HOSTS.some(d => host === d || host.endsWith('.' + d));
+}
+
 module.exports = {
   searchEducationalImages,
   searchWikimediaCommons,
   sanitizeQuery,
   isValidCategory,
   getStaticConceptImage,
+  isProxyableImageUrl,
   ALLOWED_DOMAINS,
   VALID_CATEGORIES
 };


### PR DESCRIPTION
Bring the (now-live) visual math board to reliable working order:

- Fix PROBLEM card rendering English as math. renderTex now detects prose (no LaTeX command + 3+ English words) and renders it as readable text instead of KaTeX mangling "If two triangles..." into run-on italics.
- Add an auth-gated, host-allowlisted /api/images/proxy so board diagrams load reliably from our own origin instead of hotlink-blocking. SSRF is contained by isProxyableImageUrl (allowlist + internal-host block, no redirects); client routes remote img src through it.
- Surface a client-only "Thinking Streak" on consecutive reasoning (tier-3) turns — rewards sustained reasoning, not correctness; shows no XP number so it never diverges from server-authoritative totals.
- Add MathWorkspace.boardHighlight attention pulse (presentational; pulses an existing card, reveals nothing) and a gentle one-shot pulse on the PROBLEM card. Token-level "circle the 2" attention is deferred to the canvas work.

QA: node --check + eslint (0 errors) on changed files; 31 safeImageSearch tests pass incl. 4 new SSRF cases; prose/proxy logic validated against the reported bug inputs. Browser-level board behavior needs a logged-in session (not runnable on a static server) — not browser-verified.