### PR TITLE
Fix leading-negative arithmetic losing its sign in prose/"=?" context

### DIFF
--- a/tests/unit/mathSolverUnicodeMinus.test.js
+++ b/tests/unit/mathSolverUnicodeMinus.test.js
@@ -15,7 +15,7 @@
  * to ASCII "-" in detection and in verifyAnswer/evalArithmeticString. En/em dashes
  * (– —) are deliberately NOT normalized — they are prose punctuation.
  */
-const { processMathMessage, verifyAnswer } = require('../../utils/mathSolver');
+const { processMathMessage, verifyAnswer, parseCleanProblem } = require('../../utils/mathSolver');
 
 const MINUS = '−'; // − MINUS SIGN
 
@@ -41,6 +41,45 @@ describe('Unicode minus (U+2212) — arithmetic and equations', () => {
     const r = processMathMessage(`x${MINUS}6=${MINUS}34`);
     expect(r.hasMath).toBe(true);
     expect(String(r.solution.answer)).toBe('-28');
+  });
+});
+
+// SECOND-ORDER REGRESSION (same real session): the earlier fix corrected the BARE
+// form "−34+6", but a leading-negative arithmetic step EMBEDDED in tutor prose — or
+// followed by "=?" — still fell through to the last-resort embedded-arithmetic matcher,
+// whose left-operand capture dropped the sign. So the tutor posed "compute −34+6 on the
+// right side?", the pipeline computed the expected answer as 40, and graded the student's
+// correct "−28" INCORRECT — the exact trust-killing loop, one layer deeper. The fix lets
+// the last-resort matcher capture a leading unary minus (guarded so "5−34" is unchanged).
+describe('leading-negative arithmetic keeps its sign in prose / with "=?"', () => {
+  it('evaluates "−34+6=?" to -28 (not 40)', () => {
+    expect(String(processMathMessage(`${MINUS}34+6=?`).solution.answer)).toBe('-28');
+    expect(String(processMathMessage('-34+6=?').solution.answer)).toBe('-28');
+  });
+
+  it('evaluates a leading negative embedded in prose to -28', () => {
+    const r = parseCleanProblem(
+      `So what do you get when you compute ${MINUS}34+6 on the right side?`
+    );
+    expect(r.hasMath).toBe(true);
+    expect(String(r.solution.answer)).toBe('-28');
+  });
+
+  it('the pipeline verdict now confirms the student\'s "−28" is correct', () => {
+    const posed = parseCleanProblem(`compute ${MINUS}34+6 on the right side?`);
+    expect(verifyAnswer(`${MINUS}28`, posed.solution.answer).isCorrect).toBe(true);
+  });
+
+  it('does NOT turn a binary minus into a leading sign ("5-34" stays 5 − 34 = -29)', () => {
+    // The leading-sign capture must only fire on a genuine unary minus, never on a
+    // subtraction that follows a value — otherwise "5-34" would misread as left=-34.
+    expect(String(processMathMessage('result is 5-34 here').solution.answer)).toBe('-29');
+    expect(String(processMathMessage('20-8=?').solution.answer)).toBe('12');
+  });
+
+  it('leaves "x^2 + 8" as a non-arithmetic expression (no false "2 + 8")', () => {
+    const r = processMathMessage('x^2 + 8 here');
+    expect(r.problem && r.problem.type).not.toBe('arithmetic');
   });
 });
 

--- a/utils/mathSolver.js
+++ b/utils/mathSolver.js
@@ -539,11 +539,17 @@ function detectMathProblem(message) {
     }
 
     // Last resort: scan for any embedded arithmetic with symbolic operators (e.g. "So 3 × 12 is what?")
-    // Lookbehind: reject when the left operand follows ^ or a letter (it's an exponent
-    // or part of an algebraic term like "x^2 + 8" → "2 + 8" is NOT standalone arithmetic).
+    // The left operand captures an OPTIONAL leading minus so a negative first term keeps its
+    // sign: "compute -34+6" must yield left=-34 (→ -28), not left=34 (→ 40). Dropping the sign
+    // here computed a confidently-wrong answer that then graded a correct student reply ("-28")
+    // as incorrect.
+    // Lookbehind: reject when the left operand follows a word char, dot, or ^ — so the leading
+    // minus is only consumed as a unary sign, never glued onto a preceding value ("5-34" still
+    // reads as 5 minus 34, not left=-34), and the operand isn't part of an exponent or algebraic
+    // term like "x^2 + 8" → "2 + 8" (NOT standalone arithmetic).
     // Lookahead: reject when the right operand is immediately followed by a letter or ^
     // (it's a coefficient like "8x", not a standalone number).
-    const embeddedArithmeticPattern = /(?<![a-zA-Z\^])(\d+\.?\d*)\s*([×÷+\-*/])\s*(\d+\.?\d*)(?![a-zA-Z\^])/;
+    const embeddedArithmeticPattern = /(?<![\w.\^])(-?\d+\.?\d*)\s*([×÷+\-*/])\s*(\d+\.?\d*)(?![a-zA-Z\^])/;
     const embeddedMatch = message.match(embeddedArithmeticPattern);
     if (embeddedMatch) {
         return {


### PR DESCRIPTION
## The trust-killing bug

From a real session: a student solving `3(x-2)=2x-34` correctly answered **`-34 + 6 = -28`**. Ms. Maria rejected it, dragged them through number-line and zero-pair remediation ("*let's slow down and check that arithmetic carefully*") — and only at the very end confirmed `-28` was right all along. The student's reaction (`Wtf?`, `This sucks!`, `But I was right!!!`) is exactly the trust erosion flagged.

## Root cause

The prompt correctly tells the tutor to confirm correct answers — the failure was that the **verdict injected into the prompt was wrong**. The pipeline computed the *expected* answer for the posed step as **40**, so the student's correct `-28` was graded incorrect.

In `utils/mathSolver.js`, `detectMathProblem`'s last-resort `embeddedArithmeticPattern` captured the left operand as `(\d+\.?\d*)` — **with no leading sign**. Leading-negative arithmetic that doesn't match the anchored `^…$` pattern (because it's embedded in tutor prose like `"compute -34+6 on the right side?"`, or followed by `"=?"`) fell through to this matcher, which read `-34+6` as `34+6 → 40`.

Reproduced directly:

```
detectMathProblem("-34+6")    => { left: -34, ... }   → -28  ✓
detectMathProblem("-34+6=?")  => { left:  34, ... }   →  40  ✗
```

A [prior fix](../blob/main/tests/unit/mathSolverUnicodeMinus.test.js) normalized the Unicode minus and corrected the **bare** form (`-34+6`), but the embedded/prose form still regressed through this matcher.

## The fix

Capture an optional leading unary minus in the left operand, guarded by a lookbehind so the sign is only consumed when it's a genuine unary minus at the start of an expression — never glued onto a preceding value:

```diff
-const embeddedArithmeticPattern = /(?<[a-zA-Z\^])(\d+\.?\d*)\s*([×÷+\-*/])\s*(\d+\.?\d*)(?[a-zA-Z\^])/;
+const embeddedArithmeticPattern = /(?<[\w.\^])(-?\d+\.?\d*)\s*([×÷+\-*/])\s*(\d+\.?\d*)(?[a-zA-Z\^])/;
```

- `5-34` still reads as `5 − 34 = -29` (binary minus preserved).
- `x^2 + 8` is still not standalone arithmetic.

## Verification

- Extended `tests/unit/mathSolverUnicodeMinus.test.js` (the same real session's regression file) to cover the embedded / prose / `=?` forms **and** the binary-minus guard.
- Full unit suite passes: **3133 tests, 182 suites**.

## Note / follow-up (not in this PR)

When a posed sub-step doesn't parse at all (e.g. `"what is -34 + 6?"` phrasing), `diagnose` returns `problemInfo=null` and defers to the LLM verifier — which grades correctly, so it's safe. There is a separate robustness gap worth a follow-up: `diagnose` Step 2b only consults the LLM verdict when the deterministic verdict is `null`, not when it's a low-confidence `false`. This PR fixes the concrete negative-number defect; the gating change is intentionally out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171k2hPfEX6bn6ujWFhwAF1

---
_Generated by [Claude Code](https://claude.ai/code/session_0171k2hPfEX6bn6ujWFhwAF1)_