### PR TITLE
fix(tutor): enforce distinct persona voice, ban the boilerplate opene…

### DIFF
--- a/routes/welcome.js
+++ b/routes/welcome.js
@@ -191,7 +191,7 @@ router.get('/', async (req, res) => {
 
             const exampleQuestions = questionExamples.slice(0, 3).join(' or ');
 
-            userMessagePart = `Write a short, casual greeting for ${user.firstName}. Introduce yourself briefly, then ask ONE natural question like ${exampleQuestions}. Consider the time/day (${temporalContext}) but keep it natural - not forced. Sound like you're texting. 1-2 sentences max. Don't mention grade level or info you already know.`;
+            userMessagePart = `Write a short, casual greeting for ${user.firstName}. Introduce yourself in YOUR unmistakable voice — lead with your signature energy/style, NOT a generic "I'm ${tutorNameForPrompt}, your math tutor" job description. Then ask ONE natural question like ${exampleQuestions}. Consider the time/day (${temporalContext}) but keep it natural - not forced. Sound like you're texting. 1-2 sentences max. Don't mention grade level or info you already know.`;
         }
 
         // RAPPORT IN PROGRESS: Transition to math quickly

--- a/utils/promptCompact.js
+++ b/utils/promptCompact.js
@@ -599,10 +599,12 @@ function generateSystemPrompt(userProfile, tutorProfile, childProfile = null, cu
     ? `\n${tutorProfile.humanBehaviors}`
     : '';
   parts.push(`
---- IDENTITY ---
+--- IDENTITY (who you ARE — overrides the generic-phrasing habit) ---
 You are **${tutorProfile.name}**. Catchphrase: "${tutorProfile.catchphrase}"
 ${tutorProfile.personality}${behaviorsCtx}${culturalCtx}
-Stay in character. Every response should sound like ${tutorProfile.name}.`);
+
+VOICE IS NON-NEGOTIABLE. The rules above are WHAT to do; your voice is HOW — in every line, not just greetings. The strip-the-name test: if your name were removed from this reply, ${firstName} should still know it's you from the word choice, the energy, and the kind of analogy you reach for. Two tutors must never be interchangeable.
+NEVER open with generic tutor boilerplate — not "I'm ${tutorProfile.name}, your math tutor, here to make this click", not "here to help you with math", not any job-description intro. Open the way only YOU would, lead with your signature energy, and never reuse an opener.`);
 
   // Date/time
   parts.push(`


### PR DESCRIPTION
…r (QA P1-5)

Bob and Maya read as interchangeable, both opening "Hey Jason! I'm [Name], your math tutor — here to make this click." The persona DNA in tutorConfig is actually rich and distinct (each tutor has personality + per-moment humanBehaviors), and promptCompact DOES inject it — but it sits inside a large block of shared human-tutoring rules, so the distinct voice averaged out, and nothing forbade the generic tutor-intro reflex.

- promptCompact IDENTITY block: added a "voice is non-negotiable" directive invoking the strip-the-name test (if the name were removed the student should still know who it is; two tutors must never be interchangeable) and an explicit ban on generic tutor-intro boilerplate, with "never reuse an opener."
- welcome.js new-user greeting: introduce yourself in YOUR voice, not the "I'm X, your math tutor" job description.

No tutorConfig personas changed — they were already well-differentiated; the gap was enforcement. Verified with the report's strip-the-name test: Bob vs Maya identity blocks share only 29% of words after removing names (highly distinct), signature markers are tutor-specific with no cross- contamination, and the anti-boilerplate directive is present in the built prompt. (True voice A/B is a live-read judgment, not a unit test.)