### PR TITLE
Grader audit: stop incidental arithmetic flipping wrong answers to co…

### DIFF
--- a/tests/unit/arithmeticOverride.test.js
+++ b/tests/unit/arithmeticOverride.test.js
@@ -1,0 +1,39 @@
+/**
+ * arithmeticMatchesAnswer UNIT TESTS
+ *
+ * The self-contained arithmetic check may override a solver "wrong" verdict, but
+ * ONLY when the stated arithmetic result is actually the student's answer. These
+ * lock that gate so an incidental true calculation in a longer explanation can't
+ * flip a genuinely wrong answer to "correct" (a false-correct source).
+ */
+
+const { arithmeticMatchesAnswer } = require('../../utils/pipeline/diagnose');
+
+describe('arithmeticMatchesAnswer', () => {
+  test('trusts the override when the arithmetic result IS the answer', () => {
+    // "13 - 8 is 5" → result 5, answer "5"
+    expect(arithmeticMatchesAnswer(5, '5')).toBe(true);
+    expect(arithmeticMatchesAnswer(5, 5)).toBe(true);
+    expect(arithmeticMatchesAnswer(2.75, '2.75')).toBe(true);
+  });
+
+  test('does NOT trust an incidental calculation that is not the answer', () => {
+    // Student's real answer is 3, but they mentioned "4 x 2 is 8" in passing.
+    expect(arithmeticMatchesAnswer(8, '3')).toBe(false);
+  });
+
+  test('does not fire when there was no matched arithmetic', () => {
+    expect(arithmeticMatchesAnswer(null, '5')).toBe(false);
+    expect(arithmeticMatchesAnswer(undefined, '5')).toBe(false);
+  });
+
+  test('does not fire for non-numeric answers', () => {
+    expect(arithmeticMatchesAnswer(5, 'x = 5')).toBe(false); // answer not a bare number
+    expect(arithmeticMatchesAnswer(3, '2 3/4')).toBe(false);
+    expect(arithmeticMatchesAnswer(5, '')).toBe(false);
+  });
+
+  test('tolerates tiny floating-point drift', () => {
+    expect(arithmeticMatchesAnswer(0.1 + 0.2, '0.3')).toBe(true);
+  });
+});

--- a/utils/pipeline/diagnose.js
+++ b/utils/pipeline/diagnose.js
@@ -55,6 +55,23 @@ function statesRootSet(text) {
   const hasConnector = /\bor\b|\band\b|,/.test(t);
   return nums.length >= 2 && hasConnector;
 }
+
+/**
+ * Should the self-contained arithmetic check be trusted to override a solver
+ * "wrong" verdict? Only when the stated arithmetic's RESULT is actually the
+ * student's answer — e.g. "13-8 is 5" where the answer is 5. A true but
+ * incidental calculation buried in a longer explanation ("...and 4×2 is 8...")
+ * must NOT flip a genuinely wrong final answer to "correct".
+ *
+ * @param {number|null} arithmeticResult  the result of the matched arithmetic, or null
+ * @param {string|number} studentAnswer   the extracted answer value
+ * @returns {boolean}
+ */
+function arithmeticMatchesAnswer(arithmeticResult, studentAnswer) {
+  if (arithmeticResult === null || arithmeticResult === undefined) return false;
+  const answerNum = Number(String(studentAnswer).trim());
+  return Number.isFinite(answerNum) && Math.abs(arithmeticResult - answerNum) < 0.001;
+}
 async function diagnose(observation, context = {}) {
   // Only run diagnosis on answer attempts
   if (!observation.answer) {
@@ -82,7 +99,9 @@ async function diagnose(observation, context = {}) {
   const arithmeticMatch = rawText.match(
     /(-?\d+\.?\d*)\s*([+\-*/×÷])\s*(-?\d+\.?\d*)\s+(?:is|=|equals)\s+(-?\d+\.?\d*)/i
   );
-  let studentArithmeticIsCorrect = false;
+  // Non-null once the student states a provably-correct arithmetic fact; holds
+  // that fact's result so we can check it's actually the answer (see override).
+  let arithmeticResult = null;
   if (arithmeticMatch) {
     const [, a, op, b, result] = arithmeticMatch;
     const numA = parseFloat(a);
@@ -96,7 +115,7 @@ async function diagnose(observation, context = {}) {
       case '/': case '÷': expected = numB !== 0 ? numA / numB : NaN; break;
     }
     if (expected !== undefined && Math.abs(expected - numResult) < 0.001) {
-      studentArithmeticIsCorrect = true;
+      arithmeticResult = numResult;
     }
   }
 
@@ -201,7 +220,11 @@ async function diagnose(observation, context = {}) {
   // solver-based verification says wrong, trust the student's math.
   // The solver likely misinterpreted the posed problem (e.g. "x-8" without
   // substitution context).
-  if (isCorrect === false && studentArithmeticIsCorrect) {
+  //
+  // Gated to when the arithmetic RESULT is actually the student's answer — a
+  // true but incidental calculation inside a longer explanation must not flip a
+  // genuinely wrong final answer to "correct" (a false-correct source).
+  if (isCorrect === false && arithmeticMatchesAnswer(arithmeticResult, studentAnswer)) {
     console.log(`[Diagnose] Arithmetic override: student's "${rawText}" is mathematically correct — overriding solver mismatch`);
     isCorrect = true;
     correctAnswer = studentAnswer;
@@ -415,4 +438,5 @@ module.exports = {
   gradeRootSet,
   estimateIndependence,
   hasLibraryMisconceptions,
+  arithmeticMatchesAnswer,
 };


### PR DESCRIPTION
…rrect

Audit of the diagnose/verify grader's false labels found two mechanisms; this fixes the safe one (false-correct).

The self-contained arithmetic check overrides a solver "wrong" verdict when the student states a provably-correct calculation. But it matched ANY true arithmetic anywhere in the message, so an incidental fact in a longer explanation ("...and 4x2 is 8...") flipped a genuinely wrong final answer to "correct" — the "there might be a small mistake" turn tagged correct that Jason saw. The override is now gated to when the arithmetic RESULT is actually the student's extracted answer (arithmeticMatchesAnswer), preserving the intended "13-8 is 5" case while dropping incidental matches.

The second mechanism (solver false-negatives on equivalent forms are locked in because the LLM fallback only runs when isCorrect === null, never to re-check a solver "false") is the false-INCORRECT source. It's riskier to change and gets its own PR — see the audit writeup.

QA: node --check + eslint (0 errors); arithmeticMatchesAnswer unit suite (5); pipeline/solver suites green (48).