### PR TITLE
Fix stale free-minutes value in course-chat response

### DIFF
--- a/routes/courseChat.js
+++ b/routes/courseChat.js
@@ -19,6 +19,7 @@ const { detectAndFetchResource, detectResourceMention } = require('../utils/reso
 const { buildProgressUpdate } = require('../utils/progressState');
 const { runPipeline, verify: pipelineVerify } = require('../utils/pipeline');
 const { buildCoursePipelineContext, postProcessCourseResult } = require('../utils/pipeline/courseAdapter');
+const { FREE_WEEKLY_SECONDS } = require('../middleware/usageGate');
 
 const PRIMARY_CHAT_MODEL = 'gpt-4o-mini';
 const MAX_HISTORY_LENGTH = 40;
@@ -314,7 +315,7 @@ router.post('/', async (req, res) => {
                 },
                 aiTimeUsed: aiProcessingSeconds,
                 freeWeeklySecondsRemaining: (!user.subscriptionTier || user.subscriptionTier === 'free')
-                    ? Math.max(0, (20 * 60) - (user.weeklyAISeconds || 0))
+                    ? Math.max(0, FREE_WEEKLY_SECONDS - (user.weeklyAISeconds || 0))
                     : null,
                 // Interactive tools
                 graphTool: graphToolConfig,


### PR DESCRIPTION
Course chat reported `freeWeeklySecondsRemaining` against a hardcoded `20 * 60` (20 min) while the real free quota — and every other surface (usageGate, persist) — is 30 min (`FREE_WEEKLY_SECONDS = 30 * 60`). A free course student would see a wrong "minutes left" number.

Import the canonical `FREE_WEEKLY_SECONDS` from middleware/usageGate instead of a magic number so the value can't drift again. No circular dependency (usageGate pulls in models only, not routes).

Note: courses are not currently student-accessible, so this is a latent display bug, not live-facing.