### PR TITLE
Fix negative-number grading: exact-evaluate prose arithmetic + accept spoken negatives

### DIFF
--- a/tests/unit/mathSolverUnicodeMinus.test.js
+++ b/tests/unit/mathSolverUnicodeMinus.test.js
@@ -83,6 +83,45 @@ describe('leading-negative arithmetic keeps its sign in prose / with "=?"', () =
   });
 });
 
+// ROOT-CAUSE FIX (finishing the migration): the two sign bugs above were both patches
+// on a matcher that re-parsed prose-embedded arithmetic into {left, operator, right} and
+// rebuilt a string — a lossy round-trip that kept dropping signs and could only ever see
+// ONE operator pair. The real fix isolates the arithmetic substring and hands it WHOLE to
+// the exact-rational engine (as rationalEvaluator.js's header always intended). That kills
+// the whole class: any sign, any number of operators, correct precedence — or, when the
+// slice isn't clean arithmetic, NO answer at all rather than a confident wrong one.
+describe('prose-embedded arithmetic goes through the exact evaluator (no operand re-parse)', () => {
+  it('handles multi-operand chains the old single-pair matcher could not', () => {
+    // Old path saw only "-34+6" and stopped; exact engine evaluates the whole chain.
+    expect(String(parseCleanProblem('compute -34+6-2 on the right side').solution.answer)).toBe('-30');
+  });
+
+  it('respects operator precedence in prose ("2+3*4" = 14, not 20)', () => {
+    expect(String(parseCleanProblem('so what is 2+3*4 here').solution.answer)).toBe('14');
+  });
+
+  it('keeps the sign on a negative RIGHT operand ("6+-34" = -28)', () => {
+    expect(String(parseCleanProblem('the answer to 6+-34 please').solution.answer)).toBe('-28');
+  });
+
+  it('now grades a bare "what is -34 + 6" phrasing (previously undetected)', () => {
+    expect(String(parseCleanProblem('what is -34 + 6').solution.answer)).toBe('-28');
+  });
+
+  it('SAFETY: an ambiguous slice defers (never a confidently-wrong answer)', () => {
+    // "8x" is a coefficient, "x^2 + 8" an algebraic term — the guards keep the exact
+    // engine from ever inventing "8", so these produce no arithmetic verdict at all.
+    expect(parseCleanProblem('the term 8x sits here').hasMath).toBe(false);
+    const r = parseCleanProblem('x^2 + 8 over here');
+    expect(r.hasMath && r.problem.type === 'arithmetic').toBeFalsy();
+  });
+
+  it('leaves bare two-operand arithmetic as the arithmetic type (unchanged)', () => {
+    expect(processMathMessage('15 + 27').problem.type).toBe('arithmetic');
+    expect(String(processMathMessage('15 + 27').solution.answer)).toBe('42');
+  });
+});
+
 describe('Unicode minus (U+2212) — verifyAnswer accepts the correct negative', () => {
   it('accepts a student "−28" against a correct "-28"', () => {
     expect(verifyAnswer(`${MINUS}28`, '-28').isCorrect).toBe(true);

--- a/tests/unit/spokenNegatives.test.js
+++ b/tests/unit/spokenNegatives.test.js
@@ -1,0 +1,84 @@
+/**
+ * Regression tests for SPOKEN negatives from speech-to-text (Deepgram / Whisper).
+ *
+ * THE BUG: when a student says "negative six" for a correct answer of -6, STT
+ * transcribes the WORDS ("negative 6" / "negative six"), not "-6". The main pipeline
+ * only understood digits, so:
+ *   - verifyAnswer("negative 6", -6) returned FALSE → a correct answer graded wrong.
+ *   - observe("negative 6") classified it as general_math with answer=null → the
+ *     answer wasn't even recognized as an attempt.
+ * This is the same trust-killing failure as a dropped Unicode minus, on the voice
+ * surface. (The worded-negative logic already existed in the voice ORCHESTRATOR's
+ * answerEvaluator, but the main observe→diagnose→verifyAnswer path never got it.)
+ *
+ * THE FIX: a shared normalizeSpokenNumbers() converts a LEADING unary sign word
+ * (negative / neg / minus) and standalone spoken number words to signed digits,
+ * applied in verifyAnswer and in observe's answer extraction. Binary "5 minus 6"
+ * (subtraction, not a sign) is deliberately left untouched.
+ */
+const { verifyAnswer } = require('../../utils/mathSolver');
+const { normalizeSpokenNumbers } = require('../../utils/mathUnicodeNormalizer');
+const { observe } = require('../../utils/pipeline/observe');
+
+const ctx = { recentUserMessages: [], recentAssistantMessages: [], hasRecentUpload: false };
+
+describe('normalizeSpokenNumbers — leading sign words + number words → signed digits', () => {
+  it.each([
+    ['negative six', '-6'],
+    ['negative 6', '-6'],
+    ['minus six', '-6'],
+    ['minus 6', '-6'],
+    ['neg 6', '-6'],
+    ['twenty', '20'],
+    ['seven', '7'],
+    ['-6', '-6'],       // already normalized
+    ['6', '6'],
+  ])('normalizes %j → %j', (input, expected) => {
+    expect(normalizeSpokenNumbers(input)).toBe(expected);
+  });
+
+  it('leaves a binary "minus" (subtraction, not a sign) untouched', () => {
+    expect(normalizeSpokenNumbers('5 minus 6')).toBe('5 minus 6');
+  });
+});
+
+describe('verifyAnswer accepts a spoken negative against the correct value', () => {
+  it.each(['negative 6', 'negative six', 'minus 6', 'minus six', 'neg 6', '-6'])(
+    'accepts %j as -6',
+    (spoken) => {
+      expect(verifyAnswer(spoken, -6).isCorrect).toBe(true);
+    }
+  );
+
+  it('accepts a spoken positive word ("six" = 6)', () => {
+    expect(verifyAnswer('six', 6).isCorrect).toBe(true);
+  });
+
+  it('still rejects a genuinely wrong spoken answer', () => {
+    expect(verifyAnswer('negative 6', 6).isCorrect).toBe(false);   // wrong sign
+    expect(verifyAnswer('6', -6).isCorrect).toBe(false);           // wrong sign
+    expect(verifyAnswer('negative seven', -6).isCorrect).toBe(false); // wrong value
+  });
+});
+
+describe('observe recognizes a spoken negative as an answer attempt', () => {
+  it.each([
+    ['negative 6', '-6'],
+    ['negative six', '-6'],
+    ['minus 6', '-6'],
+    ['neg 6', '-6'],
+    ['-6', '-6'],
+    ['twenty', '20'],
+  ])('observe(%j) → answer_attempt value %j', (msg, value) => {
+    const o = observe(msg, ctx);
+    expect(o.messageType).toBe('answer_attempt');
+    expect(o.answer && o.answer.value).toBe(value);
+  });
+
+  it('does NOT hijack non-answers or binary subtraction as a number answer', () => {
+    for (const m of ['5 minus 6', 'one sec', 'no']) {
+      const o = observe(m, ctx);
+      expect(o.answer && o.answer.value).toBeFalsy();
+    }
+  });
+});

--- a/utils/mathSolver.js
+++ b/utils/mathSolver.js
@@ -14,6 +14,38 @@ const { normalizeMathOperators } = require('./mathUnicodeNormalizer');
 const { evalExpression, expressionValue } = require('./rationalEvaluator');
 
 /**
+ * Isolate the first clean, contiguous numeric arithmetic expression embedded in a
+ * string and return it verbatim (or null if there isn't one).
+ *
+ * This is the single "pull the math out of a sentence" primitive. Rather than
+ * re-parse operands into {left, operator, right} — a lossy round-trip that
+ * historically kept dropping signs ("-34+6" → 34+6 = 40) — it hands the isolated
+ * slice to the exact-rational engine, which is the correctness guarantee: signs,
+ * precedence, and parentheses are handled exactly, and an invalid slice yields null
+ * so callers DEFER rather than emit a confidently-wrong answer.
+ *
+ * Boundaries (?<![\w.^]) / (?![\w.^]) prevent gluing onto letters or exponents, so
+ * "8x" (coefficient) and "x^2 + 8" (algebraic term) are not treated as arithmetic.
+ * A binary operator is required, so a bare number is not a "computation".
+ * Operators/signs are assumed already ASCII-normalized (× → *, − → -, …).
+ *
+ * @param {string} text
+ * @returns {string|null} the isolated expression (e.g. "-34+6"), or null
+ */
+function isolateNumericExpression(text) {
+    if (!text) return null;
+    const rx = /(?<![\w.^])-?\d[\d\s.+\-*/^()]*\d(?![\w.^])/g;
+    let m;
+    while ((m = rx.exec(text)) !== null) {
+        const expr = m[0].trim();
+        if (!/\d\s*[-+*/^]/.test(expr)) continue;    // no binary operator → not a computation
+        if (evalExpression(expr) === null) continue; // exact engine rejects → defer, never guess
+        return expr;
+    }
+    return null;
+}
+
+/**
  * Detect if a message contains a math problem
  * @param {string} message - User message
  * @returns {Object|null} Detected problem info or null
@@ -395,6 +427,11 @@ function detectMathProblem(message) {
         // solveEvaluation would strip the vulgar fractions and compute garbage.
         const mixedSub = detectMixedNumberArithmetic(expr);
         if (mixedSub) return mixedSub;
+        // Prefer a cleanly-isolated numeric slice ("what is 2+3*4 here" → "2+3*4")
+        // over grabbing the whole tail with its trailing prose — the latter would be
+        // distrusted downstream and the computation lost.
+        const isoExpr = isolateNumericExpression(expr);
+        if (isoExpr) return { type: 'evaluation', expression: isoExpr, evalMode: 'decimal' };
         return { type: 'evaluation', expression: expr };
     }
 
@@ -538,26 +575,23 @@ function detectMathProblem(message) {
         };
     }
 
-    // Last resort: scan for any embedded arithmetic with symbolic operators (e.g. "So 3 × 12 is what?")
-    // The left operand captures an OPTIONAL leading minus so a negative first term keeps its
-    // sign: "compute -34+6" must yield left=-34 (→ -28), not left=34 (→ 40). Dropping the sign
-    // here computed a confidently-wrong answer that then graded a correct student reply ("-28")
-    // as incorrect.
-    // Lookbehind: reject when the left operand follows a word char, dot, or ^ — so the leading
-    // minus is only consumed as a unary sign, never glued onto a preceding value ("5-34" still
-    // reads as 5 minus 34, not left=-34), and the operand isn't part of an exponent or algebraic
-    // term like "x^2 + 8" → "2 + 8" (NOT standalone arithmetic).
-    // Lookahead: reject when the right operand is immediately followed by a letter or ^
-    // (it's a coefficient like "8x", not a standalone number).
-    const embeddedArithmeticPattern = /(?<![\w.\^])(-?\d+\.?\d*)\s*([×÷+\-*/])\s*(\d+\.?\d*)(?![a-zA-Z\^])/;
-    const embeddedMatch = message.match(embeddedArithmeticPattern);
-    if (embeddedMatch) {
-        return {
-            type: 'arithmetic',
-            left: parseFloat(embeddedMatch[1]),
-            operator: embeddedMatch[2],
-            right: parseFloat(embeddedMatch[3])
-        };
+    // Last resort: an arithmetic expression embedded in prose ("So what's -34 + 6?",
+    // "-34+6=?", "3 × 12 is what?"). This path historically decomposed the match into
+    // {left, operator, right} and re-parsed each operand — a lossy round-trip that kept
+    // dropping the leading sign ("-34+6" read as 34+6 = 40) and could only ever see ONE
+    // operator pair. Both are exactly the "tutor rejected a correct answer" class of bug.
+    //
+    // Instead, isolate the maximal contiguous numeric expression and hand it WHOLE to the
+    // exact-rational engine (the same evalExpression that solveEvaluation uses). evalExpression
+    // is the correctness guarantee: signs, precedence, and parentheses are handled exactly,
+    // and if the isolated slice isn't valid arithmetic it returns null and we defer — so this
+    // path can never again emit a confidently-wrong answer. This finishes the migration noted
+    // in rationalEvaluator.js's header (it was meant to replace this "embedded last-resort regex").
+    //
+    // (see isolateNumericExpression for the boundary/operator/defer rules).
+    const embeddedExpr = isolateNumericExpression(message);
+    if (embeddedExpr) {
+        return { type: 'evaluation', expression: embeddedExpr, evalMode: 'decimal' };
     }
 
     return null;
@@ -3657,8 +3691,19 @@ function _isTrustedProblem(problem, source) {
     // whatever the matcher grabbed — often prose. Only trust it when
     // the source text reads like a math expression, not a sentence.
     if (problem.type === 'evaluation') {
-        if (PROSE_WORD_RX.test(source)) return false;
-        if (problem.expression && PROSE_WORD_RX.test(problem.expression)) return false;
+        // Trust an evaluation whose ISOLATED expression is a pure numeric computation
+        // (digits/operators/parens only, with a binary operator) even when the surrounding
+        // source is a sentence — we extracted exactly the math, so the prose around it is
+        // irrelevant. This lets prose-embedded arithmetic ("what's -34 + 6?") grade
+        // deterministically instead of being thrown away. Only fall back to the prose sniff
+        // when the expression itself still carries words (the older "what is …" catch-all,
+        // whose `expression` can be raw prose).
+        const expr = String(problem.expression || '');
+        const isPureNumericExpr = /^[\s\d.+\-*/^()]+$/.test(expr) && /\d\s*[-+*/^]/.test(expr);
+        if (!isPureNumericExpr) {
+            if (PROSE_WORD_RX.test(source)) return false;
+            if (problem.expression && PROSE_WORD_RX.test(problem.expression)) return false;
+        }
     }
     return true;
 }

--- a/utils/mathSolver.js
+++ b/utils/mathSolver.js
@@ -10,7 +10,7 @@
  * @module mathSolver
  */
 
-const { normalizeMathOperators } = require('./mathUnicodeNormalizer');
+const { normalizeMathOperators, normalizeSpokenNumbers } = require('./mathUnicodeNormalizer');
 const { evalExpression, expressionValue } = require('./rationalEvaluator');
 
 /**
@@ -2362,7 +2362,9 @@ function verifyAnswer(studentAnswer, correctAnswer, tolerance = 0.01) {
     // Normalize answers through the shared operator/sign map so a student's "−28"
     // (Unicode minus, as MathLive/LaTeX render it) is not stripped to a positive
     // "28" and rejected against a correct "-28" — and likewise for ×, ÷, dots, etc.
-    const norm = (v) => normalizeMathOperators(String(v).trim().toLowerCase());
+    // normalizeSpokenNumbers first turns speech-to-text answers into signed digits
+    // ("negative six" → "-6") so a correct spoken answer isn't graded wrong.
+    const norm = (v) => normalizeMathOperators(normalizeSpokenNumbers(String(v).trim().toLowerCase()));
     const studentStr = norm(studentAnswer);
     const correctStr = norm(correctAnswer);
 

--- a/utils/mathUnicodeNormalizer.js
+++ b/utils/mathUnicodeNormalizer.js
@@ -175,4 +175,43 @@ function normalizeMathUnicode(str) {
   return result;
 }
 
-module.exports = { normalizeMathUnicode, normalizeMathOperators, OPERATOR_MAP };
+// Spoken number words → digits. Scoped to the range that shows up in K-12 answers
+// dictated through speech-to-text ("negative six" → "-6"). Deliberately small and
+// integer-only: STT emits these forms, and a wider map (or fractional words like
+// "half") risks converting incidental prose or producing ugly repeating decimals.
+const SPOKEN_NUMBER_WORDS = {
+  zero: 0, one: 1, two: 2, three: 3, four: 4, five: 5, six: 6, seven: 7, eight: 8,
+  nine: 9, ten: 10, eleven: 11, twelve: 12, thirteen: 13, fourteen: 14, fifteen: 15,
+  sixteen: 16, seventeen: 17, eighteen: 18, nineteen: 19, twenty: 20, thirty: 30,
+  forty: 40, fifty: 50, sixty: 60, seventy: 70, eighty: 80, ninety: 90, hundred: 100,
+};
+
+/**
+ * Normalize SPOKEN math to signed digits so speech-to-text (and typed word) answers
+ * grade correctly: "negative six" / "minus 6" / "neg six" → "-6". Two conversions:
+ *   1. A LEADING unary sign word (negative / neg / minus) becomes "-". Only leading,
+ *      so a binary "5 minus 6" is left untouched (that's subtraction, not a sign).
+ *   2. Standalone spoken number words become digits ("six" → "6").
+ * Numerals and symbols pass through unchanged. Idempotent and safe on any string.
+ *
+ * WHY: Deepgram/Whisper transcribe a spoken "negative six" as words, not "-6". Without
+ * this, verifyAnswer("negative 6", -6) is false and the pipeline grades a correct answer
+ * wrong — the same trust-killing failure as a dropped Unicode minus, on the voice surface.
+ *
+ * @param {string} str
+ * @returns {string}
+ */
+function normalizeSpokenNumbers(str) {
+  if (!str || typeof str !== 'string') return str || '';
+  // Leading unary sign word → "-". "neg"/"negative" are always unary; "minus" only
+  // when it opens the string (a whole answer), never mid-expression.
+  let s = str.replace(/^\s*(?:negative|neg|minus)\s+/i, '-');
+  // Standalone spoken number words → digits.
+  s = s.replace(/\b[a-z]+\b/gi, (w) => {
+    const v = SPOKEN_NUMBER_WORDS[w.toLowerCase()];
+    return v != null ? String(v) : w;
+  });
+  return s;
+}
+
+module.exports = { normalizeMathUnicode, normalizeMathOperators, normalizeSpokenNumbers, OPERATOR_MAP };

--- a/utils/pipeline/observe.js
+++ b/utils/pipeline/observe.js
@@ -9,6 +9,8 @@
  * @module pipeline/observe
  */
 
+const { normalizeSpokenNumbers } = require('../mathUnicodeNormalizer');
+
 // ── Message categories ──
 const MESSAGE_TYPES = {
   ANSWER_ATTEMPT: 'answer_attempt',
@@ -111,25 +113,29 @@ const PATTERNS = {
  * Returns { value, raw } or null if not an answer attempt.
  */
 function extractAnswer(message) {
-  const text = message.trim();
+  const raw = message.trim();
+  // Normalize speech-to-text negatives/number-words to signed digits BEFORE matching,
+  // so a spoken "negative six" is recognized as the answer -6 (the numeric PATTERNS
+  // only understand digits). `raw` keeps the original text for downstream use.
+  const text = normalizeSpokenNumbers(raw);
 
   // For short, direct answers (< 100 chars): try all patterns
   if (text.length <= 100) {
     let match;
-    if ((match = text.match(PATTERNS.varAssignment))) return { value: match[1], raw: text };
-    if ((match = text.match(PATTERNS.justNumber))) return { value: match[1], raw: text };
-    if ((match = text.match(PATTERNS.fraction))) return { value: match[1].replace(/\s/g, ''), raw: text };
-    if ((match = text.match(PATTERNS.mixedNumber))) return { value: `${match[1]} ${match[2].replace(/\s/g, '')}`, raw: text };
-    if ((match = text.match(PATTERNS.algebraicExpr))) return { value: match[1].replace(/\s/g, ''), raw: text };
-    if ((match = text.match(PATTERNS.answerPhrase))) return { value: match[1].replace(/\s/g, ''), raw: text };
-    if ((match = text.match(PATTERNS.arithmeticStatement))) return { value: match[1].replace(/\s/g, ''), raw: text };
+    if ((match = text.match(PATTERNS.varAssignment))) return { value: match[1], raw };
+    if ((match = text.match(PATTERNS.justNumber))) return { value: match[1], raw };
+    if ((match = text.match(PATTERNS.fraction))) return { value: match[1].replace(/\s/g, ''), raw };
+    if ((match = text.match(PATTERNS.mixedNumber))) return { value: `${match[1]} ${match[2].replace(/\s/g, '')}`, raw };
+    if ((match = text.match(PATTERNS.algebraicExpr))) return { value: match[1].replace(/\s/g, ''), raw };
+    if ((match = text.match(PATTERNS.answerPhrase))) return { value: match[1].replace(/\s/g, ''), raw };
+    if ((match = text.match(PATTERNS.arithmeticStatement))) return { value: match[1].replace(/\s/g, ''), raw };
   }
 
   // Proposed / self-check answer ("…right? 10/24", "is it 5/12?") — cue-gated and
   // end-anchored, so it's safe to try regardless of message length.
   {
     const match = text.match(PATTERNS.proposedAnswer);
-    if (match) return { value: (match[1] || match[2]).replace(/\s/g, ''), raw: text, proposed: true };
+    if (match) return { value: (match[1] || match[2]).replace(/\s/g, ''), raw, proposed: true };
   }
 
   // For longer messages: try to extract answer embedded in explanation


### PR DESCRIPTION
Two related fixes for the same trust-killer: a student's **correct negative-number answer graded wrong**. First surfaced in a real session where `-34 + 6 = -28` was rejected and drilled through remediation before the tutor finally admitted it was right.

---

## Fix 1 — Evaluate prose-embedded arithmetic exactly (no operand re-parse)

PR #1122 added an optional leading-minus to the last-resort embedded-arithmetic regex so `-34+6` stopped reading as `40`. That was a band-aid on the real design flaw.

That regex **decomposed a prose-embedded expression into `{left, operator, right}`, re-parsed each operand, then rebuilt a string** for the exact evaluator — a lossy round-trip that kept dropping signs and could only ever see **one** operator pair. `rationalEvaluator.js`'s own header lists this *"embedded last-resort regex"* as one of five hand-rolled evaluators it was meant to replace. **The migration was left unfinished; this finishes it.**

One primitive, `isolateNumericExpression`, pulls the math slice out of a sentence and hands it **whole** to the exact-rational engine (correctness guarantee: signs, precedence, parentheses exact; an invalid slice returns `null` so the pipeline **defers rather than guesses**). The same primitive replaces the operand re-parse in the `"what is X"` branch, and `_isTrustedProblem` now trusts an `evaluation` whose isolated expression is pure-numeric even inside prose.

| Input | Before | After |
|---|---|---|
| `-34+6=?` | `40` ❌ | `-28` ✅ |
| `compute -34+6-2` | only saw `-34+6` | `-30` ✅ (multi-operand) |
| `what is 2+3*4` | undetected | `14` ✅ (precedence) |
| `6+-34` | sign dropped | `-28` ✅ |
| `8x`, `x^2 + 8` | risk of false `8` | **deferred**, never guessed ✅ |

Bare two-operand arithmetic (`15 + 27`, `16/4`) is unchanged.

## Fix 2 — Accept spoken negatives from speech-to-text ("negative six" → -6)

Deepgram/Whisper transcribe a spoken "negative six" as **words**, not `-6`. The main pipeline only understood digits, so `verifyAnswer("negative 6", -6)` was **false** and `observe("negative 6")` didn't even recognize it as an answer attempt. Same failure, on the voice surface. (The worded-negative logic existed in the voice *orchestrator*'s `answerEvaluator`, but the main `observe → diagnose → verifyAnswer` path never got it.)

A shared `normalizeSpokenNumbers()` converts a **leading** unary sign word (`negative` / `neg` / `minus`) and standalone spoken number words to signed digits, applied in `verifyAnswer` and `observe`. Binary `5 minus 6` (subtraction, not a sign) is left untouched; non-answers (`one sec`, `no`) aren't hijacked.

## Verification

- **Pipeline-level:** `diagnose()` returns `type=correct` for the student's `-28` / `-6`, and still `type=incorrect` for a genuinely wrong answer — real errors are still caught.
- New/extended tests: `tests/unit/mathSolverUnicodeMinus.test.js`, `tests/unit/spokenNegatives.test.js`.
- Full unit suite: **3174 tests, 185 suites** pass. `eslint` clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171k2hPfEX6bn6ujWFhwAF1