### PR TITLE
fix(board): pose word/volume problems on the board, not just algebra

### DIFF
--- a/tests/unit/boardSynthesizer.test.js
+++ b/tests/unit/boardSynthesizer.test.js
@@ -502,6 +502,36 @@ describe('boardSynthesizer — geometry pose fallback', () => {
       expect(r.sentence).toMatch(/triangle DEF\?$/);
     });
 
+    test('catches a rectangular-prism VOLUME word problem (3D solids)', () => {
+      const r = _detectGeometryProblem(
+        "A prism has volume 45.5 cm3, length 7 cm, and width 2.6 cm. What's the height?"
+      );
+      expect(r).not.toBeNull();
+      expect(r.sentence).toMatch(/prism|volume/i);
+      // must NOT bake in the answer (45.5 / (7*2.6) = 2.5)
+      expect(r.tex).not.toMatch(/2\.5/);
+    });
+
+    test('catches a cylinder volume problem', () => {
+      const r = _detectGeometryProblem(
+        'A cylinder has a radius of 3 cm and a height of 10 cm. Find the volume.'
+      );
+      expect(r).not.toBeNull();
+      expect(r.sentence).toMatch(/cylinder|volume/i);
+    });
+
+    test('catches a surface-area problem', () => {
+      const r = _detectGeometryProblem(
+        'A cube has a side length of 4 inches. What is the surface area of the cube?'
+      );
+      expect(r).not.toBeNull();
+      expect(r.sentence).toMatch(/cube|surface area/i);
+    });
+
+    test('does not fire on non-math uses of "volume" (no problem cue)', () => {
+      expect(_detectGeometryProblem('Turn the volume down, it is 11 out of 10.')).toBeNull();
+    });
+
     test('catches a "Question:" framed prompt', () => {
       const r = _detectGeometryProblem(
         "Awesome! Let's try this:\n\nQuestion: A circle has a radius of 8 units. What is the area of the circle?"

--- a/utils/pipeline/boardSynthesizer.js
+++ b/utils/pipeline/boardSynthesizer.js
@@ -443,12 +443,12 @@ const NEW_PROBLEM_CUE = /\b(solve|factor|simplify|expand|evaluate|graph|compute|
 // textContent (see public/js/workspace.js:42).
 // ---------------------------------------------------------------------------
 
-const GEOMETRY_VOCAB = /\b(triangles?|circles?|angles?|radius|diameter|circumference|hypotenuse|polygons?|quadrilaterals?|parallelograms?|rectangles?|trapezoids?|pentagons?|hexagons?|perimeters?|congruent|similar|parallel|perpendicular|bisectors?|midpoints?|chords?|tangents?|secants?|arcs?|sectors?|(?:vertex|vertices)|legs?|diagonals?|altitudes?|medians?|centroids?|equation\s+of\s+(?:a|the)\s+circle)\b/i;
+const GEOMETRY_VOCAB = /\b(triangles?|circles?|angles?|radius|diameter|circumference|hypotenuse|polygons?|quadrilaterals?|parallelograms?|rectangles?|trapezoids?|pentagons?|hexagons?|perimeters?|congruent|similar|parallel|perpendicular|bisectors?|midpoints?|chords?|tangents?|secants?|arcs?|sectors?|(?:vertex|vertices)|legs?|diagonals?|altitudes?|medians?|centroids?|equation\s+of\s+(?:a|the)\s+circle|volumes?|surface\s+areas?|prisms?|cuboids?|cubes?|cylinders?|spheres?|cones?|pyramids?|tetrahedra)\b/i;
 
 // "Question:", "Here's one", "What is …", "Find …", "Convert …",
 // etc. Conservative — bare statements without a cue don't fire so
 // concept explanations stay off the board.
-const PROBLEM_CUE = /\b(question\s*:|here'?s\s+(?:a|one|another)|try\s+(?:this|one|the\s+following)|let'?s\s+try|what\s+(?:is|are|'?s)\b|find\s+(?:the|how|out)\b|calculate\b|determine\b|convert\b|how\s+(?:many|long|wide|much|tall|far)\b|solve\s+for\b)/i;
+const PROBLEM_CUE = /\b(question\s*:|here'?s\s+(?:a|one|another)|try\s+(?:this|one|the\s+following)|let'?s\s+try|what(?:\s+(?:is|are)|'?s)\b|find\s+(?:the|how|out)\b|calculate\b|determine\b|convert\b|how\s+(?:many|long|wide|much|tall|far)\b|solve\s+for\b)/i;
 
 // Conversational offers Maya makes at the end of a concept explanation
 // ("What would you like to explore next?", "Do you want to try one?").
@@ -467,7 +467,14 @@ function extractProblemSentence(text) {
   // on the preceding sentence so we can find the one ending in '?'.
   // Skip offer questions — they're tutor next-step prompts, not problems.
   const sentences = body.split(/(?<=[.!?])\s+/).filter(s => s.trim());
-  const qIdx = sentences.findIndex(s => /\?\s*$/.test(s) && !OFFER_QUESTION.test(s));
+  let qIdx = sentences.findIndex(s => /\?\s*$/.test(s) && !OFFER_QUESTION.test(s));
+  // Imperative asks ("Find the volume.", "Calculate the surface area.") carry
+  // the problem without a '?'. Fall back to a PROBLEM_CUE sentence when no
+  // question sentence exists. Only reached from detectGeometryProblem, which
+  // has already confirmed geometry vocab + a number, so this stays scoped.
+  if (qIdx === -1) {
+    qIdx = sentences.findIndex(s => PROBLEM_CUE.test(s) && !OFFER_QUESTION.test(s));
+  }
   if (qIdx === -1) return null;
 
   // Include up to two preceding setup sentences (the parameters) so


### PR DESCRIPTION
Root cause of "the tutor taught a whole volume lesson and the board stayed empty": the deterministic board synthesizer's pose path is symbolic-only. On an empty board it already tries detectGeometryProblem(tutorResponse), but three things blocked volume/word problems from ever posing:

1. GEOMETRY_VOCAB was 2D-only (triangles/circles/angles/…). Added the 3D/ measurement family: volume, surface area, prism, cuboid, cube, cylinder, sphere, cone, pyramid, tetrahedron.
2. PROBLEM_CUE didn't match the contraction "What's" (it required a space: what\s+…). The transcript's problem was literally "…What's the height?", so it only posed when an unrelated "Let's try…" lead-in happened to supply the cue — fragile. Now matches what's / whats / what is / what are.
3. extractProblemSentence required a '?'-terminated sentence, so imperative asks ("Find the volume.", "Calculate the surface area.") never posed. Added a PROBLEM_CUE-sentence fallback — scoped: only detectGeometryProblem calls this, and it has already confirmed geometry vocab + a number.

Anti-cheat unchanged: a pose card carries the problem STATEMENT (wrapped in \text{}), never the answer, and still runs the pedagogy guard + visual gate.

Verified: replayed the exact 3 volume problems from the reported session — all 3 now pose, 0 leak their answer (72 / 3 / 2.5). boardSynthesizer suite 115 green (+4 new: prism volume, cylinder, surface area, non-math "volume" negative); full pipeline+visualGate+board suites 541 green. eslint clean.