### PR TITLE
Cache-bust board assets so the fixes reach returning students

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -82,7 +82,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <!-- Cosmetics: equipped skins + shop modal -->
   <link rel="stylesheet" href="/dist/css/chat-css2.20673ca0.css" />
 <!-- Interactive math workspace (chat right slot) -->
-  <link rel="stylesheet" href="/css/workspace.css" />
+  <link rel="stylesheet" href="/css/workspace.css?v=20260709" />
   <!-- Voice mode (layout mode of the chat stage) -->
   <link rel="stylesheet" href="/css/voice-mode.css" />
   <!-- Fresh styling for rendered math (equation cards) -->
@@ -2317,7 +2317,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <script defer src="/js/conceptModelRenderer.js"></script>
   <script defer src="/js/conceptModelTokenRenderer.js"></script>
   <!-- Interactive math workspace (chat right slot) — after the tools it can launch -->
-  <script src="/js/workspace.js"></script>
+  <script src="/js/workspace.js?v=20260709"></script>
   <!-- Phase B: executes server-emitted <BOARD> commands against the embedded WorkBoard -->
   <script src="/js/boardCommandHandler.js"></script>
   <!-- Phase C: executes server-emitted <XP> ceremony commands (confetti + caption) -->
@@ -2350,7 +2350,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     })();
   </script>
   <script src="/dist/js/chat-js8.910bc9c0.js"></script>
-<script src="/js/script.js" type="module"></script>
+<script src="/js/script.js?v=20260709" type="module"></script>
   <script src="/js/guidedPath.js" type="module"></script>
   <script src="/dist/js/chat-js9.bc0be9a3.js"></script>
   <!-- Companion HOME screen (phones only; flag-gated OFF by default) -->


### PR DESCRIPTION
public/ .css/.js are served with max-age=604800 (7 days, no hash/immutable), so a returning student would keep the stale workspace.js/script.js/workspace.css for up to a week after deploy and never see the board fixes. Add ?v=20260709 to the three references in chat.html changed by the board work.