### PR TITLE
fix(visual-gate): catch vertex + y-intercept graph leaks (unblocks P14)

### DIFF
--- a/tests/unit/visualGate.test.js
+++ b/tests/unit/visualGate.test.js
@@ -33,8 +33,20 @@ describe('visualGate — helpers', () => {
     expect(extractNumbers('No real solutions')).toEqual([]);
   });
 
-  it('graphRevealedValues computes the roots a graph would expose', () => {
-    expect(graphRevealedValues('x^2 - 5x + 6').sort()).toEqual([2, 3]);
+  it('graphRevealedValues exposes roots AND y-intercept AND vertex', () => {
+    // x^2 - 5x + 6: roots 2 & 3, y-intercept f(0)=6, vertex (2.5, -0.25).
+    const v = graphRevealedValues('x^2 - 5x + 6');
+    expect(v).toEqual(expect.arrayContaining([2, 3])); // roots
+    expect(v).toContain(6);                            // y-intercept
+    expect(v).toContain(2.5);                          // vertex x
+    expect(v).toContain(-0.25);                        // vertex y (minimum value)
+  });
+
+  it('graphRevealedValues gets the y-intercept of a line', () => {
+    // 2x + 5: root -2.5, y-intercept 5.
+    const v = graphRevealedValues('2x + 5');
+    expect(v).toContain(5);
+    expect(v).toContain(-2.5);
   });
 
   it('visualIsTheTask detects a graphing assignment', () => {
@@ -129,6 +141,44 @@ describe('visualGate — orchestrator + modes', () => {
     });
     expect(record.decision).toBe('block');
     expect(command).toEqual({ action: 'graph', fn: 'x^2 - 5x + 6' }); // unchanged in shadow
+  });
+
+  it('live_control blocks a graph that leaks the VERTEX (previously slipped through)', async () => {
+    // "minimum value" answer = the vertex y (−1). Roots {1,3} would NOT catch
+    // this; the vertex extension does.
+    const vertexProblem = {
+      problemText: 'Find the minimum value of x^2 - 4x + 3',
+      normalizedExpression: 'x^2 - 4x + 3',
+      correctAnswer: 'y = -1',
+      problemType: 'quadratic',
+      status: 'unsolved',
+    };
+    const { command, record } = await applyVisualGate({
+      command: { action: 'graph', fn: 'x^2 - 4x + 3' },
+      activeProblem: vertexProblem,
+      mode: MODES.LIVE_CONTROL,
+      valueJudge: allowJudge,
+    });
+    expect(record.decision).toBe('block');
+    expect(command).toBeNull();
+  });
+
+  it('live_control blocks a graph that leaks the Y-INTERCEPT', async () => {
+    const yIntProblem = {
+      problemText: 'What is the y-intercept of x^2 - 4x + 3?',
+      normalizedExpression: 'x^2 - 4x + 3',
+      correctAnswer: 'y-intercept = 3',
+      problemType: 'quadratic',
+      status: 'unsolved',
+    };
+    const { command, record } = await applyVisualGate({
+      command: { action: 'graph', fn: 'x^2 - 4x + 3' },
+      activeProblem: yIntProblem,
+      mode: MODES.LIVE_CONTROL,
+      valueJudge: allowJudge,
+    });
+    expect(record.decision).toBe('block');
+    expect(command).toBeNull();
   });
 
   it('live_control blocks a leaking graph (drops it)', async () => {

--- a/utils/visualGate.js
+++ b/utils/visualGate.js
@@ -33,7 +33,7 @@
  * @module utils/visualGate
  */
 
-const { parseCleanProblem } = require('./mathSolver');
+const { parseCleanProblem, parsePolynomialTerms } = require('./mathSolver');
 const { contentHash, wasRecentlyShown } = require('./problemTracking');
 
 // Modes form an audit-first ladder, matching the structured-tutor-response
@@ -99,37 +99,85 @@ function extractNumbers(answer) {
   return matches.map(Number).filter((n) => Number.isFinite(n));
 }
 
+/** Dedupe a numeric list within NUM_TOLERANCE (keeps the revealed set tidy). */
+function dedupeNumbers(list) {
+  const out = [];
+  for (const n of list) {
+    if (!Number.isFinite(n)) continue;
+    if (!out.some((m) => Math.abs(m - n) <= NUM_TOLERANCE)) out.push(n);
+  }
+  return out;
+}
+
 /**
- * Compute the values a graph of `fn` would visibly reveal — primarily its real
- * roots (x-intercepts), by solving "fn = 0" with the existing deterministic
- * solver. These are the coordinates a student could read straight off the
- * curve. Returns [] when the function can't be solved to discrete real values
- * (in which case there's nothing numeric to leak).
+ * y-intercept + vertex — coordinates a student can read straight off a curve
+ * BEYOND its roots. Deterministic + polynomial-only (returns [] for anything
+ * parsePolynomialTerms can't handle — trig/log/rational, etc.).
+ *   - y-intercept: f(0) = the constant term.
+ *   - vertex (degree-2 only): x_v = −b/2a, y_v = c − b²/4a (both are visible).
+ * These are exactly the values that make a *draggable* graph exploitable (a
+ * student drags the handle to the vertex / axis crossing and reads it off).
  *
- * NOTE: covers roots/x-intercepts, which is the dominant leak surface
- * ("find the roots/zeros/x-intercepts of f"). Vertex/y-intercept/intersection
- * leaks are a documented extension point — see README for the gate.
+ * @param {string} fn
+ * @returns {number[]}
+ */
+function polynomialFeatureValues(fn) {
+  let terms;
+  try { terms = parsePolynomialTerms(normalizeExpr(fn)); } catch (_) { return []; }
+  if (!Array.isArray(terms) || !terms.length) return [];
+
+  const constTerm = terms.filter((t) => t.exp === 0).reduce((s, t) => s + t.coeff, 0);
+  const values = [constTerm]; // y-intercept f(0)
+
+  const degree = terms.reduce((d, t) => Math.max(d, t.exp), 0);
+  if (degree === 2) {
+    const a = terms.filter((t) => t.exp === 2).reduce((s, t) => s + t.coeff, 0);
+    const b = terms.filter((t) => t.exp === 1).reduce((s, t) => s + t.coeff, 0);
+    if (a !== 0) {
+      values.push(-b / (2 * a));              // vertex x
+      values.push(constTerm - (b * b) / (4 * a)); // vertex y (the min/max value)
+    }
+  }
+  return values.filter((n) => Number.isFinite(n));
+}
+
+/**
+ * Compute the values a graph of `fn` would visibly reveal — the coordinates a
+ * student could read straight off the curve. Covers:
+ *   - roots / x-intercepts (solve "fn = 0" with the deterministic solver),
+ *   - the y-intercept f(0), and
+ *   - the vertex (x and y) of a quadratic.
+ * Returns [] when nothing numeric is derivable (e.g. a transcendental with no
+ * solvable roots and no polynomial features).
+ *
+ * REMAINING extension: intersection leaks (two graphed functions crossing at
+ * the answer) — a turn-level, multi-command concern, not a single-fn one.
  *
  * @param {string} fn
  * @returns {number[]}
  */
 function graphRevealedValues(fn) {
   if (!fn || typeof fn !== 'string') return [];
+  const values = [];
+
+  // Roots / x-intercepts (existing).
   const probe = `${fn} = 0`;
-  let parsed;
   try {
-    parsed = parseCleanProblem(probe);
-  } catch (_) {
-    return [];
-  }
-  if (!parsed || !parsed.hasMath || !parsed.solution || !parsed.solution.success) {
-    return [];
-  }
-  const sol = parsed.solution;
-  if (Array.isArray(sol.roots) && sol.roots.length) {
-    return sol.roots.map(Number).filter((n) => Number.isFinite(n));
-  }
-  return extractNumbers(sol.answer);
+    const parsed = parseCleanProblem(probe);
+    if (parsed && parsed.hasMath && parsed.solution && parsed.solution.success) {
+      const sol = parsed.solution;
+      if (Array.isArray(sol.roots) && sol.roots.length) {
+        values.push(...sol.roots.map(Number).filter((n) => Number.isFinite(n)));
+      } else {
+        values.push(...extractNumbers(sol.answer));
+      }
+    }
+  } catch (_) { /* unsolvable → contributes no roots */ }
+
+  // y-intercept + vertex (new).
+  values.push(...polynomialFeatureValues(fn));
+
+  return dedupeNumbers(values);
 }
 
 /** Do two numeric sets share any value (within tolerance)? */


### PR DESCRIPTION
The answer-leak visual-gate only computed a graph's ROOTS (x-intercepts), so graphing a function whose VERTEX or Y-INTERCEPT is the answer to the student's open problem slipped through — e.g. "find the minimum of x²−4x+3" (answer −1) or "the y-intercept" (answer 3) both leaked, because {roots 1,3} don't include −1 or 3. Draggable graph handles (Living Workspace P14) make this directly exploitable — a student drags to the vertex / axis crossing and reads the value off.

graphRevealedValues now returns roots ∪ { f(0) } ∪ { vertex x, vertex y }:
- y-intercept = the constant term (via parsePolynomialTerms),
- vertex (degree-2) = (−b/2a, c − b²/4a) — both visible coordinates. Deterministic + polynomial-only (transcendental/rational → no extra values, same as before). Deduped within tolerance.

Verified: x²−5x+6 → exposes {2,3 roots, 6 y-int, 2.5 & −0.25 vertex}; new gate tests confirm live_control now BLOCKS graphs that leak the vertex or y-intercept (previously passed). 37 gate tests green, no regressions.

REMAINING: intersection leaks (two graphed functions crossing at the answer) are a turn-level, multi-command concern — a separate follow-up.