### PR TITLE
Fix combine-like-terms answers being graded wrong

### DIFF
--- a/tests/unit/mathSolverCombineLikeTerms.test.js
+++ b/tests/unit/mathSolverCombineLikeTerms.test.js
@@ -1,0 +1,133 @@
+/**
+ * MATH SOLVER — Combine-like-terms detection & grading
+ *
+ * Regression coverage for the bug where a "simplify 7y - 10y" style prompt
+ * matched NO deterministic pattern (hasMath:false), so grading fell through to
+ * the LLM verifier — which rejected the student's CORRECT answer "-3y" as "a
+ * different problem," forced a needless re-derivation, and then mis-awarded a
+ * "self-corrected" bonus for a correction that never happened.
+ */
+
+const {
+  detectMathProblem,
+  processMathMessage,
+  parseCleanProblem,
+  verifyAnswer,
+  solveCombineLikeTerms,
+  hasLikeTermsToCombine,
+} = require('../../utils/mathSolver');
+
+describe('detectMathProblem — combine like terms', () => {
+  test('bare "7y - 10y" is detected as combine_like_terms', () => {
+    const result = detectMathProblem('7y - 10y');
+    expect(result).not.toBeNull();
+    expect(result.type).toBe('combine_like_terms');
+  });
+
+  test('"simplify 5x+3x-2x" is detected', () => {
+    const result = detectMathProblem('simplify 5x+3x-2x');
+    expect(result).not.toBeNull();
+    expect(result.type).toBe('combine_like_terms');
+  });
+
+  test('unicode minus "7y−10y" is detected', () => {
+    const result = detectMathProblem('Simplify: 7y−10y');
+    expect(result).not.toBeNull();
+    expect(result.type).toBe('combine_like_terms');
+  });
+
+  // ── Guardrails: must NOT hijack other problem types ──
+
+  test('binomial product stays with expand_polynomial', () => {
+    expect(detectMathProblem('simplify (x+1)(x+6)').type).toBe('expand_polynomial');
+  });
+
+  test('an equation is never a combine_like_terms problem', () => {
+    expect(detectMathProblem('solve 4x + 3 = 27').type).not.toBe('combine_like_terms');
+  });
+
+  test('a single term (nothing to combine) is not detected', () => {
+    expect(detectMathProblem('5x')).toBeNull();
+  });
+
+  test('an already-simplified expression (no like terms) is not detected', () => {
+    // 2x + 3y has no pair of like terms → nothing to combine → fall through
+    expect(detectMathProblem('2x + 3y')).toBeNull();
+  });
+
+  test('plain prose mentioning "simplify" is not detected', () => {
+    expect(detectMathProblem('Can you simplify this for me?')).toBeNull();
+  });
+});
+
+describe('solveCombineLikeTerms', () => {
+  test('7y - 10y → -3y', () => {
+    expect(processMathMessage('7y - 10y').solution.answer).toBe('-3y');
+  });
+
+  test('5x + 3x - 2x → 6x', () => {
+    expect(processMathMessage('simplify 5x+3x-2x').solution.answer).toBe('6x');
+  });
+
+  test('3y - 9y → -6y', () => {
+    expect(processMathMessage('3y - 9y').solution.answer).toBe('-6y');
+  });
+
+  test('combines higher-degree like terms: x^2 + 3x^2 - x → 4x^2 - x', () => {
+    expect(processMathMessage('simplify x^2 + 3x^2 - x').solution.answer).toBe('4x^2 - x');
+  });
+
+  test('preserves distinct variables: 2x + 3y + x → 3x + 3y', () => {
+    expect(processMathMessage('2x + 3y + x').solution.answer).toBe('3x + 3y');
+  });
+
+  test('fully-cancelling terms → 0', () => {
+    // solveCombineLikeTerms formats an empty canonical set as "0"
+    const result = solveCombineLikeTerms({ expression: '4y - 4y', poly: { terms: [
+      { coeff: 4, variable: 'y', exp: 1 },
+      { coeff: -4, variable: 'y', exp: 1 },
+    ] } });
+    expect(result.answer).toBe('0');
+  });
+});
+
+describe('hasLikeTermsToCombine', () => {
+  test('true when two terms share variable + exponent', () => {
+    expect(hasLikeTermsToCombine([
+      { coeff: 7, variable: 'y', exp: 1 },
+      { coeff: -10, variable: 'y', exp: 1 },
+    ])).toBe(true);
+  });
+
+  test('false when every term is distinct', () => {
+    expect(hasLikeTermsToCombine([
+      { coeff: 2, variable: 'x', exp: 1 },
+      { coeff: 3, variable: 'y', exp: 1 },
+    ])).toBe(false);
+  });
+});
+
+describe('end-to-end — the transcript scenario grades correctly', () => {
+  // Tutor poses "Simplify: 7y - 10y" inside conversational prose; persist stores
+  // the extracted correctAnswer; the student's correct "-3y" must grade CORRECT.
+  test('correct answer "-3y" to "7y - 10y" is graded correct', () => {
+    const posed = "Let's kick it up a notch with a negative in the mix. Simplify: 7y−10y.";
+    const parsed = parseCleanProblem(posed);
+    expect(parsed.hasMath).toBe(true);
+    expect(parsed.solution.success).toBe(true);
+    expect(verifyAnswer('-3y', parsed.solution.answer).isCorrect).toBe(true);
+  });
+
+  test('equivalent forms of the answer also grade correct', () => {
+    const answer = processMathMessage('7y - 10y').solution.answer; // "-3y"
+    for (const form of ['-3y', '−3y', '- 3y', '-3 y']) {
+      expect(verifyAnswer(form, answer).isCorrect).toBe(true);
+    }
+  });
+
+  test('a genuinely wrong answer to "7y - 10y" is still marked wrong', () => {
+    const answer = processMathMessage('7y - 10y').solution.answer;
+    expect(verifyAnswer('3y', answer).isCorrect).toBe(false);
+    expect(verifyAnswer('-3', answer).isCorrect).toBe(false);
+  });
+});

--- a/utils/mathSolver.js
+++ b/utils/mathSolver.js
@@ -495,6 +495,30 @@ function detectMathProblem(message) {
         };
     }
 
+    // Pattern: Combine like terms / simplify a variable expression with no '='.
+    // "simplify 5x+3x-2x" → 6x, "7y - 10y" → -3y, "combine like terms 2a+3a-a" → 4a.
+    // This skill previously matched NO pattern here, so the deterministic grader
+    // returned hasMath:false and grading fell through to the LLM verifier — which
+    // could reject a correct answer (e.g. mark "-3y" wrong for "7y-10y"). Binomial
+    // products (parentheses) stay with expand_polynomial and equations ('=') stay
+    // with their own solvers; this only claims a bare additive polynomial that
+    // actually has like terms to combine.
+    if (!/=/.test(message) && !/[()]/.test(message)) {
+        // Greedy strip up to the LAST "simplify"/"combine like terms" keyword so a
+        // prose-wrapped prompt ("Let's try one more: simplify 3y-9y") yields just
+        // the trailing expression. A bare expression (no keyword) is left untouched.
+        // parsePolynomial's 80%-consumption guard rejects anything still carrying
+        // prose, so a stray "simplify" elsewhere in a sentence can't create a
+        // bogus problem.
+        const exprOnly = message
+            .replace(/^.*\b(?:combine(?:\s+like\s+terms)?|simplify)\b\s*:?\s*/i, '')
+            .trim();
+        const poly = parsePolynomial(exprOnly);
+        if (poly && poly.terms.length >= 2 && hasLikeTermsToCombine(poly.terms)) {
+            return { type: 'combine_like_terms', expression: exprOnly, poly };
+        }
+    }
+
     // Pattern: Mixed-number arithmetic — "12 2/3 - 4 1/4", "12⅔ - 4¼", "2 1/2 + 3".
     // Must run BEFORE the arithmetic-chain detector, which would strip the space in
     // "12 2/3" to "122/3" and evaluate garbage. Requires at least one operand to be
@@ -662,6 +686,8 @@ function solveProblem(problem) {
                 return solveSlope(problem);
             case 'expand_polynomial':
                 return solveExpandPolynomial(problem);
+            case 'combine_like_terms':
+                return solveCombineLikeTerms(problem);
             case 'factor_quadratic':
                 return solveFactorQuadratic(problem);
             case 'factor_diff_of_squares':
@@ -1197,6 +1223,70 @@ function solveExpandPolynomial(problem) {
         answer,
         steps: [
             `Expand ${expression}`,
+            `= ${answer}`,
+        ],
+    };
+}
+
+/**
+ * True when the parsed terms contain at least two terms that share the same
+ * variable AND exponent — i.e. there is actually something to combine. Guards
+ * the combine_like_terms detector so an already-simplified or single-term
+ * expression falls through to other handlers instead of being "graded".
+ */
+function hasLikeTermsToCombine(terms) {
+    const seen = new Set();
+    for (const t of terms) {
+        const key = `${t.variable || '_const'}^${t.exp}`;
+        if (seen.has(key)) return true;
+        seen.add(key);
+    }
+    return false;
+}
+
+/**
+ * Format canonical polynomial terms ({coeff, variable, exp}) into a readable
+ * string, preserving the actual variable letter — unlike formatPolynomialTerms(),
+ * which is hardcoded to 'x'. [{-3,'y',1}] → "-3y", [{4,'x',2},{2,'x',1}] → "4x^2 + 2x".
+ */
+function formatCombinedPolynomial(terms) {
+    if (!terms || terms.length === 0) return '0';
+    let out = '';
+    terms.forEach((t, i) => {
+        const abs = Math.abs(t.coeff);
+        if (i === 0) {
+            if (t.coeff < 0) out += '-';
+        } else {
+            out += t.coeff < 0 ? ' - ' : ' + ';
+        }
+        const varPart = t.variable
+            ? (t.exp >= 2 ? `${t.variable}^${t.exp}` : t.variable)
+            : '';
+        if (!varPart) {
+            out += String(abs);
+        } else if (abs === 1) {
+            out += varPart;
+        } else {
+            out += `${abs}${varPart}`;
+        }
+    });
+    return out;
+}
+
+/**
+ * Combine like terms in a variable expression → simplified canonical form.
+ * "7y - 10y" → "-3y", "5x + 3x - 2x" → "6x", "2x + 3y + x" → "3x + 3y".
+ * Grading is exact: verifyAnswer() re-parses both sides as polynomials, so any
+ * equivalent form of the answer (spacing, term order, unicode minus) grades equal.
+ */
+function solveCombineLikeTerms(problem) {
+    const canon = canonicalizePolynomial(problem.poly.terms);
+    const answer = formatCombinedPolynomial(canon);
+    return {
+        success: true,
+        answer,
+        steps: [
+            `Combine like terms: ${problem.expression}`,
             `= ${answer}`,
         ],
     };
@@ -3672,7 +3762,10 @@ function processMathMessage(message) {
 // is found. Callers that need the raw catch-all (e.g. legacy chat.js
 // arithmetic checks) keep using processMathMessage directly.
 const PROSE_WORD_RX = /[a-z]{4,}/i;
-const MATH_CANDIDATE_VERB_RX = /\b(?:solve|try|find|evaluate|simplify|factor|graph|compute)\s+([^.?!\n]+?)(?=[.?!\n]|$)/gi;
+// The separator is [\s:]+ (not just \s+) so a colon-led prompt like
+// "Simplify: 7y-10y" — the natural way a tutor poses a problem — still yields
+// the bare expression "7y-10y" as a candidate.
+const MATH_CANDIDATE_VERB_RX = /\b(?:solve|try|find|evaluate|simplify|factor|graph|compute)[\s:]+([^.?!\n]+?)(?=[.?!\n]|$)/gi;
 const MATH_CANDIDATE_EQ_RX = /(?:^|[\s:>])(\(?-?\d*[a-z][a-z0-9\s+\-*/^().]*=\s*-?[a-z0-9\s+\-*/^()]+?)(?=[.?!\n]|$|\s{2})/gi;
 
 function _extractMathCandidates(text) {
@@ -3750,6 +3843,8 @@ module.exports = {
     solveQuadratic,
     solveAbsoluteValue,
     solveFactorQuadratic,
+    solveCombineLikeTerms,
+    hasLikeTermsToCombine,
     solveFractionArithmetic,
     solvePercentage,
     solveExponent,


### PR DESCRIPTION
## What & why

A tutoring session surfaced a tutor-behavior bug: a student's **correct** answer `-3y` to `7y − 10y` was rejected by Bob as *"a different problem creeping in there,"* the student was forced to re-derive the answer they already had right, and the turn then mis-awarded a **"+52 XP — self-corrected"** bonus for a correction that never happened.

### Root cause

`utils/mathSolver.js` has **no handler for combining like terms** in a plain expression (`7y − 10y`, `5x + 3x − 2x`). Every such prompt falls through every pattern in `detectMathProblem` and returns `hasMath: false`, so the deterministic grader silently punts on the exact skill this session was drilling. Grading then falls back to the LLM verifier, which misjudged the correct `-3y` — producing the false rejection, the needless re-derivation, and finally the bogus AI-awarded "self-corrected" tier‑3 XP (the whole cascade is downstream of the first turn not being recognized as correct).

Verified empirically before the fix:

```
parseCleanProblem("Simplify: 7y−10y")  →  { hasMath: false }
```

## Changes

**`utils/mathSolver.js`**
- Add a `combine_like_terms` problem type + `solveCombineLikeTerms` solver. It claims **only** a bare additive polynomial that (a) has no `=`, (b) has no parentheses, and (c) actually contains like terms to combine — so binomial products stay with `expand_polynomial` and equations stay with their own solvers. It reuses the existing `parsePolynomial` / `canonicalizePolynomial` infrastructure, and answers grade through the existing polynomial-equivalence branch of `verifyAnswer`, so any equivalent form of the answer (spacing, term order, Unicode minus) is accepted.
- Let `parseCleanProblem`'s candidate extractor accept a colon separator after the verb (`"Simplify: 7y-10y"`) so `persist.js` stores the correct `problemInfo.correctAnswer`.

**`tests/unit/mathSolverCombineLikeTerms.test.js`** (new, 19 tests)
- Detection, solving, guardrails against hijacking other problem types (products, equations, single terms, prose), and the end-to-end transcript scenario (`-3y` → correct; equivalent forms → correct; genuinely wrong answers → still wrong).

## Verification

- New regression suite: **19/19 pass**.
- Full unit suite unaffected: **3278/3278 pass**.
- Lint: **0 errors** on changed files (only pre-existing warnings remain).
- Guardrails confirmed: `expand (x+2)(x+3)` → `expand_polynomial`, `solve 4x+3=27` → `general_linear`, `x^2+5x+6=0` → `quadratic_equation`, prose/single-term → `null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9NXChD4NNHQ5kD8x1hPJ5)_