### PR TITLE
fix(brand): retint the login page to teal — product chrome = teal (QA…

### DIFF
--- a/public/login.html
+++ b/public/login.html
@@ -53,6 +53,14 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
        The default .landing-page-body adds a hard column flex; we
        override below for the split layout. */
     body.auth-modern {
+      /* QA brand standardization (option B): product chrome = teal. The login
+         page read purple because it drove chrome off the purple --cr-accent
+         token; retint those tokens to the brand teal, scoped to the auth
+         page only. Gamification (which hardcodes its own purple) is
+         untouched, so purple stays where it belongs. */
+      --cr-accent: #12B3B3;
+      --cr-accent-strong: #0E9191;
+      --cr-accent-grad: linear-gradient(135deg, #12B3B3, #0E9191);
       background: var(--cr-bg-0);
       color: var(--cr-text);
       min-height: 100dvh;
@@ -116,7 +124,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     .auth-modern .auth-brand {
       position: relative;
       padding: 64px 56px;
-      background: linear-gradient(160deg, #EDE9FF 0%, #F5F7FB 55%, #FFFFFF 100%);
+      background: linear-gradient(160deg, #E3F6F6 0%, #F5F7FB 55%, #FFFFFF 100%);
       border-right: 1px solid var(--cr-border);
       display: flex;
       flex-direction: column;


### PR DESCRIPTION
… P2, option B)

The report flagged "homepage hero is teal; the login page and gamification are purple" as an inconsistency that reads as less trustworthy to parents. Per the decision (B): product chrome standardizes on the brand teal; gamification keeps its purple identity.

Root cause: the login page drove its chrome (CTA, links, nav, headline accent, panel gradient) off the purple design-system --cr-accent / --cr-accent-grad tokens. Since those tokens are otherwise barely used and gamification hardcodes its OWN purple (#667eea etc.), retinting the tokens to teal SCOPED to body.auth-modern flips the whole login page to teal without touching gamification anywhere.

- Override --cr-accent / --cr-accent-strong / --cr-accent-grad to brand teal (#12B3B3) on body.auth-modern.
- Swap the light-purple auth-brand stage gradient (#EDE9FF) for a light-teal tint (#E3F6F6).

Verified in-browser: Log In button, "teaches them to think" headline, Forgot Password link, Sign Up outline, and the panel gradient are all teal now, matching the homepage. Signup already used teal; gamification purple is untouched.

NOTE: this is the public-chrome pass. Auth-gated internal surfaces that also carry purple (courseCatalog, floating-screener, sidebar-layout, calculator, IEP, returning-user-modal, mobile-redesign) are a per-screen pass-2 — each needs a chrome-vs-gamification judgment and visual review behind login.