### PR TITLE
Rebuild stale chat bundles (chat-css0, chat-js2) to match main source

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -68,7 +68,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     if (window.MM_FEATURES.boardPanel === true) window.loadBoardTools();
   </script>
   <link rel="stylesheet" href="/style.css" />
-  <link rel="stylesheet" href="/dist/css/chat-css0.11b0dff1.css" />
+  <link rel="stylesheet" href="/dist/css/chat-css0.2422dcfc.css" />
 <!-- returning-user-modal removed — returning users now get an AI welcome directly -->
   <link rel="stylesheet" href="/dist/css/chat-css1.dae1c280.css" />
 <!-- Design tokens (single source of truth) — must precede chat-redesign.css -->
@@ -2300,7 +2300,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <script defer src="/js/chat-redesign.js"></script>
   <!-- Drive the "Live with <tutor>" pill bars from real TTS playback -->
   <script type="module" src="/js/chat-voice-meter.js"></script>
-  <script src="/dist/js/chat-js2.eeaf2aeb.js"></script>
+  <script src="/dist/js/chat-js2.bfd25fea.js"></script>
 <!-- Voice as a layout mode of the chat stage -->
   <script src="/js/voice-mode.js?v=3"></script>
   <!-- Whiteboard stack lazy-loaded via loadBoardTools() (see boardPanel block

--- a/public/dist/chat-bundles.manifest.json
+++ b/public/dist/chat-bundles.manifest.json
@@ -1,7 +1,7 @@
 {
   "css": [
     {
-      "href": "/dist/css/chat-css0.11b0dff1.css",
+      "href": "/dist/css/chat-css0.2422dcfc.css",
       "files": [
         "/css/file-upload.css",
         "/css/calculator.css",
@@ -62,7 +62,7 @@
       ]
     },
     {
-      "src": "/dist/js/chat-js2.eeaf2aeb.js",
+      "src": "/dist/js/chat-js2.bfd25fea.js",
       "files": [
         "/js/voice-stream-client.js?v=3",
         "/js/voice-controller.js"

--- a/public/dist/css/chat-css0.2422dcfc.css
+++ b/public/dist/css/chat-css0.2422dcfc.css
@@ -13086,6 +13086,116 @@ body:not(.iep-reduced-distraction) .iep-mult-chart-btn {
   }
 }
 
+/* ── Lifecycle hero — mastery-first, effort-framed, one clear next step ── */
+.rc-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 14px;
+}
+
+.rc-hero-label {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.rc-hero-skill {
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: #fff;
+}
+
+.rc-hero-track {
+  height: 10px;
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 99px;
+  overflow: hidden;
+}
+
+.rc-hero-fill {
+  height: 100%;
+  background: #2dd4bf;
+  border-radius: 99px;
+  transition: width 0.4s ease;
+}
+
+.rc-hero-progrow {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.rc-hero-copy {
+  font-size: 0.82rem;
+  color: rgba(255, 255, 255, 0.72);
+  line-height: 1.5;
+}
+
+.rc-hero-week,
+.rc-hero-effort {
+  font-size: 0.82rem;
+  color: rgba(255, 255, 255, 0.88);
+  background: rgba(45, 212, 191, 0.12);
+  border-radius: 10px;
+  padding: 9px 11px;
+}
+
+.rc-hero-week strong,
+.rc-hero-effort strong {
+  color: #2dd4bf;
+  font-weight: 600;
+}
+
+.rc-hero-badge {
+  font-size: 0.82rem;
+  color: #2dd4bf;
+  font-weight: 600;
+}
+
+.rc-hero-cta {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  background: #2dd4bf;
+  color: #04302b;
+  border: none;
+  border-radius: 12px;
+  padding: 12px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.rc-hero-cta:hover {
+  background: #5eead4;
+}
+
+.rc-hero-alt {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.75);
+  border: none;
+  padding: 8px;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.rc-hero-alt:hover {
+  color: #fff;
+}
+
+.rc-hero-arrow {
+  font-weight: 700;
+}
+
 /* --- /css/mobile-ux-overhaul.css --- */
 /* ============================================
    MOBILE UX OVERHAUL — Stats bar, hero actions, polish

--- a/public/dist/js/chat-js2.bfd25fea.js
+++ b/public/dist/js/chat-js2.bfd25fea.js
@@ -535,10 +535,37 @@ class VoiceController {
     // STREAMING PIPELINE (Phase 2 — chat-page orb)
     // ============================================
 
+    // Best-effort client-side mirror of the server voice paywall
+    // (utils/voiceUpgrade.js → hasPremiumAccess). Read-only: the server still
+    // enforces. Returns false ONLY when we positively know the account is
+    // non-premium — if currentUser hasn't loaded yet we return true so we
+    // don't wrongly downgrade a premium user to the legacy path.
+    hasPremiumVoiceAccess() {
+        const u = window.currentUser;
+        if (!u) return true; // unknown → let the connect attempt / server decide
+        const roles = Array.isArray(u.roles) ? u.roles : [u.role || 'student'];
+        if (roles.some(r => r === 'teacher' || r === 'parent' || r === 'admin')) return true;
+        if (u.subscriptionTier === 'unlimited') return true;
+        if (u.schoolLicenseId) return true;
+        return false;
+    }
+
     async setupStreamingPipeline() {
         if (typeof window.VoiceStreamClient !== 'function') return;
         if (typeof window.AudioWorklet === 'undefined' &&
             !(window.AudioContext && AudioContext.prototype.audioWorklet)) {
+            return;
+        }
+
+        // The streaming WS enforces the same premium paywall as the HTTP routes
+        // (utils/voiceUpgrade.js → 402 Payment Required). A non-premium account
+        // would just get a handshake refusal that the browser surfaces as a
+        // contentless error Event — noisy and misleading in the console. Skip
+        // the doomed connect; the paywall intercept on the voice buttons
+        // (script.js gateVoiceTutorButton) owns the free-tier UX instead.
+        if (!this.hasPremiumVoiceAccess()) {
+            this.streamingUnavailable = true;
+            console.info('[Voice] streaming pipeline skipped — account not premium (upgrade prompt handled by voice buttons)');
             return;
         }
 
@@ -550,10 +577,19 @@ class VoiceController {
         try {
             await client.connect();
         } catch (err) {
-            console.warn('[Voice] WebSocket connect failed:', err?.message);
+            // A failed WS handshake surfaces as a bare error Event with no HTTP
+            // status (browsers hide it), so we can't distinguish 401/402/503/
+            // network here. This account already passed the paywall check
+            // above, so treat it as transient/config and degrade to the legacy
+            // push-to-talk path — which reports its own failures to the user.
+            this.streamingUnavailable = true;
+            console.warn('[Voice] streaming handshake refused; using legacy voice path', {
+                readyState: client && client.ws ? client.ws.readyState : 'n/a',
+            });
             return;
         }
 
+        this.streamingUnavailable = false;
         this.streamClient = client;
         this.useStreamingPipeline = true;
         console.log('[Voice] streaming pipeline active (chat-page orb)');


### PR DESCRIPTION
main's committed public/dist was stale: source feeding chat-css0 and chat-js2 had changed without a bundle rebuild, so prod served outdated CSS/JS (the asset-cache-busting hazard). Ran `npm run build:chat` off clean origin/main:
  chat-css0.11b0dff1 -> chat-css0.2422dcfc
  chat-js2.eeaf2aeb  -> chat-js2.bfd25fea
chat.html + manifest updated to reference them; orphaned old bundles removed. chat-js8 left unchanged (89eef321 was already current).

Supersedes #1152, which carried a stale chat-js8 (f11f7520) from an older base — that mismatch was the entire merge conflict. A fresh build off current main reproduces exactly these hashes (cross-checked; the css0/js2 hashes also match what #1152 independently produced).

QA: build succeeded; every /dist bundle referenced in chat.html exists; no stale hashes remain in chat.html.