### PR TITLE
Living Workspace P3+P4: workspace shell + equation element (the spine)

### DIFF
--- a/public/css/living-workspace.css
+++ b/public/css/living-workspace.css
@@ -1,0 +1,99 @@
+/* ============================================================
+   living-workspace.css — styles for the new workspace surface.
+   Scoped under .lws-root so it never bleeds into chat/board.
+   Grid colors are exposed as --lws-* custom properties the canvas
+   renderer reads via getComputedStyle.
+   ============================================================ */
+
+.lws-root {
+  --lws-grid-bg: #0f1422;
+  --lws-grid-minor: rgba(255, 255, 255, 0.05);
+  --lws-grid-major: rgba(255, 255, 255, 0.11);
+  --lws-grid-border: rgba(255, 255, 255, 0.22);
+  --lws-card-bg: #1b2238;
+  --lws-card-border: rgba(255, 255, 255, 0.14);
+  --lws-card-ink: #e6e9f2;
+  --lws-accent: #8b7bff;
+
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  outline: none;
+  background: var(--lws-grid-bg);
+  color: var(--lws-card-ink);
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+.lws-root:focus-visible { box-shadow: inset 0 0 0 2px var(--lws-accent); }
+
+@media (prefers-color-scheme: light) {
+  .lws-root {
+    --lws-grid-bg: #f5f7fb;
+    --lws-grid-minor: rgba(15, 23, 42, 0.06);
+    --lws-grid-major: rgba(15, 23, 42, 0.12);
+    --lws-grid-border: rgba(15, 23, 42, 0.20);
+    --lws-card-bg: #ffffff;
+    --lws-card-border: rgba(15, 23, 42, 0.14);
+    --lws-card-ink: #18202b;
+    --lws-accent: #6c5ce7;
+  }
+}
+
+.lws-grid { position: absolute; inset: 0; display: block; }
+.lws-overlay { position: absolute; inset: 0; pointer-events: none; }
+
+/* element hosts receive pointer events; the empty overlay does not,
+   so panning the substrate still works between elements. */
+.lws-el { pointer-events: auto; }
+
+/* ── equation card ── */
+.lws-eq-card {
+  min-width: 120px;
+  background: var(--lws-card-bg);
+  border: 1px solid var(--lws-card-border);
+  border-radius: 10px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
+  overflow: hidden;
+  user-select: none;
+}
+.lws-el.is-provisional .lws-eq-card {
+  border-color: var(--lws-accent);
+  border-style: dashed;
+}
+.lws-eq-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 8px;
+  cursor: grab;
+  background: rgba(139, 123, 255, 0.10);
+  border-bottom: 1px solid var(--lws-card-border);
+  font-size: 12px;
+}
+.lws-eq-header:active { cursor: grabbing; }
+.lws-eq-grip { opacity: 0.6; }
+.lws-eq-title { flex: 1; color: var(--lws-card-ink); opacity: 0.75; }
+.lws-eq-edit {
+  border: 0; background: transparent; color: var(--lws-accent);
+  cursor: pointer; font-size: 13px; padding: 2px 6px; border-radius: 6px;
+}
+.lws-eq-edit:hover { background: rgba(139, 123, 255, 0.18); }
+.lws-eq-body {
+  padding: 12px 14px;
+  cursor: text;
+  min-height: 24px;
+  color: var(--lws-card-ink);
+}
+.lws-eq-body .katex { font-size: 1.15em; }
+.lws-eq-input {
+  font-size: 15px; padding: 4px 6px; width: 180px;
+  border: 1px solid var(--lws-accent); border-radius: 6px;
+  background: var(--lws-card-bg); color: var(--lws-card-ink);
+}
+.lws-eq-body math-field { font-size: 18px; }
+
+/* screen-reader-only live region */
+.lws-sr-only {
+  position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+}

--- a/public/js/living-workspace/core/a11yCommands.js
+++ b/public/js/living-workspace/core/a11yCommands.js
@@ -1,0 +1,106 @@
+/* ============================================================
+   a11yCommands.js — the non-drag path, designed IN (spec §B5/§3.11).
+
+   Pure/no-DOM. Two responsibilities:
+     1. Canonical KEYBOARD COMMAND vocabulary — the same command
+        objects a keypress, a screen-reader user, the tutor driving
+        the board, and the test harness all produce. The Shell binds
+        keys to these; nothing about correctness is gated behind a
+        gesture a student can't perform.
+     2. Text DESCRIPTIONS of elements + view state for aria-live, so
+        a screen reader can narrate the workspace.
+
+   Element-specific command-equivalents (e.g. "Select 2x → Combine
+   with → 3x") are contributed by each element engine later (P6); this
+   module owns the workspace-level navigation/viewport commands that
+   exist from day one.
+
+   UMD-lite (jest + browser global LWS.a11y).
+   ============================================================ */
+(function (root, factory) {
+  const mod = factory();
+  if (typeof module !== 'undefined' && module.exports) module.exports = mod;
+  else { (root.LWS = root.LWS || {}).a11y = mod; }
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  const PAN_STEP = 80; // screen px per arrow press
+  const ZOOM_STEP = 1.2;
+
+  // Canonical workspace commands. `id` is stable (used by tutor/harness);
+  // `keys` are the default bindings; `describe` is the human/AT label.
+  const COMMANDS = [
+    { id: 'pan-left',   keys: ['ArrowLeft'],  describe: 'Pan left' },
+    { id: 'pan-right',  keys: ['ArrowRight'], describe: 'Pan right' },
+    { id: 'pan-up',     keys: ['ArrowUp'],    describe: 'Pan up' },
+    { id: 'pan-down',   keys: ['ArrowDown'],  describe: 'Pan down' },
+    { id: 'zoom-in',    keys: ['+', '='],     describe: 'Zoom in' },
+    { id: 'zoom-out',   keys: ['-', '_'],     describe: 'Zoom out' },
+    { id: 'zoom-reset', keys: ['0'],          describe: 'Reset view' },
+    { id: 'focus-next', keys: ['Tab'],        describe: 'Focus next element' },
+  ];
+
+  const _byKey = (() => {
+    const m = new Map();
+    for (const c of COMMANDS) for (const k of c.keys) m.set(k, c.id);
+    return m;
+  })();
+
+  // Map a raw key to a canonical command id (or null).
+  function commandForKey(key) {
+    return _byKey.get(key) || null;
+  }
+
+  // Apply a workspace-level command to a viewport. Returns true if it
+  // changed the view (so the caller can request a repaint + announce).
+  // Element-level commands (return false here) are handled by the caller.
+  function applyViewportCommand(id, viewport) {
+    if (!viewport) return false;
+    switch (id) {
+      case 'pan-left':  viewport.panByScreen(PAN_STEP, 0); return true;
+      case 'pan-right': viewport.panByScreen(-PAN_STEP, 0); return true;
+      case 'pan-up':    viewport.panByScreen(0, PAN_STEP); return true;
+      case 'pan-down':  viewport.panByScreen(0, -PAN_STEP); return true;
+      case 'zoom-in':   viewport.zoomAt(viewport.viewW / 2, viewport.viewH / 2, ZOOM_STEP); return true;
+      case 'zoom-out':  viewport.zoomAt(viewport.viewW / 2, viewport.viewH / 2, 1 / ZOOM_STEP); return true;
+      case 'zoom-reset': viewport.reset(); return true;
+      default: return false;
+    }
+  }
+
+  // ── descriptions (aria-live text) ──
+  function describeElement(el) {
+    if (!el || typeof el !== 'object') return '';
+    const kind = String(el.type || 'element').replace(/[-_]/g, ' ');
+    const s = el.semantic || {};
+    let content = '';
+    if (typeof s.plain === 'string' && s.plain) content = s.plain;
+    else if (typeof s.latex === 'string' && s.latex) content = s.latex;
+    const state = el.provisional ? ', provisional' : '';
+    return content ? `${kind}: ${content}${state}` : `${kind}${state}`;
+  }
+
+  function describeViewport(viewport) {
+    if (!viewport) return '';
+    const pct = Math.round((viewport.scale || 1) * 100);
+    return `Zoom ${pct} percent`;
+  }
+
+  function describeWorkspace(registry, viewport) {
+    const n = registry ? registry.size : 0;
+    const noun = n === 1 ? 'element' : 'elements';
+    const view = describeViewport(viewport);
+    return `Workspace with ${n} ${noun}. ${view}`.trim();
+  }
+
+  return {
+    PAN_STEP,
+    ZOOM_STEP,
+    COMMANDS,
+    commandForKey,
+    applyViewportCommand,
+    describeElement,
+    describeViewport,
+    describeWorkspace,
+  };
+});

--- a/public/js/living-workspace/core/elementRegistry.js
+++ b/public/js/living-workspace/core/elementRegistry.js
@@ -1,0 +1,109 @@
+/* ============================================================
+   elementRegistry.js — the source of truth for what's on the canvas.
+
+   Pure/no-DOM. Holds WorkspaceElement records (spec §3.2 base
+   envelope: id, type, position, size?, z, semantic, provisional).
+   The Shell renders FROM the registry; the SnapshotManager serializes
+   IT. Nothing renders an element the registry doesn't know about.
+
+   It is deliberately dumb about geometry and rendering — it stores
+   records and emits change events. Element-specific semantics live in
+   each element's own engine (e.g. the P2 algebra-tile engine).
+
+   UMD-lite (jest + browser global LWS.ElementRegistry).
+   ============================================================ */
+(function (root, factory) {
+  const mod = factory();
+  if (typeof module !== 'undefined' && module.exports) module.exports = mod;
+  else { (root.LWS = root.LWS || {}).ElementRegistry = mod; }
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  function isObj(o) { return o && typeof o === 'object'; }
+
+  class ElementRegistry {
+    constructor() {
+      this._elements = new Map();   // id → element record
+      this._listeners = new Set();  // change subscribers
+      this._z = 0;                  // monotonically increasing z-order
+    }
+
+    // ── subscription ──
+    subscribe(fn) {
+      if (typeof fn !== 'function') return function () {};
+      this._listeners.add(fn);
+      return () => this._listeners.delete(fn);
+    }
+    _emit(type, element) {
+      for (const fn of this._listeners) {
+        try { fn({ type, element, registry: this }); } catch (_) { /* isolate a bad listener */ }
+      }
+    }
+
+    // ── mutations ──
+    add(el) {
+      if (!isObj(el) || typeof el.id !== 'string' || !el.id) {
+        throw new Error('ElementRegistry.add: element needs a string id');
+      }
+      if (this._elements.has(el.id)) {
+        throw new Error(`ElementRegistry.add: duplicate id "${el.id}"`);
+      }
+      const record = Object.assign({
+        z: ++this._z,
+        position: { x: 0, y: 0 },
+        provisional: false,
+      }, el);
+      this._elements.set(el.id, record);
+      this._emit('add', record);
+      return record;
+    }
+
+    update(id, patch) {
+      const el = this._elements.get(id);
+      if (!el) return null;
+      // shallow-merge, but merge position/size objects so callers can patch x only
+      const next = Object.assign({}, el, patch);
+      if (patch && patch.position) next.position = Object.assign({}, el.position, patch.position);
+      if (patch && patch.size) next.size = Object.assign({}, el.size, patch.size);
+      this._elements.set(id, next);
+      this._emit('update', next);
+      return next;
+    }
+
+    move(id, x, y) { return this.update(id, { position: { x, y } }); }
+
+    setProvisional(id, provisional) { return this.update(id, { provisional: !!provisional }); }
+
+    bringToFront(id) {
+      const el = this._elements.get(id);
+      if (!el) return null;
+      return this.update(id, { z: ++this._z });
+    }
+
+    remove(id) {
+      const el = this._elements.get(id);
+      if (!el) return false;
+      this._elements.delete(id);
+      this._emit('remove', el);
+      return true;
+    }
+
+    clear() {
+      const had = this._elements.size > 0;
+      this._elements.clear();
+      if (had) this._emit('clear', null);
+      return this;
+    }
+
+    // ── reads ──
+    get(id) { return this._elements.get(id) || null; }
+    has(id) { return this._elements.has(id); }
+    get size() { return this._elements.size; }
+    // z-ordered list (stable): ascending z, so later items paint on top
+    list() {
+      return [...this._elements.values()].sort((a, b) => (a.z || 0) - (b.z || 0));
+    }
+  }
+
+  return ElementRegistry;
+});

--- a/public/js/living-workspace/core/flags.js
+++ b/public/js/living-workspace/core/flags.js
@@ -1,0 +1,55 @@
+/* ============================================================
+   flags.js — LIVING_WORKSPACE feature gate.
+
+   Modes (spec §P3): off | dev | beta | live. "off" is the default —
+   the new surface never shows until explicitly enabled, and the old
+   board/chat is untouched. There is no "shadow" mode for a UI.
+
+     off  → not mounted at all
+     dev  → mounted for developers / this harness; extra debug affordances
+     beta → mounted for opted-in users
+     live → mounted for everyone
+
+   Resolution order (first defined wins):
+     1. window.MM_FEATURES.livingWorkspace   (server/HTML-injected flag)
+     2. ?livingWorkspace=<mode> query param   (dev override)
+     3. 'off'                                  (safe default)
+
+   Pure/isomorphic: pass an explicit env object in Node/tests; reads
+   window/location in the browser.
+   ============================================================ */
+(function (root, factory) {
+  const mod = factory();
+  if (typeof module !== 'undefined' && module.exports) module.exports = mod;
+  else { (root.LWS = root.LWS || {}).flags = mod; }
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  const MODES = ['off', 'dev', 'beta', 'live'];
+
+  function normalize(mode) {
+    return MODES.indexOf(mode) >= 0 ? mode : 'off';
+  }
+
+  // env = { features?:object, search?:string } — injectable for tests.
+  function resolveMode(env) {
+    env = env || {};
+    const features = env.features
+      || (typeof window !== 'undefined' ? window.MM_FEATURES : null)
+      || {};
+    if (typeof features.livingWorkspace === 'string') {
+      return normalize(features.livingWorkspace);
+    }
+    const search = env.search != null
+      ? env.search
+      : (typeof location !== 'undefined' ? location.search : '');
+    const m = /[?&]livingWorkspace=([a-z]+)/i.exec(search || '');
+    if (m) return normalize(m[1].toLowerCase());
+    return 'off';
+  }
+
+  function isEnabled(env) { return resolveMode(env) !== 'off'; }
+  function isDev(env) { return resolveMode(env) === 'dev'; }
+
+  return { MODES, normalize, resolveMode, isEnabled, isDev };
+});

--- a/public/js/living-workspace/core/snapshotManager.js
+++ b/public/js/living-workspace/core/snapshotManager.js
@@ -1,0 +1,103 @@
+/* ============================================================
+   snapshotManager.js — semantic (never pixel) serialization.
+
+   Pure/no-DOM. Turns the ElementRegistry + Viewport into a
+   WorkspaceSnapshot and restores from one (spec §3.8). Persist
+   elements/positions/progress + view state — NEVER canvas JSON /
+   pixel geometry (stale on render changes). This is what makes
+   resume "for free": the registry already holds serializable
+   records, so a snapshot is just a collect + a restore is an apply.
+
+   Corrupt-snapshot safety (§3.8 DoD): restore RECOVERS — bad element
+   records are skipped, a garbage payload yields an empty workspace,
+   and it never throws into the caller.
+
+   UMD-lite (jest + browser global LWS.SnapshotManager).
+   ============================================================ */
+(function (root, factory) {
+  const mod = factory();
+  if (typeof module !== 'undefined' && module.exports) module.exports = mod;
+  else { (root.LWS = root.LWS || {}).SnapshotManager = mod; }
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  const SNAPSHOT_VERSION = 1;
+
+  function isObj(o) { return o && typeof o === 'object'; }
+  function isValidElement(el) {
+    return isObj(el)
+      && typeof el.id === 'string' && el.id.length > 0
+      && typeof el.type === 'string' && el.type.length > 0
+      && isObj(el.position)
+      && Number.isFinite(el.position.x) && Number.isFinite(el.position.y)
+      && isObj(el.semantic);
+  }
+
+  const SnapshotManager = {
+    SNAPSHOT_VERSION,
+
+    // Collect a serializable snapshot from live state.
+    capture(registry, viewport, meta) {
+      return {
+        schemaVersion: SNAPSHOT_VERSION,
+        view: viewport && typeof viewport.toJSON === 'function' ? viewport.toJSON() : null,
+        elements: registry.list().map((el) => ({
+          id: el.id,
+          type: el.type,
+          position: { x: el.position.x, y: el.position.y },
+          size: el.size ? { width: el.size.width, height: el.size.height } : undefined,
+          z: el.z,
+          provisional: !!el.provisional,
+          semantic: el.semantic,
+        })),
+        meta: meta || null,
+      };
+    },
+
+    // Restore into a (cleared) registry + viewport. Recovers from corruption.
+    // Returns { restored, skipped } counts so the caller can surface a
+    // "some of your work couldn't be restored" notice if it wants.
+    restore(snapshot, registry, viewport) {
+      const result = { restored: 0, skipped: 0, recovered: false };
+      registry.clear();
+
+      if (!isObj(snapshot)) { result.recovered = snapshot != null; return result; }
+
+      if (viewport && isObj(snapshot.view)) {
+        try { viewport.applyJSON(snapshot.view); } catch (_) { result.recovered = true; }
+      }
+
+      const els = Array.isArray(snapshot.elements) ? snapshot.elements : [];
+      if (!Array.isArray(snapshot.elements) && snapshot.elements != null) result.recovered = true;
+
+      // Preserve authored z-order; fall back to array order.
+      const ordered = els.slice().sort((a, b) => ((a && a.z) || 0) - ((b && b.z) || 0));
+      const seen = new Set();
+      for (const el of ordered) {
+        if (!isValidElement(el) || seen.has(el.id)) { result.skipped++; result.recovered = true; continue; }
+        seen.add(el.id);
+        try {
+          registry.add({
+            id: el.id,
+            type: el.type,
+            position: { x: el.position.x, y: el.position.y },
+            size: el.size,
+            provisional: !!el.provisional,
+            semantic: el.semantic,
+          });
+          result.restored++;
+        } catch (_) { result.skipped++; result.recovered = true; }
+      }
+      return result;
+    },
+
+    // Guarded parse for a snapshot that arrived as a JSON string / untrusted blob.
+    safeParse(raw) {
+      if (isObj(raw)) return raw;
+      if (typeof raw !== 'string') return null;
+      try { return JSON.parse(raw); } catch (_) { return null; }
+    },
+  };
+
+  return SnapshotManager;
+});

--- a/public/js/living-workspace/core/viewport.js
+++ b/public/js/living-workspace/core/viewport.js
@@ -1,0 +1,128 @@
+/* ============================================================
+   viewport.js — the coordinate system for the Living Workspace.
+
+   Pure math, no DOM. Owns the world↔screen transform (pan + zoom)
+   for a bounded canvas (spec §3.1 "free-feeling but bounded"). The
+   grid renderer draws through it; the OverlayManager positions DOM
+   elements through it; a future Fabric hit-test layer (P6) can be
+   backed by the SAME transform — this is the seam that lets us defer
+   Fabric without repricing the overlay contract (B4a).
+
+   Screen space = CSS pixels within the workspace viewport (origin
+   top-left, y-down). World space = logical workspace units (origin
+   top-left of the world, y-down). A tile at world (100,100) always
+   maps to the same content regardless of pan/zoom.
+
+     screen = (world - pan) * scale
+     world  = screen / scale + pan
+
+   UMD-lite: usable as `require('.../viewport')` in jest and as
+   `window.LWS.Viewport` in the browser (no bundler needed).
+   ============================================================ */
+(function (root, factory) {
+  const mod = factory();
+  if (typeof module !== 'undefined' && module.exports) module.exports = mod;
+  else { (root.LWS = root.LWS || {}).Viewport = mod; }
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  const DEFAULTS = {
+    minScale: 0.25,
+    maxScale: 4,
+    // World bounds — the canvas is bounded, not infinite (spec §3.1).
+    world: { width: 2400, height: 1600 },
+  };
+
+  function clamp(v, lo, hi) { return v < lo ? lo : (v > hi ? hi : v); }
+
+  class Viewport {
+    constructor(opts = {}) {
+      this.minScale = opts.minScale != null ? opts.minScale : DEFAULTS.minScale;
+      this.maxScale = opts.maxScale != null ? opts.maxScale : DEFAULTS.maxScale;
+      this.world = Object.assign({}, DEFAULTS.world, opts.world);
+      // viewport (screen) size in CSS px — set via resize()
+      this.viewW = opts.viewW || 0;
+      this.viewH = opts.viewH || 0;
+      // pan = world coordinate shown at the viewport's top-left corner
+      this.panX = 0;
+      this.panY = 0;
+      this.scale = clamp(opts.scale || 1, this.minScale, this.maxScale);
+    }
+
+    resize(viewW, viewH) {
+      this.viewW = Math.max(0, viewW | 0);
+      this.viewH = Math.max(0, viewH | 0);
+      this._clampPan();
+      return this;
+    }
+
+    // ── transforms ──
+    worldToScreen(x, y) {
+      return { x: (x - this.panX) * this.scale, y: (y - this.panY) * this.scale };
+    }
+    screenToWorld(x, y) {
+      return { x: x / this.scale + this.panX, y: y / this.scale + this.panY };
+    }
+    // CSS transform string for a DOM overlay anchored at world (x,y):
+    //   translate(screenX, screenY) scale(s)
+    cssTransform(x, y) {
+      const s = this.worldToScreen(x, y);
+      return `translate(${s.x}px, ${s.y}px) scale(${this.scale})`;
+    }
+
+    // ── pan ──
+    panByScreen(dxScreen, dyScreen) {
+      // Dragging content right (dx>0) reveals content to the LEFT → pan decreases.
+      this.panX -= dxScreen / this.scale;
+      this.panY -= dyScreen / this.scale;
+      this._clampPan();
+      return this;
+    }
+    setPan(x, y) { this.panX = x; this.panY = y; this._clampPan(); return this; }
+
+    // ── zoom ──
+    // Zoom toward a screen-space focus point (e.g. the cursor) so the world
+    // point under the cursor stays put — the "no drift on zoom" invariant.
+    zoomAt(screenX, screenY, factor) {
+      const before = this.screenToWorld(screenX, screenY);
+      this.scale = clamp(this.scale * factor, this.minScale, this.maxScale);
+      const after = this.screenToWorld(screenX, screenY);
+      // shift pan so the focus world-point maps back to the same screen point
+      this.panX += before.x - after.x;
+      this.panY += before.y - after.y;
+      this._clampPan();
+      return this;
+    }
+    setScale(scale, focusScreenX, focusScreenY) {
+      const fx = focusScreenX != null ? focusScreenX : this.viewW / 2;
+      const fy = focusScreenY != null ? focusScreenY : this.viewH / 2;
+      return this.zoomAt(fx, fy, clamp(scale, this.minScale, this.maxScale) / this.scale);
+    }
+
+    reset() { this.panX = 0; this.panY = 0; this.scale = 1; this._clampPan(); return this; }
+
+    // Keep the world in view: pan is clamped so you can't scroll the bounded
+    // world entirely off-screen. When the world is smaller than the viewport
+    // on an axis, it's pinned to 0 (no wobble).
+    _clampPan() {
+      const maxPanX = Math.max(0, this.world.width - this.viewW / this.scale);
+      const maxPanY = Math.max(0, this.world.height - this.viewH / this.scale);
+      this.panX = clamp(this.panX, 0, maxPanX);
+      this.panY = clamp(this.panY, 0, maxPanY);
+    }
+
+    // Serializable view state (for snapshots / resume).
+    toJSON() { return { panX: this.panX, panY: this.panY, scale: this.scale }; }
+    applyJSON(v) {
+      if (!v || typeof v !== 'object') return this;
+      if (Number.isFinite(v.scale)) this.scale = clamp(v.scale, this.minScale, this.maxScale);
+      if (Number.isFinite(v.panX)) this.panX = v.panX;
+      if (Number.isFinite(v.panY)) this.panY = v.panY;
+      this._clampPan();
+      return this;
+    }
+  }
+
+  Viewport.clamp = clamp;
+  return Viewport;
+});

--- a/public/js/living-workspace/dom/equationElement.js
+++ b/public/js/living-workspace/dom/equationElement.js
@@ -1,0 +1,144 @@
+/* ============================================================
+   equationElement.js — the equation element (spec §P4, "the spine").
+
+   A DOM card rendered in the OverlayManager layer:
+     • BODY typesets `semantic.latex` with KaTeX (crisp at any zoom —
+       it's DOM text scaled by CSS transform, never a raster).
+     • Editing swaps the body for a MathLive <math-field>; committing
+       writes latex back through onEditCommit → the registry → snapshot,
+       so a reload restores it.
+     • HEADER is the reposition handle (data-role) so dragging the card
+       moves it while dragging/typing in the body does NOT — the
+       "editing doesn't drag the canvas" rule. (The InteractionController
+       binds the actual drag; this element just zones the surfaces.)
+     • describe() returns screen-reader text; the card carries aria.
+
+   Degrades safely: no KaTeX → plain latex text; no MathLive → a plain
+   <input>. Never throws on a bad latex string (KaTeX throwOnError:false).
+
+   Browser-only. Global: window.LWS.EquationElement.
+   ============================================================ */
+(function (root) {
+  'use strict';
+  const LWS = (root.LWS = root.LWS || {});
+
+  function typeset(target, latex) {
+    const katex = root.katex;
+    if (katex && typeof katex.render === 'function') {
+      try { katex.render(latex || '', target, { throwOnError: false, displayMode: true }); return; }
+      catch (_) { /* fall through to text */ }
+    }
+    target.textContent = latex || '';
+  }
+
+  // makeRenderer({ onEditCommit }) → factory(element, api) → renderer.
+  // onEditCommit(id, latex) is called when an edit is committed.
+  function makeRenderer(hooks = {}) {
+    const onEditCommit = typeof hooks.onEditCommit === 'function' ? hooks.onEditCommit : function () {};
+
+    return function equationFactory(element, api) {
+      const doc = document;
+      const card = doc.createElement('div');
+      card.className = 'lws-eq-card';
+      card.setAttribute('role', 'group');
+
+      const header = doc.createElement('div');
+      header.className = 'lws-eq-header';
+      header.dataset.role = 'reposition-handle';        // InteractionController drag zone
+      const grip = doc.createElement('span'); grip.className = 'lws-eq-grip'; grip.textContent = '⠿'; grip.setAttribute('aria-hidden', 'true');
+      const title = doc.createElement('span'); title.className = 'lws-eq-title'; title.textContent = 'Equation';
+      const editBtn = doc.createElement('button');
+      editBtn.type = 'button'; editBtn.className = 'lws-eq-edit'; editBtn.textContent = '✎';
+      editBtn.setAttribute('aria-label', 'Edit equation');
+      header.appendChild(grip); header.appendChild(title); header.appendChild(editBtn);
+
+      const body = doc.createElement('div');
+      body.className = 'lws-eq-body';
+      body.dataset.role = 'content';                    // NOT a drag zone
+
+      card.appendChild(header);
+      card.appendChild(body);
+
+      let current = Object.assign({}, element);
+      let editing = false;
+      let field = null;
+
+      function renderStatic() {
+        typeset(body, current.semantic && current.semantic.latex);
+        card.setAttribute('aria-label', describe());
+      }
+
+      function beginEdit() {
+        if (editing) return;
+        editing = true;
+        body.textContent = '';
+        const latex = (current.semantic && current.semantic.latex) || '';
+        const hasMathLive = typeof root.customElements !== 'undefined'
+          && typeof root.customElements.get === 'function'
+          && !!root.customElements.get('math-field');
+        if (hasMathLive) {
+          field = doc.createElement('math-field');
+          field.setAttribute('math-virtual-keyboard-policy', 'manual');
+          field.value = latex;
+          body.appendChild(field);
+          field.focus && field.focus();
+          field.addEventListener('change', commitEdit);      // MathLive fires change on Enter/blur
+          field.addEventListener('blur', commitEdit);
+        } else {
+          field = doc.createElement('input');
+          field.type = 'text'; field.className = 'lws-eq-input'; field.value = latex;
+          body.appendChild(field);
+          field.focus();
+          field.addEventListener('keydown', (e) => { if (e.key === 'Enter') commitEdit(); });
+          field.addEventListener('blur', commitEdit);
+        }
+      }
+
+      function commitEdit() {
+        if (!editing || !field) return;
+        const val = (typeof field.value === 'string') ? field.value : '';
+        editing = false;
+        field = null;
+        // Write back only if changed; the registry update re-renders us.
+        const prev = (current.semantic && current.semantic.latex) || '';
+        current.semantic = Object.assign({}, current.semantic, { latex: val });
+        renderStatic();
+        if (val !== prev) onEditCommit(current.id, val);
+      }
+
+      editBtn.addEventListener('click', beginEdit);
+      // Double-clicking the math also edits (but not the header).
+      body.addEventListener('dblclick', beginEdit);
+
+      renderStatic();
+
+      return {
+        node: card,
+        update(el) {
+          current = Object.assign({}, el);
+          if (!editing) renderStatic();
+        },
+        destroy() {
+          if (field) {
+            field.removeEventListener('change', commitEdit);
+            field.removeEventListener('blur', commitEdit);
+          }
+          editBtn.removeEventListener('click', beginEdit);
+        },
+        describe() {
+          const latex = (current.semantic && current.semantic.latex) || '';
+          const plain = (current.semantic && current.semantic.plain) || latex;
+          return `Equation: ${plain}${current.provisional ? ', provisional' : ''}`;
+        },
+      };
+
+      function describe() {
+        const latex = (current.semantic && current.semantic.latex) || '';
+        const plain = (current.semantic && current.semantic.plain) || latex;
+        return `Equation: ${plain}`;
+      }
+    };
+  }
+
+  LWS.EquationElement = { makeRenderer };
+})(typeof self !== 'undefined' ? self : this);

--- a/public/js/living-workspace/dom/gridRenderer.js
+++ b/public/js/living-workspace/dom/gridRenderer.js
@@ -1,0 +1,108 @@
+/* ============================================================
+   gridRenderer.js — the graph-paper substrate (spec §P3).
+
+   Draws the bounded world's grid onto a plain 2D <canvas> through the
+   Viewport transform. Plain canvas (not Fabric) on purpose: the
+   substrate is a static backdrop with nothing to hit-test, so it
+   needs no object model. Fabric enters at P6 for hit-testable tiles,
+   plugged into the SAME Viewport — the grid stays exactly as is.
+
+   Renders on a devicePixelRatio-scaled backing store so lines stay
+   crisp at zoom / on hi-dpi Chromebooks. Only redraws when asked
+   (the Shell batches redraws into rAF), so panning is one fill + a
+   set of lineTo's — cheap.
+
+   Browser-only (needs canvas 2D). Global: window.LWS.GridRenderer.
+   ============================================================ */
+(function (root) {
+  'use strict';
+  const LWS = (root.LWS = root.LWS || {});
+
+  const MINOR = 40;   // world units between minor gridlines
+  const MAJOR = 5;    // every Nth line is a major (heavier) line
+
+  class GridRenderer {
+    constructor(canvas, viewport, opts = {}) {
+      this.canvas = canvas;
+      this.ctx = canvas.getContext('2d');
+      this.viewport = viewport;
+      this.minor = opts.minor || MINOR;
+      this.major = opts.major || MAJOR;
+      this.dpr = 1;
+    }
+
+    // Size the backing store to CSS size × dpr for crisp lines.
+    resize(cssW, cssH, dpr) {
+      this.dpr = dpr || (typeof window !== 'undefined' ? window.devicePixelRatio : 1) || 1;
+      this.canvas.width = Math.max(1, Math.round(cssW * this.dpr));
+      this.canvas.height = Math.max(1, Math.round(cssH * this.dpr));
+      this.canvas.style.width = cssW + 'px';
+      this.canvas.style.height = cssH + 'px';
+    }
+
+    _css(name, fallback) {
+      if (typeof window === 'undefined') return fallback;
+      const v = getComputedStyle(this.canvas).getPropertyValue(name);
+      return (v && v.trim()) || fallback;
+    }
+
+    draw() {
+      const ctx = this.ctx;
+      const vp = this.viewport;
+      const W = this.canvas.width;
+      const H = this.canvas.height;
+      const s = this.dpr;
+
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
+      ctx.clearRect(0, 0, W, H);
+
+      // substrate fill
+      ctx.fillStyle = this._css('--lws-grid-bg', '#0f1422');
+      ctx.fillRect(0, 0, W, H);
+
+      const minorColor = this._css('--lws-grid-minor', 'rgba(255,255,255,0.05)');
+      const majorColor = this._css('--lws-grid-major', 'rgba(255,255,255,0.11)');
+      const step = this.minor;
+
+      // world range currently visible
+      const topLeft = vp.screenToWorld(0, 0);
+      const botRight = vp.screenToWorld(vp.viewW, vp.viewH);
+      const x0 = Math.max(0, Math.floor(topLeft.x / step) * step);
+      const y0 = Math.max(0, Math.floor(topLeft.y / step) * step);
+      const x1 = Math.min(vp.world.width, botRight.x);
+      const y1 = Math.min(vp.world.height, botRight.y);
+
+      // vertical lines
+      for (let wx = x0; wx <= x1; wx += step) {
+        const isMajor = Math.round(wx / step) % this.major === 0;
+        const sx = Math.round(vp.worldToScreen(wx, 0).x * s) + 0.5;
+        ctx.beginPath();
+        ctx.moveTo(sx, Math.max(0, vp.worldToScreen(0, y0).y * s));
+        ctx.lineTo(sx, Math.min(H, vp.worldToScreen(0, y1).y * s));
+        ctx.lineWidth = isMajor ? 1.2 : 1;
+        ctx.strokeStyle = isMajor ? majorColor : minorColor;
+        ctx.stroke();
+      }
+      // horizontal lines
+      for (let wy = y0; wy <= y1; wy += step) {
+        const isMajor = Math.round(wy / step) % this.major === 0;
+        const sy = Math.round(vp.worldToScreen(0, wy).y * s) + 0.5;
+        ctx.beginPath();
+        ctx.moveTo(Math.max(0, vp.worldToScreen(x0, 0).x * s), sy);
+        ctx.lineTo(Math.min(W, vp.worldToScreen(x1, 0).x * s), sy);
+        ctx.lineWidth = isMajor ? 1.2 : 1;
+        ctx.strokeStyle = isMajor ? majorColor : minorColor;
+        ctx.stroke();
+      }
+
+      // world border (shows the bounded edge)
+      const tl = vp.worldToScreen(0, 0);
+      const br = vp.worldToScreen(vp.world.width, vp.world.height);
+      ctx.lineWidth = 1.5;
+      ctx.strokeStyle = this._css('--lws-grid-border', 'rgba(255,255,255,0.22)');
+      ctx.strokeRect(tl.x * s, tl.y * s, (br.x - tl.x) * s, (br.y - tl.y) * s);
+    }
+  }
+
+  LWS.GridRenderer = GridRenderer;
+})(typeof self !== 'undefined' ? self : this);

--- a/public/js/living-workspace/dom/interactionController.js
+++ b/public/js/living-workspace/dom/interactionController.js
@@ -1,0 +1,171 @@
+/* ============================================================
+   interactionController.js — one input surface for mouse/touch/pen/
+   keyboard (spec §3.3, §B5). Produces the same outcome from every
+   modality; every listener it binds is tracked and removed on
+   destroy() so the Shell unmounts with NO leaks (P3 DoD).
+
+   Behaviours:
+     • Pan  — drag on empty substrate (or one-finger touch).
+     • Reposition — drag starting on an element's [data-role=
+       "reposition-handle"]; dragging the element BODY does nothing
+       (so editing/selecting math never drags the canvas).
+     • Zoom — wheel, two-finger pinch, or keyboard (+/-/0), always
+       toward the focus point so nothing drifts.
+     • Keyboard — arrows pan, +/-/0 zoom, via the a11y command map.
+   `touch-action:none` on the surface (set by the Shell) stops the
+   browser stealing touch-drags for scroll.
+
+   Callbacks: onViewportChange(), onElementMove(id, worldX, worldY),
+   onElementMoveEnd(id). Browser-only. Global: LWS.InteractionController.
+   ============================================================ */
+(function (root) {
+  'use strict';
+  const LWS = (root.LWS = root.LWS || {});
+  const a11y = LWS.a11y; // loaded before this file
+
+  class InteractionController {
+    constructor(surface, viewport, opts = {}) {
+      this.surface = surface;       // the element receiving pointer/wheel/key events
+      this.viewport = viewport;
+      this.onViewportChange = opts.onViewportChange || function () {};
+      this.onElementMove = opts.onElementMove || function () {};
+      this.onElementMoveEnd = opts.onElementMoveEnd || function () {};
+      this.getElementPos = opts.getElementPos || function () { return null; }; // id → {x,y}
+
+      this._bound = [];             // { target, type, fn, opts } for teardown
+      this._pointers = new Map();   // active pointers: id → {x,y}
+      this._drag = null;            // { mode:'pan'|'element', ... }
+      this._pinch = null;           // { startDist, startScale, cx, cy }
+
+      this._bind();
+    }
+
+    _on(target, type, fn, opts) {
+      target.addEventListener(type, fn, opts);
+      this._bound.push({ target, type, fn, opts });
+    }
+
+    _bind() {
+      this._on(this.surface, 'pointerdown', this._onDown = this._onDown.bind(this));
+      this._on(this.surface, 'pointermove', this._onMove = this._onMove.bind(this));
+      this._on(this.surface, 'pointerup', this._onUp = this._onUp.bind(this));
+      this._on(this.surface, 'pointercancel', this._onUp);
+      this._on(this.surface, 'wheel', this._onWheel = this._onWheel.bind(this), { passive: false });
+      this._on(this.surface, 'keydown', this._onKey = this._onKey.bind(this));
+    }
+
+    _localXY(e) {
+      const r = this.surface.getBoundingClientRect();
+      return { x: e.clientX - r.left, y: e.clientY - r.top };
+    }
+
+    _repositionHandle(target) {
+      // Walk up to the element host if the pointer landed on a reposition handle.
+      let n = target;
+      while (n && n !== this.surface) {
+        if (n.dataset && n.dataset.role === 'reposition-handle') {
+          let host = n;
+          while (host && host !== this.surface && !(host.dataset && host.dataset.elementId)) host = host.parentNode;
+          return (host && host.dataset && host.dataset.elementId) ? host.dataset.elementId : null;
+        }
+        // pointer inside element content (not the handle) → not a reposition
+        if (n.dataset && n.dataset.role === 'content') return null;
+        n = n.parentNode;
+      }
+      return null;
+    }
+
+    _onDown(e) {
+      this.surface.focus && this.surface.focus();
+      this._pointers.set(e.pointerId, this._localXY(e));
+      try { this.surface.setPointerCapture(e.pointerId); } catch (_) { /* ok */ }
+
+      if (this._pointers.size === 2) { this._beginPinch(); return; }
+
+      const p = this._localXY(e);
+      const id = this._repositionHandle(e.target);
+      if (id) {
+        const pos = this.getElementPos(id) || { x: 0, y: 0 };
+        this._drag = { mode: 'element', id, startWorld: this.viewport.screenToWorld(p.x, p.y), startPos: pos };
+      } else {
+        this._drag = { mode: 'pan', last: p };
+      }
+    }
+
+    _onMove(e) {
+      if (this._pointers.has(e.pointerId)) this._pointers.set(e.pointerId, this._localXY(e));
+      if (this._pinch && this._pointers.size >= 2) { this._updatePinch(); return; }
+      if (!this._drag) return;
+      const p = this._localXY(e);
+      if (this._drag.mode === 'pan') {
+        this.viewport.panByScreen(p.x - this._drag.last.x, p.y - this._drag.last.y);
+        this._drag.last = p;
+        this.onViewportChange();
+      } else {
+        const w = this.viewport.screenToWorld(p.x, p.y);
+        const nx = this._drag.startPos.x + (w.x - this._drag.startWorld.x);
+        const ny = this._drag.startPos.y + (w.y - this._drag.startWorld.y);
+        this.onElementMove(this._drag.id, nx, ny);
+      }
+    }
+
+    _onUp(e) {
+      this._pointers.delete(e.pointerId);
+      try { this.surface.releasePointerCapture(e.pointerId); } catch (_) { /* ok */ }
+      if (this._pointers.size < 2) this._pinch = null;
+      if (this._drag && this._drag.mode === 'element') this.onElementMoveEnd(this._drag.id);
+      if (this._pointers.size === 0) this._drag = null;
+    }
+
+    _beginPinch() {
+      const pts = [...this._pointers.values()];
+      const dx = pts[0].x - pts[1].x, dy = pts[0].y - pts[1].y;
+      this._pinch = {
+        startDist: Math.hypot(dx, dy) || 1,
+        startScale: this.viewport.scale,
+        cx: (pts[0].x + pts[1].x) / 2,
+        cy: (pts[0].y + pts[1].y) / 2,
+      };
+      this._drag = null; // a second finger cancels pan/drag
+    }
+
+    _updatePinch() {
+      const pts = [...this._pointers.values()];
+      const dx = pts[0].x - pts[1].x, dy = pts[0].y - pts[1].y;
+      const dist = Math.hypot(dx, dy) || 1;
+      const target = this._pinch.startScale * (dist / this._pinch.startDist);
+      const cx = (pts[0].x + pts[1].x) / 2, cy = (pts[0].y + pts[1].y) / 2;
+      this.viewport.zoomAt(cx, cy, target / this.viewport.scale);
+      this.onViewportChange();
+    }
+
+    _onWheel(e) {
+      e.preventDefault();
+      const p = this._localXY(e);
+      const factor = e.deltaY < 0 ? 1.1 : 1 / 1.1;
+      this.viewport.zoomAt(p.x, p.y, factor);
+      this.onViewportChange();
+    }
+
+    _onKey(e) {
+      if (!a11y) return;
+      const id = a11y.commandForKey(e.key);
+      if (!id) return;
+      if (a11y.applyViewportCommand(id, this.viewport)) {
+        e.preventDefault();
+        this.onViewportChange();
+      }
+      // focus-next etc. are handled by the Shell's roving tabindex.
+    }
+
+    destroy() {
+      for (const b of this._bound) b.target.removeEventListener(b.type, b.fn, b.opts);
+      this._bound.length = 0;
+      this._pointers.clear();
+      this._drag = null;
+      this._pinch = null;
+    }
+  }
+
+  LWS.InteractionController = InteractionController;
+})(typeof self !== 'undefined' ? self : this);

--- a/public/js/living-workspace/dom/overlayManager.js
+++ b/public/js/living-workspace/dom/overlayManager.js
@@ -1,0 +1,141 @@
+/* ============================================================
+   overlayManager.js — DOM overlay synced to canvas coords (resolves
+   B4a: crisp math as DOM, positioned over the Fabric/canvas world).
+
+   Each WorkspaceElement gets a host <div> in an absolutely-positioned
+   overlay layer above the grid canvas. The host's CSS transform is
+   `translate(screenX,screenY) scale(viewScale)` with transform-origin
+   top-left, so it tracks the viewport on pan/zoom with NO reflow and
+   NO drift — the same transform math the grid uses, so DOM and canvas
+   never disagree.
+
+   Element rendering is pluggable: register a renderer factory per
+   element type. A renderer returns { node, update(el), destroy(),
+   describe() } — OverlayManager knows nothing about equations vs
+   tiles. This is the one mechanism P6 tiles will reuse.
+
+   syncTransforms() (viewport changed) only rewrites transforms — it
+   never re-renders content, so pan/zoom stays cheap.
+
+   Browser-only. Global: window.LWS.OverlayManager.
+   ============================================================ */
+(function (root) {
+  'use strict';
+  const LWS = (root.LWS = root.LWS || {});
+
+  class OverlayManager {
+    constructor(layerEl, viewport) {
+      this.layer = layerEl;         // the absolutely-positioned overlay div
+      this.viewport = viewport;
+      this._renderers = new Map();  // type → factory(element, api) → renderer
+      this._hosts = new Map();      // elementId → { host, renderer, element }
+    }
+
+    registerRenderer(type, factory) {
+      this._renderers.set(type, factory);
+      return this;
+    }
+
+    // ── registry event handler ──
+    // Wire this to ElementRegistry.subscribe.
+    onRegistryEvent(evt) {
+      if (!evt) return;
+      switch (evt.type) {
+        case 'add': this.addElement(evt.element); break;
+        case 'update': this.updateElement(evt.element); break;
+        case 'remove': this.removeElement(evt.element && evt.element.id); break;
+        case 'clear': this.clear(); break;
+        default: break;
+      }
+    }
+
+    addElement(element) {
+      if (!element || this._hosts.has(element.id)) {
+        if (element && this._hosts.has(element.id)) return this.updateElement(element);
+        return null;
+      }
+      const factory = this._renderers.get(element.type);
+      const host = (typeof document !== 'undefined') ? document.createElement('div') : null;
+      if (host) {
+        host.className = 'lws-el';
+        host.dataset.elementId = element.id;
+        host.style.position = 'absolute';
+        host.style.left = '0';
+        host.style.top = '0';
+        host.style.transformOrigin = 'top left';
+        host.style.willChange = 'transform';
+      }
+      let renderer = null;
+      if (factory && host) {
+        renderer = factory(element, { host, viewport: this.viewport });
+        if (renderer && renderer.node) host.appendChild(renderer.node);
+      } else if (host) {
+        // Unknown type — render a labelled placeholder so nothing silently vanishes.
+        host.textContent = `[${element.type}]`;
+      }
+      const entry = { host, renderer, element };
+      this._hosts.set(element.id, entry);
+      if (host && this.layer) this.layer.appendChild(host);
+      this._applyTransform(entry);
+      this._applyZ(entry);
+      return entry;
+    }
+
+    updateElement(element) {
+      const entry = this._hosts.get(element.id);
+      if (!entry) return this.addElement(element);
+      entry.element = element;
+      if (entry.renderer && typeof entry.renderer.update === 'function') {
+        entry.renderer.update(element);
+      }
+      if (entry.host) {
+        entry.host.classList.toggle('is-provisional', !!element.provisional);
+      }
+      this._applyTransform(entry);
+      this._applyZ(entry);
+      return entry;
+    }
+
+    removeElement(id) {
+      const entry = this._hosts.get(id);
+      if (!entry) return false;
+      if (entry.renderer && typeof entry.renderer.destroy === 'function') {
+        try { entry.renderer.destroy(); } catch (_) { /* isolate */ }
+      }
+      if (entry.host && entry.host.parentNode) entry.host.parentNode.removeChild(entry.host);
+      this._hosts.delete(id);
+      return true;
+    }
+
+    clear() {
+      for (const id of [...this._hosts.keys()]) this.removeElement(id);
+    }
+
+    // Only rewrites transforms — call on every viewport change (cheap).
+    syncTransforms() {
+      for (const entry of this._hosts.values()) this._applyTransform(entry);
+    }
+
+    // aria/screen-reader description of everything on the overlay.
+    describeAll() {
+      const out = [];
+      for (const entry of this._hosts.values()) {
+        if (entry.renderer && typeof entry.renderer.describe === 'function') {
+          out.push(entry.renderer.describe());
+        }
+      }
+      return out;
+    }
+
+    _applyTransform(entry) {
+      if (!entry.host) return;
+      const p = entry.element.position || { x: 0, y: 0 };
+      entry.host.style.transform = this.viewport.cssTransform(p.x, p.y);
+    }
+    _applyZ(entry) {
+      if (entry.host && entry.element.z != null) entry.host.style.zIndex = String(entry.element.z);
+    }
+  }
+
+  LWS.OverlayManager = OverlayManager;
+})(typeof self !== 'undefined' ? self : this);

--- a/public/js/living-workspace/dom/shell.js
+++ b/public/js/living-workspace/dom/shell.js
@@ -1,0 +1,164 @@
+/* ============================================================
+   shell.js — the Living Workspace orchestration shell (spec §P3).
+
+   "One surface ≠ one class." The Shell owns no math and no rendering
+   detail; it composes the independent systems and manages lifecycle:
+     Viewport · GridRenderer · OverlayManager · ElementRegistry ·
+     InteractionController · SnapshotManager · a11y · (LayoutController
+     = the ResizeObserver here).
+
+   Lifecycle contract (P3 DoD):
+     mount(container) → builds DOM, wires everything, first paint.
+     unmount()        → tears down EVERY listener/observer/rAF so it
+                        leaves no leaks and doesn't touch chat/board.
+   Redraws are coalesced into one rAF (pan/zoom stay at frame rate).
+
+   Gated by the LIVING_WORKSPACE flag — mount() is a no-op when off.
+
+   Browser-only. Global: window.LWS.Shell.
+   ============================================================ */
+(function (root) {
+  'use strict';
+  const LWS = (root.LWS = root.LWS || {});
+  const { Viewport, ElementRegistry, SnapshotManager, GridRenderer, OverlayManager, InteractionController, a11y, flags } = LWS;
+
+  class Shell {
+    constructor(opts = {}) {
+      this.opts = opts;
+      this.mode = flags ? flags.resolveMode(opts.env) : 'off';
+      this.mounted = false;
+      this._rafId = 0;
+      this._needsPaint = false;
+      this._ro = null;   // ResizeObserver (LayoutController)
+      this._nodes = {};
+      this.registry = new ElementRegistry();
+      this.viewport = new Viewport({ world: opts.world });
+    }
+
+    mount(container) {
+      if (this.mounted) return this;
+      if (this.mode === 'off') return this; // flag gate: never mount when off
+      const doc = document;
+
+      const rootEl = doc.createElement('div');
+      rootEl.className = 'lws-root';
+      rootEl.setAttribute('data-mode', this.mode);
+
+      // grid canvas (bottom) + overlay layer (top) + a11y live region
+      const canvas = doc.createElement('canvas');
+      canvas.className = 'lws-grid';
+      const overlay = doc.createElement('div');
+      overlay.className = 'lws-overlay';
+      const live = doc.createElement('div');
+      live.className = 'lws-sr-only';
+      live.setAttribute('aria-live', 'polite');
+      live.setAttribute('role', 'status');
+
+      // focusable surface for keyboard input + touch-action gate
+      rootEl.tabIndex = 0;
+      rootEl.setAttribute('role', 'application');
+      rootEl.setAttribute('aria-label', 'Math workspace');
+      rootEl.style.touchAction = 'none';
+
+      rootEl.appendChild(canvas);
+      rootEl.appendChild(overlay);
+      rootEl.appendChild(live);
+      container.appendChild(rootEl);
+      this._nodes = { container, rootEl, canvas, overlay, live };
+
+      // compose systems
+      this.grid = new GridRenderer(canvas, this.viewport, this.opts.grid);
+      this.overlayMgr = new OverlayManager(overlay, this.viewport);
+      if (typeof this.opts.registerRenderers === 'function') this.opts.registerRenderers(this.overlayMgr, this);
+
+      this._unsub = this.registry.subscribe((evt) => {
+        this.overlayMgr.onRegistryEvent(evt);
+        this.requestPaint();
+        this._announce(a11y ? a11y.describeWorkspace(this.registry, this.viewport) : '');
+      });
+
+      this.interaction = new InteractionController(rootEl, this.viewport, {
+        onViewportChange: () => this.requestPaint(),
+        onElementMove: (id, x, y) => this.registry.move(id, x, y),
+        onElementMoveEnd: () => this._emitChange(),
+        getElementPos: (id) => { const el = this.registry.get(id); return el ? el.position : null; },
+      });
+
+      // LayoutController: keep canvas + viewport sized to the container.
+      this._resize();
+      if (typeof ResizeObserver !== 'undefined') {
+        this._ro = new ResizeObserver(() => this._resize());
+        this._ro.observe(rootEl);
+      } else {
+        this._onWinResize = () => this._resize();
+        root.addEventListener('resize', this._onWinResize);
+      }
+
+      this.mounted = true;
+      this.requestPaint();
+      return this;
+    }
+
+    _resize() {
+      const r = this._nodes.rootEl.getBoundingClientRect();
+      const w = Math.max(1, r.width), h = Math.max(1, r.height);
+      this.viewport.resize(w, h);
+      this.grid.resize(w, h, root.devicePixelRatio);
+      this.overlayMgr.syncTransforms();
+      this.requestPaint();
+    }
+
+    // Coalesce paints into one rAF — pan/zoom never draw more than once/frame.
+    requestPaint() {
+      if (!this.mounted) return;
+      this._needsPaint = true;
+      if (this._rafId) return;
+      const raf = root.requestAnimationFrame || ((fn) => root.setTimeout(fn, 16));
+      this._rafId = raf(() => {
+        this._rafId = 0;
+        if (!this._needsPaint || !this.mounted) return;
+        this._needsPaint = false;
+        this.grid.draw();
+        this.overlayMgr.syncTransforms();
+      });
+    }
+
+    _announce(text) {
+      if (this._nodes.live && text) this._nodes.live.textContent = text;
+    }
+    _emitChange() {
+      if (typeof this.opts.onChange === 'function') this.opts.onChange(this.snapshot());
+    }
+
+    // ── element API (thin pass-throughs so callers don't reach into the registry) ──
+    addElement(el) { return this.registry.add(el); }
+    updateElement(id, patch) { return this.registry.update(id, patch); }
+    removeElement(id) { return this.registry.remove(id); }
+
+    // ── snapshot / resume ──
+    snapshot(meta) { return SnapshotManager.capture(this.registry, this.viewport, meta); }
+    restore(snapshot) {
+      const res = SnapshotManager.restore(SnapshotManager.safeParse(snapshot) || snapshot, this.registry, this.viewport);
+      this.requestPaint();
+      return res;
+    }
+
+    unmount() {
+      if (!this.mounted) return this;
+      if (this._rafId) { (root.cancelAnimationFrame || root.clearTimeout)(this._rafId); this._rafId = 0; }
+      if (this.interaction) this.interaction.destroy();
+      if (this._unsub) this._unsub();
+      if (this.overlayMgr) this.overlayMgr.clear();
+      if (this._ro) { this._ro.disconnect(); this._ro = null; }
+      if (this._onWinResize) { root.removeEventListener('resize', this._onWinResize); this._onWinResize = null; }
+      if (this._nodes.rootEl && this._nodes.rootEl.parentNode) {
+        this._nodes.rootEl.parentNode.removeChild(this._nodes.rootEl);
+      }
+      this._nodes = {};
+      this.mounted = false;
+      return this;
+    }
+  }
+
+  LWS.Shell = Shell;
+})(typeof self !== 'undefined' ? self : this);

--- a/public/js/living-workspace/workspace-dev.js
+++ b/public/js/living-workspace/workspace-dev.js
@@ -1,0 +1,108 @@
+/* Dev harness driver for the Living Workspace shell. Not shipped —
+   exercises mount/unmount, add/edit/reposition, snapshot save+restore,
+   and lets us eyeball pan/zoom drift in a plain static page. */
+(function () {
+  'use strict';
+  // Force the flag on for the harness (default is 'off').
+  window.MM_FEATURES = Object.assign({}, window.MM_FEATURES, { livingWorkspace: 'dev' });
+
+  var LWS = window.LWS;
+  var mountpoint = document.getElementById('mountpoint');
+  var statusEl = document.getElementById('status');
+  var shell = null;
+  var savedSnapshot = null;
+  var counter = 0;
+
+  function setStatus(t) { statusEl.textContent = t; }
+
+  // expose for browser-based verification/debugging
+  window.__lws = { get shell() { return shell; }, addEquation: function (l, x, y) { return addEquation(l, x, y); } };
+
+  function makeShell() {
+    return new LWS.Shell({
+      world: { width: 2400, height: 1600 },
+      registerRenderers: function (overlayMgr, sh) {
+        overlayMgr.registerRenderer('equation', LWS.EquationElement.makeRenderer({
+          onEditCommit: function (id, latex) {
+            sh.updateElement(id, { semantic: { latex: latex, plain: latex } });
+            setStatus('edited ' + id + ' → ' + latex);
+          },
+        }));
+      },
+      onChange: function () { setStatus('changed — ' + (shell.registry.size) + ' elements'); },
+    });
+  }
+
+  function addEquation(latex, x, y) {
+    counter += 1;
+    var id = 'eq-' + counter;
+    shell.addElement({
+      id: id, type: 'equation',
+      position: { x: x != null ? x : 200 + counter * 40, y: y != null ? y : 180 + counter * 30 },
+      semantic: { latex: latex || '2x + 3x = 5x', plain: latex || '2x + 3x = 5x' },
+    });
+    return id;
+  }
+
+  document.getElementById('btn-mount').addEventListener('click', function () {
+    if (shell && shell.mounted) return;
+    shell = makeShell();
+    shell.mount(mountpoint);
+    if (shell.registry.size === 0) addEquation('2x + 3x = 5x', 260, 220);
+    setStatus('mounted (mode=' + shell.mode + ')');
+  });
+
+  document.getElementById('btn-unmount').addEventListener('click', function () {
+    if (!shell || !shell.mounted) return;
+    var boundBefore = shell.interaction ? shell.interaction._bound.length : 0;
+    shell.unmount();
+    var boundAfter = shell.interaction ? shell.interaction._bound.length : 0;
+    setStatus('unmounted — listeners ' + boundBefore + '→' + boundAfter + ', children=' + mountpoint.childElementCount);
+  });
+
+  document.getElementById('btn-add').addEventListener('click', function () {
+    if (!shell || !shell.mounted) return;
+    addEquation(['x^2 - 4', '\\frac{a}{b}', 'y = mx + b', '3x + 5 = 20'][counter % 4]);
+  });
+
+  document.getElementById('btn-provisional').addEventListener('click', function () {
+    if (!shell || !shell.mounted) return;
+    var first = shell.registry.list()[0];
+    if (first) shell.updateElement(first.id, { provisional: !first.provisional });
+  });
+
+  document.getElementById('btn-reset').addEventListener('click', function () {
+    if (!shell || !shell.mounted) return;
+    shell.viewport.reset(); shell.requestPaint();
+    setStatus('view reset');
+  });
+
+  document.getElementById('btn-save').addEventListener('click', function () {
+    if (!shell || !shell.mounted) return;
+    savedSnapshot = JSON.stringify(shell.snapshot({ savedAt: 'dev' }));
+    setStatus('snapshot saved (' + savedSnapshot.length + ' bytes)');
+  });
+
+  document.getElementById('btn-restore').addEventListener('click', function () {
+    if (!shell || !shell.mounted || !savedSnapshot) { setStatus('no snapshot yet'); return; }
+    // Simulate a fresh reload: unmount, re-mount, restore.
+    shell.unmount();
+    shell = makeShell();
+    shell.mount(mountpoint);
+    var res = shell.restore(savedSnapshot);
+    setStatus('restored ' + res.restored + ' elements (skipped ' + res.skipped + ')');
+  });
+
+  document.getElementById('btn-listeners').addEventListener('click', function () {
+    var n = shell && shell.interaction ? shell.interaction._bound.length : 0;
+    setStatus('interaction listeners bound: ' + n + '; mounted=' + (shell && shell.mounted));
+  });
+
+  // Auto-mount on load for convenience.
+  window.addEventListener('DOMContentLoaded', function () {
+    shell = makeShell();
+    shell.mount(mountpoint);
+    addEquation('2x + 3x = 5x', 260, 220);
+    setStatus('auto-mounted (mode=' + shell.mode + ')');
+  });
+})();

--- a/public/workspace-dev.html
+++ b/public/workspace-dev.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
+  <title>Living Workspace — dev harness</title>
+
+  <!-- vendored math libs (same-origin, CSP-safe) -->
+  <link rel="stylesheet" href="/vendor/katex/katex.min.css" />
+  <link rel="stylesheet" href="/vendor/mathlive/mathlive-static.css" />
+  <link rel="stylesheet" href="/vendor/mathlive/mathlive-fonts.css" />
+  <link rel="stylesheet" href="/css/living-workspace.css" />
+  <script defer src="/vendor/katex/katex.min.js"></script>
+  <script defer src="/vendor/mathlive/mathlive.min.js"></script>
+
+  <!-- living-workspace: core (pure) then dom (glue). Order matters:
+       flags/a11y before shell/interaction that read them. -->
+  <script defer src="/js/living-workspace/core/flags.js"></script>
+  <script defer src="/js/living-workspace/core/viewport.js"></script>
+  <script defer src="/js/living-workspace/core/elementRegistry.js"></script>
+  <script defer src="/js/living-workspace/core/snapshotManager.js"></script>
+  <script defer src="/js/living-workspace/core/a11yCommands.js"></script>
+  <script defer src="/js/living-workspace/dom/gridRenderer.js"></script>
+  <script defer src="/js/living-workspace/dom/overlayManager.js"></script>
+  <script defer src="/js/living-workspace/dom/equationElement.js"></script>
+  <script defer src="/js/living-workspace/dom/interactionController.js"></script>
+  <script defer src="/js/living-workspace/dom/shell.js"></script>
+
+  <style>
+    html, body { margin: 0; height: 100%; background: #0b0f1a; color: #e6e9f2;
+      font-family: system-ui, sans-serif; }
+    #toolbar { position: fixed; z-index: 10; top: 8px; left: 8px; display: flex; gap: 6px;
+      flex-wrap: wrap; background: rgba(0,0,0,0.35); padding: 6px 8px; border-radius: 8px; }
+    #toolbar button { font-size: 12px; padding: 5px 9px; border-radius: 6px; border: 1px solid #3a3f55;
+      background: #1b2238; color: #e6e9f2; cursor: pointer; }
+    #toolbar button:hover { background: #26304d; }
+    #mountpoint { position: absolute; inset: 0; }
+    #status { position: fixed; bottom: 8px; left: 8px; z-index: 10; font-size: 11px;
+      color: #9aa3b8; background: rgba(0,0,0,0.35); padding: 4px 8px; border-radius: 6px; }
+  </style>
+</head>
+<body>
+  <div id="toolbar">
+    <button id="btn-mount">Mount</button>
+    <button id="btn-unmount">Unmount</button>
+    <button id="btn-add">Add equation</button>
+    <button id="btn-provisional">Toggle provisional</button>
+    <button id="btn-reset">Reset view</button>
+    <button id="btn-save">Save snapshot</button>
+    <button id="btn-restore">Reload from snapshot</button>
+    <button id="btn-listeners">Log listener count</button>
+  </div>
+  <div id="mountpoint"></div>
+  <div id="status">not mounted</div>
+
+  <script defer src="/js/living-workspace/workspace-dev.js"></script>
+</body>
+</html>

--- a/tests/unit/workspace/livingWorkspaceCore.test.js
+++ b/tests/unit/workspace/livingWorkspaceCore.test.js
@@ -1,0 +1,205 @@
+// tests/unit/workspace/livingWorkspaceCore.test.js
+// Pure-logic core of the Living Workspace shell (P3): Viewport transform,
+// ElementRegistry, SnapshotManager round-trip + corruption recovery, the
+// LIVING_WORKSPACE flag resolver, and the a11y command/description layer.
+// DOM glue (grid render, overlay sync, equation element) is verified in the
+// browser harness — this file is the headless, deterministic half.
+
+const Viewport = require('../../../public/js/living-workspace/core/viewport');
+const ElementRegistry = require('../../../public/js/living-workspace/core/elementRegistry');
+const SnapshotManager = require('../../../public/js/living-workspace/core/snapshotManager');
+const flags = require('../../../public/js/living-workspace/core/flags');
+const a11y = require('../../../public/js/living-workspace/core/a11yCommands');
+
+describe('Viewport transform', () => {
+  test('world↔screen round-trips exactly', () => {
+    const vp = new Viewport({ viewW: 800, viewH: 600, scale: 1.5 }).setPan(100, 50);
+    const s = vp.worldToScreen(300, 200);
+    const w = vp.screenToWorld(s.x, s.y);
+    expect(w.x).toBeCloseTo(300, 9);
+    expect(w.y).toBeCloseTo(200, 9);
+  });
+
+  test('identity at scale 1, zero pan', () => {
+    const vp = new Viewport({ viewW: 800, viewH: 600 });
+    expect(vp.worldToScreen(120, 80)).toEqual({ x: 120, y: 80 });
+  });
+
+  test('zoomAt keeps the world point under the cursor fixed (no drift)', () => {
+    const vp = new Viewport({ viewW: 800, viewH: 600, world: { width: 5000, height: 5000 } }).setPan(200, 200);
+    const focus = { x: 500, y: 300 };
+    const worldBefore = vp.screenToWorld(focus.x, focus.y);
+    vp.zoomAt(focus.x, focus.y, 1.7);
+    const worldAfter = vp.screenToWorld(focus.x, focus.y);
+    expect(worldAfter.x).toBeCloseTo(worldBefore.x, 6);
+    expect(worldAfter.y).toBeCloseTo(worldBefore.y, 6);
+  });
+
+  test('scale clamps to [min,max]', () => {
+    const vp = new Viewport({ viewW: 800, viewH: 600, minScale: 0.5, maxScale: 2 });
+    vp.setScale(99); expect(vp.scale).toBe(2);
+    vp.setScale(0.01); expect(vp.scale).toBe(0.5);
+  });
+
+  test('pan is clamped so the bounded world cannot scroll fully off-screen', () => {
+    const vp = new Viewport({ viewW: 800, viewH: 600, world: { width: 2400, height: 1600 } });
+    vp.setPan(-500, -500);
+    expect(vp.panX).toBe(0);
+    expect(vp.panY).toBe(0);
+    vp.setPan(99999, 99999);
+    expect(vp.panX).toBeCloseTo(2400 - 800, 6);
+    expect(vp.panY).toBeCloseTo(1600 - 600, 6);
+  });
+
+  test('view state serializes and restores', () => {
+    const vp = new Viewport({ viewW: 800, viewH: 600 }).setPan(120, 90).setScale(1.25);
+    const json = vp.toJSON();
+    const vp2 = new Viewport({ viewW: 800, viewH: 600 }).applyJSON(json);
+    expect(vp2.toJSON()).toEqual(json);
+  });
+});
+
+describe('ElementRegistry', () => {
+  const eq = (id, x, y) => ({ id, type: 'equation', position: { x, y }, semantic: { latex: 'x+1' } });
+
+  test('add/get/list with ascending z-order', () => {
+    const r = new ElementRegistry();
+    r.add(eq('a', 0, 0)); r.add(eq('b', 10, 10));
+    expect(r.size).toBe(2);
+    expect(r.list().map((e) => e.id)).toEqual(['a', 'b']);
+    r.bringToFront('a');
+    expect(r.list().map((e) => e.id)).toEqual(['b', 'a']);
+  });
+
+  test('duplicate id and id-less add throw', () => {
+    const r = new ElementRegistry();
+    r.add(eq('a', 0, 0));
+    expect(() => r.add(eq('a', 1, 1))).toThrow(/duplicate/);
+    expect(() => r.add({ type: 'equation' })).toThrow(/string id/);
+  });
+
+  test('move patches only position; update merges', () => {
+    const r = new ElementRegistry();
+    r.add(eq('a', 0, 0));
+    r.move('a', 5, 7);
+    expect(r.get('a').position).toEqual({ x: 5, y: 7 });
+    r.update('a', { position: { x: 9 } });
+    expect(r.get('a').position).toEqual({ x: 9, y: 7 }); // y preserved
+  });
+
+  test('subscribers see add/update/remove/clear and unsubscribe works', () => {
+    const r = new ElementRegistry();
+    const events = [];
+    const off = r.subscribe((e) => events.push(e.type));
+    r.add(eq('a', 0, 0)); r.move('a', 1, 1); r.remove('a'); r.clear();
+    off();
+    r.add(eq('b', 0, 0));
+    expect(events).toEqual(['add', 'update', 'remove']); // clear on empty emits nothing; post-unsub add not seen
+  });
+
+  test('a throwing listener does not break the registry', () => {
+    const r = new ElementRegistry();
+    r.subscribe(() => { throw new Error('bad listener'); });
+    expect(() => r.add(eq('a', 0, 0))).not.toThrow();
+    expect(r.size).toBe(1);
+  });
+});
+
+describe('SnapshotManager', () => {
+  const eq = (id, x, y, latex) => ({ id, type: 'equation', position: { x, y }, semantic: { latex } });
+
+  test('capture → restore round-trips elements + view state', () => {
+    const r = new ElementRegistry();
+    r.add(eq('a', 10, 20, 'x+1')); r.add(eq('b', 30, 40, '2x'));
+    const vp = new Viewport({ viewW: 800, viewH: 600 }).setPan(50, 60).setScale(1.25);
+
+    const snap = SnapshotManager.capture(r, vp, { conversationId: 'c1' });
+    expect(snap.meta).toEqual({ conversationId: 'c1' });
+
+    const r2 = new ElementRegistry();
+    const vp2 = new Viewport({ viewW: 800, viewH: 600 });
+    const res = SnapshotManager.restore(snap, r2, vp2);
+    expect(res).toMatchObject({ restored: 2, skipped: 0 });
+    expect(r2.list().map((e) => e.semantic.latex)).toEqual(['x+1', '2x']);
+    expect(vp2.toJSON()).toEqual(vp.toJSON());
+  });
+
+  test('restore recovers from a corrupt snapshot (skips bad elements, never throws)', () => {
+    const r = new ElementRegistry();
+    const snap = {
+      schemaVersion: 1,
+      view: { scale: 'bad', panX: 10, panY: 20 },
+      elements: [
+        eq('good', 1, 2, 'x'),
+        { id: 'nopos', type: 'equation', semantic: {} },      // missing position
+        null,                                                  // junk
+        { id: 'good', type: 'equation', position: { x: 0, y: 0 }, semantic: {} }, // dup id
+        { type: 'equation', position: { x: 0, y: 0 }, semantic: {} },             // no id
+      ],
+    };
+    const vp = new Viewport({ viewW: 800, viewH: 600 });
+    const res = SnapshotManager.restore(snap, r, vp);
+    expect(res.restored).toBe(1);
+    expect(res.skipped).toBe(4);
+    expect(res.recovered).toBe(true);
+    expect(r.list().map((e) => e.id)).toEqual(['good']);
+    // bad view.scale ignored, but valid pan applied
+    expect(vp.panX).toBe(10);
+  });
+
+  test('garbage payload yields an empty workspace', () => {
+    const r = new ElementRegistry(); r.add(eq('x', 0, 0, 'x'));
+    const res = SnapshotManager.restore('not json at all', r, null);
+    expect(r.size).toBe(0);
+    expect(res.restored).toBe(0);
+    expect(SnapshotManager.safeParse('{bad json')).toBeNull();
+    expect(SnapshotManager.safeParse('{"a":1}')).toEqual({ a: 1 });
+  });
+});
+
+describe('LIVING_WORKSPACE flag resolver', () => {
+  test('defaults to off', () => {
+    expect(flags.resolveMode({ features: {}, search: '' })).toBe('off');
+    expect(flags.isEnabled({ features: {}, search: '' })).toBe(false);
+  });
+  test('MM_FEATURES wins over query param', () => {
+    expect(flags.resolveMode({ features: { livingWorkspace: 'beta' }, search: '?livingWorkspace=live' })).toBe('beta');
+  });
+  test('query param used when no feature flag', () => {
+    expect(flags.resolveMode({ features: {}, search: '?foo=1&livingWorkspace=dev' })).toBe('dev');
+    expect(flags.isDev({ features: {}, search: '?livingWorkspace=dev' })).toBe(true);
+  });
+  test('unknown modes normalize to off', () => {
+    expect(flags.resolveMode({ features: { livingWorkspace: 'banana' } })).toBe('off');
+  });
+});
+
+describe('a11y command + description layer', () => {
+  test('keys map to canonical commands', () => {
+    expect(a11y.commandForKey('ArrowLeft')).toBe('pan-left');
+    expect(a11y.commandForKey('+')).toBe('zoom-in');
+    expect(a11y.commandForKey('0')).toBe('zoom-reset');
+    expect(a11y.commandForKey('q')).toBeNull();
+  });
+
+  test('viewport commands move/zoom the view', () => {
+    const vp = new Viewport({ viewW: 800, viewH: 600, world: { width: 5000, height: 5000 } }).setPan(500, 500);
+    const beforePan = vp.panX;
+    expect(a11y.applyViewportCommand('pan-right', vp)).toBe(true);
+    expect(vp.panX).toBeGreaterThan(beforePan);
+    const beforeScale = vp.scale;
+    expect(a11y.applyViewportCommand('zoom-in', vp)).toBe(true);
+    expect(vp.scale).toBeGreaterThan(beforeScale);
+    expect(a11y.applyViewportCommand('focus-next', vp)).toBe(false); // element-level, not viewport
+  });
+
+  test('describes elements and workspace for screen readers', () => {
+    expect(a11y.describeElement({ type: 'equation', semantic: { plain: 'x + 1 = 5' } })).toBe('equation: x + 1 = 5');
+    expect(a11y.describeElement({ type: 'algebra-tiles', semantic: { latex: '2x' }, provisional: true }))
+      .toBe('algebra tiles: 2x, provisional');
+    const r = new ElementRegistry();
+    r.add({ id: 'a', type: 'equation', position: { x: 0, y: 0 }, semantic: { latex: 'x' } });
+    const vp = new Viewport({ viewW: 800, viewH: 600 }).setScale(1.25);
+    expect(a11y.describeWorkspace(r, vp)).toBe('Workspace with 1 element. Zoom 125 percent');
+  });
+});


### PR DESCRIPTION
The new free-2D surface, behind LIVING_WORKSPACE=off, built beside the old board (touches neither chat nor board). Decomposed per spec §P3 — "one surface ≠ one class":

Core (pure, no DOM — jest-tested, 21 cases):
- viewport.js       — world↔screen pan/zoom transform for the bounded
                      world; zoom-toward-focus keeps the point under the
                      cursor fixed (the no-drift invariant).
- elementRegistry.js — source of truth for on-canvas elements (add/update/
                      move/z-order/remove + change events).
- snapshotManager.js — semantic (never pixel) capture/restore with
                      corrupt-snapshot recovery → resume "for free" (§3.8).
- flags.js          — LIVING_WORKSPACE off|dev|beta|live resolver (default off).
- a11yCommands.js   — keyboard command vocabulary + screen-reader text,
                      designed IN per §B5 (not bolted on).

DOM glue (browser-verified in a static harness):
- gridRenderer.js   — graph-paper substrate on a dpr-scaled 2D canvas.
- overlayManager.js — DOM elements synced to the viewport transform, with
                      a pluggable per-type renderer registry (resolves B4a;
                      P6 tiles reuse the same mechanism).
- equationElement.js — KaTeX-typeset card, MathLive editing, header=reposition
                      / body=edit zones, serialize/restore, aria text.
- interactionController.js — unified pointer/touch/pen pan + drag-reposition +
                      wheel/pinch/keyboard zoom; every listener tracked and
                      removed on destroy (leak-free).
- shell.js          — orchestrator: composes the systems, ResizeObserver
                      layout, rAF-batched paint, mount/unmount lifecycle.

DESIGN DEVIATION (flagged for review): the spec named Fabric for the substrate, but Fabric is CDN-only/unvendored (~680KB) and won't run in an offline-verifiable harness — wrong for the load-bearing spine. I built a native Viewport + plain-canvas grid + DOM overlays instead. The B4a resolution (DOM math synced to the canvas transform) is preserved exactly; Fabric can drop in at P6 as the hit-test backend behind the same Viewport seam without changing the OverlayManager contract.

Browser-verified (static harness public/workspace-dev.html): mount renders grid+card; unmount tears down every listener (6→0) + DOM + rAF; DOM overlay tracks the canvas transform with driftX/Y=0 through pan+zoom; MathLive edit commits + re-typesets; header drags / body does not; snapshot round-trips elements + view state on reload; resize is dpr-crisp. Cannot certify frame rate on the target Chromebook from here (architected for it: one canvas fill per rAF + transform-only overlay sync).