### PR TITLE
Restore critical coverage ratchet: test diagnose.js arithmeticMatches…

### DIFF
--- a/jest.critical.config.js
+++ b/jest.critical.config.js
@@ -29,6 +29,7 @@ module.exports = {
     '<rootDir>/tests/unit/verifyMetrics.test.js',
     '<rootDir>/tests/unit/irt.test.js',
     '<rootDir>/tests/unit/knowledgeTracer.test.js',
+    '<rootDir>/tests/unit/diagnoseArithmeticGuard.test.js',
     '<rootDir>/tests/unit/mathSolver*.test.js',
     '<rootDir>/tests/golden/goldenTranscripts.test.js',
   ],

--- a/tests/unit/diagnoseArithmeticGuard.test.js
+++ b/tests/unit/diagnoseArithmeticGuard.test.js
@@ -1,0 +1,37 @@
+// Unit tests for diagnose.js `arithmeticMatchesAnswer` — the guard that decides
+// whether a self-contained arithmetic result may override a solver "wrong"
+// verdict. It exists to stop an INCIDENTAL true calculation buried in a longer
+// explanation ("...and 4×2 is 8...") from flipping a genuinely wrong final
+// answer to "correct". Mis-grading here mis-teaches students, so it's part of
+// the critical-path coverage ratchet.
+
+const { arithmeticMatchesAnswer } = require('../../utils/pipeline/diagnose');
+
+describe('arithmeticMatchesAnswer', () => {
+  test('returns false when there is no arithmetic result', () => {
+    expect(arithmeticMatchesAnswer(null, '5')).toBe(false);
+    expect(arithmeticMatchesAnswer(undefined, '5')).toBe(false);
+  });
+
+  test('returns true when the arithmetic result IS the student answer', () => {
+    expect(arithmeticMatchesAnswer(5, '5')).toBe(true);
+    expect(arithmeticMatchesAnswer(5, 5)).toBe(true);      // numeric answer
+    expect(arithmeticMatchesAnswer(5, ' 5 ')).toBe(true);  // trims whitespace
+  });
+
+  test('returns false when the true calculation is incidental (result ≠ answer)', () => {
+    // The anti-mis-grade case: "13 - 8 is 5" is a true statement, but the
+    // student's final answer was 8 — a wrong answer must NOT be flipped correct.
+    expect(arithmeticMatchesAnswer(8, '5')).toBe(false);
+  });
+
+  test('respects the 0.001 tolerance band', () => {
+    expect(arithmeticMatchesAnswer(5, '5.0005')).toBe(true);  // inside band
+    expect(arithmeticMatchesAnswer(5, '5.01')).toBe(false);   // outside band
+  });
+
+  test('returns false for non-numeric / unparseable answers', () => {
+    expect(arithmeticMatchesAnswer(5, 'x = 5')).toBe(false); // NaN → not finite
+    expect(arithmeticMatchesAnswer(-2.3333, '-7/3')).toBe(false); // fractions aren't Number()-parseable
+  });
+});


### PR DESCRIPTION
…Answer

CI's coverage-critical gate went red on main (surfaced by PR #1125, but not caused by it). Root cause: PR #1124 (grader-arithmetic-override, commit 0b565b3) added `arithmeticMatchesAnswer` to utils/pipeline/diagnose.js with no test, dropping the file's function coverage to 40% — below the 42% ratchet floor.

Fix per the ratchet policy (investigate the drop; never lower the floor): add a behavioral unit test for the guard, which decides whether a self-contained arithmetic result may override a solver "wrong" verdict — the safeguard that stops an incidental true calculation from flipping a wrong answer to correct. Covers the null-guard, exact-match, incidental-mismatch, tolerance-band, and non-numeric cases, and wires the test into jest.critical.config.js.

Critical gate now green: 31 suites / 684 tests, diagnose.js back over the floor.