### PR TITLE
fix(chat): hoist streamRef so streamed turns don't throw "streamRef i…

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -2792,12 +2792,17 @@ document.addEventListener("DOMContentLoaded", () => {
             // Check if response is SSE stream (text/event-stream)
             const contentType = response.headers.get('Content-Type') || '';
             let data;
+            // Declared out here (not inside the stream branch) because the
+            // post-stream dead-air guard below reads `!streamRef` — with a
+            // block-scoped `let`, that read threw "streamRef is not defined"
+            // on every streamed turn (the error surfaced *after* the reply
+            // rendered, since finalize runs inside the branch).
+            let streamRef = null;
 
             if (contentType.includes('text/event-stream')) {
                 // Read SSE stream: show words as they arrive
                 // Don't create the bubble yet — wait until first chunk arrives
                 // to avoid showing a blank pill during pipeline processing.
-                let streamRef = null;
                 let fullText = '';
                 let completeData = null;
 


### PR DESCRIPTION
…s not defined"

Regression from PR #1161 (fix/silent-chat-turn): the dead-air guard added at the end of handleSend reads `!streamRef`, but streamRef was declared with a block-scoped `let` inside the `if (text/event-stream)` branch. On every STREAMED turn (the normal path) `wasStreamed` is true, so `!wasStreamed` short-circuits false and JS evaluates `!streamRef` — a ReferenceError, since that name isn't in scope outside the branch.

The reply still streamed and finalized (that happens inside the branch), so the student saw the tutor's message AND an error card ("streamRef is not defined / Try Again") right below it — exactly the reported symptom.

Fix: declare `let streamRef = null;` in the outer scope (next to `let data`) so both the stream branch and the post-stream guard reference the same binding. No behavior change beyond removing the throw.

Verified: eslint parses clean (0 errors); a minimal repro of the exact control flow throws "streamRef is not defined" with the block-scoped decl and returns normally once hoisted.