### PR TITLE
fix(build): rebuild stale chat-css0 + chat-js8 bundles for Resume Car…

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -68,7 +68,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     if (window.MM_FEATURES.boardPanel === true) window.loadBoardTools();
   </script>
   <link rel="stylesheet" href="/style.css" />
-  <link rel="stylesheet" href="/dist/css/chat-css0.11b0dff1.css" />
+  <link rel="stylesheet" href="/dist/css/chat-css0.2422dcfc.css" />
 <!-- returning-user-modal removed — returning users now get an AI welcome directly -->
   <link rel="stylesheet" href="/dist/css/chat-css1.dae1c280.css" />
 <!-- Design tokens (single source of truth) — must precede chat-redesign.css -->
@@ -2354,7 +2354,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       updateIcon();
     })();
   </script>
-  <script src="/dist/js/chat-js8.910bc9c0.js"></script>
+  <script src="/dist/js/chat-js8.f11f7520.js"></script>
 <script src="/js/script.js?v=20260709" type="module"></script>
   <script src="/js/guidedPath.js" type="module"></script>
   <script src="/dist/js/chat-js9.bc0be9a3.js"></script>

--- a/public/dist/chat-bundles.manifest.json
+++ b/public/dist/chat-bundles.manifest.json
@@ -1,7 +1,7 @@
 {
   "css": [
     {
-      "href": "/dist/css/chat-css0.11b0dff1.css",
+      "href": "/dist/css/chat-css0.2422dcfc.css",
       "files": [
         "/css/file-upload.css",
         "/css/calculator.css",
@@ -119,7 +119,7 @@
       ]
     },
     {
-      "src": "/dist/js/chat-js8.910bc9c0.js",
+      "src": "/dist/js/chat-js8.f11f7520.js",
       "files": [
         "/js/student-resources.js",
         "/js/settings.js",

--- a/public/dist/css/chat-css0.2422dcfc.css
+++ b/public/dist/css/chat-css0.2422dcfc.css
@@ -13086,6 +13086,116 @@ body:not(.iep-reduced-distraction) .iep-mult-chart-btn {
   }
 }
 
+/* ── Lifecycle hero — mastery-first, effort-framed, one clear next step ── */
+.rc-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 14px;
+}
+
+.rc-hero-label {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.rc-hero-skill {
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: #fff;
+}
+
+.rc-hero-track {
+  height: 10px;
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 99px;
+  overflow: hidden;
+}
+
+.rc-hero-fill {
+  height: 100%;
+  background: #2dd4bf;
+  border-radius: 99px;
+  transition: width 0.4s ease;
+}
+
+.rc-hero-progrow {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.rc-hero-copy {
+  font-size: 0.82rem;
+  color: rgba(255, 255, 255, 0.72);
+  line-height: 1.5;
+}
+
+.rc-hero-week,
+.rc-hero-effort {
+  font-size: 0.82rem;
+  color: rgba(255, 255, 255, 0.88);
+  background: rgba(45, 212, 191, 0.12);
+  border-radius: 10px;
+  padding: 9px 11px;
+}
+
+.rc-hero-week strong,
+.rc-hero-effort strong {
+  color: #2dd4bf;
+  font-weight: 600;
+}
+
+.rc-hero-badge {
+  font-size: 0.82rem;
+  color: #2dd4bf;
+  font-weight: 600;
+}
+
+.rc-hero-cta {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  background: #2dd4bf;
+  color: #04302b;
+  border: none;
+  border-radius: 12px;
+  padding: 12px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.rc-hero-cta:hover {
+  background: #5eead4;
+}
+
+.rc-hero-alt {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.75);
+  border: none;
+  padding: 8px;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.rc-hero-alt:hover {
+  color: #fff;
+}
+
+.rc-hero-arrow {
+  font-weight: 700;
+}
+
 /* --- /css/mobile-ux-overhaul.css --- */
 /* ============================================
    MOBILE UX OVERHAUL — Stats bar, hero actions, polish

--- a/public/dist/js/chat-js8.f11f7520.js
+++ b/public/dist/js/chat-js8.f11f7520.js
@@ -2783,53 +2783,97 @@ if (typeof window !== 'undefined') {
       </div>`;
   }
 
-  // Build weekly stats strip
-  function weeklyStatsHTML(stats) {
-    if (!stats) return '';
-    const items = [];
-    if (stats.problemsSolved != null && stats.problemsSolved > 0) {
-      items.push(`<div class="rc-stat"><span class="rc-stat-val">${stats.problemsSolved}</span><span class="rc-stat-label">problems</span></div>`);
-    }
-    if (stats.accuracy != null) {
-      items.push(`<div class="rc-stat"><span class="rc-stat-val">${stats.accuracy}%</span><span class="rc-stat-label">accuracy</span></div>`);
-    }
-    if (stats.xpEarned != null && stats.xpEarned > 0) {
-      items.push(`<div class="rc-stat"><span class="rc-stat-val">+${stats.xpEarned}</span><span class="rc-stat-label">XP this week</span></div>`);
-    }
-    if (stats.skillsMastered != null && stats.skillsMastered > 0) {
-      items.push(`<div class="rc-stat"><span class="rc-stat-val">${stats.skillsMastered}</span><span class="rc-stat-label">mastered</span></div>`);
-    }
-    if (items.length === 0) return '';
-    return `<div class="rc-stats-strip">${items.join('')}</div>`;
+  // Escape text going into innerHTML
+  function esc(s) {
+    return String(s == null ? '' : s).replace(/[&<>"']/g, (c) => (
+      { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+    ));
   }
 
-  // Build learning progress section
-  function learningHTML(summary) {
+  // A CTA that types a prompt to the tutor and sends it (wired in wireCtaClicks)
+  function ctaButton(label, prompt, kind) {
+    const cls = kind === 'alt' ? 'rc-hero-alt' : 'rc-hero-cta';
+    const arrow = kind === 'alt' ? '' : '<span class="rc-hero-arrow">→</span>';
+    return `<button class="${cls}" data-rc-prompt="${esc(prompt)}">${esc(label)}${arrow}</button>`;
+  }
+
+  // Progress bar toward mastery of a skill
+  function masteryBar(displayName, pct, labelText) {
+    const p = Math.max(0, Math.min(100, Math.round(pct || 0)));
+    const state = p >= 100 ? 'mastered' : (p >= 50 ? 'halfway to mastery' : 'building it up');
+    return `
+      <div class="rc-hero-label">${esc(labelText || 'Working toward mastery')}</div>
+      <div class="rc-hero-skill">${esc(displayName)}</div>
+      <div class="rc-hero-track"><div class="rc-hero-fill" style="width: ${p}%"></div></div>
+      <div class="rc-hero-progrow"><span>${state}</span><span>${p}%</span></div>`;
+  }
+
+  // State-aware hero — leads with the ONE thing that matters and ends with a
+  // single next step. Framing is honest per lifecycle state: effort and growth,
+  // never a verdict number. Driven by summary.cardState from the server.
+  function heroHTML(summary) {
     if (!summary) return '';
+    const learning = summary.currentLearning;
+    const stats = summary.weeklyStats || {};
+    const reviewDue = summary.reviewDue || 0;
+
+    // FIRST SESSION — an invitation, never a wall of zeros.
+    if (summary.cardState === 'first_session') {
+      return `
+        <div class="rc-hero">
+          <div class="rc-hero-label">Your journey starts here</div>
+          <div class="rc-hero-skill">A quick warm-up</div>
+          <div class="rc-hero-copy">A few short problems so we can find the right place to start. No grades, no pressure.</div>
+          ${ctaButton('Start the warm-up', "I'm ready for a warm-up.")}
+        </div>`;
+    }
+
+    // MASTERY — celebrate, then open the next door.
+    if (summary.cardState === 'mastery') {
+      const mastered = summary.recentMastery;
+      const next = summary.nextReady;
+      return `
+        <div class="rc-hero">
+          <div class="rc-hero-badge">★ skill mastered</div>
+          ${masteryBar(mastered ? mastered.displayName : 'Your skill', 100, 'You just mastered')}
+          <div class="rc-hero-copy">Ready for something new.</div>
+          ${next
+            ? ctaButton(`Start ${next.displayName}`, `I'm ready to start ${next.displayName}.`)
+            : ctaButton('Start something new', 'What should I work on next?')}
+        </div>`;
+    }
+
+    // STRUGGLING — name the persistence, no percentage, gentler on-ramp.
+    if (summary.cardState === 'struggling') {
+      const solved = stats.problemsSolved || 0;
+      return `
+        <div class="rc-hero">
+          ${learning ? masteryBar(learning.displayName, learning.progress, 'Working toward mastery') : ''}
+          <div class="rc-hero-effort">You worked through <strong>${solved} tricky problem${solved === 1 ? '' : 's'}</strong> and didn't quit.</div>
+          ${ctaButton('Review the tricky part together', 'Can we review the part I keep getting stuck on?')}
+          ${ctaButton('or try an easier warm-up', 'Can we try an easier warm-up first?', 'alt')}
+        </div>`;
+    }
+
+    // PROGRESS (default) — mastery bar + honest week + continue.
+    const wins = stats.problemsCorrect || 0;
+    const practiced = stats.problemsSolved || 0;
+    const weekBlock = practiced > 0
+      ? `<div class="rc-hero-week"><strong>${wins} first-try win${wins === 1 ? '' : 's'}</strong> · ${practiced} practiced this week</div>`
+      : '';
     const parts = [];
-
-    if (summary.currentLearning) {
-      const pct = summary.currentLearning.progress || 0;
-      parts.push(`
-        <div class="rc-learning-item">
-          <div class="rc-learning-header">
-            <span class="rc-learning-status">📖 Currently learning</span>
-            <span class="rc-learning-pct">${pct}%</span>
-          </div>
-          <div class="rc-learning-name">${summary.currentLearning.displayName}</div>
-          <div class="rc-learning-track"><div class="rc-learning-fill" style="width: ${pct}%"></div></div>
-        </div>`);
+    if (learning) {
+      parts.push(masteryBar(learning.displayName, learning.progress, 'Working toward mastery'));
+      parts.push(weekBlock);
+      parts.push(ctaButton(`Continue ${learning.displayName}`, `Let's keep working on ${learning.displayName}.`));
+    } else {
+      parts.push(weekBlock);
+      parts.push(ctaButton('Keep practicing', "Let's practice."));
     }
-
-    if (summary.recentMastery) {
-      parts.push(`
-        <div class="rc-learning-item rc-mastery-item">
-          <span class="rc-mastery-badge">⭐</span>
-          <span>Recently mastered <strong>${summary.recentMastery.displayName}</strong></span>
-        </div>`);
+    if (reviewDue > 0) {
+      parts.push(ctaButton(`${reviewDue} skill${reviewDue === 1 ? '' : 's'} ready to review`, "Let's review what I've learned.", 'alt'));
     }
-
-    return parts.length > 0 ? `<div class="rc-learning">${parts.join('')}</div>` : '';
+    return `<div class="rc-hero">${parts.join('')}</div>`;
   }
 
   // Build recent session buttons
@@ -2881,13 +2925,13 @@ if (typeof window !== 'undefined') {
     const firstName = user?.firstName || user?.name?.split(' ')[0] || '';
     const greeting = `${getTimeGreeting()}${firstName ? ', ' + firstName : ''}!`;
 
-    // Only show card if there's meaningful content
-    const hasStreak = summary?.streak > 0;
+    // Show the card whenever we have a lifecycle hero to render (any assessed
+    // student — including the brand-new, no-activity first-session state), or
+    // when there are sessions to resume.
+    const hasHero = !!summary?.cardState;
     const hasSessions = returning?.isReturningUser && (returning.courses?.length > 0 || returning.recentSessions?.length > 0);
-    const hasLearning = summary?.currentLearning || summary?.recentMastery;
-    const hasStats = summary?.weeklyStats && (summary.weeklyStats.problemsSolved > 0 || summary.weeklyStats.xpEarned > 0);
 
-    if (!hasSessions && !hasLearning && !hasStats && !hasStreak) return null;
+    if (!hasHero && !hasSessions) return null;
 
     const html = `
       <div id="${CARD_ID}" class="rc-card" role="region" aria-label="Welcome back">
@@ -2896,12 +2940,11 @@ if (typeof window !== 'undefined') {
           <button class="rc-dismiss" id="rc-dismiss-btn" aria-label="Dismiss">&times;</button>
         </div>
         <div class="rc-body">
+          ${heroHTML(summary)}
           <div class="rc-top-row">
             ${streakHTML(summary?.streak)}
             ${xpBarHTML(user)}
           </div>
-          ${weeklyStatsHTML(summary?.weeklyStats)}
-          ${learningHTML(summary)}
           ${sessionsHTML(returning)}
         </div>
       </div>`;
@@ -2966,6 +3009,7 @@ if (typeof window !== 'undefined') {
       const dismissBtn = document.getElementById('rc-dismiss-btn');
       if (dismissBtn) dismissBtn.addEventListener('click', dismissCard);
       wireSessionClicks();
+      wireCtaClicks();
 
       // Card stays until the user dismisses it or taps a session.
       // No auto-dismiss — let them read at their own pace.
@@ -2975,6 +3019,31 @@ if (typeof window !== 'undefined') {
     }
   }
 
+  // A CTA types its prompt into the chat and sends it, as if the student typed
+  // it — reusing the chat's own input + send button (no private API).
+  function wireCtaClicks() {
+    const card = document.getElementById(CARD_ID);
+    if (!card) return;
+    card.querySelectorAll('[data-rc-prompt]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const prompt = btn.getAttribute('data-rc-prompt') || '';
+        dismissCard();
+        const input = document.getElementById('user-input');
+        if (input) {
+          input.textContent = prompt;
+          input.dispatchEvent(new Event('input', { bubbles: true }));
+        }
+        const sendBtn = document.getElementById('send-button');
+        if (sendBtn && !sendBtn.disabled) sendBtn.click();
+      });
+    });
+  }
+
   // Expose globally so initializeApp can call it
-  window.showResumeCard = showResumeCard;
+  if (typeof window !== 'undefined') window.showResumeCard = showResumeCard;
+
+  // Testable surface (no-op in the browser)
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { heroHTML };
+  }
 })();


### PR DESCRIPTION
…d redesign

The Progress/Resume Card redesign updated public/css/resume-card.css and public/js/resume-card.js, but `npm run build:chat` was never re-run — so the committed chat-css0 and chat-js8 bundles still embedded the OLD sources. chat.html loads both only via these hashed bundles (no raw <link>/<script>), so production served the stale, pre-redesign card.

Re-ran build:chat and shipped only the two Resume Card bundles:
  - chat-css0.11b0dff1 -> chat-css0.2422dcfc  (redesigned resume-card.css, adds .rc-hero*)
  - chat-js8.910bc9c0  -> chat-js8.f11f7520   (redesigned resume-card.js: heroHTML, esc, CTA wiring)

Deliberately left chat-js2 (voice-controller.js premium-voice paywall) at its existing committed hash — that drift is unrelated to this fix and out of scope.

Verified: resumeCardHero unit test passes; new bundles rebuilt from current sources; redesigned card renders from the shipped bundles in-browser (teal mastery bar, effort-framed week, single Continue CTA) with no console errors.