### PR TITLE
Evaluate implicit multiplication ("2(2)-5") in the exact arithmetic engine

### DIFF
--- a/tests/unit/boardSynthesizer.test.js
+++ b/tests/unit/boardSynthesizer.test.js
@@ -270,7 +270,7 @@ describe('boardSynthesizer — full turns', () => {
     expect(cards[0]).toEqual({ action: 'verify', tex: 'x = 6' });
   });
 
-  test('Substitution check turn: student "4(6) + 3 = 27" + tutor affirms → verify card', () => {
+  test('Substitution check turn: student "4(6) + 3 = 27" (implicit multiplication) poses + verifies', () => {
     const cards = synthesizeBoardCommands({
       studentMessage: '4(6) + 3 = 27',
       tutorResponse: 'Yes! Exactly! So your solution x = 6 is correct!',
@@ -278,12 +278,16 @@ describe('boardSynthesizer — full turns', () => {
       observation: { messageType: 'general_math' },
       lastBoardAction: 'verify',
     });
-    // lastBoardAction === 'verify' means cycle is closed — pose
-    // would fire if a new problem is in the text, but here it's
-    // just a substitution check, no new problem to parse.
-    // Without an open cycle, apply/resolve/verify are suppressed.
-    // Substitution check only fires within an open cycle.
-    expect(cards).toHaveLength(0);
+    // The student's substitution check "4(6) + 3 = 27" is a complete, TRUE numeric
+    // equation, so it poses + verifies like any other parseable numeric statement
+    // ("24 + 3 = 27", "4*6 + 3 = 27" behave identically here). This case previously
+    // returned 0 cards ONLY because the engine couldn't evaluate the implicit
+    // multiplication "4(6)" — a bug (students write substitutions this way). Now that
+    // the exact engine handles implicit multiplication, it's consistent with its siblings.
+    expect(cards).toEqual([
+      { action: 'pose', tex: '4(6) + 3' },
+      { action: 'verify', tex: '4(6) + 3 = 27' },
+    ]);
   });
 
   test('Substitution check during open cycle: student "3(7) - 5 = 16" + tutor affirms', () => {

--- a/tests/unit/rationalEvaluator.test.js
+++ b/tests/unit/rationalEvaluator.test.js
@@ -18,6 +18,18 @@ describe('rationalEvaluator — exact arithmetic', () => {
     expect(ans('-34+6')).toBe('-28');
   });
 
+  test('implicit multiplication (how students write substitutions: f\'(2) = 2(2) - 5)', () => {
+    expect(ans('2(2)-5')).toBe('-1');     // the real worksheet's f'(2) evaluation
+    expect(ans('2(2)')).toBe('4');
+    expect(ans('3(4)+1')).toBe('13');
+    expect(ans('(2)(3)')).toBe('6');      // )( between factors
+    expect(ans('2(3)(4)')).toBe('24');
+    expect(ans('(2)3')).toBe('6');        // ) before a value
+    expect(ans('-2(3)')).toBe('-6');      // unary sign + implicit mult
+    expect(ans('2(3+1)')).toBe('8');      // grouped sub-expression
+    expect(ans('2.5(4)')).toBe('10');     // decimal coefficient
+  });
+
   test('no floating-point error (the reason for BigInt rationals)', () => {
     expect(ans('0.1 + 0.2')).toBe('0.3');          // not 0.30000000000000004
     expect(ans('1/3 + 1/3 + 1/3')).toBe('1');       // not 0.9999...

--- a/utils/mathSolver.js
+++ b/utils/mathSolver.js
@@ -38,7 +38,10 @@ function isolateNumericExpression(text) {
     let m;
     while ((m = rx.exec(text)) !== null) {
         const expr = m[0].trim();
-        if (!/\d\s*[-+*/^]/.test(expr)) continue;    // no binary operator → not a computation
+        // Require an actual computation, not a bare number. A binary operator or a
+        // parenthesis (implicit multiplication, e.g. "2(2)-5") both qualify; a lone
+        // leading minus does not (strip it before checking).
+        if (!/[-+*/^()]/.test(expr.replace(/^-/, ''))) continue;
         if (evalExpression(expr) === null) continue; // exact engine rejects → defer, never guess
         return expr;
     }
@@ -3701,7 +3704,10 @@ function _isTrustedProblem(problem, source) {
         // when the expression itself still carries words (the older "what is …" catch-all,
         // whose `expression` can be raw prose).
         const expr = String(problem.expression || '');
-        const isPureNumericExpr = /^[\s\d.+\-*/^()]+$/.test(expr) && /\d\s*[-+*/^]/.test(expr);
+        // Pure numeric chars only, AND an actual computation — a binary operator or a
+        // parenthesis (implicit multiplication like "2(2)-5"), not a bare number. A lone
+        // leading minus doesn't count, so strip it before the operator check.
+        const isPureNumericExpr = /^[\s\d.+\-*/^()]+$/.test(expr) && /[-+*/^()]/.test(expr.replace(/^\s*-/, ''));
         if (!isPureNumericExpr) {
             if (PROSE_WORD_RX.test(source)) return false;
             if (problem.expression && PROSE_WORD_RX.test(problem.expression)) return false;

--- a/utils/rationalEvaluator.js
+++ b/utils/rationalEvaluator.js
@@ -56,7 +56,17 @@ function preprocess(expr) {
   return expr
     .replace(new RegExp(`(\\d+)\\s*([${VC}])`, 'g'), (_, w, g) => { const [n, d] = VULGAR[g]; return `(${w}+${n}/${d})`; })
     .replace(new RegExp(`[${VC}]`, 'g'), (g) => { const [n, d] = VULGAR[g]; return `(${n}/${d})`; })
-    .replace(/(\d+)\s+(\d+\s*\/\s*\d+)/g, '($1+$2)');
+    .replace(/(\d+)\s+(\d+\s*\/\s*\d+)/g, '($1+$2)')
+    // Implicit multiplication: a value abutting a parenthesis means multiply.
+    // Students write derivative/substitution work this way — "f'(2) = 2(2) - 5" —
+    // and without this the exact engine returns null, so a correct "-1" can't be
+    // verified deterministically and falls back to the (fallible) LLM grader.
+    //   "2(2)" → "2*(2)",  ")(" → ")*(",  "(2)3" → "(2)*3"
+    // Runs AFTER the fraction/mixed rewrites so the parens they introduce (e.g.
+    // "(12+2/3)") get the same treatment. Letters never reach the engine (tokenize
+    // rejects them), so function-call forms like "f(2)" are unaffected.
+    .replace(/(\d|\))\s*\(/g, '$1*(')
+    .replace(/\)\s*(\d|\.)/g, ')*$1');
 }
 
 function tokenize(s) {


### PR DESCRIPTION
## The gap

From a real session: a student uploaded **correct** work for `f(x)=x²−5x+6` — factoring to roots `x=2, x=3`, then `f'(x)=2x−5` and `f'(2)=2(2)−5=4−5=−1` — and later typed `2(2)-5` in chat as their answer.

The exact-rational engine returned **null** for *any* implicit-multiplication form:

```
2(2)-5  -> null      2(2)   -> null      3(4)+1 -> null
(2)(3)  -> null      -2(3)  -> null
2*2-5   -> -1  ✓  (explicit * works)
```

Students write substitutions this way constantly (`f'(2) = 2(2) - 5`). Because the deterministic verifier couldn't evaluate it, it couldn't confirm the correct `−1` and fell back to the fallible LLM grader.

## Fix

Insert implicit multiplication in `rationalEvaluator`'s `preprocess` — a value abutting a parenthesis means multiply:

```
"2(2)" → "2*(2)"    ")(" → ")*("    "(2)3" → "(2)*3"
```

Placed **after** the fraction/mixed-number rewrites so the parens they introduce get the same treatment. Letters never reach the engine (`tokenize` rejects them), so function-call forms like `f(2)` are unaffected.

Also aligned the two operator-presence checks in `mathSolver`'s `isolateNumericExpression` and `_isTrustedProblem` so a parenthesised computation (`2(2)-5`) counts as a computation (a lone leading minus still doesn't) — otherwise a prose-embedded `"what is 2(2)-5"` was extracted but then rejected.

| Input | Before | After |
|---|---|---|
| `2(2)-5` | null | `-1` ✅ |
| `3(4)+1` | null | `13` ✅ |
| `(2)(3)` | null | `6` ✅ |
| `-2(3)` | null | `-6` ✅ |
| `what is 2(2)-5` | no-solve | `-1` ✅ |

## Verification

- `boardSynthesizer` test updated: `4(6)+3=27` now parses like its already-supported siblings (`24+3=27`, `4*6+3=27`) and poses+verifies identically — it previously returned 0 cards *only* because the engine couldn't evaluate `4(6)`. Confirmed all three produce the same cards.
- New regression test in `rationalEvaluator.test.js`; negatives/precedence/bare-number-defer all still hold.
- Full unit suite: **3174 tests, 185 suites** pass. `eslint` clean.

## Scope note

This closes a concrete engine gap directly implicated in that session (the student's `2(2)-5` answer now verifies deterministically). It does **not** by itself fix the separate issue in the same transcript where the *worksheet-image grading* (vision/LLM path) falsely flagged the student's correct `f'(2)=−1` as "a small mistake" — that's an LLM-grounding problem on a different path, worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0171k2hPfEX6bn6ujWFhwAF1

---
_Generated by [Claude Code](https://claude.ai/code/session_0171k2hPfEX6bn6ujWFhwAF1)_