### PR TITLE
fix(workspace): strip math delimiters before KaTeX in the derivation

### DIFF
--- a/public/js/living-workspace/dom/derivationView.js
+++ b/public/js/living-workspace/dom/derivationView.js
@@ -43,13 +43,27 @@
 
   function norm(s) { return String(s == null ? '' : s).replace(/\s+/g, '').toLowerCase(); }
 
+  // KaTeX.render expects RAW math and errors on math-mode delimiters ("Can't
+  // use function '\(' in math mode"), rendering the source in red. The tutor
+  // sometimes wraps board tex in \(...\) / \[...\] / $...$, so strip those
+  // wrappers before typesetting. Interior \left( … \right) are untouched
+  // (only a backslash IMMEDIATELY before ( ) [ ] is a delimiter). Exported
+  // for tests.
+  function cleanLatex(s) {
+    var t = String(s == null ? '' : s).trim();
+    t = t.replace(/\\[()[\]]/g, ' ');        // \( \) \[ \] delimiters -> space
+    t = t.replace(/^\$\$?/, '').replace(/\$\$?$/, ''); // $ … $ or $$ … $$
+    return t.trim();
+  }
+
   function typeset(target, latex) {
     var katex = root.katex;
+    var tex = cleanLatex(latex);
     if (katex && typeof katex.render === 'function') {
-      try { katex.render(latex || '', target, { throwOnError: false, displayMode: false }); return; }
+      try { katex.render(tex, target, { throwOnError: false, displayMode: false }); return; }
       catch (_) { /* fall through to text */ }
     }
-    target.textContent = latex || '';
+    target.textContent = tex;
   }
 
   function DerivationView(container, opts) {
@@ -170,6 +184,7 @@
   };
 
   DerivationView.classify = classify;
+  DerivationView.cleanLatex = cleanLatex;
   LWS.DerivationView = DerivationView;
-  if (typeof module !== 'undefined' && module.exports) module.exports = { DerivationView: DerivationView, classify: classify };
+  if (typeof module !== 'undefined' && module.exports) module.exports = { DerivationView: DerivationView, classify: classify, cleanLatex: cleanLatex };
 })(typeof self !== 'undefined' ? self : this);

--- a/tests/unit/workspace/derivationView.test.js
+++ b/tests/unit/workspace/derivationView.test.js
@@ -1,4 +1,33 @@
-const { classify } = require('../../../public/js/living-workspace/dom/derivationView.js');
+const { classify, cleanLatex } = require('../../../public/js/living-workspace/dom/derivationView.js');
+
+// The tutor sometimes wraps board tex in math delimiters, which make
+// KaTeX.render error ("Can't use function '\(' in math mode") and show raw
+// red source. cleanLatex strips those wrappers so the equation typesets.
+describe('derivationView.cleanLatex', () => {
+  it('strips the \\(...\\) delimiters seen live (multi-wrapped answer)', () => {
+    // \(x^{5}\)-\(x^{3}\)+7x+C  ->  x^{5} - x^{3} +7x+C  (renderable)
+    const out = cleanLatex('\\(x^{5}\\)-\\(x^{3}\\)+7x+C');
+    expect(out).not.toMatch(/\\[()]/);
+    expect(out).toContain('x^{5}');
+    expect(out).toContain('+C');
+  });
+
+  it('strips \\[...\\] display delimiters and $ / $$ wrappers', () => {
+    expect(cleanLatex('\\[ x = 5 \\]')).toBe('x = 5');
+    expect(cleanLatex('$$\\int x\\,dx$$')).toBe('\\int x\\,dx');
+    expect(cleanLatex('$x+1$')).toBe('x+1');
+  });
+
+  it('leaves clean tex and interior \\left( … \\right) untouched', () => {
+    expect(cleanLatex('x^2 - 4x + 3')).toBe('x^2 - 4x + 3');
+    expect(cleanLatex('\\left( x+1 \\right)^2')).toBe('\\left( x+1 \\right)^2');
+  });
+
+  it('handles junk', () => {
+    expect(cleanLatex(null)).toBe('');
+    expect(cleanLatex(undefined)).toBe('');
+  });
+});
 
 // classify() decides how each adapted element renders in the focused
 // derivation. Pure function; the DOM layout is verified in-browser.


### PR DESCRIPTION
Caught in a live session: the tutor emitted board tex wrapped in \(...\) (e.g. `\(x^{5}\)-\(x^{3}\)+7x+C`), and KaTeX.render errors on math-mode delimiters ("Can't use function '\(' in math mode"), rendering the raw source in red.

Add cleanLatex() and run it before typesetting: strips \( \) \[ \] delimiters and surrounding $ / $$ wrappers, while leaving clean tex and interior \left( … \right) untouched (only a backslash IMMEDIATELY before a bracket is a delimiter). Defense-in-depth at the render layer — upstream normalization would also help, but the board should never show raw source regardless of input.

Verified: 8 workspace unit tests (incl. the exact live-broken string); browser — the real session's `∫(5x^4-3x^2+7)dx` + `\(x^{5}\)-...` now typeset cleanly with no visible delimiters.