### PR TITLE
fix(middleware): stop www→apex redirect loop (ERR_TOO_MANY_REDIRECTS)

### DIFF
--- a/config/middleware.js
+++ b/config/middleware.js
@@ -77,9 +77,12 @@ function configureMiddleware(app) {
       if (req.headers['x-forwarded-proto'] !== 'https') {
         return res.redirect(301, `https://${req.hostname}${req.originalUrl}`);
       }
-      if (req.hostname === 'www.mathmatix.ai') {
-        return res.redirect(301, `https://mathmatix.ai${req.originalUrl}`);
-      }
+      // NOTE: Do NOT redirect www → apex here. Render's edge already
+      // canonicalizes host by redirecting apex → www, and there is no dashboard
+      // toggle to reverse that direction. A www → apex redirect at the origin
+      // fights Render's apex → www edge redirect and produces an infinite
+      // loop (ERR_TOO_MANY_REDIRECTS). www is the canonical host; the origin
+      // only ever sees www, so no host canonicalization is needed here.
       next();
     });
   }


### PR DESCRIPTION
Render's edge canonicalizes the host by redirecting apex → www, and its dashboard exposes no toggle to reverse that direction. The origin was also redirecting www → apex, so the two layers ping-ponged forever and every hit to www.mathmatix.ai/* died with ERR_TOO_MANY_REDIRECTS.

Remove the origin's www → apex redirect. www is now the single canonical host (chosen by Render's edge); the origin only ever sees www, so no host canonicalization is needed here. HTTPS enforcement is unchanged.