### PR TITLE
fix(pipeline): scrub leaked internal scaffolding from tutor replies

### DIFF
--- a/tests/unit/internalTagSanitizer.test.js
+++ b/tests/unit/internalTagSanitizer.test.js
@@ -1,0 +1,88 @@
+const { stripInternalTags, hasInternalTags } = require('../../utils/internalTagSanitizer');
+
+describe('internalTagSanitizer', () => {
+  describe('ANSWER_PRE_CHECK leak (the reported bug)', () => {
+    it('strips an echoed pre-check tag from the start of a reply', () => {
+      const input = '[ANSWER_PRE_CHECK: VERIFIED CORRECT. The student\'s answer "3" matches "3". Confirm immediately.] Yes! 3 cm is exactly right, Jason.';
+      expect(stripInternalTags(input)).toBe('Yes! 3 cm is exactly right, Jason.');
+    });
+
+    it('strips the VERIFIED INCORRECT variant', () => {
+      const input = 'Hmm. [ANSWER_PRE_CHECK: VERIFIED INCORRECT. The student answered "5".] Let\'s look again.';
+      expect(stripInternalTags(input)).toBe('Hmm. Let\'s look again.');
+    });
+
+    it('strips a check-my-work injected note', () => {
+      const input = '[CHECK MY WORK — INDEPENDENTLY VERIFIED CORRECT: A separate check confirms the work.] Nice job!';
+      expect(stripInternalTags(input)).toBe('Nice job!');
+    });
+
+    it('is case-insensitive on the tag name', () => {
+      expect(stripInternalTags('[answer_pre_check: verified correct] ok')).toBe('ok');
+    });
+  });
+
+  describe('stray board-command JSON leak', () => {
+    it('strips a verify command emitted as JSON instead of a <BOARD> tag', () => {
+      const input = 'Great work! {"action":"verify","tex":"h = 3 , cm","check":"5 \\\\times 4 \\\\times 3 = 60"} Want another?';
+      expect(stripInternalTags(input)).toBe('Great work! Want another?');
+    });
+
+    it('strips a pose JSON with single spacing variations', () => {
+      expect(stripInternalTags('Try this {"action": "pose", "tex": "2x+4=20"} now')).toBe('Try this now');
+    });
+
+    it('strips multiple stray JSON commands in one message', () => {
+      const input = 'a {"action":"pose","tex":"x"} b {"action":"resolve","tex":"x=1"} c';
+      expect(stripInternalTags(input)).toBe('a b c');
+    });
+  });
+
+  describe('LaTeX-brace safety (must NOT corrupt math)', () => {
+    it('leaves \\frac and \\boxed braces untouched', () => {
+      const input = 'We get \\frac{1}{2} and then \\boxed{x = 4}.';
+      expect(stripInternalTags(input)).toBe(input);
+    });
+
+    it('does not touch a JSON-looking object without a board action', () => {
+      const input = 'Config looks like {"color":"red","size":3}.';
+      expect(stripInternalTags(input)).toBe(input);
+    });
+
+    it('leaves an interval like [0, 5] alone', () => {
+      const input = 'The domain is [0, 5] here.';
+      expect(stripInternalTags(input)).toBe(input);
+    });
+
+    it('leaves a nested-brace object (not a flat board command) alone', () => {
+      const input = 'Odd: {"action":"verify","meta":{"x":1}} stays.';
+      expect(stripInternalTags(input)).toBe(input);
+    });
+  });
+
+  describe('combined + edge cases', () => {
+    it('strips both a pre-check tag and stray JSON in one reply', () => {
+      const input = '[ANSWER_PRE_CHECK: VERIFIED CORRECT] You nailed it. {"action":"verify","tex":"x=8"}';
+      expect(stripInternalTags(input)).toBe('You nailed it.');
+    });
+
+    it('returns clean text unchanged', () => {
+      const input = 'Nice work — combine the x-terms first.';
+      expect(stripInternalTags(input)).toBe(input);
+    });
+
+    it('handles empty / non-string input', () => {
+      expect(stripInternalTags('')).toBe('');
+      expect(stripInternalTags(null)).toBe('');
+      expect(stripInternalTags(undefined)).toBe('');
+    });
+
+    it('hasInternalTags predicate matches stripInternalTags work (and is not stateful)', () => {
+      const dirty = 'x {"action":"pose","tex":"y"} z';
+      // Call twice to catch any leaked regex lastIndex state.
+      expect(hasInternalTags(dirty)).toBe(true);
+      expect(hasInternalTags(dirty)).toBe(true);
+      expect(hasInternalTags('all clean here')).toBe(false);
+    });
+  });
+});

--- a/utils/internalTagSanitizer.js
+++ b/utils/internalTagSanitizer.js
@@ -1,0 +1,96 @@
+// ============================================================
+// internalTagSanitizer.js — last-line defense against internal
+// scaffolding leaking into the student-facing bubble.
+//
+// Two classes of leak this strips from the tutor's FINAL text:
+//
+//   1. Internal instruction tags we INJECT into the model's
+//      context and that the model sometimes parrots back:
+//        [ANSWER_PRE_CHECK: VERIFIED CORRECT ...]   (pipeline/generate.js)
+//        [CHECK MY WORK — INDEPENDENTLY VERIFIED ...] (routes/chat.js)
+//      These are directives, never meant for the student. When
+//      echoed they also render badly — KaTeX turns the
+//      `ANSWER_PRE_CHECK` underscores into subscripts.
+//
+//   2. Board commands the model emitted as raw JSON instead of the
+//      locked <BOARD .../> tag syntax (boardTagParser.js). The tag
+//      parser doesn't recognize the JSON shape, so a stray
+//        {"action":"verify","tex":"h = 3","check":"5*4*3 = 60"}
+//      leaks as visible text AND never reaches the board. We strip
+//      it here so it can't leak; recovering it as a real board
+//      command is a separate, guarded concern (boardCommandGuard).
+//
+// IMPORTANT: this is a PURE post-processor, not a streaming filter.
+// A brace-aware stream filter would be unsafe — LaTeX is full of
+// `{}` (\frac{1}{2}, \boxed{}) and we'd corrupt math mid-stream.
+// The JSON pattern here is safe precisely because it requires an
+// "action":"<board-verb>" pair inside the braces, which LaTeX never
+// contains. Transient stream flicker is overwritten by the
+// authoritative `complete`/replacement event, which carries the
+// sanitized final text.
+// ============================================================
+
+'use strict';
+
+// Internal instruction tags injected into model context. Matched by
+// their distinctive opener up to the closing `]` (the injected tags
+// never contain a `]` themselves).
+const INTERNAL_BRACKET_TAGS = [
+    /\[ANSWER_PRE_CHECK\b[^\]]*\]/gi,
+    /\[CHECK MY WORK\b[^\]]*\]/gi,
+];
+
+// Board verbs (mirror of boardTagParser.VALID_ACTIONS). A JSON object
+// carrying one of these as its "action" is a mis-formatted board
+// command, not prose.
+const BOARD_VERBS = 'pose|apply|resolve|verify|clear|graph|image|scaffold|model|example';
+
+// A flat JSON object (no nested braces) whose keys include
+// "action":"<board-verb>". `[^{}]*?` bans nested braces so this can
+// never span across / swallow legitimate LaTeX braces around it.
+// Kept as a source string so each use builds a fresh RegExp — sharing
+// a /g regex across .test()/.replace() would leak lastIndex state.
+const BOARD_JSON_SRC = `\\{[^{}]*?"action"\\s*:\\s*"(?:${BOARD_VERBS})"[^{}]*?\\}`;
+
+/**
+ * Remove leaked internal scaffolding from a tutor message.
+ *
+ * @param {string} text - the model's (already board-tag-stripped) text
+ * @returns {string} text safe to show the student
+ */
+function stripInternalTags(text) {
+    if (!text || typeof text !== 'string') return text || '';
+
+    let out = text;
+    for (const re of INTERNAL_BRACKET_TAGS) {
+        out = out.replace(new RegExp(re.source, re.flags), '');
+    }
+    out = out.replace(new RegExp(BOARD_JSON_SRC, 'gi'), '');
+
+    // Heal whitespace scars left by removal — same normalization the
+    // board tag parser applies so the two are visually consistent.
+    out = out
+        .replace(/[ \t]+\n/g, '\n')   // trailing space before newline
+        .replace(/\n[ \t]+/g, '\n')   // leading space after newline
+        .replace(/\n{3,}/g, '\n\n')   // collapse 3+ newlines
+        .replace(/[ \t]{2,}/g, ' ')   // collapse runs of inline spaces
+        .trim();
+
+    return out;
+}
+
+/**
+ * Cheap predicate — is there anything for stripInternalTags to do?
+ * Lets hot-path callers skip the regex work on the common clean case.
+ */
+function hasInternalTags(text) {
+    if (!text || typeof text !== 'string') return false;
+    return /\[ANSWER_PRE_CHECK\b/i.test(text)
+        || /\[CHECK MY WORK\b/i.test(text)
+        || new RegExp(BOARD_JSON_SRC, 'i').test(text);
+}
+
+module.exports = {
+    stripInternalTags,
+    hasInternalTags,
+};

--- a/utils/pipeline/generate.js
+++ b/utils/pipeline/generate.js
@@ -16,6 +16,7 @@ const { STATIC_RULES, RULE_1_SOCRATIC, RULE_1_TEACHING } = require('../promptCom
 const { buildSlimRules } = require('./promptSlim');
 const { VISUAL_TOOLS, resolveToolCalls, describeTools } = require('../visualTools');
 const { parseBoardTags } = require('../boardTagParser');
+const { stripInternalTags } = require('../internalTagSanitizer');
 const { createBoardTagStreamFilter } = require('../boardTagStreamFilter');
 const { createXpTagStreamFilter } = require('../xpTagStreamFilter');
 const { createVisualTabTagStreamFilter } = require('../visualTabTagStreamFilter');
@@ -37,7 +38,14 @@ const {
 // filter instead, because tags can fragment across chunks.
 function stripBoardTagsForStream(text) {
   if (!text) return text;
-  return parseBoardTags(text).cleanedText;
+  // Strip <BOARD/> tags, then scrub any internal scaffolding (echoed
+  // [ANSWER_PRE_CHECK: ...] directives, board commands mis-emitted as
+  // raw JSON). These paths — deterministic responses, tool narration,
+  // and the streaming-error fallback — write straight to the client
+  // without passing through the incremental board filter, so they need
+  // the scrub inline. The main streamed path is scrubbed authoritatively
+  // in the pipeline's final stage (index.js) via the `complete` event.
+  return stripInternalTags(parseBoardTags(text).cleanedText);
 }
 
 // Primary teaching model. Env-overridable so the tutor can be pointed at a

--- a/utils/pipeline/index.js
+++ b/utils/pipeline/index.js
@@ -43,6 +43,7 @@ const { detectModeTransition } = require('../modeTransitionDetector');
 const { gradeTurn, summarizeSession, createScorecard } = require('../sessionGrader');
 const { detectPatterns, summarizeSession: summarizeForPatterns } = require('../sessionPatternDetector');
 const { parseBoardTags } = require('../boardTagParser');
+const { stripInternalTags, hasInternalTags } = require('../internalTagSanitizer');
 const { enforcePedagogyRule } = require('../boardCommandGuard');
 const { resolveModelCommands } = require('../conceptModelCommand');
 const { parseXpTags } = require('../xpTagParser');
@@ -1082,6 +1083,23 @@ async function runPipeline(message, ctx) {
     verified.visualTabCommands = visualTabParsed.visualTabCommands.slice(0, 2);
   } else {
     verified.visualTabCommands = [];
+  }
+
+  // ── Stage 5f: INTERNAL-TAG SCRUB (last line of defense) ──
+  // After every legitimate side-channel tag has been extracted above,
+  // strip any internal scaffolding the model echoed into the prose —
+  // an injected [ANSWER_PRE_CHECK: ...] directive, or a board command
+  // the model wrote as raw JSON instead of a <BOARD/> tag. This is the
+  // authoritative student-facing text (returned as `text` below and
+  // sent as the `complete` event, which REPLACES the streamed bubble),
+  // so scrubbing here fixes the persisted leak regardless of what
+  // flickered mid-stream. Guarded by a cheap predicate — no-op on the
+  // clean common case.
+  if (hasInternalTags(verified.text)) {
+    boardLogger.warn('Internal scaffolding leaked into tutor text; scrubbed', {
+      conversationId: ctx.conversation?._id ? String(ctx.conversation._id) : null,
+    });
+    verified.text = stripInternalTags(verified.text);
   }
 
   // ── Merge LLM signals into sidecar ──


### PR DESCRIPTION
A student saw "[ANSWER_PRE_CHECK: VERIFIED CORRECT ...]" and a raw {"action":"verify",...} board command rendered in Bob's reply (the underscores even KaTeX-subscripted into "ANSWERₚRE..."). Two gaps:

1. [ANSWER_PRE_CHECK: ...] is an internal directive we inject into the model's context (generate.js) for it to ACT on, not echo. Nothing stripped it from output.
2. The board contract is the <BOARD action="verify" .../> tag; the model emitted JSON instead, which boardTagParser doesn't match — so it leaked as text AND never reached the board.

Add utils/internalTagSanitizer.js (pure post-processor) and wire it in:
- index.js final stage scrubs verified.text after all side-channel tag extraction — this is the authoritative text returned as `text` and sent via the `complete` event, which REPLACES the streamed bubble, so the persisted leak is fixed regardless of mid-stream flicker.
- generate.js stripBoardTagsForStream also scrubs, covering the deterministic / tool-narration / error-fallback paths that bypass the incremental board filter.

Deliberately NOT a streaming brace-filter: LaTeX is full of {} so a filter reacting to `{` would corrupt math. The JSON strip is safe because it requires "action":"<board-verb>" inside flat braces, which LaTeX never contains — covered by tests (\frac, \boxed, [0,5], nested).

15 new unit tests; board/pipeline/generate suites green. (Pre-existing openaiClient/anthropicClient failures are missing-SDK env issues, unrelated.)