### PR TITLE
fix(billing): AI-time meter updates in real time after each turn (QA …

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -2915,6 +2915,22 @@ document.addEventListener("DOMContentLoaded", () => {
                 data = await response.json();
             }
 
+            // QA P1-7: refresh the AI-time meter from the POST-response balance
+            // the server computed for THIS turn (freeWeeklySecondsRemaining).
+            // The X-Free-Remaining-Seconds header is set by usageGate BEFORE the
+            // turn's AI time is measured, so the pill lagged a full turn and
+            // "didn't move". This value already has the current turn deducted.
+            // Merge the cached usage so the "Resets in…" line survives the update.
+            if (data && typeof data.freeWeeklySecondsRemaining === 'number' &&
+                typeof updateFreeTimeIndicator === 'function') {
+                const prevUsage = (window._billingStatus && window._billingStatus.usage) || {};
+                updateFreeTimeIndicator({
+                    ...prevUsage,
+                    secondsRemaining: data.freeWeeklySecondsRemaining,
+                    limitReached: data.freeWeeklySecondsRemaining <= 0,
+                });
+            }
+
             // Process AI response (same logic as original sendMessage)
             let aiText = data.text || '';
             const wasStreamed = contentType.includes('text/event-stream');


### PR DESCRIPTION
…P1-7)

The "AI time left" pill sat unchanged through several tutor responses (and a reload), only ticking down much later — which reads as a broken meter and undermines the upgrade prompt on the free tier.

Cause: the client updated the pill from the X-Free-Remaining-Seconds response header, but that header is set in usageGate middleware BEFORE the turn's AI processing time is measured and deducted — so it always lagged a full turn. The chat 'complete' event already carries the authoritative post-deduction balance (freeWeeklySecondsRemaining, computed in pipeline/persist as FREE_WEEKLY - updatedWeekly), but the client ignored it.

Fix (client-only): after each response, refresh the indicator from data.freeWeeklySecondsRemaining (present on both the streaming 'complete' event and the non-streaming JSON). Merge the cached billing usage so the "Resets in…" line survives the update. Null for non-free users → skipped.

Verified by driving the real updateFreeTimeIndicator through successive balances (27 → 25 → 4 min low-state → exhausted) and confirming the pill text and styling change each time.