### PR TITLE
fix(voice): restore the voice-mode mic — re-mount the orb

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -2297,7 +2297,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <script defer src="/js/chat-redesign.js"></script>
   <!-- Drive the "Live with <tutor>" pill bars from real TTS playback -->
   <script type="module" src="/js/chat-voice-meter.js"></script>
-  <script src="/dist/js/chat-js2.0c1f9d9e.js"></script>
+  <script src="/dist/js/chat-js2.0c1f1731.js"></script>
 <!-- Voice as a layout mode of the chat stage -->
   <script src="/js/voice-mode.js?v=3"></script>
   <!-- Whiteboard stack lazy-loaded via loadBoardTools() (see boardPanel block

--- a/public/dist/chat-bundles.manifest.json
+++ b/public/dist/chat-bundles.manifest.json
@@ -62,7 +62,7 @@
       ]
     },
     {
-      "src": "/dist/js/chat-js2.0c1f9d9e.js",
+      "src": "/dist/js/chat-js2.0c1f1731.js",
       "files": [
         "/js/voice-stream-client.js?v=3",
         "/js/voice-controller.js"

--- a/public/dist/js/chat-js2.0c1f1731.js
+++ b/public/dist/js/chat-js2.0c1f1731.js
@@ -693,13 +693,14 @@ class VoiceController {
     // ============================================
 
     createVoiceUI() {
-        // The floating voice orb has been removed from the UI entirely — it's
-        // never mounted to the DOM (see the appendChild note below), so it can't
-        // appear in normal chat OR voice mode. Voice is entered/exited from the
-        // composer headset (#voice-mode-btn) and the sidebar "Voice Tutor" button;
-        // in-voice feedback comes from the "Live with <tutor>" pill meter.
-        // The orb elements are still constructed (detached) so the controller's
-        // state machine — driven by voice-mode.js — stays null-safe.
+        // The orb IS the microphone in voice mode — the central mic/listening
+        // control that voice-mode.js flanks with #mpc-voice-work and
+        // #mpc-voice-end (see voice-mode.js: "The orb is the mic"). It is hidden
+        // during normal chat and shown only in voice mode via CSS
+        // (body.cr-mode:not(.cr-voice) #voice-chat-container { display:none }).
+        // Do NOT unmount it, or voice mode loses its mic. The old settings
+        // "Voice Chat Orb" toggle / voiceChatEnabled preference is gone, so the
+        // orb is always available (CSS decides when it's visible).
         const voiceEnabled = true;
 
         // Create floating voice button (like GPT's orb)
@@ -743,9 +744,7 @@ class VoiceController {
 
         voiceContainer.appendChild(orbButton);
         voiceContainer.appendChild(statusText);
-        // Intentionally NOT mounted to the DOM — the floating orb is fully
-        // removed from the UI. Refs below stay valid for the state machine.
-        // (was: document.body.appendChild(voiceContainer);)
+        document.body.appendChild(voiceContainer);
 
         this.voiceButton = orbButton;
         this.voiceOrb = orbButton.querySelector('.orb-inner');

--- a/public/js/voice-controller.js
+++ b/public/js/voice-controller.js
@@ -252,13 +252,14 @@ class VoiceController {
     // ============================================
 
     createVoiceUI() {
-        // The floating voice orb has been removed from the UI entirely — it's
-        // never mounted to the DOM (see the appendChild note below), so it can't
-        // appear in normal chat OR voice mode. Voice is entered/exited from the
-        // composer headset (#voice-mode-btn) and the sidebar "Voice Tutor" button;
-        // in-voice feedback comes from the "Live with <tutor>" pill meter.
-        // The orb elements are still constructed (detached) so the controller's
-        // state machine — driven by voice-mode.js — stays null-safe.
+        // The orb IS the microphone in voice mode — the central mic/listening
+        // control that voice-mode.js flanks with #mpc-voice-work and
+        // #mpc-voice-end (see voice-mode.js: "The orb is the mic"). It is hidden
+        // during normal chat and shown only in voice mode via CSS
+        // (body.cr-mode:not(.cr-voice) #voice-chat-container { display:none }).
+        // Do NOT unmount it, or voice mode loses its mic. The old settings
+        // "Voice Chat Orb" toggle / voiceChatEnabled preference is gone, so the
+        // orb is always available (CSS decides when it's visible).
         const voiceEnabled = true;
 
         // Create floating voice button (like GPT's orb)
@@ -302,9 +303,7 @@ class VoiceController {
 
         voiceContainer.appendChild(orbButton);
         voiceContainer.appendChild(statusText);
-        // Intentionally NOT mounted to the DOM — the floating orb is fully
-        // removed from the UI. Refs below stay valid for the state machine.
-        // (was: document.body.appendChild(voiceContainer);)
+        document.body.appendChild(voiceContainer);
 
         this.voiceButton = orbButton;
         this.voiceOrb = orbButton.querySelector('.orb-inner');


### PR DESCRIPTION
The orb (#voice-chat-container) IS the microphone in voice mode: voice-mode.js flanks it with the work/end buttons and the CSS restages it as "the dock's centre mic" (mobile-poster-chat.css / voice-mode.css). Un-mounting it in the previous commit left voice mode with the two flanking buttons and no mic — the "most important ingredient" was gone.

Re-mount the orb. It stays hidden in normal chat via the existing CSS gate (body.cr-mode:not(.cr-voice) #voice-chat-container { display:none }) and shows only in voice mode. The settings "Voice Chat Orb" toggle stays removed; the orb is CSS-gated, not preference-gated.

Rebuilt chat-js2.