### PR TITLE
Fix tutor falsely claiming it can't see re-attached homework

### DIFF
--- a/routes/chat.js
+++ b/routes/chat.js
@@ -57,18 +57,16 @@ const fsSync = require('fs');
 const sharp = require('sharp');
 const pdfOcr = require('../utils/pdfOcr');
 const { validateUpload, uploadRateLimiter } = require('../middleware/uploadSecurity');
-const { applyWorksheetGuard } = require('../utils/worksheetGuard');
+const { applyWorksheetGuard, isCheckWorkIntent } = require('../utils/worksheetGuard');
 const { UPLOAD_CONTEXT_REMINDER, WORKSHEET_REATTACH_REMINDER } = require('../utils/visualCapabilities');
 const { isImageStillActive, buildImageDataUrl, downscaleToDataUrl } = require('../utils/activeWorksheetImage');
 
 // When a student shares their work and asks to be checked, nudge the tutor to
 // engage the ACTUAL steps and the specific error — not fall back to generic
 // "what was your first step?" coaching. Still never reveals the answer.
+// `isCheckWorkIntent` lives in utils/worksheetGuard.js (imported below) so it
+// can be unit-tested alongside the other worksheet/answer-key detectors.
 const CHECK_WORK_GUIDANCE = "\n\n[CHECK MY WORK: The student shared their OWN worked solution (shown in the image) and asked you to check it. Actually READ their steps. If it's correct, name specifically what they did right. If there's a mistake, point them to the SPECIFIC step where it goes wrong with ONE guiding question — name that step. Do NOT ask them to re-explain the problem from scratch, do NOT ignore a mistake you can see, and do NOT simply give the answer.]";
-function isCheckWorkIntent(text) {
-    if (!text || typeof text !== 'string') return false;
-    return /\b(check (my|the|this)|on the right track|did i (do|get|solve)|is (this|my answer|that) (right|correct)|am i (right|correct|on track))\b/i.test(text);
-}
 
 // Multer disk storage for file uploads (prevents server crashes vs memoryStorage)
 const upload = multer({

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -58,7 +58,7 @@ const sharp = require('sharp');
 const pdfOcr = require('../utils/pdfOcr');
 const { validateUpload, uploadRateLimiter } = require('../middleware/uploadSecurity');
 const { applyWorksheetGuard } = require('../utils/worksheetGuard');
-const { UPLOAD_CONTEXT_REMINDER } = require('../utils/visualCapabilities');
+const { UPLOAD_CONTEXT_REMINDER, WORKSHEET_REATTACH_REMINDER } = require('../utils/visualCapabilities');
 const { isImageStillActive, buildImageDataUrl, downscaleToDataUrl } = require('../utils/activeWorksheetImage');
 
 // When a student shares their work and asks to be checked, nudge the tutor to
@@ -1064,8 +1064,13 @@ router.post('/', isAuthenticated, promptInjectionFilter, conditionalUpload, cond
                 const checkSuffix = isCheckWorkIntent(combinedMessage) ? CHECK_WORK_GUIDANCE : '';
                 const baseText = typeof lastMsg.content === 'string' ? lastMsg.content : combinedMessage;
                 const guardedText = applyWorksheetGuard(baseText);
+                // Use the FOLLOW-UP reminder (not UPLOAD_CONTEXT_REMINDER): the
+                // student didn't attach anything this turn, and the image is
+                // re-attached BELOW. The fresh-upload wording ("uploaded with
+                // this message", image "above") reads as false here and makes
+                // the model deflect with "I can't see your work right now."
                 lastMsg.content = [
-                    { type: "text", text: `${UPLOAD_CONTEXT_REMINDER}\n\n${guardedText}${checkSuffix}` },
+                    { type: "text", text: `${WORKSHEET_REATTACH_REMINDER}\n\n${guardedText}${checkSuffix}` },
                     { type: "image_url", image_url: { url: activeWorksheetImageUrl, detail: "high" } }
                 ];
                 logger.debug('Re-threaded active worksheet image into follow-up turn');

--- a/tests/unit/worksheetGuard.test.js
+++ b/tests/unit/worksheetGuard.test.js
@@ -24,6 +24,7 @@ const {
   detectAnswerKeyResponse,
   filterAnswerKeyResponse,
   detectParallelExampleIntroduction,
+  isCheckWorkIntent,
 } = require('../../utils/worksheetGuard');
 
 describe('detectAnswerAnnouncement', () => {
@@ -343,5 +344,56 @@ describe('detectParallelExampleIntroduction', () => {
     expect(detectParallelExampleIntroduction('')).toBe(false);
     expect(detectParallelExampleIntroduction(undefined)).toBe(false);
     expect(detectParallelExampleIntroduction(123)).toBe(false);
+  });
+});
+
+describe('isCheckWorkIntent', () => {
+  // Origin: a student uploaded a worked "Review of Equations" worksheet and
+  // opened with "Can you check to make sure it is correct first?" — a canonical
+  // check-my-work request that the previous narrow regex missed, so the tutor
+  // never got the CHECK_WORK guidance and fell back to generic scaffolding.
+
+  test('flags "Can you check to make sure it is correct first?"', () => {
+    expect(isCheckWorkIntent('Can you check to make sure it is correct first?')).toBe(true);
+  });
+
+  test('flags "What answer did I get?"', () => {
+    expect(isCheckWorkIntent('What answer did I get?')).toBe(true);
+  });
+
+  test('flags common check-my-work phrasings', () => {
+    for (const t of [
+      'check my work',
+      'can you check these?',
+      'is this right?',
+      'is it correct',
+      'are these correct?',
+      'did I do this right?',
+      'am I on the right track',
+      'make sure it is right',
+      'did I solve this correctly? (is my answer right)',
+    ]) {
+      expect(isCheckWorkIntent(t)).toBe(true);
+    }
+  });
+
+  // Negative: normal help/scaffolding requests must NOT trigger check-work mode.
+  test('does NOT flag requests to start or get help with a problem', () => {
+    for (const t of [
+      '1, 4, and 13',
+      "What's the first step?",
+      'I need help with number 5',
+      'can you solve it',
+      'I have no idea how to start',
+    ]) {
+      expect(isCheckWorkIntent(t)).toBe(false);
+    }
+  });
+
+  test('handles empty / non-string input', () => {
+    expect(isCheckWorkIntent(null)).toBe(false);
+    expect(isCheckWorkIntent('')).toBe(false);
+    expect(isCheckWorkIntent(undefined)).toBe(false);
+    expect(isCheckWorkIntent(123)).toBe(false);
   });
 });

--- a/tests/unit/worksheetReattachReminder.test.js
+++ b/tests/unit/worksheetReattachReminder.test.js
@@ -1,0 +1,63 @@
+/**
+ * Worksheet re-attach reminder — the SYSTEM note placed next to a worksheet
+ * IMAGE that is re-threaded on a FOLLOW-UP turn ("check #4", "what answer did
+ * I get?"), when the student did NOT attach anything this turn.
+ *
+ * Regression for the geometry-homework-check bug: a student uploaded a
+ * problem set, then asked the tutor to check specific problems. On the
+ * follow-up turn the worksheet image WAS re-threaded into context, but the
+ * reminder reused from the fresh-upload path ("uploaded with this message",
+ * image "above") read as false — nothing was attached "this message" and the
+ * image sits BELOW the text. The model latched onto that and deflected with
+ * "I actually can't see your uploaded work from my end right now," breaking
+ * the whole homework-check feature.
+ *
+ * The follow-up reminder must describe the situation accurately so the model
+ * reads the re-attached image instead of denying it can see it.
+ */
+
+const {
+  UPLOAD_CONTEXT_REMINDER,
+  WORKSHEET_REATTACH_REMINDER,
+} = require('../../utils/visualCapabilities');
+
+describe('WORKSHEET_REATTACH_REMINDER — follow-up turn worksheet re-thread', () => {
+  it('is exported as a non-empty string', () => {
+    expect(typeof WORKSHEET_REATTACH_REMINDER).toBe('string');
+    expect(WORKSHEET_REATTACH_REMINDER.length).toBeGreaterThan(0);
+  });
+
+  it('is distinct from the fresh-upload reminder', () => {
+    // The whole point: the follow-up turn must NOT reuse the upload-turn wording.
+    expect(WORKSHEET_REATTACH_REMINDER).not.toBe(UPLOAD_CONTEXT_REMINDER);
+  });
+
+  it('frames the worksheet as uploaded EARLIER, not "with this message"', () => {
+    // The misleading fresh-upload phrasing must be gone.
+    expect(WORKSHEET_REATTACH_REMINDER).not.toMatch(/with this message/i);
+    expect(WORKSHEET_REATTACH_REMINDER).toMatch(/earlier/i);
+  });
+
+  it('does not claim the image is "above" (it is re-attached below the text)', () => {
+    expect(WORKSHEET_REATTACH_REMINDER).not.toMatch(/\babove\b/i);
+    expect(WORKSHEET_REATTACH_REMINDER).toMatch(/\bbelow\b/i);
+  });
+
+  it('asserts the tutor CAN see the image', () => {
+    expect(WORKSHEET_REATTACH_REMINDER).toMatch(/you can see/i);
+  });
+
+  it('explicitly forbids the "can\'t see it right now" deflection', () => {
+    expect(WORKSHEET_REATTACH_REMINDER).toMatch(/can'?t see it right now/i);
+  });
+
+  it('forbids asking the student to re-upload or re-type their work', () => {
+    expect(WORKSHEET_REATTACH_REMINDER).toMatch(/re-?upload/i);
+    expect(WORKSHEET_REATTACH_REMINDER).toMatch(/re-?type/i);
+  });
+
+  it('is wrapped as a SYSTEM note so the tutor does not echo it', () => {
+    expect(WORKSHEET_REATTACH_REMINDER).toMatch(/^\[SYSTEM:/);
+    expect(WORKSHEET_REATTACH_REMINDER.trim()).toMatch(/\]$/);
+  });
+});

--- a/utils/visualCapabilities.js
+++ b/utils/visualCapabilities.js
@@ -44,6 +44,21 @@ const UPLOAD_CONTEXT_REMINDER = `[SYSTEM: The student has uploaded file(s) with 
 
 
 // ============================================================================
+// 2b. WORKSHEET RE-ATTACH REMINDER — for FOLLOW-UP turns (image re-threaded)
+// ============================================================================
+// On a follow-up turn ("check #4", "what answer did I get?"), the student did
+// NOT attach anything this turn — the system re-attaches the worksheet they
+// uploaded EARLIER so the tutor can still see it. UPLOAD_CONTEXT_REMINDER is
+// worded for the upload turn ("uploaded with this message", image "above"),
+// which reads as false here: the image is placed BELOW this text, and a
+// literal-minded model concludes "you didn't upload anything right now" and
+// deflects with "I can't see your work right now." This variant states the
+// situation accurately for a follow-up so the model actually reads the image.
+
+const WORKSHEET_REATTACH_REMINDER = `[SYSTEM: This is the worksheet/work the student uploaded EARLIER in this conversation. It is re-attached below so you can still see it — the student did not need to send it again. You CAN see this image. Read it directly, including any answers or work the student wrote on it, and respond to what's actually there. NEVER say you "can't see it right now," NEVER claim nothing was uploaded, and NEVER ask them to re-upload, re-type, or read their own answer aloud when it is visible on the sheet.]`;
+
+
+// ============================================================================
 // 3. VISUAL TOOLS SECTION — full tool documentation for the system prompt
 // ============================================================================
 
@@ -211,6 +226,7 @@ This student identifies as a VISUAL LEARNER. Lean toward visuals more often, but
 module.exports = {
   CAPABILITY_IDENTITY,
   UPLOAD_CONTEXT_REMINDER,
+  WORKSHEET_REATTACH_REMINDER,
   VISUAL_TOOLS_SECTION,
   IMAGE_SEARCH_SECTION,
   STUDENT_UPLOAD_SECTION,

--- a/utils/worksheetGuard.js
+++ b/utils/worksheetGuard.js
@@ -44,6 +44,29 @@ ACT LIKE A HUMAN TUTOR SITTING NEXT TO THEM. Here's what a real tutor would do:
 [END SYSTEM INSTRUCTION]`;
 
 /**
+ * Detect when a student is asking the tutor to CHECK work they already did
+ * (as opposed to asking for help starting a problem). When true, the tutor
+ * should actually read the student's own steps/answers off their uploaded
+ * work and check them — naming what's right or pointing to the specific
+ * wrong step — instead of falling back to generic "what's your first step?"
+ * scaffolding or (worse) deflecting with "I can't see your work."
+ *
+ * Kept deliberately inclusive across the natural phrasings students use
+ * ("can you check to make sure it's correct", "did I get this right?",
+ * "are these correct?", "is it right?"). Over-triggering is low-risk: the
+ * CHECK_WORK guidance still never reveals answers and still guides
+ * Socratically — it only changes the tutor from "re-explain from scratch"
+ * to "read what they did and respond to it."
+ *
+ * @param {string} text - The student's message
+ * @returns {boolean}
+ */
+function isCheckWorkIntent(text) {
+    if (!text || typeof text !== 'string') return false;
+    return /\b(check\s+(this|these|my|the|it|them|mine|answers?|work)|check\s+to\s+(make|see)|can\s+you\s+check|did\s+i\s+(do|get|solve|set\s+up)|is\s+(this|that|it|my\s+answer|my\s+work)\s+(right|correct|ok|okay)|are\s+(these|those|my\s+answers?)\s+(right|correct|ok|okay)|make\s+sure\s+(it|this|that)(?:'?s|\s+is)?\s+(right|correct)|am\s+i\s+(right|correct|on\s+track|doing\s+(?:this|it)\s+right)|on\s+the\s+right\s+track)\b/i.test(text);
+}
+
+/**
  * Heuristic to detect if uploaded content looks like a multi-problem worksheet.
  * Returns a confidence score (0-1) so the guard can be calibrated.
  *
@@ -475,6 +498,7 @@ function detectParallelExampleIntroduction(text) {
 module.exports = {
     WORKSHEET_GUARD_INSTRUCTION,
     applyWorksheetGuard,
+    isCheckWorkIntent,
     detectWorksheetSignals,
     detectBlankWork,
     stripCorrectAnswers,


### PR DESCRIPTION
## Problem

A student uploaded a worked **Kuta "Review of Equations"** worksheet (linear equations, from the Infinite Geometry packet) and asked Ms. Maria to check specific problems — "check 1, 4, and 13", "what answer did I get?". The answers were written right on the page (#1 `n=−2` ✓, #4 `x=−1` ✓, #13 `x=13/5` ✗ — should be `x=−1`). Instead of reading the work and catching the #13 error, the tutor deflected:

> I hear you asking me to just read off your answer, Jason — but here's the thing, **I actually can't see your uploaded work from my end right now**, so I need YOU to tell me.

This is false — the system already re-threads the most-recent worksheet image back into the tutor's vision on follow-up turns — and it breaks the homework-check flow. Two distinct defects fed the bad interaction.

## Fix 1 — misleading re-thread reminder (the "I can't see it" claim)

The image re-thread branch in `routes/chat.js` reused `UPLOAD_CONTEXT_REMINDER`, which is written for the **fresh-upload** turn: *"uploaded file(s) **with this message** … image(s) **above**."* On a **follow-up** turn neither clause is true — nothing was attached that turn and the re-attached image sits *below* the text — so a literal-minded model reconciles it into "I can't see your work **right now**."

- Added `WORKSHEET_REATTACH_REMINDER` in `utils/visualCapabilities.js`, worded accurately for the follow-up case (uploaded *earlier*, re-attached *below*, you *can* see it, read the student's own answers off the sheet, never claim you can't see it "right now" or ask them to re-upload/re-type).
- Used it in the re-thread branch instead of the fresh-upload reminder; the fresh-upload turn keeps `UPLOAD_CONTEXT_REMINDER` unchanged.

## Fix 2 — check-my-work intent detection was too narrow

The student's opening request, *"Can you check to make sure it is correct first?"*, is a canonical check-my-work ask but the old `isCheckWorkIntent` regex didn't match it, so the CHECK_WORK guidance ("actually read their steps, name the specific wrong step") never fired and the tutor fell back to generic "walk me through what you did" scaffolding.

- Moved `isCheckWorkIntent` from `routes/chat.js` into `utils/worksheetGuard.js` (co-located with the other worksheet/answer-key detectors, now unit-testable).
- Broadened it to cover natural phrasings: "can you check to make sure it's correct", "can you check these", "is it right?", "are these correct?", "did I do this right?", "make sure it's right". Normal help/scaffolding requests ("what's the first step?", "1, 4, and 13", "can you solve it") still don't trigger it. Over-triggering is low-risk — CHECK_WORK guidance never reveals answers and still guides Socratically.

## Testing

- New `tests/unit/worksheetReattachReminder.test.js` (8 tests) pins the reminder contract.
- New `isCheckWorkIntent` tests in `tests/unit/worksheetGuard.test.js` (incl. the exact transcript phrasing) — positive/negative/edge cases.
- Full related suites green: `worksheetGuard`, `worksheetReattachReminder`, `activeWorksheetImage`, `activeWorksheetPrompt` — **80 tests pass**.
- `node --check` on `routes/chat.js` and ESLint on changed files: no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANPtEH1is9PWco9fwqt7iQ