### PR TITLE
Landing: cache-bust CSS/JS so the new hero renders for returning visi…

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -86,11 +86,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <script defer src="https://cdn.jsdelivr.net/npm/marked@11.1.1/marked.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
   <script src="/js/csrf.js"></script>
-  <script src="/js/landing.js" defer></script>
+  <script src="/js/landing.js?v=2" defer></script>
   <script src="/js/analytics.js" data-ga="G-EMX73QXF5H" data-fbp=""></script>
   <!-- Chat design tokens (--cr-*) so the chat preview block can mirror the real product. -->
   <link rel="stylesheet" href="/css/design-system.css" />
-  <link rel="stylesheet" href="/css/landing-page.css" />
+  <link rel="stylesheet" href="/css/landing-page.css?v=2" />
 </head>
 <body>
 <!-- Google Tag Manager (noscript) -->


### PR DESCRIPTION
…tors

New index.html markup shipped, but /css/landing-page.css and /js/landing.js are served with max-age=604800 (7 days) and no version string. Returning visitors got new HTML with stale cached CSS/JS, so the composer button and tutor chips rendered unstyled. Add ?v=2 to both (matching pwa-register.js?v=2) to force a refetch.