### PR TITLE
fix(screener): anchor difficulty to ability + honest, faster stop (QA…

### DIFF
--- a/public/js/adaptiveScreener.js
+++ b/public/js/adaptiveScreener.js
@@ -699,9 +699,11 @@ function displayProblem(problem) {
 function updateProgressFromProblem(progress) {
   const { current, target, percentComplete } = progress;
 
-  // Update progress text
+  // Honest adaptive progress: the test length adapts, so show an
+  // APPROXIMATE soft target with a tilde rather than a hard "N / 15" that
+  // the test then blows past (QA P1-4). The "~" signals it can vary.
   if (elements.questionCount) {
-    elements.questionCount.textContent = `${current} / ${target}`;
+    elements.questionCount.textContent = `Question ${current} of ~${target}`;
   }
 
   // Students don't see theta/confidence for privacy

--- a/routes/screener.js
+++ b/routes/screener.js
@@ -19,7 +19,7 @@ const User = require('../models/user');
 const Problem = require('../models/problem');
 const Skill = require('../models/skill');
 const ScreenerSession = require('../models/screenerSession'); // CTO REVIEW FIX: Persistent session storage
-const { initializeSession, processResponse, generateReport, identifyInterviewSkills, calculateJumpSize } = require('../utils/adaptiveScreener');
+const { initializeSession, processResponse, generateReport, identifyInterviewSkills } = require('../utils/adaptiveScreener');
 const { generateProblem, TEMPLATES } = require('../utils/problemGenerator');
 const { awardBadgesForSkills } = require('../utils/badgeAwarder');
 const { generateInterviewQuestions, evaluateResponse } = require('../utils/dynamicInterviewGenerator');
@@ -253,25 +253,31 @@ router.get('/next-problem', isAuthenticated, async (req, res) => {
       targetDifficulty = session.theta;
       console.log(`[Screener] First question using starting θ=${session.theta.toFixed(2)} based on grade level`);
     } else {
-      // Get last response to determine jump direction
+      // Aim the next item at the CURRENT ability estimate (θ) — standard
+      // CAT maximum-information selection — but cap how far difficulty may
+      // move from the last item in one step so it never swings wildly.
+      //
+      // The previous scheme jumped from the LAST difficulty and bounded with
+      // Math.max(θ±1, lastD±1.5) on BOTH ends. Once difficulty drifted above
+      // θ, both bounds tracked lastD instead of θ, so selection stopped being
+      // anchored to ability — it random-walked, items landed off-level (a 6th
+      // grader seeing AP-Statistics then 4th-grade arithmetic), SE never
+      // dropped, and the test ran to ~27 questions. Anchoring to θ with a
+      // per-question step cap keeps items on-level and lets the estimate
+      // settle (verified by simulation: consistent students converge in ~15
+      // questions vs ~28, across the ability range). The theta floor in
+      // adaptiveScreener + the step cap keep a transient low estimate from
+      // dragging difficulty off a cliff — the concern the old Math.max
+      // addressed. (QA P1-4)
       const lastResponse = session.responses[session.responses.length - 1];
       const lastDifficulty = lastResponse.difficulty;
-      const wasCorrect = lastResponse.correct;
+      const MAX_STEP = 1.5;
+      targetDifficulty = Math.max(
+        lastDifficulty - MAX_STEP,
+        Math.min(lastDifficulty + MAX_STEP, session.theta)
+      );
 
-      // Calculate dampened jump size based on correctness, question count, and SE
-      const jumpSize = calculateJumpSize(wasCorrect, session.questionCount, session.standardError);
-
-      // Apply jump to previous difficulty (not raw theta!)
-      targetDifficulty = lastDifficulty + jumpSize;
-
-      // Bound jumps to reasonable range to prevent wild swings
-      // Allow theta to influence bounds, but don't jump to theta directly
-      // FIX: Use Math.max (conservative/higher bound) so a crashed theta can't drag difficulty down
-      const lowerBound = Math.max(session.theta - 1.0, lastDifficulty - 1.5);
-      const upperBound = Math.max(session.theta + 1.0, lastDifficulty + 1.5);
-      targetDifficulty = Math.max(lowerBound, Math.min(upperBound, targetDifficulty));
-
-      console.log(`[Screener Jump] Q${session.questionCount}: ${wasCorrect ? 'CORRECT' : 'INCORRECT'} at d=${lastDifficulty.toFixed(2)} → jump ${jumpSize.toFixed(2)} → target ${targetDifficulty.toFixed(2)} (θ=${session.theta.toFixed(2)}, SE=${session.standardError.toFixed(2)})`);
+      console.log(`[Screener Aim] Q${session.questionCount}: ${lastResponse.correct ? 'CORRECT' : 'INCORRECT'} at d=${lastDifficulty.toFixed(2)} → aim θ=${session.theta.toFixed(2)} (capped ±${MAX_STEP}) → target ${targetDifficulty.toFixed(2)} (SE=${session.standardError.toFixed(2)})`);
     }
 
     // ADAPTIVE SKILL SELECTION - Use new modular skill selection system

--- a/tests/unit/screenerStabilityStop.test.js
+++ b/tests/unit/screenerStabilityStop.test.js
@@ -1,0 +1,59 @@
+/**
+ * QA P1-4 — theta-stabilized early stop.
+ *
+ * At typical item discrimination the SE≤0.30 threshold is unreachable within
+ * maxQuestions, so a consistent student ran to ~27 questions. checkConvergence
+ * now stops once the ability estimate has settled (small spread over the
+ * recent window) after enough questions — while erratic responders keep going.
+ */
+
+const { checkConvergence } = require('../../utils/catConvergence');
+
+// Minimal session shaped like the real one. High SE on purpose, so ONLY the
+// stability tier (not the SE tiers) can trigger a stop.
+function session(thetaAfters, { standardError = 0.55 } = {}) {
+  return {
+    questionCount: thetaAfters.length,
+    standardError,
+    theta: thetaAfters[thetaAfters.length - 1],
+    minQuestions: 8,
+    targetQuestions: 15,
+    maxQuestions: 30,
+    responses: thetaAfters.map((t, i) => ({
+      difficulty: t, discrimination: 1, correct: i % 2 === 0, thetaAfter: t,
+    })),
+  };
+}
+
+describe('theta-stabilized early stop', () => {
+  test('stops when theta has settled after enough questions (SE still high)', () => {
+    // 13 questions, last 6 thetas within a 0.1 band → stable.
+    const thetas = [0.9, 0.6, 0.4, 0.35, 0.3, 0.28, 0.30, 0.31, 0.29, 0.30, 0.28, 0.31, 0.30];
+    const r = checkConvergence(session(thetas));
+    expect(r.canStop).toBe(true);
+    expect(r.reason).toBe('theta-stabilized');
+  });
+
+  test('does NOT stop early when the estimate is still swinging', () => {
+    // 13 questions but the last 6 span > 0.35 → not stable.
+    const thetas = [0.9, 0.6, 0.4, 0.35, 0.3, 0.28, 0.9, 0.1, 0.8, 0.2, 0.7, 0.15, 0.75];
+    const r = checkConvergence(session(thetas));
+    // No SE tier can fire (SE 0.55), and stability fails → keep going.
+    expect(r.canStop).toBe(false);
+    expect(r.reason).toBe('continue');
+  });
+
+  test('does NOT stop before the minimum question count even if stable', () => {
+    // Only 10 questions (< STABILITY_MIN_QUESTIONS = 12), all stable.
+    const thetas = [0.30, 0.30, 0.29, 0.31, 0.30, 0.30, 0.29, 0.31, 0.30, 0.30];
+    const r = checkConvergence(session(thetas));
+    expect(r.reason).not.toBe('theta-stabilized');
+  });
+
+  test('a low SE still stops via the high-confidence tier (stability is additive)', () => {
+    const thetas = [0.3, 0.31, 0.29, 0.30, 0.30, 0.31, 0.30, 0.29, 0.30];
+    const r = checkConvergence(session(thetas, { standardError: 0.20 }));
+    expect(r.canStop).toBe(true);
+    expect(r.reason).toBe('high-confidence');
+  });
+});

--- a/utils/catConvergence.js
+++ b/utils/catConvergence.js
@@ -17,6 +17,17 @@
 const { SESSION_DEFAULTS } = require('./catConfig');
 const { thetaToPercentile } = require('./irt');
 
+// Theta-stabilized early stop (QA P1-4). At typical item discrimination the
+// SE≤0.30 threshold is often unreachable within maxQuestions, so a consistent
+// student would run to the cap (~27 questions). Once the ability estimate has
+// settled — small spread over a recent window after enough questions — we
+// know the placement and can stop honestly. Tuned via simulation so
+// consistent students finish in ~15 questions across the ability range while
+// erratic responders keep going.
+const STABILITY_MIN_QUESTIONS = SESSION_DEFAULTS.stabilityMinQuestions ?? 12;
+const STABILITY_WINDOW = SESSION_DEFAULTS.stabilityWindow ?? 6;
+const STABILITY_RANGE = SESSION_DEFAULTS.stabilityRange ?? 0.35;
+
 // ===========================================================================
 // CONVERGENCE CRITERIA
 // ===========================================================================
@@ -270,6 +281,18 @@ function checkConvergence(session) {
     result.converged = true;
     result.canStop = true;
     result.reason = 'plateau-detected';
+    result.confidence = 'medium';
+    return result;
+  }
+
+  // TIER 5b: Theta-stabilized early stop. The ability estimate has settled
+  // (small spread over the recent window) after enough questions — the honest
+  // "we're confident" signal when SE can't reach 0.30 in time (QA P1-4).
+  if (questionCount >= STABILITY_MIN_QUESTIONS &&
+      checkThetaStability(responses, STABILITY_WINDOW, STABILITY_RANGE)) {
+    result.converged = true;
+    result.canStop = true;
+    result.reason = 'theta-stabilized';
     result.confidence = 'medium';
     return result;
   }


### PR DESCRIPTION
… P1-4)

A consistent 6th grader took ~27 questions and saw wildly off-level items (6th grade → AP Statistics → 4th-grade arithmetic → 8th grade). A simulation with the real CAT functions reproduced it: avg 28.8 questions, difficulty random-walking up to θ=1.58 for a true θ=0.27 student.

Two root causes, both verified by simulation:

1. Difficulty selection wasn't anchored to ability. It jumped from the LAST difficulty and bounded with Math.max(θ±1, lastD±1.5) on BOTH ends, so once difficulty drifted above θ both bounds tracked lastD, not θ — it stopped being adaptive and random-walked, so items landed off-level and SE never dropped. Now: aim each item at the current θ estimate (max-information selection) with a per-question step cap (±1.5) to avoid wild swings. The theta floor + step cap cover the "crashed theta" case the old Math.max guarded. Difficulty now stays in a tight band around ability.

2. It couldn't stop. At typical item discrimination, SE≤0.30 is unreachable within 30 questions, so a consistent student ran to the target/max cap. New checkConvergence tier: stop once the estimate has SETTLED (theta spread < 0.35 over the last 6) after ≥12 questions — the honest "we're confident" signal — while erratic responders keep going. Tunable via SESSION_DEFAULTS.

3. Honest progress: the counter now reads "Question N of ~M" (adaptive), not a hard "N / 15" the test blew past.

Verified by simulation across the ability range (all via the real processResponse + checkConvergence):
  6th θ=0.27  → 15.4 Q (was 28.8), est. error 0.23
  struggling  → 14.9 Q,            est. error 0.31
  advanced    → 15.8 Q,            est. error 0.26
No premature stops (min 12) or runaways (max 21). 64 screener/convergence/
irt tests green.

Follow-up (NOT in this change): topic balance (probability over-represented) and cross-skill repetition live in skillSelector + depend on the item bank's difficulty distribution — a separate, data-driven pass.