### PR TITLE
Bill a fair per-turn floor for AI time, not raw LLM latency

### DIFF
--- a/tests/unit/pipelineIntegration.test.js
+++ b/tests/unit/pipelineIntegration.test.js
@@ -285,6 +285,47 @@ describe('Pipeline Integration: runPipeline', () => {
     expect(result._pipeline.signalStats.total).toBeGreaterThanOrEqual(0);
   });
 
+  test('fair-time floor: a fast turn still bills at least the floor', async () => {
+    // A single gpt-4o-mini turn returns in well under a second, so raw
+    // aiProcessingSeconds ≈ 0. Without the floor, a dense multi-turn session
+    // meters to near-zero ("2 minutes" for 10+ real minutes of tutoring).
+    const user = mockUser({ weeklyAISeconds: 0 });
+    const conversation = mockConversation([
+      { role: 'assistant', content: 'What is 6 + 6?', problemResult: null },
+      { role: 'user', content: '12' },
+    ]);
+
+    mockLLMResponse('Nice! 12 is correct. <PROBLEM_RESULT:correct>');
+
+    // aiProcessingStartTime = now → raw elapsed rounds to ~0s, so the floor governs.
+    const result = await runPipeline('12', buildCtx(user, conversation));
+
+    const FLOOR = Number(process.env.AI_TIME_FLOOR_SECONDS) || 30;
+    expect(result.aiTimeUsed).toBe(FLOOR);
+  });
+
+  test('fair-time floor: a slow turn still bills its true (higher) latency', async () => {
+    // A slow vision-grading turn on gpt-4o exceeds the floor — bill real latency,
+    // don't clamp down to it.
+    const user = mockUser({ weeklyAISeconds: 0 });
+    const conversation = mockConversation([
+      { role: 'assistant', content: 'What is 6 + 6?', problemResult: null },
+      { role: 'user', content: '12' },
+    ]);
+
+    mockLLMResponse('Nice! 12 is correct. <PROBLEM_RESULT:correct>');
+
+    const FLOOR = Number(process.env.AI_TIME_FLOOR_SECONDS) || 30;
+    // Backdate the start so raw elapsed is ~90s — well above the floor.
+    const ctx = buildCtx(user, conversation, {
+      aiProcessingStartTime: Date.now() - 90_000,
+    });
+    const result = await runPipeline('12', ctx);
+
+    expect(result.aiTimeUsed).toBeGreaterThan(FLOOR);
+    expect(result.aiTimeUsed).toBeGreaterThanOrEqual(89);
+  });
+
   test('persists session mood to conversation document', async () => {
     const user = mockUser();
     const conversation = mockConversation([

--- a/utils/pipeline/persist.js
+++ b/utils/pipeline/persist.js
@@ -494,10 +494,21 @@ async function persist(params) {
   }
 
   // ── 9. AI time tracking ──
-  if (aiProcessingSeconds > 0) {
+  // Fair-time floor: a genuine tutoring turn always meters at least
+  // AI_TIME_FLOOR_SECONDS. Without this, the quota counts only raw server
+  // LLM latency, so a dense multi-turn session on fast gpt-4o-mini (a few
+  // seconds per turn) under-counts to near-zero — e.g. a 10-turn, ~12-minute
+  // session billed as "2 minutes". Slow turns (gpt-4o vision grading) still
+  // bill their true latency via max(). Only real turns are lifted: the
+  // aiProcessingSeconds > 0 guard means non-turns still bill nothing.
+  const AI_TIME_FLOOR_SECONDS = Number(process.env.AI_TIME_FLOOR_SECONDS) || 30;
+  const billedSeconds = aiProcessingSeconds > 0
+    ? Math.max(aiProcessingSeconds, AI_TIME_FLOOR_SECONDS)
+    : 0;
+  if (billedSeconds > 0) {
     const previousWeekly = user.weeklyAISeconds || 0;
-    const updatedWeekly = previousWeekly + aiProcessingSeconds;
-    const aiTimeUpdate = { $inc: { weeklyAISeconds: aiProcessingSeconds, totalAISeconds: aiProcessingSeconds } };
+    const updatedWeekly = previousWeekly + billedSeconds;
+    const aiTimeUpdate = { $inc: { weeklyAISeconds: billedSeconds, totalAISeconds: billedSeconds } };
 
     const FREE_WEEKLY = 30 * 60;
     const packStillValid = (user.subscriptionTier === 'pack_60' || user.subscriptionTier === 'pack_120') &&
@@ -518,7 +529,7 @@ async function persist(params) {
       console.error('[Persist] AI time tracking error:', err);
     }
 
-    results.aiTimeUsed = aiProcessingSeconds;
+    results.aiTimeUsed = billedSeconds;
     results.freeWeeklySecondsRemaining =
       (!user.subscriptionTier || user.subscriptionTier === 'free')
         ? Math.max(0, FREE_WEEKLY - updatedWeekly)


### PR DESCRIPTION
The 30-free-minute quota and paid 60/120 packs meter against `weeklyAISeconds`, which is the summed server-side LLM latency per turn (`Date.now() - aiProcessingStartTime`). On fast gpt-4o-mini turns that is a few seconds each, so a dense, high-value multi-turn session (~12 real minutes, 10+ exchanges) meters as ~2 minutes — the app under-counts the tutoring it actually delivered and packs deplete at latency-speed.

Add a per-turn floor at the single billing chokepoint (persist stage): each genuine tutoring turn now bills at least AI_TIME_FLOOR_SECONDS (default 30, env-tunable). Slow turns (e.g. gpt-4o vision grading) still bill their true, higher latency via max(). The existing `aiProcessingSeconds > 0` guard is preserved, so non-turns still bill nothing. Course chat inherits the floored value through `pipelineResult.aiTimeUsed`; no second write path exists.

Adds two pipeline-integration tests covering the fast-turn (floored) and slow-turn (true-latency) cases.