### PR TITLE
fix(xp): reconcile Progress-card XP so it can't show current > next (…

### DIFF
--- a/routes/chat.js
+++ b/routes/chat.js
@@ -2315,6 +2315,10 @@ async function handleGreetingRequest(req, res, userId) {
                     res.write(`data: ${JSON.stringify({ done: true, voiceId: contTutor.voiceId, isGreeting: true, continued: true, conversationId: activeConversation._id, messages: visibleMessages })}\n\n`);
                     return res.end();
                 }
+                // QA P1-6: send WITHIN-level XP (and a level reconciled from
+                // actual XP), never total XP. Sending user.xp here with a stale
+                // level produced the "577 / 140" broken fraction on return.
+                const contXp = BRAND_CONFIG.xpProgress(user.xp);
                 return res.json({
                     text: '',
                     continued: true,
@@ -2322,9 +2326,9 @@ async function handleGreetingRequest(req, res, userId) {
                     messages: visibleMessages,
                     voiceId: contTutor.voiceId,
                     isGreeting: true,
-                    userXp: user.xp || 0,
-                    userLevel: user.level || 1,
-                    xpNeeded: BRAND_CONFIG.xpRequiredForLevel(user.level || 1)
+                    userXp: contXp.xpForCurrentLevel,
+                    userLevel: contXp.level,
+                    xpNeeded: contXp.xpForNextLevel
                 });
             }
         }

--- a/tests/unit/xpProgress.test.js
+++ b/tests/unit/xpProgress.test.js
@@ -1,0 +1,58 @@
+/**
+ * QA P1-6 — XP progress must reconcile.
+ *
+ * The Progress card showed "577 / 140" (current > next) with Total XP 528:
+ * a total-XP value was paired with a next-level threshold (and a stale
+ * level). xpProgress derives everything from levelForXp so within-level XP
+ * is ALWAYS in [0, xpForNextLevel).
+ */
+
+const BRAND = require('../../utils/brand');
+const { levelForXp, xpProgress, cumulativeXpForLevel, xpRequiredForLevel } = BRAND;
+
+describe('levelForXp', () => {
+  test('xp 0 → level 1', () => expect(levelForXp(0)).toBe(1));
+  test('reaches the next level exactly at the cumulative threshold', () => {
+    for (let lvl = 1; lvl <= 20; lvl++) {
+      const atThreshold = cumulativeXpForLevel(lvl);
+      expect(levelForXp(atThreshold)).toBe(lvl);
+      if (lvl > 1) expect(levelForXp(atThreshold - 1)).toBe(lvl - 1);
+    }
+  });
+  test('528 XP → level 5 (the report account)', () => {
+    // cumulative: L5=460, L6=600 → 528 is level 5.
+    expect(levelForXp(528)).toBe(5);
+  });
+  test('handles null/undefined/negative safely', () => {
+    expect(levelForXp(undefined)).toBe(1);
+    expect(levelForXp(null)).toBe(1);
+    expect(levelForXp(-50)).toBe(1);
+  });
+});
+
+describe('xpProgress — the broken-fraction guard', () => {
+  test('528 XP → level 5, 68 / 140 (not 577 / 140)', () => {
+    expect(xpProgress(528)).toEqual({ level: 5, xpForCurrentLevel: 68, xpForNextLevel: 140 });
+  });
+
+  test('xpForCurrentLevel is ALWAYS in [0, xpForNextLevel) across a wide range', () => {
+    for (let xp = 0; xp <= 20000; xp += 37) {
+      const p = xpProgress(xp);
+      expect(p.xpForCurrentLevel).toBeGreaterThanOrEqual(0);
+      expect(p.xpForCurrentLevel).toBeLessThan(p.xpForNextLevel);
+      // current level XP + cumulative-to-level reconstructs total exactly
+      expect(cumulativeXpForLevel(p.level) + p.xpForCurrentLevel).toBe(xp);
+    }
+  });
+
+  test('exactly at a level boundary → 0 progress into the new level', () => {
+    const p = xpProgress(cumulativeXpForLevel(6)); // 600
+    expect(p.level).toBe(6);
+    expect(p.xpForCurrentLevel).toBe(0);
+    expect(p.xpForNextLevel).toBe(xpRequiredForLevel(6));
+  });
+
+  test('xp 0 → level 1, 0 / 100', () => {
+    expect(xpProgress(0)).toEqual({ level: 1, xpForCurrentLevel: 0, xpForNextLevel: 100 });
+  });
+});

--- a/utils/brand.js
+++ b/utils/brand.js
@@ -212,6 +212,41 @@ function cumulativeXpForLevel(level) {
     return total;
 }
 
+/**
+ * The correct level for a total XP: the highest level whose cumulative
+ * requirement the student has met. Single source of truth so a legacy or
+ * stale stored `level` can always be reconciled against actual XP.
+ */
+function levelForXp(xp) {
+    const total = Math.max(0, xp || 0);
+    let level = 1;
+    // cumulativeXpForLevel is strictly increasing (each step ≥ xpPerLevel),
+    // so this always terminates.
+    while (total >= cumulativeXpForLevel(level + 1)) level++;
+    return level;
+}
+
+/**
+ * Full XP-progress breakdown for a total XP. Derived from levelForXp, so
+ * xpForCurrentLevel is ALWAYS in [0, xpForNextLevel) — it can never exceed
+ * the threshold, which is the "577 / 140" broken-fraction bug (QA P1-6)
+ * caused by pairing a total-XP value with a stale level.
+ *
+ * @param {number} xp - total lifetime XP
+ * @returns {{ level:number, xpForCurrentLevel:number, xpForNextLevel:number }}
+ */
+function xpProgress(xp) {
+    const total = Math.max(0, xp || 0);
+    const level = levelForXp(total);
+    return {
+        level,
+        xpForCurrentLevel: Math.max(0, total - cumulativeXpForLevel(level)),
+        xpForNextLevel: xpRequiredForLevel(level),
+    };
+}
+
 module.exports = BRAND_CONFIG;
 module.exports.xpRequiredForLevel = xpRequiredForLevel;
 module.exports.cumulativeXpForLevel = cumulativeXpForLevel;
+module.exports.levelForXp = levelForXp;
+module.exports.xpProgress = xpProgress;


### PR DESCRIPTION
…QA P1-6)

The Progress card showed "577 / 140" XP-to-next-level (current exceeds the target — a broken fraction) with Total XP 528. Cause: the "continued session" greeting response in routes/chat.js sent `userXp: user.xp` — the TOTAL lifetime XP — paired with a next-level threshold from a possibly stale stored level. The client renders userXp / xpNeeded verbatim, so total-XP / small-threshold produced current > next. Every OTHER response correctly sends within-level XP; this path was the lone offender.

Fix: single source of truth in brand.js.
- levelForXp(xp): the correct level for a total XP (reconciles a stale stored level, the root issue for lower-level/legacy accounts).
- xpProgress(xp): { level, xpForCurrentLevel, xpForNextLevel } derived from levelForXp, so xpForCurrentLevel is ALWAYS in [0, xpForNextLevel). The greeting path now sends xpProgress(user.xp) instead of raw total.

Verified: unit tests for the report's account (528 → level 5, 68/140) and the invariant xpForCurrentLevel ∈ [0, xpForNextLevel) across xp 0–20000; xpEngine + trialXp suites still green.