### PR TITLE
fix(board): dedupe notation-variant cards + strip raw LaTeX junk (QA …

### DIFF
--- a/tests/unit/boardDedupSanitize.test.js
+++ b/tests/unit/boardDedupSanitize.test.js
@@ -1,0 +1,74 @@
+/**
+ * QA P1-2 — Work Board: duplicate cards + raw LaTeX.
+ *
+ * A multiplication check spawned a pile of cards including duplicates and
+ * raw LaTeX: "6 * 7", "6 × 7 = 42", "6 \times 7 = 42 \". These are the
+ * same content in different notations, so:
+ *   1. dedup keyed on the raw string and never folded them → duplicates.
+ *   2. the trailing lone "\" rendered as raw junk on the card.
+ *
+ * Fixes: normalizeForCompare canonicalizes operator synonyms (so the
+ * variants dedupe), and sanitizeBoardTex strips trailing dangling
+ * backslashes before render.
+ */
+
+const { dropRedundantPoses, _commandsOverlap } = require('../../utils/pipeline/boardSynthesizer');
+const { sanitizeBoardTex, normalizeBoardCommand } = require('../../utils/boardResponseSchema');
+
+describe('dedup — operator synonyms fold (commandsOverlap)', () => {
+  const variants = ['6 × 7 = 42', '6 \\times 7 = 42', '6 * 7 = 42', '6 \\cdot 7 = 42', '6 · 7 = 42', '6 \\times 7 = 42 \\'];
+  test('all multiplication notations of "6×7=42" are treated as the same card', () => {
+    for (const v of variants) {
+      expect(_commandsOverlap({ action: 'pose', tex: '6 × 7 = 42' }, { action: 'pose', tex: v })).toBe(true);
+    }
+  });
+  test('genuinely different problems do NOT overlap', () => {
+    expect(_commandsOverlap({ action: 'pose', tex: '6 × 7 = 42' }, { action: 'pose', tex: '9 × 6 = 54' })).toBe(false);
+  });
+  test('division synonyms fold too', () => {
+    expect(_commandsOverlap({ action: 'resolve', tex: '12 ÷ 4 = 3' }, { action: 'resolve', tex: '12 \\div 4 = 3' })).toBe(true);
+  });
+});
+
+describe('dropRedundantPoses — folds notation variants', () => {
+  test('keeps one pose, drops the notation-variant duplicates', () => {
+    const commands = [
+      { action: 'pose', tex: '6 × 7 = 42' },
+      { action: 'pose', tex: '6 \\times 7 = 42 \\' },
+      { action: 'pose', tex: '6 * 7 = 42' },
+    ];
+    const { kept, dropped } = dropRedundantPoses(commands, null);
+    expect(kept.filter(c => c.action === 'pose')).toHaveLength(1);
+    expect(dropped).toHaveLength(2);
+  });
+
+  test('drops a pose that only restates the already-pinned problem (any notation)', () => {
+    const commands = [{ action: 'pose', tex: '6 \\times 7 = 42' }];
+    const { kept, dropped } = dropRedundantPoses(commands, '6 * 7 = 42');
+    expect(kept.filter(c => c.action === 'pose')).toHaveLength(0);
+    expect(dropped).toHaveLength(1);
+  });
+});
+
+describe('sanitizeBoardTex — strips trailing dangling backslashes', () => {
+  test('removes the trailing lone backslash artifact', () => {
+    expect(sanitizeBoardTex('6 \\times 7 = 42 \\')).toBe('6 \\times 7 = 42');
+    expect(sanitizeBoardTex('9 \\times 6 \\')).toBe('9 \\times 6');
+    expect(sanitizeBoardTex('x = 8 \\\\')).toBe('x = 8');
+  });
+  test('leaves valid LaTeX command tokens in the body untouched', () => {
+    expect(sanitizeBoardTex('\\frac{1}{2} + \\frac{1}{4}')).toBe('\\frac{1}{2} + \\frac{1}{4}');
+    expect(sanitizeBoardTex('6 \\times 7 = 42')).toBe('6 \\times 7 = 42');
+  });
+});
+
+describe('normalizeBoardCommand applies tex sanitization', () => {
+  test('sanitizes tex and check fields, not op/query', () => {
+    const out = normalizeBoardCommand({
+      action: 'verify', tex: 'x = 8 \\', op: null, check: '2(8)+4 = 20 \\',
+      fn: null, query: null, caption: null, model: null, spec: null, prompt: null,
+    });
+    expect(out.tex).toBe('x = 8');
+    expect(out.check).toBe('2(8)+4 = 20');
+  });
+});

--- a/utils/boardResponseSchema.js
+++ b/utils/boardResponseSchema.js
@@ -182,6 +182,21 @@ const OPENAI_RESPONSE_FORMAT = {
  * @returns {object|null} Compact command, or null if `action`
  *   is missing or not in the allowed enum.
  */
+// Fields whose value is LaTeX rendered on a card — sanitize before render.
+const TEX_FIELDS = new Set(['tex', 'check']);
+
+/**
+ * Strip trailing LaTeX line-continuation / dangling-backslash artifacts the
+ * model emits (e.g. "6 \times 7 = 42 \"), which otherwise render as raw junk
+ * on the card or make KaTeX throw and fall back to showing source (QA P1-2).
+ * Only removes trailing backslashes at the very end — command tokens like
+ * \times / \frac in the body are untouched (they render correctly).
+ */
+function sanitizeBoardTex(tex) {
+  if (typeof tex !== 'string') return tex;
+  return tex.trim().replace(/\\+\s*$/g, '').trim();
+}
+
 function normalizeBoardCommand(cmd) {
   if (!cmd || typeof cmd !== 'object') return null;
   if (!BOARD_ACTIONS.includes(cmd.action)) return null;
@@ -189,7 +204,8 @@ function normalizeBoardCommand(cmd) {
   const out = { action: cmd.action };
   const FIELDS = ['tex', 'op', 'check', 'fn', 'query', 'caption', 'model', 'spec', 'prompt'];
   for (const field of FIELDS) {
-    const v = cmd[field];
+    let v = cmd[field];
+    if (typeof v === 'string' && TEX_FIELDS.has(field)) v = sanitizeBoardTex(v);
     if (typeof v === 'string' && v.length > 0) {
       out[field] = v;
     }
@@ -298,6 +314,7 @@ module.exports = {
   BOARD_RESPONSE_SCHEMA,
   OPENAI_RESPONSE_FORMAT,
   normalizeBoardCommand,
+  sanitizeBoardTex,
   normalizeStructuredResponse,
   isStructuredModeEnabled,
   buildStructuredResponseInstructions,

--- a/utils/pipeline/boardSynthesizer.js
+++ b/utils/pipeline/boardSynthesizer.js
@@ -515,7 +515,16 @@ function detectGeometryProblem(tutorText) {
 
 function normalizeForCompare(s) {
   if (!s || typeof s !== 'string') return '';
-  return s.toLowerCase().replace(/\s+/g, '').replace(/[\\${}()[\]]/g, '');
+  let out = s.toLowerCase();
+  // Canonicalize operator synonyms so equivalent cards dedupe (QA P1-2):
+  // "6 × 7", "6 \times 7", "6 * 7", "6 \cdot 7", "6 · 7" must all compare
+  // equal. Fold BEFORE stripping backslashes so \times / \cdot / \div match.
+  out = out
+    .replace(/\\times\b|\\cdot\b|×|·|∗|\*/g, '*')
+    .replace(/\\div\b|÷/g, '/');
+  // strip whitespace and LaTeX structural punctuation/backslashes (this also
+  // removes a trailing lone "\" artifact, so "6 \times 7 = 42 \" folds too)
+  return out.replace(/\s+/g, '').replace(/[\\${}()[\]]/g, '');
 }
 
 function commandsOverlap(a, b) {


### PR DESCRIPTION
…P1-2)

A multiplication check spawned duplicate WorkBoard cards and raw LaTeX: "6 * 7", "6 × 7 = 42", "6 \times 7 = 42 \". Two bugs, both content-triggered (the same class as the P0-1 single-backslash LaTeX leak):

1. Dedup missed them. normalizeForCompare stripped backslashes but did not fold operator synonyms, so "6×7=42", "6 \times 7=42", "6*7=42" produced different keys and never deduped. Now it canonicalizes × / \times / \cdot / · / * → one token (and ÷ / \div → /), so equivalent cards fold (and the trailing "\" artifact is stripped in the key too).
2. Raw LaTeX rendered as junk. The model's trailing dangling backslash ("6 \times 7 = 42 \") rendered literally / made KaTeX fall back to source. New sanitizeBoardTex strips trailing dangling backslashes from the tex/check fields in normalizeBoardCommand; valid command tokens (\times, \frac) in the body are untouched.

Verified: unit tests for the report's exact variants (fold + dedup + sanitize); all 16 board suites (311 tests) still green.