### PR TITLE
feat(verify): deterministic symbolic answer verifier (mathjs) before …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "jsdom": "^27.4.0",
         "jsxgraph": "1.10.1",
         "katex": "^0.16.21",
+        "mathjs": "^15.2.0",
         "mathlive": "^0.105.3",
         "mongodb": "^6.21.0",
         "mongoose": "^8.22.1",
@@ -7275,6 +7276,18 @@
         "npm": ">=8.5.0"
       }
     },
+    "node_modules/complex.js": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.4.3.tgz",
+      "integrity": "sha512-UrQVSUur14tNX6tiP4y8T4w4FeJAX3bi2cIv0pu/DTLFNxoq7z2Yh83Vfzztj6Px3X/lubqQ9IrPp7Bpn6p4MQ==",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
     "node_modules/component-emitter": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
@@ -8185,6 +8198,11 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
+    "node_modules/escape-latex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.2.0.tgz",
+      "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw=="
+    },
     "node_modules/escape-string-regexp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
@@ -9020,6 +9038,18 @@
       "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
       "license": "MIT"
     },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -9782,6 +9812,11 @@
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
       }
+    },
+    "node_modules/javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw=="
     },
     "node_modules/jest": {
       "version": "29.7.0",
@@ -10835,6 +10870,28 @@
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mathjs": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-15.2.0.tgz",
+      "integrity": "sha512-UAQzSVob9rNLdGpqcFMYmSu9dkuLYy7Lr2hBEQS5SHQdknA9VppJz3cy2KkpMzTODunad6V6cNv+5kOLsePLow==",
+      "dependencies": {
+        "@babel/runtime": "^7.26.10",
+        "complex.js": "^2.2.5",
+        "decimal.js": "^10.4.3",
+        "escape-latex": "^1.2.0",
+        "fraction.js": "^5.2.1",
+        "javascript-natural-sort": "^0.7.1",
+        "seedrandom": "^3.0.5",
+        "tiny-emitter": "^2.1.0",
+        "typed-function": "^4.2.1"
+      },
+      "bin": {
+        "mathjs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mathlive": {
@@ -12858,6 +12915,11 @@
         "node": ">=v12.22.7"
       }
     },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
+    },
     "node_modules/selderee": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
@@ -13636,6 +13698,11 @@
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
       "license": "MIT"
     },
+    "node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -13837,6 +13904,14 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/typed-function": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.2.2.tgz",
+      "integrity": "sha512-VwaXim9Gp1bngi/q3do8hgttYn2uC3MoT/gfuMWylnj1IeZBUAyPddHZlo1K05BDoj8DYPpMdiHqH1dDYdJf2A==",
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/typed-query-selector": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "jsdom": "^27.4.0",
     "jsxgraph": "1.10.1",
     "katex": "^0.16.21",
+    "mathjs": "^15.2.0",
     "mathlive": "^0.105.3",
     "mongodb": "^6.21.0",
     "mongoose": "^8.22.1",

--- a/tests/unit/symbolicVerifier.test.js
+++ b/tests/unit/symbolicVerifier.test.js
@@ -1,0 +1,87 @@
+const { symbolicVerify, equivalent, verifyAntiderivative, latexToExpr, extractIntegral } = require('../../utils/pipeline/symbolicVerifier');
+
+describe('symbolicVerifier — extractIntegral + problemTex path', () => {
+  it('pulls the integrand + variable from integral problem tex', () => {
+    expect(extractIntegral('\\int (6x^5 - 4x)\\,dx')).toMatchObject({ variable: 'x' });
+    expect(extractIntegral('\\int 3x^{2} dx').integrand).toContain('3x^(2)');
+    expect(extractIntegral('solve 2x+4=20')).toBeNull();
+  });
+  it('verifies an integral straight from the problem tex (no stored answer)', () => {
+    const v = symbolicVerify({ studentAnswer: 'x^{4} + x^{2} + C', problemTex: '\\int (4x^3 + 2x)\\,dx' });
+    expect(v.isCorrect).toBe(true);
+    expect(v.method).toBe('antiderivative');
+  });
+  it('flags a wrong integral answer against the problem tex', () => {
+    const v = symbolicVerify({ studentAnswer: 'x^{4} + C', problemTex: '\\int (4x^3 + 2x)\\,dx' });
+    expect(v.isCorrect).toBe(false);
+  });
+});
+
+describe('symbolicVerifier — latexToExpr', () => {
+  it('converts the LaTeX student answers actually arrive as', () => {
+    expect(latexToExpr('x^{6}')).toBe('x^(6)');
+    expect(latexToExpr('\\frac{2}{3}x^{3/2}')).toContain('(2)/(3)');
+    expect(latexToExpr('\\sqrt{x}')).toBe('sqrt(x)');
+    expect(latexToExpr('2\\cdot x')).toBe('2* x');
+    expect(latexToExpr('\\left(x+1\\right)^{2}')).toContain('(x+1)^(2)');
+  });
+  it('returns null on empty / junk, never throws', () => {
+    expect(latexToExpr('')).toBeNull();
+    expect(latexToExpr(null)).toBeNull();
+  });
+});
+
+describe('symbolicVerifier — equivalent (numeric)', () => {
+  it('accepts equal-but-different forms', () => {
+    expect(equivalent('2*(x+3)', '2x+6')).toBe(true);        // expanded/factored
+    expect(equivalent('10/24', '5/12')).toBe(true);          // un-simplified fraction
+    expect(equivalent('x^2 - x^2 + 3x', '3x')).toBe(true);   // rearranged/cancelling
+    expect(equivalent('0.5', '1/2')).toBe(true);             // decimal vs fraction
+    expect(equivalent('(x^2-1)/(x-1)', 'x+1')).toBe(true);   // simplifiable rational
+  });
+  it('rejects genuinely different expressions', () => {
+    expect(equivalent('2x+6', '2x+5')).toBe(false);
+    expect(equivalent('x^2', 'x^3')).toBe(false);
+  });
+  it('returns null (undecidable) on unparseable input', () => {
+    expect(equivalent('%%%', 'x')).toBeNull();
+  });
+});
+
+describe('symbolicVerifier — verifyAntiderivative (the live-failing case)', () => {
+  it('verifies a correct multi-term integral by differentiating it back', () => {
+    // ∫(6x^5 - 4x + sqrt(x)) dx  =  x^6 - 2x^2 + (2/3)x^(3/2) + C
+    expect(verifyAntiderivative('x^6 - 2x^2 + (2/3)x^(3/2) + C', '6x^5 - 4x + sqrt(x)')).toBe(true);
+    // and the simplest one from the session: ∫2x dx = x^2 + C
+    expect(verifyAntiderivative('x^2 + C', '2x')).toBe(true);
+    // ∫(4x^3 + 2x) dx = x^4 + x^2 + C
+    expect(verifyAntiderivative('x^4 + x^2 + C', '4x^3 + 2x')).toBe(true);
+  });
+  it('accepts a correct answer even without the +C written', () => {
+    expect(verifyAntiderivative('x^2', '2x')).toBe(true);
+  });
+  it('rejects wrong integrals (missing term, wrong coefficient)', () => {
+    expect(verifyAntiderivative('x^6 - 2x^2 + C', '6x^5 - 4x + sqrt(x)')).toBe(false); // dropped sqrt term
+    expect(verifyAntiderivative('2x^2 + C', '4x^3 + 2x')).toBe(false);                 // wrong first term
+  });
+});
+
+describe('symbolicVerifier — symbolicVerify (top-level)', () => {
+  it('resolves the integral via the antiderivative path (no stored answer needed)', () => {
+    const v = symbolicVerify({ studentAnswer: 'x^6 - 2x^2 + (2/3)x^(3/2) + C', integrand: '6x^5 - 4x + sqrt(x)' });
+    expect(v.isCorrect).toBe(true);
+    expect(v.method).toBe('antiderivative');
+  });
+  it('resolves algebra via equivalence against the correct answer', () => {
+    expect(symbolicVerify({ studentAnswer: '\\frac{10}{24}', correctAnswer: '5/12' }).isCorrect).toBe(true);
+    expect(symbolicVerify({ studentAnswer: '2x+5', correctAnswer: '2x+6' }).isCorrect).toBe(false);
+  });
+  it('returns isCorrect:null (never a false verdict) when it cannot decide', () => {
+    expect(symbolicVerify({ studentAnswer: 'the answer is blue', correctAnswer: 'x=4' }).isCorrect).toBeNull();
+    expect(symbolicVerify({}).isCorrect).toBeNull();
+  });
+  it('NEVER throws, whatever the input', () => {
+    expect(() => symbolicVerify({ studentAnswer: '\\frac{', correctAnswer: '}{}\\' })).not.toThrow();
+    expect(() => symbolicVerify(null)).not.toThrow();
+  });
+});

--- a/utils/pipeline/diagnose.js
+++ b/utils/pipeline/diagnose.js
@@ -11,6 +11,7 @@
  */
 
 const { parseCleanProblem, verifyAnswer, matchRootsInText } = require('../mathSolver');
+const { symbolicVerify } = require('./symbolicVerifier');
 const { analyzeError, findKnownMisconception, MISCONCEPTION_LIBRARY } = require('../misconceptionDetector');
 
 /**
@@ -229,6 +230,30 @@ async function diagnose(observation, context = {}) {
     isCorrect = true;
     correctAnswer = studentAnswer;
     verificationSource = 'arithmetic_override';
+  }
+
+  // ── Step 2a.5: SYMBOLIC verification (deterministic, before the LLM) ──
+  // Differentiate an integral answer back to the integrand, or numerically
+  // compare an expression to the known answer — resolving the algebra/calculus
+  // the solver can't parse (multi-term integrals, un-simplified forms, factored
+  // vs expanded). This is where the tutor was getting isCorrect=null and then
+  // guessing/false-flagging correct work. Deterministic and high-confidence;
+  // it only ever ADDS a verdict — unparseable/undecidable stays null and falls
+  // through to the LLM fallback, never a manufactured verdict.
+  if (isCorrect === null && multiRoot === null) {
+    try {
+      const sym = symbolicVerify({
+        studentAnswer,
+        correctAnswer: problemInfo && problemInfo.correctAnswer,
+        problemTex: context.pinnedProblemTex,
+      });
+      if (sym.isCorrect !== null) {
+        isCorrect = sym.isCorrect;
+        if (sym.isCorrect && correctAnswer == null) correctAnswer = studentAnswer;
+        verificationSource = 'symbolic:' + sym.method;
+        console.log(`[Diagnose] Symbolic ${sym.method}: ${isCorrect ? 'correct' : 'incorrect'}`);
+      }
+    } catch (_) { /* never break diagnosis */ }
   }
 
   // ── Step 2b: LLM verification fallback ──

--- a/utils/pipeline/symbolicVerifier.js
+++ b/utils/pipeline/symbolicVerifier.js
@@ -1,0 +1,156 @@
+'use strict';
+/* ============================================================
+   symbolicVerifier.js — deterministic answer verification via mathjs.
+
+   The deterministic mathSolver covers ~30% of topics and the LLM verifier
+   is unreliable on multi-term / calculus answers, so those come back
+   isCorrect=null and the tutor is forced to guess (and false-flags correct
+   work). This adds a SYMBOLIC tier that resolves the algebra/calculus cases
+   exactly:
+
+     • EQUIVALENCE — two expressions are equal iff they agree at many random
+       sample points. Catches un-simplified forms (10/24 = 5/12), rearranged
+       terms, factored/expanded, different-but-equal notation. No brittle
+       string matching.
+     • ANTIDERIVATIVE — an integral answer F is correct iff d/dx(F) equals the
+       integrand. Differentiates F symbolically, then checks equivalence.
+
+   Contract: NEVER throws. Returns { isCorrect: true|false|null, method,
+   confidence }. null = genuinely couldn't decide (unparseable / too few valid
+   samples), so callers fall through to the existing LLM verifier — the tier
+   only ever ADDS confident verdicts, never manufactures one.
+   ============================================================ */
+const math = require('mathjs');
+
+const CONSTS = /^(pi|e|i|Infinity|NaN|true|false|PI|E)$/;
+
+// LaTeX (how student answers arrive) -> a mathjs-parseable string. Bounded and
+// defensive; anything it can't map falls out as a parse failure -> null upstream.
+function latexToExpr(input) {
+  if (input == null) return null;
+  let s = String(input).trim();
+  if (!s) return null;
+  s = s.replace(/\\[()[\]]/g, ' ').replace(/^\$+|\$+$/g, '');           // math delimiters
+  s = s.replace(/\\left|\\right/g, '')
+    .replace(/\\cdot|\\times/g, '*')
+    .replace(/\\div/g, '/')
+    .replace(/\\pi\b/g, ' pi ')
+    .replace(/\\(?:!|,|;|:| )/g, '')                                     // thin spaces
+    .replace(/\\sqrt\s*\[([^\][]*)\]\s*\{([^{}]*)\}/g, 'nthRoot(($2),($1))') // \sqrt[n]{x}
+    .replace(/\\sqrt\s*\{([^{}]*)\}/g, 'sqrt($1)');
+  for (let i = 0; i < 4 && /\\frac/.test(s); i++) {                      // \frac (nesting)
+    s = s.replace(/\\frac\s*\{([^{}]*)\}\s*\{([^{}]*)\}/g, '(($1)/($2))');
+  }
+  s = s.replace(/\^\s*\{([^{}]*)\}/g, '^($1)')                           // x^{6} -> x^(6)
+    .replace(/_\s*\{([^{}]*)\}/g, '_$1')                                 // subscripts
+    .replace(/\\([a-zA-Z]+)/g, '$1')                                     // \ln \sin -> ln sin
+    .replace(/[{}]/g, '')
+    .replace(/−/g, '-').replace(/×/g, '*').replace(/÷/g, '/').replace(/·/g, '*');
+  return s.trim();
+}
+
+function compile(expr) {
+  try { return math.compile(expr); } catch (_) { return null; }
+}
+
+function collectVars(expr) {
+  const out = new Set();
+  try {
+    math.parse(expr).traverse(function (node) {
+      if (node && node.isSymbolNode) {
+        const n = node.name;
+        if (!CONSTS.test(n) && typeof math[n] !== 'function') out.add(n);
+      }
+    });
+  } catch (_) { return []; }
+  return [...out];
+}
+
+// Positive, growing, irrational-ish sample points — keep sqrt/log in-domain
+// while staying dense enough to separate genuinely different expressions.
+function samplePoint(i, varIndex) { return 0.3 + 0.37 * i + 0.13 * varIndex; }
+
+// true | false | null(undecidable). Two expressions are equal iff they agree
+// at every valid sample; a single clear disagreement among agreements is
+// treated as undecidable (guards float flukes), two+ disagreements -> false.
+function equivalent(a, b) {
+  const ca = compile(a); const cb = compile(b);
+  if (!ca || !cb) return null;
+  const vars = [...new Set(collectVars(a).concat(collectVars(b)))];
+  // K-12 math answers use single-letter variables; a multi-letter "variable"
+  // means mathjs parsed prose ("the answer is blue" -> the*answer*is*blue) as
+  // a math expression. Refuse to verdict on that — fall through to the LLM.
+  if (vars.some(function (v) { return v.length > 1; })) return null;
+  let tried = 0; let agree = 0; let disagree = 0;
+  for (let i = 0; i < 32 && tried < 12; i++) {
+    const scope = {};
+    vars.forEach(function (v, idx) { scope[v] = samplePoint(i, idx); });
+    let va; let vb;
+    try { va = ca.evaluate(scope); vb = cb.evaluate(scope); } catch (_) { continue; }
+    if (typeof va !== 'number' || typeof vb !== 'number' || !isFinite(va) || !isFinite(vb)) continue;
+    tried += 1;
+    if (Math.abs(va - vb) <= 1e-6 * (1 + Math.abs(va))) agree += 1; else disagree += 1;
+  }
+  if (tried < 5) return null;                 // couldn't sample enough (singular/complex)
+  if (disagree === 0) return true;
+  if (disagree >= 2 || agree === 0) return false;
+  return null;                                // 1 flaky disagreement — don't gamble
+}
+
+// Verify F is an antiderivative of `integrand`: d/dx(F) must equal integrand.
+function verifyAntiderivative(studentF, integrand, variable) {
+  const F = latexToExpr(studentF);
+  const f = latexToExpr(integrand);
+  if (!F || !f) return null;
+  const v = variable || 'x';
+  const Fnoc = F.replace(/([+\-]\s*)C\b/gi, '');   // drop the +C
+  let dF;
+  try { dF = math.derivative(Fnoc, v).toString(); } catch (_) { return null; }
+  return equivalent(dF, f);
+}
+
+// Pull the integrand + variable out of an integral problem tex:
+// "\int (6x^5 - 4x)\,dx" / "∫ 6x^5 dx" -> { integrand:'6x^5 - 4x', variable:'x' }.
+function extractIntegral(tex) {
+  if (tex == null) return null;
+  const m = String(tex).match(/(?:\\int|∫)\s*(.+?)\s*\\?[, ]*\bd\s*([a-zA-Z])\b/);
+  if (!m) return null;
+  const integrand = latexToExpr(m[1]);
+  if (!integrand) return null;
+  return { integrand, variable: m[2] };
+}
+
+/**
+ * @param {object} p
+ * @param {string} p.studentAnswer  the student's answer (LaTeX or plain)
+ * @param {string} [p.correctAnswer] the known-correct answer, if any
+ * @param {string} [p.integrand]    for integrals: the expression being integrated
+ * @param {string} [p.problemTex]   the problem tex — integrand auto-extracted if it's an integral
+ * @param {string} [p.variable]     defaults to 'x'
+ * @returns {{isCorrect: (boolean|null), method: string, confidence: number}}
+ */
+function symbolicVerify(p) {
+  p = p || {};
+  try {
+    let integrand = p.integrand;
+    let variable = p.variable;
+    if (!integrand && p.problemTex) {
+      const ig = extractIntegral(p.problemTex);
+      if (ig) { integrand = ig.integrand; variable = variable || ig.variable; }
+    }
+    if (integrand && p.studentAnswer) {
+      const r = verifyAntiderivative(p.studentAnswer, integrand, variable);
+      if (r !== null) return { isCorrect: r, method: 'antiderivative', confidence: 0.98 };
+    }
+    if (p.correctAnswer != null && p.studentAnswer != null) {
+      const a = latexToExpr(p.studentAnswer); const b = latexToExpr(p.correctAnswer);
+      if (a && b) {
+        const r = equivalent(a, b);
+        if (r !== null) return { isCorrect: r, method: 'equivalence', confidence: 0.97 };
+      }
+    }
+  } catch (_) { /* never throw — fall through to unverifiable */ }
+  return { isCorrect: null, method: 'unverifiable', confidence: 0 };
+}
+
+module.exports = { symbolicVerify, equivalent, verifyAntiderivative, latexToExpr, extractIntegral };


### PR DESCRIPTION
…the LLM

The tutor was false-flagging CORRECT work because multi-term / calculus answers come back isCorrect=null (the deterministic solver can't parse them and the LLM verifier is unreliable), forcing the tutor to guess. Add a SYMBOLIC verification tier that resolves those exactly:

utils/pipeline/symbolicVerifier.js (new, mathjs):
  • EQUIVALENCE — two expressions are equal iff they agree at many random sample
    points. Catches un-simplified forms (10/24 = 5/12), factored vs expanded,
    rearranged terms, decimal vs fraction — no brittle string matching.
  • ANTIDERIVATIVE — an integral answer F is correct iff d/dx(F) equals the
    integrand; extracts the integrand from the problem tex, differentiates F,
    checks equivalence. No stored "correct answer" needed.
  Contract: NEVER throws, NEVER manufactures a verdict. Returns isCorrect=null
  when it genuinely can't decide (unparseable, prose parsed as vars, too few
  valid samples) so the existing LLM fallback still runs. Converts the LaTeX
  answers arrive as (\frac, x^{n}, \sqrt, \cdot, …) to mathjs syntax first.

diagnose.js: run it as Step 2a.5 — after the deterministic solver, before the LLM fallback. It only fires when isCorrect is still null, and only overrides null (never an existing verdict). verificationSource='symbolic:<method>' flows into verifyMetrics, so the unverifiable rate is measurable.

NOT literal 100%: unparseable input, un-pinned integral problems, and multi-letter variables still fall to the LLM — but the class that was breaking (multi-term integrals, un-simplified/rearranged algebra) is now deterministic.

Verified: 15 unit tests incl. the exact live-failing integral (∫(6x^5-4x+√x)dx = x^6-2x^2+⅔x^{3/2}+C -> correct), wrong-answer rejection, un-simplified equivalence, prose -> null, never-throws. Full diagnose+pipeline suite 178 green; eslint clean.