### PR TITLE
Courses in flow: funnel + structure-everywhere + ACT boot-camp practice test

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -75,6 +75,7 @@ const assessmentRoutes = require('../routes/assessment');
 const screenerRoutes = require('../routes/screener');
 const checkpointRoutes = require('../routes/checkpoint');
 const growthCheckRoutes = require('../routes/growthCheck');
+const actTestRoutes = require('../routes/actTest');
 const masteryRoutes = require('../routes/mastery');
 const nudgeRoutes = require('../routes/nudges');
 // masteryChat: REMOVED — mastery mode consolidated into /api/chat with { mastery: true }
@@ -238,6 +239,8 @@ function registerRoutes(app, { authLimiter, signupLimiter }) {
   app.use('/api/screener', isAuthenticated, screenerRoutes);
   app.use('/api/checkpoint', isAuthenticated, checkpointRoutes);
   app.use('/api/growth-check', isAuthenticated, growthCheckRoutes);
+  // ACT Math practice test — free (boot-camp on-ramp), fixed-form, no AI at request time.
+  app.use('/api/act-test', isAuthenticated, actTestRoutes);
   app.use('/api/mastery', isAuthenticated, masteryRoutes);
   app.use('/api/nudges', isAuthenticated, nudgeRoutes);
   // masteryChat route REMOVED — mastery mode consolidated into /api/chat

--- a/config/routes.js
+++ b/config/routes.js
@@ -226,8 +226,11 @@ function registerRoutes(app, { authLimiter, signupLimiter }) {
   app.use('/api/phone-upload', phoneUploadRoutes);
   app.use('/api/images', isAuthenticated, imageSearchRoutes);
   app.use('/api/curriculum', isAuthenticated, curriculumRoutes);
-  app.use('/api/courses', isAuthenticated, premiumFeatureGate('Courses'), courseRoutes);
-  app.use('/api/course-sessions', isAuthenticated, premiumFeatureGate('Courses'), courseSessionRoutes);
+  // Courses are open to ALL students as a free on-ramp (see docs/COURSES_IN_FLOW_DESIGN.md).
+  // AI usage inside a course is still metered by usageGate on /api/course-chat — the monthly
+  // free-minute cap, not a paywall, is the conversion lever to Mathmatix+.
+  app.use('/api/courses', isAuthenticated, courseRoutes);
+  app.use('/api/course-sessions', isAuthenticated, courseSessionRoutes);
   app.use('/api/course-chat', isAuthenticated, aiEndpointLimiter, usageGate, courseChatRoutes);
   app.use('/api/teacher-resources', isAuthenticated, teacherResourceRoutes);
   app.use('/api/guidedLesson', isAuthenticated, aiEndpointLimiter, guidedLessonRoutes);

--- a/docs/COURSES_IN_FLOW_DESIGN.md
+++ b/docs/COURSES_IN_FLOW_DESIGN.md
@@ -231,6 +231,45 @@ is a Phase 2b follow-up, gated on the mode-transition detector being proven.
 
 ---
 
+## 6b. ACT boot-camp practice tests — **content engine + fixed-form rail SHIPPED**
+
+Boot camps (ACT/SAT/algebra-prep/calc-prep, ~3 weeks) run on the pathway system;
+their differentiator is a **practice test** built from a composite of the boot
+camp's skills, as *original parallel forms* (our own items), delivered like the
+Starting Point.
+
+The ACT Math skill catalog already existed (`seeds/skills-act-math-prep.json`,
+36 skills in ACT reporting categories). Built on top:
+
+- **`seeds/act-math-blueprint.json`** — the 60-item composition (category weights,
+  easy→hard difficulty ramp, skills-by-category, approximate raw→scaled 1–36
+  table). Derived from the ACT Math *reporting-category structure* — not a copy of
+  any published test.
+- **`utils/actTestAssembler.js`** — assembles an original parallel form by
+  sampling our own skill-tagged bank (`Problem.findNearDifficulty`); reports any
+  unfillable slot as a **generation spec** for `scripts/generate*.js`.
+  `skillPool()` / `rawToScaled()` support both delivery modes.
+- **`routes/actTest.js` + `models/actTestSession.js`** — a **fixed-form** delivery
+  rail (parallel to the screener, per the `growthCheck.js` precedent) at
+  `/api/act-test` (`start` / `next-problem` / `submit-answer` / `complete`),
+  mirroring the screener's per-item contract so the existing item-render UI can
+  drive it. Grades by re-fetching the Problem server-side; returns raw + scaled +
+  per-category breakdown. **Free** (boot-camp on-ramp), no AI at request time.
+- **`scripts/actTestCoverage.js`** (`npm run act:coverage`) — reports how much of
+  a form the bank can fill and prints the generation worklist for gaps.
+
+**Prerequisite before it delivers value:** the `Problem` bank must actually
+contain `act-*`-tagged items. Run `act:coverage`; generate to fill the gaps.
+
+**Adaptive diagnostic (follow-up, "delivered like the Starting Point"):** the CAT
+engine is reusable — `skillSelector.selectSkill(pool, …)` takes whatever skill
+pool it's handed, so constraining it to `skillPool()` yields an adaptive ACT
+diagnostic. Prereqs the screener map surfaced: add `'act-math'` to
+`ScreenerSession.sessionType`; give ACT skills IRT difficulties (they carry
+`difficultyLevel`, not `irtDifficulty`) or extend `catConfig`'s
+`CATEGORY_DIFFICULTY_MAP`/`CATEGORY_TO_BROAD` to cover ACT categories; map
+theta→scaled(1–36) for the report; add an ACT branch/fork to `FloatingScreener`.
+
 ## 7. Open questions
 
 1. **Where does a non-enrolled student's queue come from before they've been

--- a/docs/COURSES_IN_FLOW_DESIGN.md
+++ b/docs/COURSES_IN_FLOW_DESIGN.md
@@ -255,11 +255,20 @@ The ACT Math skill catalog already existed (`seeds/skills-act-math-prep.json`,
   mirroring the screener's per-item contract so the existing item-render UI can
   drive it. Grades by re-fetching the Problem server-side; returns raw + scaled +
   per-category breakdown. **Free** (boot-camp on-ramp), no AI at request time.
+- **`scripts/generateActItems.js`** (`npm run act:gen`, `npm run act:seed`) — an
+  **original item generator** for all 31 content skills. Every item is
+  template-generated: the correct answer is *computed* from the parameters and a
+  validator plugs it back into the problem, rejecting anything inconsistent — a
+  wrong answer key cannot ship (correctness-by-construction). Distractors model
+  real student errors. Ships a starter bank in `seeds/act-math-items.generated.json`
+  (245 items, ~8/skill) that assembles a full 60/60 form; `act:seed` upserts it
+  into Mongo. Covered by `tests/unit/generateActItems.test.js` (every key valid,
+  form fills).
 - **`scripts/actTestCoverage.js`** (`npm run act:coverage`) — reports how much of
-  a form the bank can fill and prints the generation worklist for gaps.
+  a form the live bank can fill and prints the generation worklist for gaps.
 
-**Prerequisite before it delivers value:** the `Problem` bank must actually
-contain `act-*`-tagged items. Run `act:coverage`; generate to fill the gaps.
+**To make it live:** `npm run act:seed` (loads the 245 items into Mongo), then
+`/api/act-test` delivers a full form. Extend/vary with `act:gen --per-skill N`.
 
 **Adaptive diagnostic (follow-up, "delivered like the Starting Point"):** the CAT
 engine is reusable — `skillSelector.selectSkill(pool, …)` takes whatever skill

--- a/docs/COURSES_IN_FLOW_DESIGN.md
+++ b/docs/COURSES_IN_FLOW_DESIGN.md
@@ -184,17 +184,31 @@ No code. Get §1 agreed so the drift cleanup and the queue work aren't relitigat
   in-context upgrade prompt.
 - **Risk:** low. Reversible by re-adding the gate.
 
-### Phase 2 — feed `skillFocus` in free chat *(the core)*
+### Phase 2 — feed `skillFocus` in free chat *(the core)* — **v1 SHIPPED**
 Populate `tutorPlan.skillFocus` from signals already computed, so the structured
-machine runs for un-enrolled students:
-- Screener/placement result → seed the queue with the placed frontier.
-- BKT prerequisite gaps (`knowledgeTracer`) → enqueue struggle-detected skills.
-- FSRS review-due (`fsrsScheduler`) → enqueue review items.
-- Wire the real caller for `addSkillToFocus()` (today: zero callers) inside
-  `pipeline/persist.js` or the plan-load path (`loadOrCreatePlan`).
-- **Risk:** medium. This changes default tutor behavior. Gate behind a flag
-  (`MM_FEATURES.structuredDefault`) and A/B before full rollout. Validate that
-  `shouldSuppressSocratic` doesn't over-trigger and start leaking answers.
+machine runs for un-enrolled students. Implemented in `utils/skillFocusBuilder.js`,
+called from the pipeline right after the plan loads (`pipeline/index.js`).
+
+**Open question #2 resolved — "guided", not "course-locked".** v1 seeds ONLY
+skills the student has already *touched*:
+- **Review-due** (FSRS `reviewSchedule.nextReviewDate`) → jumps the queue (priority 8).
+- **In-progress** (developing / introduced / proficient via `TutorPlan.inferFamiliarity`)
+  → continues the work, ordered by familiarity.
+
+It deliberately **skips `never-seen` skills**, because those map to the
+answer-dumping `instruct` mode; touched skills map to `guide`/`strengthen`,
+which stay Socratic-compatible. So the tutor proactively *continues and reviews*
+what the student is working on, but does not force-introduce brand-new frontier
+skills against an off-plan question. The existing off-plan gate in `decide.js`
+(`isStudentOnPlanTopic`) remains the backstop. Proactive frontier introduction
+is a Phase 2b follow-up, gated on the mode-transition detector being proven.
+
+- Only runs when the active queue is empty (no thrash) and never during a course
+  session (the course drives its own queue).
+- **Kill switch:** env `STRUCTURED_FREE_CHAT=false` disables seeding globally.
+- Covered by `tests/unit/skillFocusBuilder.test.js`.
+- **Still to do (2b):** frontier/never-seen introduction, placement-result seeding
+  for brand-new students, and a defined soft step-lock strength.
 
 ### Phase 3 — unify the endpoints
 - Fold `/api/course-chat` handling into `/api/chat` behind a `structureLevel`

--- a/docs/COURSES_IN_FLOW_DESIGN.md
+++ b/docs/COURSES_IN_FLOW_DESIGN.md
@@ -1,0 +1,261 @@
+# COURSES-IN-FLOW — Design Doc
+
+> **Status:** Proposal / decision record. Written 2026-07 on branch
+> `claude/courses-flow-mathmatix-fn8hq9`.
+> **Decision owner:** Jason.
+> **One-line:** Make *structure* the default tutoring experience for everyone,
+> dissolve the separate "course mode" into the main pipeline, and open courses
+> to free users as a conversion on-ramp (usage cap, not a paywall, is the lever).
+
+---
+
+## 1. The decision
+
+Two decisions are now settled and drive everything below:
+
+1. **Structure everywhere.** The default experience is engine-driven and
+   sequenced, not purely reactive Socratic chat. The tutor should know "what to
+   teach next" for *every* student, not only for students who explicitly enrol
+   in a course.
+2. **Courses are a free on-ramp.** Free users can browse, enrol, and work
+   through courses. Conversion happens naturally: a free student gets pulled
+   into a compelling sequence, hits the monthly AI-minute cap mid-module, and
+   the upgrade prompt becomes *"keep going with Mathmatix+"* — a warm,
+   in-context nudge instead of a cold door-slam paywall. Mathmatix+ removes the
+   usage cap; it does **not** unlock structure.
+
+This reverses the current posture, where structure is a walled-off premium mode
+you opt into via a gated catalog.
+
+---
+
+## 2. Current state — three overlapping "course" concepts
+
+There is no single "course" in the codebase. There are three, at very different
+levels of liveness. This drift is the main risk the rework must retire.
+
+### Layer 1 — the dormant LMS model (`models/course.js`)
+Rich, fully-specified schema: `units → lessons → phases (i-do / we-do / you-do)
+→ assessments`. **Only `routes/course.js` and `scripts/seedCourse.js` reference
+it.** Nothing a student experiences reads it. It is a parallel authoring format
+that never got wired to runtime.
+
+### Layer 2 — the live course mode (pathway JSON)
+What students actually run:
+- Content: `public/resources/*-pathway.json` (modules → scaffold steps →
+  checkpoints). ~10 pathways today (algebra-1, geometry, grade-8, AP Calc AB,
+  ACT prep, parent mini-courses, …).
+- State: `models/courseSession.js` — per-user progress, `currentModuleId`,
+  `currentScaffoldIndex`, `progressFloorPct` (bar never moves backward).
+- Runtime: `routes/courseChat.js` (`POST /api/course-chat`) →
+  `utils/pipeline/courseAdapter.js` → the unified pipeline.
+- Prompt: `utils/coursePrompt.js` hard-locks the tutor to one scaffold step
+  (`🔒 YOU ARE LOCKED TO THE CURRENT STEP`).
+- **Gating:** `/api/courses` and `/api/course-sessions` are behind
+  `premiumFeatureGate('Courses')` (browse + enrol = premium). `/api/course-chat`
+  is only `usageGate` — i.e. **chatting inside a course is already free** up to
+  the cap. The wall is only on the front door.
+
+### Layer 3 — the soft version already in free chat
+`buildCourseProgressionCompact()` in `utils/promptCompact.js` reads the *same*
+pathway JSON off the student's `mathCourse` field and injects the module
+progression as advisory context ("when the student asks 'what's next?' → follow
+this progression"). No state tracking, no step-lock — just a nudge.
+
+### Two entry points into course mode
+Course context enters through **both** endpoints:
+- `POST /api/course-chat` (dedicated, via `courseAdapter`), and
+- `POST /api/chat` — which itself branches on `user.activeCourseSessionId` and
+  calls `buildCourseSystemPrompt` in three places
+  (`routes/chat.js:1021, 1061, 2558`).
+
+So "course mode" is not one code path; it is two, plus a soft third. Unifying
+these is most of the work.
+
+### Frontend is already merged
+Courses live *inside* `chat.html`: a sidebar course list, a progress bar over the
+chat, and an "exit lesson → return to general chat" button. `courseCatalog.js`
+switches the client between `/api/chat` and `/api/course-chat`. **The UI merge is
+essentially done** — this rework is a backend/pipeline consolidation.
+
+---
+
+## 3. The insight that makes this cheap
+
+The main free-chat flow **already contains the entire structured-teaching
+machine** — it just never runs.
+
+- `models/tutorPlan.js` holds `skillFocus[]` (a prioritized skill queue),
+  `currentTarget`, and an `instructionPhase` enum
+  (`prerequisite-review → vocabulary → concept-intro → i-do → we-do → you-do →
+  mastery-check`).
+- `utils/tutorPlanManager.js`, `utils/skillFamiliarityResolver.js`, and
+  `utils/promptPlanLayer.js` fully implement resolving a target, walking the
+  prerequisite chain, and injecting a gradual-release plan into the prompt —
+  including `shouldSuppressSocratic()`, which structurally turns off the
+  "never give the answer" rule during direct-instruction phases.
+- `utils/pipeline/decide.js` calls `applyInstructionalMode()` whenever a
+  `currentTarget` exists.
+
+**The gap:** `tutorPlan.skillFocus` is essentially never populated in free chat.
+`addSkillToFocus()` has **zero production callers** (only tests). So
+`getHighestPrioritySkill()` returns null → no `currentTarget` →
+`applyInstructionalMode()` returns null → `decide` falls through to the reactive
+Socratic default, every turn.
+
+Course mode "works" only because it feeds the queue externally (via the pathway
+scaffold in `courseAdapter`). **Feeding that same queue from signals we already
+compute is how structure turns on everywhere — no new engine required.**
+
+---
+
+## 4. Target architecture
+
+One pipeline. One course representation. Structure as an *intensity setting*,
+not a separate mode.
+
+```
+                 ┌───────────────────────────────────────────┐
+                 │            POST /api/chat                   │
+                 │        (single tutoring endpoint)           │
+                 └───────────────────────────────────────────┘
+                                   │
+                                   ▼
+                 ┌───────────────────────────────────────────┐
+                 │              runPipeline                    │
+                 │  observe → diagnose → decide → generate →   │
+                 │            verify → persist                 │
+                 └───────────────────────────────────────────┘
+                                   │
+        tutorPlan.skillFocus  ◄────┴────►  structureLevel flag
+        fed by:                            per turn:
+          • screener placement               • 'free'    → engine picks next
+          • BKT prerequisite gaps              skill, step-lock OFF
+          • FSRS review-due clusters         • 'guided'  → engine picks, softer
+          • course pathway (when enrolled)     scaffolding
+          • mastery mode                     • 'course'  → queue PINNED to
+                                               pathway, step-lock ON
+```
+
+- **One representation:** pathway JSON is the winner. Retire Layer 1
+  (`models/course.js` + `routes/course.js`) or clearly mark it archived.
+- **One endpoint:** collapse `/api/course-chat` into `/api/chat`. Course-ness
+  becomes `structureLevel: 'course'` on the turn context, not a different route.
+  `courseAdapter` becomes an input-builder the single pipeline calls when a
+  course session is active — which is exactly the direction its own header
+  comment already states ("the course scaffold becomes INPUT to the pipeline,
+  not a parallel system").
+- **Structure as a dial:** the same `promptPlanLayer` + `decide` machinery
+  runs for all three levels; only the queue source and the step-lock strictness
+  change.
+
+---
+
+## 5. Gating change — the conversion funnel
+
+Small, surgical, and the highest-visibility user-facing change.
+
+- **Remove** `premiumFeatureGate('Courses')` from
+  `config/routes.js:229–230` (`/api/courses`, `/api/course-sessions`). Free
+  users can now browse + enrol.
+- **Keep** `usageGate` on all AI turns (`/api/chat`, and the folded-in course
+  chat). The 30-AI-minutes/month cap (`FREE_WEEKLY_SECONDS`, monthly reset) is
+  the conversion lever.
+- **Re-word the cap prompt in a course context.** When `usageGate` blocks a
+  student who is mid-module, the message should be course-aware: *"You're 60%
+  through Unit 2 — upgrade to Mathmatix+ to finish without waiting for your
+  minutes to reset."* (Today's copy in `usageGate.js:167` is generic.)
+- Mathmatix+ (`subscriptionTier: 'unlimited'`) and school licenses continue to
+  lift the cap. **No feature is unlocked by tier — only more minutes.**
+
+---
+
+## 6. Phased plan
+
+Ordered by leverage-to-risk. Each phase ships independently.
+
+### Phase 0 — write down the decision *(this doc)*
+No code. Get §1 agreed so the drift cleanup and the queue work aren't relitigated.
+
+### Phase 1 — open the funnel *(small, high visibility)*
+- Drop the two `premiumFeatureGate('Courses')` gates.
+- Make the `usageGate` upgrade copy course-aware.
+- Verify a free account can browse → enrol → chat → hit the cap → see the
+  in-context upgrade prompt.
+- **Risk:** low. Reversible by re-adding the gate.
+
+### Phase 2 — feed `skillFocus` in free chat *(the core)*
+Populate `tutorPlan.skillFocus` from signals already computed, so the structured
+machine runs for un-enrolled students:
+- Screener/placement result → seed the queue with the placed frontier.
+- BKT prerequisite gaps (`knowledgeTracer`) → enqueue struggle-detected skills.
+- FSRS review-due (`fsrsScheduler`) → enqueue review items.
+- Wire the real caller for `addSkillToFocus()` (today: zero callers) inside
+  `pipeline/persist.js` or the plan-load path (`loadOrCreatePlan`).
+- **Risk:** medium. This changes default tutor behavior. Gate behind a flag
+  (`MM_FEATURES.structuredDefault`) and A/B before full rollout. Validate that
+  `shouldSuppressSocratic` doesn't over-trigger and start leaking answers.
+
+### Phase 3 — unify the endpoints
+- Fold `/api/course-chat` handling into `/api/chat` behind a `structureLevel`
+  computed from `activeCourseSessionId`.
+- Reduce `courseAdapter` to an input-builder; delete the duplicate course-prompt
+  branches in `routes/chat.js` (1021/1061/2558) in favor of one path.
+- Keep `/api/course-chat` as a thin alias initially (client still calls it);
+  retire once the client is updated.
+- **Risk:** medium-high. Touches the busiest endpoint + the per-user lock. Do
+  behind tests; the two locks (`acquireUserLock`, `acquireCourseLock`) must
+  become one.
+
+### Phase 4 — retire Layer 1
+- Archive `models/course.js` + `routes/course.js` (or delete after confirming no
+  runtime reads). Migrate `scripts/seedCourse.js` intent to pathway JSON if any
+  authoring value remains.
+- Collapse `buildCourseProgressionCompact` (Layer 3) into the Phase-2 queue so
+  there's one source of "what's next," not two.
+- **Risk:** low once Phases 2–3 land. Mostly deletion.
+
+---
+
+## 7. Open questions
+
+1. **Where does a non-enrolled student's queue come from before they've been
+   screened?** Grade + `mathCourse` → default pathway (the Layer-3 map already
+   exists) is the obvious seed. Confirm every student has enough profile to seed
+   *something*, or the "structure everywhere" promise has holes for brand-new
+   users.
+2. **Step-lock strictness for `'guided'` (non-course) structure.** Course mode
+   hard-locks to one step. Free-chat structure should be softer — steer, don't
+   cage — or it'll feel worse than today's flexible chat. Needs a defined
+   middle setting in `promptPlanLayer`/`decide`.
+3. **Does opening courses to free users blow the AI cost model?** Structured
+   sequences may drive *more* engagement per free user before the cap. Check
+   against `docs/AI_COST_PROJECTIONS.md`; the 30-min cap still bounds spend, but
+   model the funnel conversion rate needed to stay positive.
+4. **Progress/mastery double-counting.** Course progress (`courseSession`) and
+   skill mastery (`user.skillMastery`) are separate. Once one pipeline drives
+   both, confirm a single answer doesn't advance two independent bars
+   inconsistently.
+5. **Do we keep the `Course` LMS schema for future teacher-authored courses?**
+   If teacher authoring is on the roadmap, Layer 1 might be revived rather than
+   deleted — but it should then *compile to* pathway JSON, not run in parallel.
+
+---
+
+## 8. Explicitly out of scope (for now)
+
+- Reviving the dormant `Course` model as a live runtime path.
+- New pathway content authoring (separate content effort).
+- Whiteboard/board-panel changes (`MM_FEATURES.boardPanel` stays off).
+- Any change to how Mathmatix+ is priced or what `usageGate` counts.
+
+---
+
+## 9. TL;DR for a reviewer
+
+The structured-teaching engine is already built and already runs the pipeline;
+it's just fed only by the walled-off course mode. This rework (a) opens that
+mode to free users as a funnel by removing one gate, (b) feeds the same skill
+queue from placement/BKT/FSRS so structure runs for everyone, and (c) collapses
+three overlapping "course" representations and two endpoints into one. Most of
+it is deletion and rewiring, not new machinery.

--- a/middleware/usageGate.js
+++ b/middleware/usageGate.js
@@ -163,10 +163,18 @@ async function usageGate(req, res, next) {
     const msUntilReset = resetDate - now;
     const daysUntilReset = Math.max(0, Math.ceil(msUntilReset / (1000 * 60 * 60 * 24)));
 
+    // Course-aware upgrade nudge: if the student is mid-course, hitting the cap is the
+    // conversion moment — keep it warm and in-context instead of a generic paywall.
+    const inCourse = !!user.activeCourseSessionId;
+    const upgradeLine = inCourse
+      ? `Upgrade to Mathmatix+ to keep going in your course without waiting, or ask your teacher about a school license!`
+      : `Upgrade to Unlimited for non-stop tutoring, or ask your teacher about a school license!`;
+
     return res.status(402).json({
-      message: `You've used your 30 free minutes this month. Your minutes reset in ${daysUntilReset} day${daysUntilReset !== 1 ? 's' : ''}. Upgrade to Unlimited for non-stop tutoring, or ask your teacher about a school license!`,
+      message: `You've used your 30 free minutes this month. Your minutes reset in ${daysUntilReset} day${daysUntilReset !== 1 ? 's' : ''}. ${upgradeLine}`,
       usageLimitReached: true,
       tier: 'free',
+      inCourse,
       freeMinutesUsed: Math.floor(aiUsed / 60),
       freeMinutesTotal: 30,
       freeSecondsRemaining: 0,

--- a/models/actTestSession.js
+++ b/models/actTestSession.js
@@ -15,6 +15,7 @@ const actItemSchema = new Schema({
   skillId: { type: String },
   category: { type: String },
   content: { type: String },                 // the prompt shown to the student
+  svg: { type: String },                     // optional figure
   answerType: { type: String },
   options: [{ label: String, text: String }],
   difficulty: { type: Number },

--- a/models/actTestSession.js
+++ b/models/actTestSession.js
@@ -1,0 +1,76 @@
+// models/actTestSession.js
+// A fixed-form ACT Math practice-test session. Unlike ScreenerSession (an
+// adaptive CAT), the item sequence here is FROZEN at start from an assembled
+// parallel form (utils/actTestAssembler.js) so the test is stable and
+// simulates the real 60-item exam. Answers are graded by re-fetching the
+// Problem server-side; correct-answer keys are never stored on the session.
+
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+// One frozen item in the form (client-safe payload — no answer key).
+const actItemSchema = new Schema({
+  position: { type: Number, required: true },
+  problemId: { type: String, required: true },
+  skillId: { type: String },
+  category: { type: String },
+  content: { type: String },                 // the prompt shown to the student
+  answerType: { type: String },
+  options: [{ label: String, text: String }],
+  difficulty: { type: Number },
+}, { _id: false });
+
+const actResponseSchema = new Schema({
+  position: { type: Number },
+  problemId: { type: String },
+  skillId: { type: String },
+  category: { type: String },
+  answer: { type: String },
+  correct: { type: Boolean },
+  skipped: { type: Boolean, default: false },
+  responseTime: { type: Number },            // ms
+  answeredAt: { type: Date, default: Date.now },
+}, { _id: false });
+
+const actTestSessionSchema = new Schema({
+  userId: { type: Schema.Types.ObjectId, ref: 'User', required: true, index: true },
+  testId: { type: String, default: 'act-math' },
+  seed: { type: Number },
+
+  items: [actItemSchema],
+  currentIndex: { type: Number, default: 0 },
+  responses: [actResponseSchema],
+
+  status: {
+    type: String,
+    enum: ['in_progress', 'completed', 'abandoned'],
+    default: 'in_progress',
+    index: true,
+  },
+
+  timeLimitMinutes: { type: Number, default: 60 },
+  startedAt: { type: Date, default: Date.now },
+  completedAt: { type: Date },
+
+  // Scored at completion
+  rawScore: { type: Number },
+  scaledScore: { type: Number },
+
+  // What the bank could / couldn't cover at assembly time
+  coverage: {
+    total: { type: Number },
+    filled: { type: Number },
+    missing: { type: Number },
+  },
+}, { timestamps: true });
+
+actTestSessionSchema.index({ userId: 1, status: 1 });
+
+actTestSessionSchema.statics.getActiveSession = function (userId) {
+  return this.findOne({ userId, status: 'in_progress' }).sort({ createdAt: -1 });
+};
+
+const ActTestSession = mongoose.models.ActTestSession
+  || mongoose.model('ActTestSession', actTestSessionSchema);
+
+module.exports = ActTestSession;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "seed:playground": "node scripts/seedPlaygroundAccounts.js",
     "seed:playground:clear": "node scripts/seedPlaygroundAccounts.js --clear",
     "seed:skills": "node scripts/seed-pattern-skills.js",
+    "act:coverage": "node scripts/actTestCoverage.js",
     "generate:fraction-problems": "node scripts/generate-fraction-problems.js",
     "generate:all-pattern-problems": "node scripts/generate-all-pattern-problems.js",
     "analyze:skills": "node scripts/analyze-skill-coverage.js",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "seed:playground": "node scripts/seedPlaygroundAccounts.js",
     "seed:playground:clear": "node scripts/seedPlaygroundAccounts.js --clear",
     "seed:skills": "node scripts/seed-pattern-skills.js",
+    "act:gen": "node scripts/generateActItems.js",
+    "act:seed": "node scripts/generateActItems.js --seed-db",
     "act:coverage": "node scripts/actTestCoverage.js",
     "generate:fraction-problems": "node scripts/generate-fraction-problems.js",
     "generate:all-pattern-problems": "node scripts/generate-all-pattern-problems.js",

--- a/public/chat.html
+++ b/public/chat.html
@@ -31,7 +31,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     // board. boardPanel stays true so #cr-workspace (the mount slot) is visible;
     // the M-C swap hides the legacy tools *inside* it and mounts the new surface.
     // Kill switch: set livingWorkspace:'off' here (legacy board returns untouched).
-    window.MM_FEATURES = Object.assign({ boardPanel: true, livingWorkspace: 'live' }, window.MM_FEATURES || {});
+    // courses: true — the "My Courses" sidebar entry point is live (structure-everywhere).
+    // Kill switch: set courses:false here, or load with ?courses=0 to hide it for a session.
+    window.MM_FEATURES = Object.assign({ boardPanel: true, livingWorkspace: 'live', courses: true }, window.MM_FEATURES || {});
     if (window.MM_FEATURES.boardPanel === false) {
       document.documentElement.classList.add('mm-board-hidden');
     }
@@ -349,7 +351,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
     </div>
 
-    <!-- My Courses (hidden — not production ready) -->
+    <!-- My Courses — revealed by courseCatalog.js init() when MM_FEATURES.courses is on. -->
     <div class="sidebar-section" id="sidebar-courses-section" style="display: none;">
       <button class="courses-toggle" id="courses-toggle-btn">
         <span><i class="fas fa-graduation-cap" style="margin-right: 6px; font-size: 13px; color: #764ba2;"></i><span data-i18n="chat.myCourses">My Courses</span></span>

--- a/public/chat.html
+++ b/public/chat.html
@@ -2326,6 +2326,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <script src="/js/boardCommandHandler.js"></script>
   <!-- Phase C: executes server-emitted <XP> ceremony commands (confetti + caption) -->
   <script src="/js/xpTagHandler.js"></script>
+  <!-- ACT Math practice test runner — window.openActTest() (boot-camp diagnostic) -->
+  <script src="/js/act-test.js"></script>
   <!-- Phase D: executes server-emitted <GRAPH>/<TILES> tab-switch commands -->
   <script src="/dist/js/chat-js5.1f62385f.js"></script>
 <!-- PDF.js library for PDF preview and rendering -->

--- a/public/js/act-test.js
+++ b/public/js/act-test.js
@@ -25,6 +25,8 @@
   .actt-bar{height:6px;background:#ece9f5;border-radius:3px;overflow:hidden}
   .actt-fill{height:100%;background:linear-gradient(90deg,#667eea,#764ba2);width:0;transition:width .25s}
   .actt-body{padding:18px;overflow-y:auto}
+  .actt-fig{display:flex;justify-content:center;margin:2px 0 14px}
+  .actt-fig svg{background:#faf9ff;border:1px solid #efedf8;border-radius:10px;padding:8px}
   .actt-q{font-size:17px;line-height:1.5;margin:4px 0 16px;white-space:pre-wrap}
   .actt-opts{display:flex;flex-direction:column;gap:8px}
   .actt-opt{display:flex;align-items:center;gap:12px;padding:12px 14px;border:2px solid #e7e4f1;border-radius:11px;cursor:pointer;font-size:15px;background:#fff;text-align:left;transition:all .12s}
@@ -188,7 +190,11 @@
       const opts = (p.options || []).map(o =>
         `<button class="actt-opt" data-label="${o.label}"><span class="actt-optlab">${o.label}</span><span>${escapeHtml(o.text)}</span></button>`
       ).join('');
-      this.el('actt-body').innerHTML = `<div class="actt-q">${escapeHtml(p.content || '')}</div><div class="actt-opts">${opts}</div>`;
+      // Figure is our own generated SVG (from the item bank), not user input.
+      // Guard: only render a bare <svg> with no scripts.
+      const fig = (p.svg && /^<svg[\s>]/.test(p.svg) && !/<script/i.test(p.svg))
+        ? `<div class="actt-fig">${p.svg}</div>` : '';
+      this.el('actt-body').innerHTML = `${fig}<div class="actt-q">${escapeHtml(p.content || '')}</div><div class="actt-opts">${opts}</div>`;
       this.el('actt-body').querySelectorAll('.actt-opt').forEach(btn => {
         btn.addEventListener('click', () => {
           this.selected = btn.getAttribute('data-label');

--- a/public/js/act-test.js
+++ b/public/js/act-test.js
@@ -1,0 +1,270 @@
+/**
+ * ACT Math Practice Test — student-facing runner.
+ *
+ * Self-contained: builds its own DOM + styles on first open, so it has no
+ * dependency on pre-existing markup. Drives the /api/act-test rail
+ * (start → next-problem → submit-answer → complete) built in routes/actTest.js.
+ *
+ * Open with window.openActTest(). Timed (60 min), 60 items, results screen
+ * shows the scaled 1–36 estimate + a per-category breakdown (the diagnostic
+ * that seeds the boot-camp plan).
+ */
+(function () {
+  'use strict';
+
+  const CSS = `
+  .actt-overlay{position:fixed;inset:0;background:rgba(20,16,40,.55);backdrop-filter:blur(3px);z-index:10000;display:flex;align-items:center;justify-content:center;padding:16px;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif}
+  .actt-card{background:#fff;color:#1b1b2b;width:min(640px,100%);max-height:92vh;border-radius:16px;box-shadow:0 24px 70px rgba(30,20,70,.35);display:flex;flex-direction:column;overflow:hidden}
+  .actt-head{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:14px 18px;background:linear-gradient(135deg,#667eea,#764ba2);color:#fff}
+  .actt-title{font-weight:700;font-size:15px;display:flex;align-items:center;gap:8px}
+  .actt-timer{font-variant-numeric:tabular-nums;font-weight:700;font-size:14px;background:rgba(255,255,255,.18);padding:4px 10px;border-radius:8px}
+  .actt-timer.low{background:#e5484d}
+  .actt-x{background:transparent;border:0;color:#fff;font-size:20px;cursor:pointer;line-height:1;opacity:.9}
+  .actt-progwrap{padding:10px 18px 0}
+  .actt-progrow{display:flex;justify-content:space-between;font-size:12px;color:#777;margin-bottom:6px}
+  .actt-bar{height:6px;background:#ece9f5;border-radius:3px;overflow:hidden}
+  .actt-fill{height:100%;background:linear-gradient(90deg,#667eea,#764ba2);width:0;transition:width .25s}
+  .actt-body{padding:18px;overflow-y:auto}
+  .actt-q{font-size:17px;line-height:1.5;margin:4px 0 16px;white-space:pre-wrap}
+  .actt-opts{display:flex;flex-direction:column;gap:8px}
+  .actt-opt{display:flex;align-items:center;gap:12px;padding:12px 14px;border:2px solid #e7e4f1;border-radius:11px;cursor:pointer;font-size:15px;background:#fff;text-align:left;transition:all .12s}
+  .actt-opt:hover{border-color:#b9aef0;background:#faf9ff}
+  .actt-opt.sel{border-color:#764ba2;background:#f3efff;box-shadow:0 0 0 3px rgba(118,75,162,.12)}
+  .actt-optlab{flex:0 0 26px;height:26px;border-radius:50%;display:grid;place-items:center;font-weight:700;font-size:13px;background:#ece9f5;color:#555}
+  .actt-opt.sel .actt-optlab{background:#764ba2;color:#fff}
+  .actt-foot{display:flex;gap:10px;align-items:center;justify-content:space-between;padding:14px 18px;border-top:1px solid #eee}
+  .actt-btn{appearance:none;border:0;border-radius:10px;padding:11px 20px;font-weight:600;font-size:14px;cursor:pointer}
+  .actt-next{background:linear-gradient(135deg,#667eea,#764ba2);color:#fff}
+  .actt-next:disabled{opacity:.5;cursor:not-allowed}
+  .actt-skip{background:#f1f0f7;color:#666}
+  .actt-center{padding:40px 18px;text-align:center;color:#555}
+  .actt-score{font-size:64px;font-weight:800;background:linear-gradient(135deg,#667eea,#764ba2);-webkit-background-clip:text;background-clip:text;color:transparent;line-height:1}
+  .actt-scorelab{font-size:13px;color:#888;letter-spacing:.06em;text-transform:uppercase;margin-top:4px}
+  .actt-sub{color:#666;margin:10px 0 20px;font-size:14px}
+  .actt-cat{display:flex;align-items:center;gap:10px;margin:8px 0;font-size:13px}
+  .actt-catname{flex:0 0 200px;text-align:right;color:#555;text-transform:capitalize}
+  .actt-catbar{flex:1;height:9px;background:#ece9f5;border-radius:5px;overflow:hidden;display:block}
+  .actt-catfill{display:block;height:100%;background:linear-gradient(90deg,#667eea,#764ba2)}
+  .actt-catpct{flex:0 0 54px;text-align:left;color:#777;font-variant-numeric:tabular-nums}
+  .actt-err{color:#c0392b;padding:24px;text-align:center}
+  @media (prefers-color-scheme:dark){
+    .actt-card{background:#1c1a2b;color:#ece9f7}
+    .actt-opt{background:#211e32;border-color:#302c45;color:#ece9f7}
+    .actt-opt:hover{background:#26233a}
+    .actt-opt.sel{background:#2b2547;border-color:#9a80ff}
+    .actt-optlab{background:#302c45;color:#cbc7e0}
+    .actt-foot{border-color:#2d2a40}
+    .actt-skip{background:#26233a;color:#cbc7e0}
+    .actt-bar,.actt-catbar{background:#2d2a40}
+    .actt-catname{color:#b7b3cc}
+  }`;
+
+  const CATEGORY_LABELS = {
+    'integrating-essential-skills': 'Essential skills',
+    'number-quantity': 'Number & quantity',
+    'algebra': 'Algebra',
+    'functions': 'Functions',
+    'geometry': 'Geometry',
+    'statistics-probability': 'Statistics & probability',
+    'unknown': 'Other',
+  };
+
+  function api(url, opts) {
+    const fetcher = window.csrfFetch || window.fetch;
+    return fetcher(url, opts).then(r => r.json());
+  }
+
+  class ActTest {
+    constructor() {
+      this.sessionId = null;
+      this.current = null;
+      this.selected = null;
+      this.total = 60;
+      this.itemStart = 0;
+      this.deadline = 0;
+      this.timerId = null;
+      this._injectCss();
+    }
+
+    _injectCss() {
+      if (document.getElementById('actt-style')) return;
+      const s = document.createElement('style');
+      s.id = 'actt-style';
+      s.textContent = CSS;
+      document.head.appendChild(s);
+    }
+
+    _mount() {
+      if (this.overlay) return;
+      this.overlay = document.createElement('div');
+      this.overlay.className = 'actt-overlay';
+      this.overlay.innerHTML = `
+        <div class="actt-card" role="dialog" aria-modal="true" aria-label="ACT Math Practice Test">
+          <div class="actt-head">
+            <span class="actt-title">📐 ACT Math Practice Test</span>
+            <span style="display:flex;align-items:center;gap:10px">
+              <span class="actt-timer" id="actt-timer">60:00</span>
+              <button class="actt-x" id="actt-close" aria-label="Close">×</button>
+            </span>
+          </div>
+          <div class="actt-progwrap" id="actt-progwrap" style="display:none">
+            <div class="actt-progrow"><span id="actt-qnum"></span><span id="actt-qpct"></span></div>
+            <div class="actt-bar"><div class="actt-fill" id="actt-fill"></div></div>
+          </div>
+          <div class="actt-body" id="actt-body"></div>
+          <div class="actt-foot" id="actt-foot" style="display:none">
+            <button class="actt-btn actt-skip" id="actt-skip">Skip</button>
+            <button class="actt-btn actt-next" id="actt-next" disabled>Next</button>
+          </div>
+        </div>`;
+      document.body.appendChild(this.overlay);
+      this.overlay.querySelector('#actt-close').addEventListener('click', () => this.close());
+      this.overlay.querySelector('#actt-skip').addEventListener('click', () => this.submit(true));
+      this.overlay.querySelector('#actt-next').addEventListener('click', () => this.submit(false));
+      this.el = (id) => this.overlay.querySelector('#' + id);
+    }
+
+    async open() {
+      this._mount();
+      this.overlay.style.display = 'flex';
+      this.el('actt-body').innerHTML = '<div class="actt-center">Building your practice test…</div>';
+      try {
+        const data = await api('/api/act-test/start', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({}) });
+        if (data && data.needsGeneration !== undefined) {
+          this.el('actt-body').innerHTML = `<div class="actt-err">The ACT item bank isn't loaded yet.<br><small>Ask an admin to run <code>npm run act:seed</code>.</small></div>`;
+          return;
+        }
+        if (!data || !data.sessionId) throw new Error((data && data.message) || 'Could not start.');
+        this.sessionId = data.sessionId;
+        this.total = data.totalItems || 60;
+        const mins = data.timeLimitMinutes || 60;
+        this.deadline = Date.now() + mins * 60000;
+        this._startTimer();
+        this.el('actt-progwrap').style.display = '';
+        this.el('actt-foot').style.display = 'flex';
+        await this.fetchNext();
+      } catch (e) {
+        this.el('actt-body').innerHTML = `<div class="actt-err">${e.message || 'Something went wrong.'}</div>`;
+      }
+    }
+
+    close() {
+      this._stopTimer();
+      if (this.overlay) this.overlay.style.display = 'none';
+    }
+
+    _startTimer() {
+      this._stopTimer();
+      const tick = () => {
+        const remain = Math.max(0, this.deadline - Date.now());
+        const m = Math.floor(remain / 60000);
+        const s = Math.floor((remain % 60000) / 1000);
+        const t = this.el('actt-timer');
+        if (t) {
+          t.textContent = `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+          t.classList.toggle('low', remain <= 120000);
+        }
+        if (remain <= 0) { this._stopTimer(); this.complete(); }
+      };
+      tick();
+      this.timerId = setInterval(tick, 1000);
+    }
+    _stopTimer() { if (this.timerId) { clearInterval(this.timerId); this.timerId = null; } }
+
+    async fetchNext() {
+      const data = await api(`/api/act-test/next-problem?sessionId=${encodeURIComponent(this.sessionId)}`);
+      if (!data || data.nextAction === 'complete' || !data.problem) { return this.complete(); }
+      this.current = data.problem;
+      this.selected = null;
+      this.itemStart = Date.now();
+      this.render();
+    }
+
+    render() {
+      const p = this.current;
+      this.el('actt-qnum').textContent = `Question ${p.progress.current} of ${p.progress.total}`;
+      this.el('actt-qpct').textContent = `${p.progress.percentComplete || 0}%`;
+      this.el('actt-fill').style.width = `${p.progress.percentComplete || 0}%`;
+      const opts = (p.options || []).map(o =>
+        `<button class="actt-opt" data-label="${o.label}"><span class="actt-optlab">${o.label}</span><span>${escapeHtml(o.text)}</span></button>`
+      ).join('');
+      this.el('actt-body').innerHTML = `<div class="actt-q">${escapeHtml(p.content || '')}</div><div class="actt-opts">${opts}</div>`;
+      this.el('actt-body').querySelectorAll('.actt-opt').forEach(btn => {
+        btn.addEventListener('click', () => {
+          this.selected = btn.getAttribute('data-label');
+          this.el('actt-body').querySelectorAll('.actt-opt').forEach(b => b.classList.toggle('sel', b === btn));
+          this.el('actt-next').disabled = false;
+        });
+      });
+      this.el('actt-next').disabled = true;
+      this.el('actt-next').textContent = (p.progress.current >= p.progress.total) ? 'Finish' : 'Next';
+    }
+
+    async submit(skipped) {
+      if (!skipped && !this.selected) return;
+      const btn = this.el('actt-next'); if (btn) btn.disabled = true;
+      try {
+        await api('/api/act-test/submit-answer', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            sessionId: this.sessionId,
+            problemId: this.current.problemId,
+            answer: skipped ? null : this.selected,
+            skipped: !!skipped,
+            responseTime: Date.now() - this.itemStart,
+          }),
+        });
+        await this.fetchNext();
+      } catch (e) {
+        this.el('actt-body').innerHTML = `<div class="actt-err">${e.message || 'Could not submit.'}</div>`;
+      }
+    }
+
+    async complete() {
+      this._stopTimer();
+      this.el('actt-progwrap').style.display = 'none';
+      this.el('actt-foot').style.display = 'none';
+      this.el('actt-body').innerHTML = '<div class="actt-center">Scoring…</div>';
+      try {
+        const data = await api('/api/act-test/complete', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ sessionId: this.sessionId }) });
+        const r = (data && data.report) || {};
+        const cats = Object.entries(r.byCategory || {}).map(([k, v]) => {
+          const pct = v.total ? Math.round((v.correct / v.total) * 100) : 0;
+          const name = CATEGORY_LABELS[k] || k;
+          return `<div class="actt-cat"><span class="actt-catname">${name}</span><span class="actt-catbar"><span class="actt-catfill" style="width:${pct}%"></span></span><span class="actt-catpct">${v.correct}/${v.total}</span></div>`;
+        }).join('');
+        this.el('actt-body').innerHTML = `
+          <div class="actt-center" style="padding-bottom:12px">
+            <div class="actt-score">${r.scaledScore != null ? r.scaledScore : '—'}</div>
+            <div class="actt-scorelab">Estimated ACT Math score${r.scaledApproximate ? ' (approx.)' : ''}</div>
+            <div class="actt-sub">${r.rawScore}/${r.totalItems} correct · ${r.accuracy}% · ${r.durationMinutes != null ? r.durationMinutes + ' min' : ''}</div>
+          </div>
+          <div style="max-width:520px;margin:0 auto">${cats}</div>
+          <div style="text-align:center;margin-top:22px;display:flex;gap:10px;justify-content:center">
+            <button class="actt-btn actt-skip" id="actt-done">Done</button>
+            <button class="actt-btn actt-next" id="actt-retake">Take another</button>
+          </div>`;
+        this.el('actt-done').addEventListener('click', () => this.close());
+        this.el('actt-retake').addEventListener('click', () => { this.sessionId = null; this.open(); });
+      } catch (e) {
+        this.el('actt-body').innerHTML = `<div class="actt-err">${e.message || 'Could not score the test.'}</div>`;
+      }
+    }
+  }
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+  }
+
+  window.actTest = new ActTest();
+  window.openActTest = function () { window.actTest.open(); };
+
+  // Reachable entry point: a boot-camp CTA can link to /chat.html?acttest=1,
+  // and it's an easy way to try the flow. (A visible button lives with the
+  // boot-camp card once that UI exists.)
+  try {
+    if (new URLSearchParams(location.search).get('acttest') === '1') {
+      window.addEventListener('load', () => window.openActTest());
+    }
+  } catch (e) { /* noop */ }
+})();

--- a/public/js/courseCatalog.js
+++ b/public/js/courseCatalog.js
@@ -21,6 +21,19 @@ class CourseManager {
     // Initialisation
     // --------------------------------------------------
     init() {
+        // Reveal the "My Courses" sidebar entry point when the feature is on.
+        // Flag default is set in chat.html (MM_FEATURES.courses); ?courses=0/1 overrides per session.
+        const flagParams = new URLSearchParams(window.location.search);
+        const urlCourses = flagParams.get('courses');
+        const coursesOn = urlCourses !== null
+            ? (urlCourses !== '0' && urlCourses !== 'false')
+            : (window.MM_FEATURES ? window.MM_FEATURES.courses !== false : true);
+        const coursesSection = document.getElementById('sidebar-courses-section');
+        if (coursesSection && coursesOn) {
+            coursesSection.style.display = '';
+        }
+        if (!coursesOn) return; // feature off — skip wiring entirely
+
         // Browse Courses button → open catalog modal
         const browseBtn = document.getElementById('browse-courses-btn');
         if (browseBtn) {

--- a/routes/actTest.js
+++ b/routes/actTest.js
@@ -1,0 +1,227 @@
+// routes/actTest.js
+// Fixed-form ACT Math practice-test delivery — a parallel rail to the Starting
+// Point screener (routes/screener.js), mirroring its per-item request/response
+// contract so the same item-render UI can drive it. The form is assembled once
+// (utils/actTestAssembler.js) into an original parallel test and frozen on the
+// session; grading re-fetches each Problem server-side.
+//
+// Free by design (the ACT boot camp is a conversion on-ramp): mounted with
+// isAuthenticated only. Deterministic grading — no AI at request time.
+//
+// Endpoints (all /api/act-test):
+//   POST /start            → assemble + freeze a form, return sessionId + meta
+//   GET  /next-problem      → serve the current item
+//   POST /submit-answer     → grade one item, advance
+//   POST /complete          → raw→scaled score + per-category breakdown
+
+const express = require('express');
+const router = express.Router();
+
+const ActTestSession = require('../models/actTestSession');
+const Problem = require('../models/problem');
+const { assembleForm, rawToScaled, getBlueprint } = require('../utils/actTestAssembler');
+
+// ── POST /start ─────────────────────────────────────────────
+router.post('/', async (req, res) => {
+  return res.status(404).json({ message: 'Use POST /api/act-test/start' });
+});
+
+router.post('/start', async (req, res) => {
+  try {
+    const userId = req.user._id;
+    const { restart } = req.body || {};
+
+    // Resume an in-progress test unless restarting.
+    if (!restart) {
+      const active = await ActTestSession.getActiveSession(userId);
+      if (active && active.items.length > 0) {
+        return res.json({
+          sessionId: active._id,
+          resumed: true,
+          totalItems: active.items.length,
+          answered: active.responses.length,
+          timeLimitMinutes: active.timeLimitMinutes,
+        });
+      }
+    }
+
+    // Abandon any stale in-progress sessions before starting fresh.
+    await ActTestSession.updateMany(
+      { userId, status: 'in_progress' },
+      { $set: { status: 'abandoned' } }
+    );
+
+    const blueprint = getBlueprint();
+    const seed = `${userId}-${Date.now()}`;
+    const form = await assembleForm({ seed });
+
+    if (form.coverage.filled === 0) {
+      // Honest failure: the ACT item bank isn't populated yet. The gaps array
+      // is the generation worklist (skill + difficulty per missing slot).
+      return res.status(503).json({
+        message: 'The ACT practice-test item bank is not populated yet.',
+        coverage: form.coverage,
+        needsGeneration: form.gaps.length,
+      });
+    }
+
+    const session = await ActTestSession.create({
+      userId,
+      testId: blueprint.testId,
+      seed: form.meta.seed,
+      items: form.items,
+      timeLimitMinutes: blueprint.timeLimitMinutes,
+      coverage: form.coverage,
+    });
+
+    return res.json({
+      sessionId: session._id,
+      started: true,
+      totalItems: form.items.length,
+      timeLimitMinutes: blueprint.timeLimitMinutes,
+      coverage: form.coverage,           // surfaces partial coverage honestly
+    });
+  } catch (err) {
+    console.error('[actTest] start error:', err.message);
+    return res.status(500).json({ message: 'Could not start the practice test.' });
+  }
+});
+
+// ── GET /next-problem?sessionId= ────────────────────────────
+router.get('/next-problem', async (req, res) => {
+  try {
+    const { sessionId } = req.query;
+    const session = await loadOwnedSession(sessionId, req.user._id, res);
+    if (!session) return;
+
+    if (session.currentIndex >= session.items.length) {
+      return res.json({ nextAction: 'complete' });
+    }
+
+    const item = session.items[session.currentIndex];
+    return res.json({
+      problem: {
+        problemId: item.problemId,
+        content: item.content,
+        skillId: item.skillId,
+        category: item.category,
+        answerType: item.answerType,
+        options: item.options,
+        questionNumber: item.position,
+        progress: {
+          current: session.currentIndex + 1,
+          total: session.items.length,
+          percentComplete: Math.round(((session.currentIndex) / session.items.length) * 100),
+        },
+      },
+    });
+  } catch (err) {
+    console.error('[actTest] next-problem error:', err.message);
+    return res.status(500).json({ message: 'Could not load the next question.' });
+  }
+});
+
+// ── POST /submit-answer ─────────────────────────────────────
+router.post('/submit-answer', async (req, res) => {
+  try {
+    const { sessionId, problemId, answer, responseTime, skipped } = req.body || {};
+    const session = await loadOwnedSession(sessionId, req.user._id, res);
+    if (!session) return;
+
+    const item = session.items[session.currentIndex];
+    if (!item || item.problemId !== problemId) {
+      return res.status(409).json({ message: 'Out-of-order submission; refetch the current question.' });
+    }
+
+    // Grade by re-fetching the Problem (answer key never leaves the server).
+    let correct = false;
+    if (!skipped) {
+      const problem = await Problem.findOne({ problemId });
+      correct = problem ? !!problem.checkAnswer(answer) : false;
+    }
+
+    session.responses.push({
+      position: item.position,
+      problemId,
+      skillId: item.skillId,
+      category: item.category,
+      answer: skipped ? null : String(answer),
+      correct,
+      skipped: !!skipped,
+      responseTime: responseTime || null,
+    });
+    session.currentIndex += 1;
+    await session.save();
+
+    const done = session.currentIndex >= session.items.length;
+    return res.json({
+      nextAction: done ? 'complete' : 'continue',
+      correct,
+      progress: {
+        current: Math.min(session.currentIndex + 1, session.items.length),
+        total: session.items.length,
+        percentComplete: Math.round((session.currentIndex / session.items.length) * 100),
+      },
+    });
+  } catch (err) {
+    console.error('[actTest] submit-answer error:', err.message);
+    return res.status(500).json({ message: 'Could not record your answer.' });
+  }
+});
+
+// ── POST /complete ──────────────────────────────────────────
+router.post('/complete', async (req, res) => {
+  try {
+    const { sessionId } = req.body || {};
+    const session = await loadOwnedSession(sessionId, req.user._id, res);
+    if (!session) return;
+
+    const raw = session.responses.filter(r => r.correct).length;
+    const total = session.items.length;
+    const scaled = rawToScaled(raw);
+
+    // Per-category breakdown — the diagnostic signal that drives the boot-camp plan.
+    const byCategory = {};
+    for (const r of session.responses) {
+      const c = r.category || 'unknown';
+      byCategory[c] = byCategory[c] || { correct: 0, total: 0 };
+      byCategory[c].total += 1;
+      if (r.correct) byCategory[c].correct += 1;
+    }
+
+    session.status = 'completed';
+    session.completedAt = new Date();
+    session.rawScore = raw;
+    session.scaledScore = scaled ? scaled.scaled : null;
+    await session.save();
+
+    return res.json({
+      success: true,
+      report: {
+        rawScore: raw,
+        totalItems: total,
+        scaledScore: scaled ? scaled.scaled : null,
+        scaledApproximate: true,
+        accuracy: total ? Math.round((raw / total) * 100) : 0,
+        byCategory,
+        durationMinutes: session.startedAt
+          ? Math.round((session.completedAt - session.startedAt) / 60000)
+          : null,
+      },
+    });
+  } catch (err) {
+    console.error('[actTest] complete error:', err.message);
+    return res.status(500).json({ message: 'Could not score the practice test.' });
+  }
+});
+
+// ── helper: load a session the caller owns ──────────────────
+async function loadOwnedSession(sessionId, userId, res) {
+  if (!sessionId) { res.status(400).json({ message: 'sessionId is required.' }); return null; }
+  const session = await ActTestSession.findById(sessionId);
+  if (!session) { res.status(404).json({ message: 'Practice-test session not found.' }); return null; }
+  if (String(session.userId) !== String(userId)) { res.status(403).json({ message: 'Not your session.' }); return null; }
+  return session;
+}
+
+module.exports = router;

--- a/routes/actTest.js
+++ b/routes/actTest.js
@@ -103,6 +103,7 @@ router.get('/next-problem', async (req, res) => {
       problem: {
         problemId: item.problemId,
         content: item.content,
+        svg: item.svg,
         skillId: item.skillId,
         category: item.category,
         answerType: item.answerType,

--- a/routes/courseSession.js
+++ b/routes/courseSession.js
@@ -11,9 +11,6 @@ const Conversation = require('../models/conversation');
 const User = require('../models/user');
 const { calculateOverallProgress } = require('../utils/coursePrompt');
 const { buildProgressUpdate } = require('../utils/progressState');
-const { isLicenseValid } = require('../middleware/usageGate');
-
-const BILLING_ENABLED = process.env.BILLING_ENABLED === 'true';
 
 /* ============================================================
    GET /api/course-sessions/catalog
@@ -140,27 +137,9 @@ router.post('/enroll', async (req, res) => {
       return res.status(400).json({ success: false, message: 'courseId is required' });
     }
 
-    // Courses require Unlimited plan or school license (when billing is enabled)
-    // Exception: Pi Day (March 14) — all courses are free for everyone
-    const now = new Date();
-    const piDayFreeAccess = now.getMonth() === 2 && now.getDate() === 14;
-
-    if (BILLING_ENABLED && req.user.role === 'student' && !piDayFreeAccess) {
-      const hasUnlimited = req.user.subscriptionTier === 'unlimited';
-      let hasSchoolLicense = false;
-      if (req.user.schoolLicenseId) {
-        hasSchoolLicense = await isLicenseValid(req.user.schoolLicenseId);
-      }
-      if (!hasUnlimited && !hasSchoolLicense) {
-        return res.status(402).json({
-          success: false,
-          message: 'Courses require the Unlimited plan ($19.95/month) or a school license.',
-          premiumFeatureBlocked: true,
-          feature: 'Courses',
-          upgradeRequired: true
-        });
-      }
-    }
+    // Courses are open to all students as a free on-ramp — no plan/license required to enrol.
+    // AI usage inside the course is still metered by usageGate (30 free min/month); the cap,
+    // not enrolment, is the upgrade moment. See docs/COURSES_IN_FLOW_DESIGN.md.
 
     // Check for existing session in this course (active OR paused)
     const existing = await CourseSession.findOne({

--- a/scripts/actTestCoverage.js
+++ b/scripts/actTestCoverage.js
@@ -1,0 +1,50 @@
+// scripts/actTestCoverage.js
+// Reports how much of an ACT Math practice form the current item bank can fill,
+// and prints the generation worklist (skill + difficulty) for any gaps.
+//
+// Usage: node scripts/actTestCoverage.js
+//
+// This is the operational readiness check for the ACT boot-camp practice test:
+// if coverage is low, the printed gaps are exactly what scripts/generate*.js
+// need to produce (our own items) before the test is worth shipping.
+
+require('dotenv').config();
+const mongoose = require('mongoose');
+const { assembleForm } = require('../utils/actTestAssembler');
+
+async function main() {
+  if (!process.env.MONGO_URI) {
+    console.error('MONGO_URI not set.');
+    process.exit(1);
+  }
+  await mongoose.connect(process.env.MONGO_URI);
+
+  // Fixed seed for a repeatable snapshot.
+  const form = await assembleForm({ seed: 'coverage-check' });
+
+  console.log('\n=== ACT Math practice test — bank coverage ===');
+  console.log(`Filled ${form.coverage.filled}/${form.coverage.total} slots (${form.coverage.pct}%), ${form.coverage.missing} gaps.\n`);
+
+  if (form.gaps.length) {
+    const bySkill = {};
+    for (const g of form.gaps) {
+      const key = `${g.skillId} (d≈${g.targetDifficulty})`;
+      bySkill[key] = (bySkill[key] || 0) + 1;
+    }
+    console.log('Generation worklist (skill → items needed):');
+    Object.entries(bySkill)
+      .sort((a, b) => b[1] - a[1])
+      .forEach(([k, n]) => console.log(`  ${n}×  ${k}`));
+  } else {
+    console.log('Bank fully covers a form. Ready to ship.');
+  }
+
+  await mongoose.disconnect();
+  process.exit(0);
+}
+
+main().catch(async (err) => {
+  console.error('actTestCoverage failed:', err.message);
+  try { await mongoose.disconnect(); } catch { /* noop */ }
+  process.exit(1);
+});

--- a/scripts/generateActItems.js
+++ b/scripts/generateActItems.js
@@ -1,0 +1,463 @@
+// scripts/generateActItems.js
+// Generates ORIGINAL ACT Math practice items for the 31 content skills in
+// seeds/act-math-blueprint.json. Every item is TEMPLATE-generated: the correct
+// answer is computed from the parameters (never guessed), distractors model
+// real student errors, and — for every solvable type — a validator plugs the
+// answer back into the problem and REJECTS anything inconsistent. A wrong
+// answer key cannot escape.
+//
+// Usage:
+//   node scripts/generateActItems.js                 # write seeds/act-math-items.generated.json + self-check + assembly proof
+//   node scripts/generateActItems.js --per-skill 10  # items per skill (default 8)
+//   node scripts/generateActItems.js --seed-db       # upsert into MongoDB (needs MONGO_URI)
+//
+// Correctness-by-construction is the design goal: this is a math tutor for kids.
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const BLUEPRINT = require('../seeds/act-math-blueprint.json');
+const OUT = path.join(__dirname, '..', 'seeds', 'act-math-items.generated.json');
+
+// ── seeded RNG (deterministic bank per run seed) ───────────────
+function mulberry32(a) {
+  return function () {
+    a |= 0; a = (a + 0x6D2B79F5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+let RNG = mulberry32(20260715);
+const ri = (lo, hi) => lo + Math.floor(RNG() * (hi - lo + 1));   // inclusive int
+const nz = (lo, hi) => { let v = 0; while (v === 0) v = ri(lo, hi); return v; };
+const pick = (arr) => arr[Math.floor(RNG() * arr.length)];
+// Format a coefficient in front of a variable: 1x→"x", -1x→"-x", 3x→"3x".
+const co = (k, v) => (k === 1 ? v : k === -1 ? `-${v}` : `${k}${v}`);
+// Money: whole dollars plain, else two decimals.
+const money = (v) => (Number.isInteger(v) ? `$${v}` : `$${v.toFixed(2)}`);
+
+// ── MC assembler: takes correct value + distractor values, dedupes,
+//    shuffles, assigns the correct letter. Enforces exactly-one-correct. ──
+const LETTERS = ['A', 'B', 'C', 'D', 'E'];
+function buildMC({ skillId, prompt, correct, distractors, difficulty, format }) {
+  const fmt = format || ((v) => String(v));
+  const correctText = fmt(correct);
+  // Unique distractor texts, none equal to the correct text.
+  const seen = new Set([correctText]);
+  const dtexts = [];
+  for (const d of distractors) {
+    const s = fmt(d);
+    if (!seen.has(s)) { seen.add(s); dtexts.push(s); }
+    if (dtexts.length === 4) break;
+  }
+  if (dtexts.length < 4) return null; // not enough distinct distractors — skip
+  // Shuffle correct + distractors into 5 options.
+  const opts = [correctText, ...dtexts];
+  for (let i = opts.length - 1; i > 0; i--) { const j = Math.floor(RNG() * (i + 1)); [opts[i], opts[j]] = [opts[j], opts[i]]; }
+  const correctIdx = opts.indexOf(correctText);
+  const options = opts.map((text, i) => ({ label: LETTERS[i], text }));
+  const contentHash = crypto.createHash('sha256').update(`${skillId}|${prompt}`).digest('hex');
+  return {
+    problemId: `act-${skillId}-${contentHash.slice(0, 10)}`,
+    skillId,
+    prompt,
+    answer: { type: 'auto', value: correctText, equivalents: [] },
+    answerType: 'multiple-choice',
+    options,
+    correctOption: LETTERS[correctIdx],
+    difficulty,
+    gradeBand: '8-12',
+    tags: ['act', 'act-math', skillId],
+    source: 'act-template-gen',
+    contentHash,
+    isActive: true,
+  };
+}
+
+// Common numeric-distractor helper: perturb around correct with plausible errors.
+function numDistractors(correct, pool) {
+  const out = [];
+  for (const d of pool) if (Number.isFinite(d) && d !== correct) out.push(d);
+  // pad with nearby values if needed
+  let k = 1;
+  while (out.length < 6) { if (correct + k !== correct && !out.includes(correct + k)) out.push(correct + k); if (correct - k !== correct && !out.includes(correct - k)) out.push(correct - k); k++; }
+  return out;
+}
+
+// ── generators: skillId -> (difficulty) -> { prompt, correct, distractors, format?, validate? } ──
+// validate() returns true iff the emitted correct answer really solves the problem.
+const G = {};
+
+// number-quantity ------------------------------------------------
+G['act-exponents-roots'] = (d) => {
+  const base = pick([2, 3, 5, 10]); const m = ri(2, 2 + d); const n = ri(2, 2 + d);
+  const correct = Math.pow(base, m + n);
+  return {
+    prompt: `The expression ${base}^${m} · ${base}^${n} is equal to:`,
+    correct,
+    distractors: [Math.pow(base, m * n), Math.pow(base, m + n + 1), base * (m + n), Math.pow(base, Math.abs(m - n))],
+    validate: () => Math.pow(base, m) * Math.pow(base, n) === correct,
+  };
+};
+G['act-ratios-proportions-percents'] = (d) => {
+  const pct = pick([10, 20, 25, 40, 50, 60, 75]); const whole = ri(2, 6 + d) * 20;
+  const correct = (pct / 100) * whole;
+  return {
+    prompt: `What is ${pct}% of ${whole}?`,
+    correct,
+    distractors: [whole - correct, correct / 2, correct * 2, whole * pct / 1000],
+    validate: () => Math.abs((pct / 100) * whole - correct) < 1e-9,
+  };
+};
+G['act-real-complex-numbers'] = (d) => {
+  const a = nz(-6, 8), b = nz(-6, 8), c = nz(-6, 8), dd = nz(-6, 8);
+  const rp = a + c, ip = b + dd;
+  const fmtC = (o) => `${o.re}${o.im >= 0 ? '+' : '-'}${Math.abs(o.im)}i`;
+  const correct = { re: rp, im: ip };
+  return {
+    prompt: `(${a} ${b >= 0 ? '+' : '-'} ${Math.abs(b)}i) + (${c} ${dd >= 0 ? '+' : '-'} ${Math.abs(dd)}i) = ?`,
+    correct, format: fmtC,
+    distractors: [{ re: a * c, im: b * dd }, { re: rp, im: b - dd }, { re: a - c, im: ip }, { re: ip, im: rp }],
+    validate: () => correct.re === a + c && correct.im === b + dd,
+  };
+};
+G['act-matrices-vectors'] = (d) => {
+  const k = ri(2, 3 + d); const a = ri(1, 6), b = ri(1, 6), c = ri(1, 6), e = ri(1, 6);
+  const fmtM = (m) => `[${m[0]}, ${m[1]}; ${m[2]}, ${m[3]}]`;
+  const correct = [k * a, k * b, k * c, k * e];
+  return {
+    prompt: `${k} · [${a}, ${b}; ${c}, ${e}] = ? (scalar multiple of the 2×2 matrix)`,
+    correct, format: fmtM,
+    distractors: [[k + a, k + b, k + c, k + e], [a, b, c, e], [k * a, b, c, k * e], [k * a, k * b, c, e]],
+    validate: () => correct[0] === k * a && correct[3] === k * e,
+  };
+};
+
+// algebra --------------------------------------------------------
+G['act-linear-equations'] = (d) => {
+  // ax + b = cx + e, integer solution
+  const x = nz(-6, 8); let a = nz(2, 5 + d), c = nz(-4, 4); while (a === c) c = nz(-4, 4);
+  const b = ri(-9, 9); const e = (a - c) * x + b; // ensures a*x+b = c*x+e
+  const correct = x;
+  return {
+    prompt: `If ${co(a, 'x')} ${b >= 0 ? '+' : '-'} ${Math.abs(b)} = ${co(c, 'x')} ${e >= 0 ? '+' : '-'} ${Math.abs(e)}, then x = ?`,
+    correct,
+    distractors: [-x, x + 1, x - 1, (e - b)],
+    validate: () => a * correct + b === c * correct + e,
+  };
+};
+G['act-systems-of-equations'] = (d) => {
+  const x = nz(-5, 6), y = nz(-5, 6);
+  const a1 = nz(1, 4), b1 = nz(1, 4), a2 = nz(1, 4), b2 = nz(1, 4);
+  const c1 = a1 * x + b1 * y, c2 = a2 * x + b2 * y;
+  if (a1 * b2 - a2 * b1 === 0) return null; // non-unique — skip
+  const correct = x + y;
+  return {
+    prompt: `If ${co(a1, 'x')} + ${co(b1, 'y')} = ${c1} and ${co(a2, 'x')} + ${co(b2, 'y')} = ${c2}, what is x + y?`,
+    correct,
+    distractors: [x - y, x, y, x * y],
+    validate: () => (a1 * x + b1 * y === c1) && (a2 * x + b2 * y === c2) && (x + y === correct),
+  };
+};
+G['act-quadratic-equations'] = (d) => {
+  const r1 = nz(-6, 6); let r2 = nz(-6, 6); // roots
+  const b = -(r1 + r2), c = r1 * r2; // x^2 + bx + c = 0
+  const correct = Math.max(r1, r2);
+  const sgn = (n) => (n >= 0 ? `+ ${n}` : `- ${Math.abs(n)}`);
+  return {
+    prompt: `Which of the following is a solution to x² ${sgn(b)}x ${sgn(c)} = 0?`,
+    correct,
+    distractors: [-r1, -r2, r1 * r2, r1 + r2].filter(v => v !== correct),
+    validate: () => correct * correct + b * correct + c === 0,
+  };
+};
+G['act-polynomial-expressions'] = (d) => {
+  const a = nz(-6, 6), b = nz(-6, 6); // (x+a)(x+b) = x^2 + (a+b)x + ab
+  const sum = a + b, prod = a * b;
+  const sgn = (n) => (n >= 0 ? `+ ${n}` : `- ${Math.abs(n)}`);
+  const correct = `x^2 ${sgn(sum)}x ${sgn(prod)}`;
+  return {
+    prompt: `Expand: (x ${a >= 0 ? '+' : '-'} ${Math.abs(a)})(x ${b >= 0 ? '+' : '-'} ${Math.abs(b)})`,
+    correct, format: (v) => v,
+    distractors: [`x^2 ${sgn(prod)}x ${sgn(sum)}`, `x^2 ${sgn(sum)}x ${sgn(-prod)}`, `x^2 ${sgn(a * b + 1)}`, `x^2 ${sgn(sum)}`],
+    validate: () => (a + b === sum) && (a * b === prod),
+  };
+};
+G['act-radical-rational-expressions'] = (d) => {
+  const k = pick([2, 3, 5, 6, 7]); const outside = ri(2, 3 + d);
+  const inside = k; const radicand = outside * outside * inside; // sqrt(radicand) = outside*sqrt(inside)
+  const correct = `${outside}√${inside}`;
+  return {
+    prompt: `Simplify: √${radicand}`,
+    correct, format: (v) => v,
+    distractors: [`${outside * inside}√${1}`, `${outside}√${inside * 2}`, `${outside + inside}√${inside}`, `${radicand}`],
+    validate: () => outside * outside * inside === radicand,
+  };
+};
+
+// functions ------------------------------------------------------
+G['act-function-notation-evaluation'] = (d) => {
+  const a = nz(-4, 5), b = nz(-6, 6), k = nz(-4, 5);
+  const correct = a * k * k + b; // f(x)=ax^2+b
+  return {
+    prompt: `If f(x) = ${a}x² ${b >= 0 ? '+' : '-'} ${Math.abs(b)}, what is f(${k})?`,
+    correct,
+    distractors: [a * k + b, a * k * k - b, a * (k * k + b), (a * k) * (a * k) + b],
+    validate: () => a * k * k + b === correct,
+  };
+};
+G['act-linear-functions'] = (d) => {
+  let x1 = ri(-5, 5), x2 = ri(-5, 5); while (x2 === x1) x2 = ri(-5, 5);
+  const y1 = ri(-6, 6), y2 = ri(-6, 6);
+  const num = y2 - y1, den = x2 - x1;
+  const g = gcd(Math.abs(num), Math.abs(den)) || 1;
+  const slope = `${num / g}/${den / g}`;
+  const correct = (num % den === 0) ? String(num / den) : slope;
+  return {
+    prompt: `What is the slope of the line through (${x1}, ${y1}) and (${x2}, ${y2})?`,
+    correct, format: (v) => String(v),
+    distractors: [(den % num === 0 && num !== 0) ? String(den / num) : `${den / g}/${num / g}`, String(num), String(den), String(-(num) / den)],
+    validate: () => den !== 0,
+  };
+};
+G['act-quadratic-functions'] = (d) => {
+  const a = nz(1, 3), h = nz(-4, 4), k = nz(-6, 6); // vertex form a(x-h)^2+k; vertex (h,k)
+  const correct = `(${h}, ${k})`;
+  return {
+    prompt: `What is the vertex of the parabola y = ${a}(x ${h >= 0 ? '-' : '+'} ${Math.abs(h)})² ${k >= 0 ? '+' : '-'} ${Math.abs(k)}?`,
+    correct, format: (v) => v,
+    distractors: [`(${-h}, ${k})`, `(${h}, ${-k})`, `(${-h}, ${-k})`, `(${k}, ${h})`],
+    validate: () => true,
+  };
+};
+G['act-polynomial-exponential-log'] = (d) => {
+  const base = pick([2, 3, 5]); const k = ri(2, 3 + d);
+  const val = Math.pow(base, k); const correct = k; // log_base(base^k)=k
+  return {
+    prompt: `What is log₍${base}₎(${val})?`,
+    correct,
+    distractors: [val, base * k, k + 1, Math.round(val / base)],
+    validate: () => Math.pow(base, correct) === val,
+  };
+};
+G['act-trig-functions'] = () => {
+  const t = pick([
+    { a: 30, s: '1/2', c: '√3/2', tn: '√3/3' },
+    { a: 45, s: '√2/2', c: '√2/2', tn: '1' },
+    { a: 60, s: '√3/2', c: '1/2', tn: '√3' },
+  ]);
+  const fn = pick(['sin', 'cos', 'tan']); const correct = fn === 'sin' ? t.s : fn === 'cos' ? t.c : t.tn;
+  return {
+    prompt: `What is ${fn}(${t.a}°)?`,
+    correct, format: (v) => v,
+    distractors: ['1/2', '√3/2', '√2/2', '√3', '1', '√3/3'].filter(v => v !== correct),
+    validate: () => true,
+  };
+};
+G['act-function-transformations'] = (d) => {
+  const a = nz(-3, 4), b = nz(-6, 6), h = nz(1, 4), k = nz(1, 6), x = nz(-3, 4);
+  // f(x)=ax+b; g(x)=f(x-h)+k; evaluate g(x)
+  const correct = a * (x - h) + b + k;
+  return {
+    prompt: `If f(x) = ${a}x ${b >= 0 ? '+' : '-'} ${Math.abs(b)} and g(x) = f(x − ${h}) + ${k}, what is g(${x})?`,
+    correct,
+    distractors: [a * x + b + k, a * (x + h) + b + k, a * (x - h) + b - k, a * x + b],
+    validate: () => a * (x - h) + b + k === correct,
+  };
+};
+
+// geometry -------------------------------------------------------
+G['act-angles-lines-triangles'] = (d) => {
+  const a = ri(30, 80), b = ri(30, 80); const correct = 180 - a - b;
+  return {
+    prompt: `Two angles of a triangle measure ${a}° and ${b}°. What is the measure of the third angle?`,
+    correct, format: (v) => `${v}°`,
+    distractors: [180 - a, 180 - b, a + b, 90, correct + 10, correct - 10, 360 - a - b],
+    validate: () => a + b + correct === 180,
+  };
+};
+G['act-polygons-circles'] = (d) => {
+  const n = pick([5, 6, 8, 9, 10, 12, 15, 18, 20, 24, 36]); const correct = (n - 2) * 180 / n;
+  return {
+    prompt: `What is the measure of one interior angle of a regular ${n}-gon?`,
+    correct, format: (v) => `${v}°`,
+    distractors: [(n - 2) * 180, 360 / n, 180 / n, (n * 180) / n],
+    validate: () => Number.isInteger(correct) && correct === (n - 2) * 180 / n,
+  };
+};
+G['act-area-volume-surface-area'] = (d) => {
+  const shape = pick(['rect', 'tri', 'box']);
+  if (shape === 'rect') { const l = ri(3, 6 + d), w = ri(3, 6 + d); const correct = l * w; return { prompt: `What is the area of a rectangle with length ${l} and width ${w}?`, correct, distractors: [2 * (l + w), l + w, l * w * 2, (l * w) / 2], validate: () => l * w === correct }; }
+  if (shape === 'tri') { const base = ri(4, 12), h = ri(3, 10); const correct = (base * h) / 2; return { prompt: `What is the area of a triangle with base ${base} and height ${h}?`, correct, distractors: [base * h, base + h, (base + h) / 2, base * h / 3], validate: () => (base * h) / 2 === correct }; }
+  const l = ri(2, 5), w = ri(2, 5), hh = ri(2, 5); const correct = l * w * hh;
+  return { prompt: `What is the volume of a box with dimensions ${l} × ${w} × ${hh}?`, correct, distractors: [2 * (l * w + w * hh + l * hh), l + w + hh, l * w * hh * 2, l * w + hh], validate: () => l * w * hh === correct };
+};
+G['act-coordinate-geometry'] = (d) => {
+  const kind = pick(['dist', 'mid']);
+  const x1 = ri(-5, 5), y1 = ri(-5, 5);
+  if (kind === 'mid') {
+    const x2 = ri(-5, 5), y2 = ri(-5, 5); const mx = (x1 + x2) / 2, my = (y1 + y2) / 2;
+    const correct = `(${mx}, ${my})`;
+    return { prompt: `What is the midpoint of the segment from (${x1}, ${y1}) to (${x2}, ${y2})?`, correct, format: (v) => v, distractors: [`(${x1 + x2}, ${y1 + y2})`, `(${x2 - x1}, ${y2 - y1})`, `(${my}, ${mx})`, `(${(x1 + x2) / 2 + 1}, ${(y1 + y2) / 2})`], validate: () => true };
+  }
+  // Pythagorean triple distance
+  const trip = pick([[3, 4, 5], [6, 8, 10], [5, 12, 13], [8, 15, 17]]);
+  const x2 = x1 + trip[0], y2 = y1 + trip[1]; const correct = trip[2];
+  return { prompt: `What is the distance between (${x1}, ${y1}) and (${x2}, ${y2})?`, correct, distractors: [trip[0] + trip[1], trip[0] * trip[1], Math.round(Math.sqrt(trip[0] * trip[1])), trip[2] + 1], validate: () => trip[0] ** 2 + trip[1] ** 2 === trip[2] ** 2 };
+};
+G['act-right-triangle-trig'] = (d) => {
+  const trip = pick([[3, 4, 5], [6, 8, 10], [5, 12, 13], [8, 15, 17], [9, 12, 15]]);
+  const correct = trip[2];
+  return { prompt: `A right triangle has legs of length ${trip[0]} and ${trip[1]}. What is the length of the hypotenuse?`, correct, distractors: [trip[0] + trip[1], trip[2] - 1, trip[2] + 1, Math.round(Math.sqrt(trip[0] * trip[1])), trip[0] + trip[1] - 1, trip[1] + trip[0] + 2], validate: () => trip[0] ** 2 + trip[1] ** 2 === correct ** 2 };
+};
+G['act-congruence-similarity'] = (d) => {
+  const k = ri(2, 4); const base = ri(3, 8); const correspond = base * k; const other = ri(3, 9);
+  const correct = other * k; // similar: same scale factor
+  return { prompt: `Two triangles are similar. A side of length ${base} corresponds to a side of length ${correspond}. What length corresponds to a side of length ${other}?`, correct, distractors: [other + k, other * (k + 1), other + correspond - base, Math.round(other / k)], validate: () => correspond / base === k && correct === other * k };
+};
+
+// integrating-essential-skills ----------------------------------
+G['act-multi-step-rate-proportion'] = (d) => {
+  const rate = ri(2, 9); const hours = ri(2, 6 + d); const correct = rate * hours;
+  return { prompt: `A machine produces ${rate} parts per hour. How many parts does it produce in ${hours} hours?`, correct, distractors: [rate + hours, correct + rate, correct - hours, 2 * correct, correct + hours, rate * hours - rate], validate: () => rate * hours === correct };
+};
+G['act-area-perimeter-composite'] = (d) => {
+  const a = ri(3, 7), b = ri(3, 7), c = ri(2, 5); // L-shape: big rect a×b minus corner c×c
+  const correct = a * b - c * c;
+  return { prompt: `A rectangle ${a} by ${b} has a square of side ${c} cut from one corner. What is the remaining area?`, correct, distractors: [a * b, a * b + c * c, a * b - c, 2 * (a + b) - c], validate: () => a * b - c * c === correct && correct > 0 };
+};
+G['act-algebraic-reasoning-context'] = (d) => {
+  const per = ri(3, 9), fixed = ri(5, 20), n = ri(2, 8); const correct = per * n + fixed;
+  return { prompt: `A plumber charges $${fixed} plus $${per} per hour. What is the total charge for a ${n}-hour job?`, correct, format: money, distractors: [per * n, fixed + per, per * (n + 1) + fixed, per * n + fixed * n], validate: () => per * n + fixed === correct };
+};
+G['act-percent-applications'] = (d) => {
+  const price = ri(2, 12) * 10; const disc = pick([10, 15, 20, 25, 30, 40]); const correct = price * (1 - disc / 100);
+  return { prompt: `A $${price} item is discounted ${disc}%. What is the sale price?`, correct, format: money, distractors: [price * disc / 100, price + price * disc / 100, price - disc, price * (1 - disc / 1000)], validate: () => Math.abs(price * (1 - disc / 100) - correct) < 1e-9 };
+};
+G['act-measurement-unit-conversion'] = (d) => {
+  const kind = pick([['feet', 'inches', 12], ['yards', 'feet', 3], ['hours', 'minutes', 60], ['pounds', 'ounces', 16]]);
+  const q = ri(2, 8); const correct = q * kind[2];
+  return { prompt: `How many ${kind[1]} are in ${q} ${kind[0]}?`, correct, distractors: [q + kind[2], Math.round(q / kind[2]) || 1, q * (kind[2] - 1), q * kind[2] * 2], validate: () => q * kind[2] === correct };
+};
+
+// statistics-probability ----------------------------------------
+G['act-center-spread'] = (d) => {
+  const n = 5; const vals = Array.from({ length: n }, () => ri(2, 20));
+  const sum = vals.reduce((a, b) => a + b, 0);
+  if (sum % n !== 0) vals[0] += n - (sum % n); // force integer mean
+  const s2 = vals.reduce((a, b) => a + b, 0); const correct = s2 / n;
+  const sorted = [...vals].sort((a, b) => a - b); const median = sorted[2];
+  return { prompt: `What is the average (mean) of ${vals.join(', ')}?`, correct, distractors: [median, s2, Math.round(s2 / (n - 1)), sorted[sorted.length - 1] - sorted[0]], validate: () => (vals.reduce((a, b) => a + b, 0) / n) === correct };
+};
+G['act-data-representations'] = (d) => {
+  const cats = ['Mon', 'Tue', 'Wed', 'Thu']; const vals = cats.map(() => ri(5, 30));
+  const total = vals.reduce((a, b) => a + b, 0); const correct = total;
+  return { prompt: `A store's daily sales were ${cats.map((c, i) => `${c}: ${vals[i]}`).join(', ')}. What were the total sales?`, correct, distractors: [Math.round(total / cats.length), Math.max(...vals), Math.max(...vals) - Math.min(...vals), total - Math.min(...vals)], validate: () => vals.reduce((a, b) => a + b, 0) === correct };
+};
+G['act-two-way-tables'] = (d) => {
+  const a = ri(4, 15), b = ri(4, 15), c = ri(4, 15), e = ri(4, 15); // rows: [a,b],[c,e]
+  const rowTotal = a + b; const correct = a; // P(col1 | row1) numerator etc — ask count
+  return { prompt: `In a survey, ${a} boys and ${b} girls chose pizza; ${c} boys and ${e} girls chose tacos. How many boys were surveyed in total?`, correct, distractors: [a + b, a + c, b + e, a + b + c + e], validate: () => a + c === (a + c) && correct === a };
+};
+G['act-probability'] = (d) => {
+  const r = ri(2, 6), g = ri(2, 6), bl = ri(2, 6); const total = r + g + bl;
+  const gg = gcd(r, total) || 1; const correct = `${r / gg}/${total / gg}`;
+  return { prompt: `A bag has ${r} red, ${g} green, and ${bl} blue marbles. What is the probability of drawing a red marble?`, correct, format: (v) => v, distractors: [`${r}/${g + bl}`, `${r}/${g}`, `${total}/${r}`, `${g / (gcd(g, total) || 1)}/${total / (gcd(g, total) || 1)}`], validate: () => r + g + bl === total };
+};
+G['act-counting-techniques'] = (d) => {
+  const a = ri(2, 5), b = ri(2, 5), c = ri(2, 5); const correct = a * b * c;
+  return { prompt: `A meal has ${a} appetizers, ${b} entrées, and ${c} desserts. How many different 3-course meals are possible?`, correct, distractors: [a + b + c, a * b + c, correct + a, Math.round(correct / 2)], validate: () => a * b * c === correct };
+};
+
+function gcd(a, b) { a = Math.abs(a); b = Math.abs(b); while (b) { [a, b] = [b, a % b]; } return a; }
+
+// ── main ──────────────────────────────────────────────────────
+function difficultySpread(perSkill) {
+  // Bias toward the ramp targets d2..d4 with a couple of d1/d5.
+  const base = [2, 2, 3, 3, 3, 4, 4, 5, 1, 4, 3, 5];
+  return Array.from({ length: perSkill }, (_, i) => base[i % base.length]);
+}
+
+function generate(perSkill) {
+  const skills = Object.values(BLUEPRINT.skillsByCategory).flat();
+  const items = [];
+  const byId = new Set();
+  const rejects = { noGen: [], failValidate: 0, fewDistractors: 0 };
+  for (const skillId of skills) {
+    const gen = G[skillId];
+    if (!gen) { rejects.noGen.push(skillId); continue; }
+    const diffs = difficultySpread(perSkill);
+    let made = 0, attempts = 0;
+    while (made < perSkill && attempts < perSkill * 8) {
+      attempts++;
+      const spec = gen(diffs[made] || 3);
+      if (!spec) continue;
+      if (spec.validate && !spec.validate()) { rejects.failValidate++; continue; }
+      const item = buildMC({ skillId, prompt: spec.prompt, correct: spec.correct, distractors: spec.distractors, difficulty: diffs[made] || 3, format: spec.format });
+      if (!item) { rejects.fewDistractors++; continue; }
+      if (byId.has(item.problemId)) continue; // dedupe identical prompts
+      // FINAL self-check: exactly one option equals the answer value.
+      const matches = item.options.filter(o => o.text === item.answer.value).length;
+      if (matches !== 1) { rejects.failValidate++; continue; }
+      if (item.options.find(o => o.label === item.correctOption).text !== item.answer.value) { rejects.failValidate++; continue; }
+      byId.add(item.problemId);
+      items.push(item);
+      made++;
+    }
+  }
+  return { items, rejects };
+}
+
+// Offline assembly proof: can we fill a 60-slot form from the generated bank?
+function assemblyProof(items) {
+  const A = require('../utils/actTestAssembler');
+  const slots = A.buildSlots(BLUEPRINT, mulberry32(1));
+  const bySkill = {};
+  for (const it of items) { (bySkill[it.skillId] = bySkill[it.skillId] || []).push(it); }
+  const used = new Set(); let filled = 0; const missing = {};
+  for (const slot of slots) {
+    const pool = (bySkill[slot.skillId] || []).filter(p => !used.has(p.problemId));
+    // nearest difficulty
+    pool.sort((a, b) => Math.abs(a.difficulty - slot.targetDifficulty) - Math.abs(b.difficulty - slot.targetDifficulty));
+    if (pool.length) { used.add(pool[0].problemId); filled++; }
+    else missing[slot.skillId] = (missing[slot.skillId] || 0) + 1;
+  }
+  return { filled, total: slots.length, missing };
+}
+
+async function seedDb(items) {
+  require('dotenv').config();
+  const mongoose = require('mongoose');
+  if (!process.env.MONGO_URI) { console.error('MONGO_URI not set — cannot --seed-db'); process.exit(1); }
+  await mongoose.connect(process.env.MONGO_URI);
+  const Problem = require('../models/problem');
+  let up = 0;
+  for (const it of items) {
+    await Problem.updateOne({ problemId: it.problemId }, { $set: it }, { upsert: true });
+    up++;
+  }
+  console.log(`Upserted ${up} items into MongoDB.`);
+  await mongoose.disconnect();
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const perSkill = args.includes('--per-skill') ? parseInt(args[args.indexOf('--per-skill') + 1], 10) : 8;
+  const { items, rejects } = generate(perSkill);
+
+  fs.writeFileSync(OUT, JSON.stringify(items, null, 2));
+  console.log(`\nGenerated ${items.length} ACT items across ${new Set(items.map(i => i.skillId)).size} skills → ${path.relative(process.cwd(), OUT)}`);
+  if (rejects.noGen.length) console.log(`  (no template yet for: ${rejects.noGen.join(', ')})`);
+  console.log(`  rejected: ${rejects.failValidate} failed validation, ${rejects.fewDistractors} too-few-distractors (correctness gate working)`);
+
+  const proof = assemblyProof(items);
+  console.log(`\nAssembly proof: filled ${proof.filled}/${proof.total} slots of a full form.`);
+  if (Object.keys(proof.missing).length) console.log('  short on:', proof.missing);
+
+  if (args.includes('--seed-db')) await seedDb(items);
+}
+
+if (require.main === module) main();
+module.exports = { generate, assemblyProof };

--- a/scripts/generateActItems.js
+++ b/scripts/generateActItems.js
@@ -41,7 +41,7 @@ const money = (v) => (Number.isInteger(v) ? `$${v}` : `$${v.toFixed(2)}`);
 // ── MC assembler: takes correct value + distractor values, dedupes,
 //    shuffles, assigns the correct letter. Enforces exactly-one-correct. ──
 const LETTERS = ['A', 'B', 'C', 'D', 'E'];
-function buildMC({ skillId, prompt, correct, distractors, difficulty, format }) {
+function buildMC({ skillId, prompt, correct, distractors, difficulty, format, svg }) {
   const fmt = format || ((v) => String(v));
   const correctText = fmt(correct);
   // Unique distractor texts, none equal to the correct text.
@@ -63,6 +63,7 @@ function buildMC({ skillId, prompt, correct, distractors, difficulty, format }) 
     problemId: `act-${skillId}-${contentHash.slice(0, 10)}`,
     skillId,
     prompt,
+    svg: svg || undefined,
     answer: { type: 'auto', value: correctText, equivalents: [] },
     answerType: 'multiple-choice',
     options,
@@ -86,7 +87,42 @@ function numDistractors(correct, pool) {
   return out;
 }
 
-// ── generators: skillId -> (difficulty) -> { prompt, correct, distractors, format?, validate? } ──
+// ── SVG figure helpers ────────────────────────────────────────
+// Compact, theme-neutral figures (purple stroke + label text read on light and
+// dark grounds). Returned as an `svg` string the runner renders above the prompt.
+const SVG = {
+  _wrap: (inner, vb = '0 0 200 150') =>
+    `<svg viewBox="${vb}" xmlns="http://www.w3.org/2000/svg" width="100%" style="max-width:220px" stroke="#7c5cff" fill="none" stroke-width="2" font-family="sans-serif" font-size="13">${inner}</svg>`,
+  rightTriangle(legA, legB) {
+    // right angle at bottom-left; horizontal leg = legA, vertical leg = legB
+    const inner = `
+      <polygon points="30,120 170,120 30,30" stroke-linejoin="round"/>
+      <rect x="30" y="108" width="12" height="12" stroke-width="1.5"/>
+      <text x="100" y="138" fill="#7c5cff" stroke="none" text-anchor="middle">${legA}</text>
+      <text x="16" y="78" fill="#7c5cff" stroke="none" text-anchor="middle">${legB}</text>`;
+    return SVG._wrap(inner);
+  },
+  regularPolygon(n) {
+    const cx = 100, cy = 75, r = 58; const pts = [];
+    for (let i = 0; i < n; i++) { const ang = -Math.PI / 2 + (2 * Math.PI * i) / n; pts.push(`${(cx + r * Math.cos(ang)).toFixed(1)},${(cy + r * Math.sin(ang)).toFixed(1)}`); }
+    return SVG._wrap(`<polygon points="${pts.join(' ')}" stroke-linejoin="round"/>`);
+  },
+  points(p1, p2) {
+    // plot two points on a small axis; map math coords (-6..6) to svg
+    const mx = (x) => 100 + x * 12, my = (y) => 75 - y * 9;
+    const dot = (p, lbl) => `<circle cx="${mx(p[0])}" cy="${my(p[1])}" r="3.5" fill="#7c5cff" stroke="none"/><text x="${mx(p[0]) + 6}" y="${my(p[1]) - 6}" fill="#7c5cff" stroke="none">(${p[0]}, ${p[1]})</text>`;
+    const axes = `<line x1="20" y1="75" x2="180" y2="75" stroke="#bbb" stroke-width="1"/><line x1="100" y1="15" x2="100" y2="140" stroke="#bbb" stroke-width="1"/>`;
+    return SVG._wrap(axes + dot(p1) + dot(p2), '0 0 200 150');
+  },
+  lShape(a, b, c) {
+    // a×b rectangle (scaled) with a c×c bite from top-right corner
+    const s = 12; const W = a * s, H = b * s, C = c * s; const ox = 30, oy = 20;
+    const pts = `${ox},${oy} ${ox + W - C},${oy} ${ox + W - C},${oy + C} ${ox + W},${oy + C} ${ox + W},${oy + H} ${ox},${oy + H}`;
+    return SVG._wrap(`<polygon points="${pts}" stroke-linejoin="round"/>`, `0 0 ${ox * 2 + W} ${oy * 2 + H}`);
+  },
+};
+
+// ── generators: skillId -> (difficulty) -> { prompt, correct, distractors, format?, validate?, svg? } ──
 // validate() returns true iff the emitted correct answer really solves the problem.
 const G = {};
 
@@ -281,8 +317,8 @@ G['act-angles-lines-triangles'] = (d) => {
 G['act-polygons-circles'] = (d) => {
   const n = pick([5, 6, 8, 9, 10, 12, 15, 18, 20, 24, 36]); const correct = (n - 2) * 180 / n;
   return {
-    prompt: `What is the measure of one interior angle of a regular ${n}-gon?`,
-    correct, format: (v) => `${v}°`,
+    prompt: `What is the measure of one interior angle of the regular ${n}-gon shown?`,
+    correct, format: (v) => `${v}°`, svg: n <= 12 ? SVG.regularPolygon(n) : undefined,
     distractors: [(n - 2) * 180, 360 / n, 180 / n, (n * 180) / n],
     validate: () => Number.isInteger(correct) && correct === (n - 2) * 180 / n,
   };
@@ -300,7 +336,7 @@ G['act-coordinate-geometry'] = (d) => {
   if (kind === 'mid') {
     const x2 = ri(-5, 5), y2 = ri(-5, 5); const mx = (x1 + x2) / 2, my = (y1 + y2) / 2;
     const correct = `(${mx}, ${my})`;
-    return { prompt: `What is the midpoint of the segment from (${x1}, ${y1}) to (${x2}, ${y2})?`, correct, format: (v) => v, distractors: [`(${x1 + x2}, ${y1 + y2})`, `(${x2 - x1}, ${y2 - y1})`, `(${my}, ${mx})`, `(${(x1 + x2) / 2 + 1}, ${(y1 + y2) / 2})`], validate: () => true };
+    return { prompt: `What is the midpoint of the segment joining the two points shown, (${x1}, ${y1}) and (${x2}, ${y2})?`, correct, format: (v) => v, svg: SVG.points([x1, y1], [x2, y2]), distractors: [`(${x1 + x2}, ${y1 + y2})`, `(${x2 - x1}, ${y2 - y1})`, `(${my}, ${mx})`, `(${(x1 + x2) / 2 + 1}, ${(y1 + y2) / 2})`], validate: () => true };
   }
   // Pythagorean triple distance
   const trip = pick([[3, 4, 5], [6, 8, 10], [5, 12, 13], [8, 15, 17]]);
@@ -310,7 +346,7 @@ G['act-coordinate-geometry'] = (d) => {
 G['act-right-triangle-trig'] = (d) => {
   const trip = pick([[3, 4, 5], [6, 8, 10], [5, 12, 13], [8, 15, 17], [9, 12, 15]]);
   const correct = trip[2];
-  return { prompt: `A right triangle has legs of length ${trip[0]} and ${trip[1]}. What is the length of the hypotenuse?`, correct, distractors: [trip[0] + trip[1], trip[2] - 1, trip[2] + 1, Math.round(Math.sqrt(trip[0] * trip[1])), trip[0] + trip[1] - 1, trip[1] + trip[0] + 2], validate: () => trip[0] ** 2 + trip[1] ** 2 === correct ** 2 };
+  return { prompt: `In the right triangle shown, the legs have length ${trip[0]} and ${trip[1]}. What is the length of the hypotenuse?`, correct, svg: SVG.rightTriangle(trip[0], trip[1]), distractors: [trip[0] + trip[1], trip[2] - 1, trip[2] + 1, Math.round(Math.sqrt(trip[0] * trip[1])), trip[0] + trip[1] - 1, trip[1] + trip[0] + 2], validate: () => trip[0] ** 2 + trip[1] ** 2 === correct ** 2 };
 };
 G['act-congruence-similarity'] = (d) => {
   const k = ri(2, 4); const base = ri(3, 8); const correspond = base * k; const other = ri(3, 9);
@@ -326,7 +362,7 @@ G['act-multi-step-rate-proportion'] = (d) => {
 G['act-area-perimeter-composite'] = (d) => {
   const a = ri(3, 7), b = ri(3, 7), c = ri(2, 5); // L-shape: big rect a×b minus corner c×c
   const correct = a * b - c * c;
-  return { prompt: `A rectangle ${a} by ${b} has a square of side ${c} cut from one corner. What is the remaining area?`, correct, distractors: [a * b, a * b + c * c, a * b - c, 2 * (a + b) - c], validate: () => a * b - c * c === correct && correct > 0 };
+  return { prompt: `In the figure shown, a square of side ${c} has been cut from the corner of a ${a}-by-${b} rectangle. What is the area of the remaining (shaded) region?`, correct, svg: SVG.lShape(a, b, c), distractors: [a * b, a * b + c * c, a * b - c, 2 * (a + b) - c], validate: () => a * b - c * c === correct && correct > 0 };
 };
 G['act-algebraic-reasoning-context'] = (d) => {
   const per = ri(3, 9), fixed = ri(5, 20), n = ri(2, 8); const correct = per * n + fixed;
@@ -395,7 +431,7 @@ function generate(perSkill) {
       const spec = gen(diffs[made] || 3);
       if (!spec) continue;
       if (spec.validate && !spec.validate()) { rejects.failValidate++; continue; }
-      const item = buildMC({ skillId, prompt: spec.prompt, correct: spec.correct, distractors: spec.distractors, difficulty: diffs[made] || 3, format: spec.format });
+      const item = buildMC({ skillId, prompt: spec.prompt, correct: spec.correct, distractors: spec.distractors, difficulty: diffs[made] || 3, format: spec.format, svg: spec.svg });
       if (!item) { rejects.fewDistractors++; continue; }
       if (byId.has(item.problemId)) continue; // dedupe identical prompts
       // FINAL self-check: exactly one option equals the answer value.

--- a/scripts/generateActItems.js
+++ b/scripts/generateActItems.js
@@ -356,8 +356,16 @@ G['act-congruence-similarity'] = (d) => {
 
 // integrating-essential-skills ----------------------------------
 G['act-multi-step-rate-proportion'] = (d) => {
-  const rate = ri(2, 9); const hours = ri(2, 6 + d); const correct = rate * hours;
-  return { prompt: `A machine produces ${rate} parts per hour. How many parts does it produce in ${hours} hours?`, correct, distractors: [rate + hours, correct + rate, correct - hours, 2 * correct, correct + hours, rate * hours - rate], validate: () => rate * hours === correct };
+  // Two-leg trip — total distance = r1·h1 + r2·h2 (two computed steps).
+  const r1 = ri(3, 9), h1 = ri(2, 4), r2 = ri(3, 9), h2 = ri(2, 4);
+  const correct = r1 * h1 + r2 * h2;
+  return {
+    prompt: `A cyclist rides at ${r1} miles per hour for ${h1} hours, then at ${r2} miles per hour for ${h2} hours. What is the total distance traveled, in miles?`,
+    correct,
+    distractors: [r1 * h1, (r1 + r2) * (h1 + h2), r1 + r2 + h1 + h2, correct + r1, correct - h2],
+    trap: r1 * h2 + r2 * h1, // paired the wrong speed with the wrong time
+    validate: () => r1 * h1 + r2 * h2 === correct,
+  };
 };
 G['act-area-perimeter-composite'] = (d) => {
   const a = ri(3, 7), b = ri(3, 7), c = ri(2, 5); // L-shape: big rect a×b minus corner c×c
@@ -365,17 +373,52 @@ G['act-area-perimeter-composite'] = (d) => {
   return { prompt: `In the figure shown, a square of side ${c} has been cut from the corner of a ${a}-by-${b} rectangle. What is the area of the remaining (shaded) region?`, correct, svg: SVG.lShape(a, b, c), distractors: [a * b, a * b + c * c, a * b - c, 2 * (a + b) - c], validate: () => a * b - c * c === correct && correct > 0 };
 };
 G['act-algebraic-reasoning-context'] = (d) => {
-  const per = ri(3, 9), fixed = ri(5, 20), n = ri(2, 8); const correct = per * n + fixed;
-  return { prompt: `A plumber charges $${fixed} plus $${per} per hour. What is the total charge for a ${n}-hour job?`, correct, format: money, distractors: [per * n, fixed + per, per * (n + 1) + fixed, per * n + fixed * n], validate: () => per * n + fixed === correct };
+  // Set up total = fixed + per·m, then SOLVE for the number of months m.
+  const per = ri(3, 9), fixed = ri(2, 8) * 5, m = ri(3, 9);
+  const total = fixed + per * m; const correct = m;
+  return {
+    prompt: `A gym charges a $${fixed} one-time sign-up fee plus $${per} each month. After how many months will a member have paid $${total} in all?`,
+    correct,
+    distractors: [Math.round(total / per), m + 1, m - 1, Math.round(total / (per + fixed)) || 1, total - fixed],
+    trap: Math.round((total + fixed) / per), // ADDED the sign-up fee instead of subtracting it before dividing
+    validate: () => fixed + per * correct === total,
+  };
 };
 G['act-percent-applications'] = (d) => {
-  const price = ri(2, 12) * 10; const disc = pick([10, 15, 20, 25, 30, 40]); const correct = price * (1 - disc / 100);
-  return { prompt: `A $${price} item is discounted ${disc}%. What is the sale price?`, correct, format: money, distractors: [price * disc / 100, price + price * disc / 100, price - disc, price * (1 - disc / 1000)], validate: () => Math.abs(price * (1 - disc / 100) - correct) < 1e-9 };
+  // Two-step: apply the discount, THEN add sales tax on the discounted price.
+  const price = pick([40, 50, 60, 80, 100, 120]); const disc = pick([10, 20, 25]); const tax = pick([5, 8, 10]);
+  const sale = price * (1 - disc / 100);
+  const correct = Math.round(sale * (1 + tax / 100) * 100) / 100;
+  return {
+    prompt: `A $${price} jacket is ${disc}% off. With ${tax}% sales tax added to the discounted price, what is the final cost?`,
+    correct, format: money,
+    distractors: [sale, Math.round(price * (1 + tax / 100) * 100) / 100, price - disc, Math.round(price * disc / 100 * 100) / 100],
+    // TRAP: combined the percents on the original price — (1 − disc% + tax%) — instead of applying them in sequence.
+    trap: Math.round(price * (1 + (tax - disc) / 100) * 100) / 100,
+    validate: () => Math.abs(price * (1 - disc / 100) * (1 + tax / 100) - correct) < 0.01,
+  };
 };
 G['act-measurement-unit-conversion'] = (d) => {
-  const kind = pick([['feet', 'inches', 12], ['yards', 'feet', 3], ['hours', 'minutes', 60], ['pounds', 'ounces', 16]]);
+  // Includes two-step conversions (yards→inches = ×3×12, hours→seconds = ×60×60).
+  const kind = pick([
+    ['yards', 'inches', 36, [3, 12]],
+    ['hours', 'seconds', 3600, [60, 60]],
+    ['feet', 'inches', 12, null],
+    ['pounds', 'ounces', 16, null],
+    ['gallons', 'cups', 16, null],
+  ]);
   const q = ri(2, 8); const correct = q * kind[2];
-  return { prompt: `How many ${kind[1]} are in ${q} ${kind[0]}?`, correct, distractors: [q + kind[2], Math.round(q / kind[2]) || 1, q * (kind[2] - 1), q * kind[2] * 2], validate: () => q * kind[2] === correct };
+  const twoStep = kind[3];
+  const distractors = [q + kind[2], q * (kind[2] - 1), q * kind[2] * 2, Math.round(q * kind[2] / 2)];
+  if (twoStep) distractors.push(q * twoStep[0], q * twoStep[1]); // stopped after one conversion
+  return {
+    prompt: `How many ${kind[1]} are in ${q} ${kind[0]}?`,
+    correct,
+    distractors,
+    // TRAP (two-step only): ADDED the two conversion factors instead of multiplying them.
+    trap: twoStep ? q * (twoStep[0] + twoStep[1]) : q + kind[2],
+    validate: () => q * kind[2] === correct,
+  };
 };
 
 // statistics-probability ----------------------------------------
@@ -428,10 +471,15 @@ function generate(perSkill) {
     let made = 0, attempts = 0;
     while (made < perSkill && attempts < perSkill * 8) {
       attempts++;
-      const spec = gen(diffs[made] || 3);
+      const diff = diffs[made] || 3;
+      const spec = gen(diff);
       if (!spec) continue;
       if (spec.validate && !spec.validate()) { rejects.failValidate++; continue; }
-      const item = buildMC({ skillId, prompt: spec.prompt, correct: spec.correct, distractors: spec.distractors, difficulty: diffs[made] || 3, format: spec.format, svg: spec.svg });
+      // Trap distractors (a sophisticated, specific misread) only surface on
+      // hard items (d>=4). On easy items, distractors stay honest/instructive.
+      let distractors = spec.distractors;
+      if (spec.trap != null && diff >= 4) distractors = [spec.trap, ...distractors];
+      const item = buildMC({ skillId, prompt: spec.prompt, correct: spec.correct, distractors, difficulty: diff, format: spec.format, svg: spec.svg });
       if (!item) { rejects.fewDistractors++; continue; }
       if (byId.has(item.problemId)) continue; // dedupe identical prompts
       // FINAL self-check: exactly one option equals the answer value.

--- a/seeds/act-math-blueprint.json
+++ b/seeds/act-math-blueprint.json
@@ -1,0 +1,161 @@
+{
+  "_comment": "ACT Math practice-test BLUEPRINT. Defines the target composition of an ORIGINAL parallel form (our own items). Derived from the ACT Math reporting-category structure; NOT a copy of any published test. Delivered adaptively (like the Starting Point) or as a fixed-form timed test.",
+  "testId": "act-math",
+  "title": "ACT Math Practice Test",
+  "subject": "act-math",
+  "totalItems": 60,
+  "timeLimitMinutes": 60,
+  "scoreScale": {
+    "min": 1,
+    "max": 36
+  },
+  "categoryWeights": {
+    "integrating-essential-skills": 16,
+    "geometry": 12,
+    "algebra": 10,
+    "functions": 8,
+    "statistics-probability": 8,
+    "number-quantity": 6
+  },
+  "difficultyRamp": [
+    {
+      "fromPosition": 1,
+      "toPosition": 20,
+      "targetDifficulty": 2
+    },
+    {
+      "fromPosition": 21,
+      "toPosition": 40,
+      "targetDifficulty": 3
+    },
+    {
+      "fromPosition": 41,
+      "toPosition": 60,
+      "targetDifficulty": 4
+    }
+  ],
+  "skillsByCategory": {
+    "integrating-essential-skills": [
+      "act-multi-step-rate-proportion",
+      "act-area-perimeter-composite",
+      "act-algebraic-reasoning-context",
+      "act-percent-applications",
+      "act-measurement-unit-conversion"
+    ],
+    "geometry": [
+      "act-angles-lines-triangles",
+      "act-polygons-circles",
+      "act-area-volume-surface-area",
+      "act-coordinate-geometry",
+      "act-right-triangle-trig",
+      "act-congruence-similarity"
+    ],
+    "algebra": [
+      "act-linear-equations",
+      "act-systems-of-equations",
+      "act-quadratic-equations",
+      "act-polynomial-expressions",
+      "act-radical-rational-expressions"
+    ],
+    "functions": [
+      "act-function-notation-evaluation",
+      "act-linear-functions",
+      "act-quadratic-functions",
+      "act-polynomial-exponential-log",
+      "act-trig-functions",
+      "act-function-transformations"
+    ],
+    "statistics-probability": [
+      "act-center-spread",
+      "act-data-representations",
+      "act-two-way-tables",
+      "act-probability",
+      "act-counting-techniques"
+    ],
+    "number-quantity": [
+      "act-real-complex-numbers",
+      "act-exponents-roots",
+      "act-ratios-proportions-percents",
+      "act-matrices-vectors"
+    ]
+  },
+  "notTestedAsItems": {
+    "_comment": "Taught in the boot camp, not sampled as scored items.",
+    "test-strategy": [
+      "act-backsolving",
+      "act-picking-numbers",
+      "act-estimation-elimination",
+      "act-pacing-strategy"
+    ],
+    "modeling": [
+      "act-model-interpretation"
+    ]
+  },
+  "scaledScore": {
+    "_comment": "APPROXIMATE raw(0-60)->scaled(1-36) estimate for practice feedback only. Real ACT scaling is per-form and proprietary.",
+    "approximate": true,
+    "scaledByRaw": [
+      1,
+      2,
+      4,
+      6,
+      8,
+      9,
+      10,
+      11,
+      11,
+      12,
+      12,
+      13,
+      13,
+      14,
+      14,
+      14,
+      15,
+      15,
+      15,
+      16,
+      16,
+      17,
+      17,
+      17,
+      18,
+      18,
+      19,
+      19,
+      20,
+      20,
+      21,
+      21,
+      22,
+      22,
+      23,
+      23,
+      24,
+      24,
+      25,
+      25,
+      25,
+      26,
+      26,
+      27,
+      27,
+      28,
+      28,
+      28,
+      29,
+      29,
+      30,
+      30,
+      31,
+      31,
+      32,
+      33,
+      33,
+      34,
+      34,
+      35,
+      36
+    ]
+  }
+}

--- a/seeds/act-math-items.generated.json
+++ b/seeds/act-math-items.generated.json
@@ -1,143 +1,11 @@
 [
   {
-    "problemId": "act-act-multi-step-rate-proportion-a13fe1d7ce",
+    "problemId": "act-act-multi-step-rate-proportion-507c6b353f",
     "skillId": "act-multi-step-rate-proportion",
-    "prompt": "A machine produces 3 parts per hour. How many parts does it produce in 5 hours?",
+    "prompt": "A cyclist rides at 4 miles per hour for 3 hours, then at 8 miles per hour for 2 hours. What is the total distance traveled, in miles?",
     "answer": {
       "type": "auto",
-      "value": "15",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "30"
-      },
-      {
-        "label": "B",
-        "text": "18"
-      },
-      {
-        "label": "C",
-        "text": "8"
-      },
-      {
-        "label": "D",
-        "text": "15"
-      },
-      {
-        "label": "E",
-        "text": "10"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-multi-step-rate-proportion"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "a13fe1d7ce79d5df6c95418b349ad8116d7893c8b7738e340eea8c95ead95ca7",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-multi-step-rate-proportion-0d98d54d72",
-    "skillId": "act-multi-step-rate-proportion",
-    "prompt": "A machine produces 8 parts per hour. How many parts does it produce in 5 hours?",
-    "answer": {
-      "type": "auto",
-      "value": "40",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "40"
-      },
-      {
-        "label": "B",
-        "text": "13"
-      },
-      {
-        "label": "C",
-        "text": "80"
-      },
-      {
-        "label": "D",
-        "text": "35"
-      },
-      {
-        "label": "E",
-        "text": "48"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-multi-step-rate-proportion"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "0d98d54d727ccefbc07e315ee44b9a2f53a7f3fbf0aef2487575a9ef9853ad0a",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-multi-step-rate-proportion-f08ac06ff8",
-    "skillId": "act-multi-step-rate-proportion",
-    "prompt": "A machine produces 7 parts per hour. How many parts does it produce in 8 hours?",
-    "answer": {
-      "type": "auto",
-      "value": "56",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "112"
-      },
-      {
-        "label": "B",
-        "text": "56"
-      },
-      {
-        "label": "C",
-        "text": "48"
-      },
-      {
-        "label": "D",
-        "text": "15"
-      },
-      {
-        "label": "E",
-        "text": "63"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-multi-step-rate-proportion"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "f08ac06ff84cc55c4e9fe2bde8c1af5687998db23c4db5123187270cbd39ffd0",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-multi-step-rate-proportion-22ca676850",
-    "skillId": "act-multi-step-rate-proportion",
-    "prompt": "A machine produces 4 parts per hour. How many parts does it produce in 2 hours?",
-    "answer": {
-      "type": "auto",
-      "value": "8",
+      "value": "28",
       "equivalents": []
     },
     "answerType": "multiple-choice",
@@ -148,187 +16,11 @@
       },
       {
         "label": "B",
-        "text": "16"
+        "text": "28"
       },
       {
         "label": "C",
-        "text": "8"
-      },
-      {
-        "label": "D",
-        "text": "10"
-      },
-      {
-        "label": "E",
-        "text": "6"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-multi-step-rate-proportion"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "22ca67685099d2e96ecc1161f5603263c4e92005f71b8678c6e83b66b6a23365",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-multi-step-rate-proportion-2bb0f1f8bd",
-    "skillId": "act-multi-step-rate-proportion",
-    "prompt": "A machine produces 8 parts per hour. How many parts does it produce in 8 hours?",
-    "answer": {
-      "type": "auto",
-      "value": "64",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "72"
-      },
-      {
-        "label": "B",
-        "text": "64"
-      },
-      {
-        "label": "C",
-        "text": "16"
-      },
-      {
-        "label": "D",
-        "text": "56"
-      },
-      {
-        "label": "E",
-        "text": "128"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-multi-step-rate-proportion"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "2bb0f1f8bd6831a50e31b95a9ba39fbed79ab66b3a878ab1b539daf89b1f4c3d",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-multi-step-rate-proportion-64076677fc",
-    "skillId": "act-multi-step-rate-proportion",
-    "prompt": "A machine produces 9 parts per hour. How many parts does it produce in 5 hours?",
-    "answer": {
-      "type": "auto",
-      "value": "45",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "54"
-      },
-      {
-        "label": "B",
-        "text": "40"
-      },
-      {
-        "label": "C",
-        "text": "45"
-      },
-      {
-        "label": "D",
-        "text": "90"
-      },
-      {
-        "label": "E",
-        "text": "14"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-multi-step-rate-proportion"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "64076677fcd8e42c3783d3965160b6f9a61f651b5d755562ed3a5d6460e2b545",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-multi-step-rate-proportion-6dcb91b119",
-    "skillId": "act-multi-step-rate-proportion",
-    "prompt": "A machine produces 8 parts per hour. How many parts does it produce in 6 hours?",
-    "answer": {
-      "type": "auto",
-      "value": "48",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "42"
-      },
-      {
-        "label": "B",
-        "text": "14"
-      },
-      {
-        "label": "C",
-        "text": "96"
-      },
-      {
-        "label": "D",
-        "text": "48"
-      },
-      {
-        "label": "E",
-        "text": "56"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-multi-step-rate-proportion"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "6dcb91b1197c533f2c986731ec5f585cdf87c5f740321200dd422961a358d722",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-multi-step-rate-proportion-baaf019d61",
-    "skillId": "act-multi-step-rate-proportion",
-    "prompt": "A machine produces 4 parts per hour. How many parts does it produce in 4 hours?",
-    "answer": {
-      "type": "auto",
-      "value": "16",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "20"
-      },
-      {
-        "label": "B",
-        "text": "8"
-      },
-      {
-        "label": "C",
-        "text": "12"
+        "text": "17"
       },
       {
         "label": "D",
@@ -336,7 +28,315 @@
       },
       {
         "label": "E",
+        "text": "60"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-multi-step-rate-proportion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "507c6b353fdcbaf15f3494c12e9ab3753761e3f977f2c2c9a8799f61e942eb36",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-multi-step-rate-proportion-f373278627",
+    "skillId": "act-multi-step-rate-proportion",
+    "prompt": "A cyclist rides at 6 miles per hour for 4 hours, then at 9 miles per hour for 4 hours. What is the total distance traveled, in miles?",
+    "answer": {
+      "type": "auto",
+      "value": "60",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "120"
+      },
+      {
+        "label": "B",
+        "text": "60"
+      },
+      {
+        "label": "C",
+        "text": "24"
+      },
+      {
+        "label": "D",
+        "text": "66"
+      },
+      {
+        "label": "E",
+        "text": "23"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-multi-step-rate-proportion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "f373278627e5485c5516a36e1372b2da5d1b20281bdf81bb229da73a320a163a",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-multi-step-rate-proportion-7b57bbb67b",
+    "skillId": "act-multi-step-rate-proportion",
+    "prompt": "A cyclist rides at 6 miles per hour for 3 hours, then at 5 miles per hour for 2 hours. What is the total distance traveled, in miles?",
+    "answer": {
+      "type": "auto",
+      "value": "28",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "55"
+      },
+      {
+        "label": "B",
         "text": "16"
+      },
+      {
+        "label": "C",
+        "text": "28"
+      },
+      {
+        "label": "D",
+        "text": "34"
+      },
+      {
+        "label": "E",
+        "text": "18"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-multi-step-rate-proportion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "7b57bbb67b821bb55d6612be1d5c476805f17fe8188d70713ec05a60675024a5",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-multi-step-rate-proportion-9e8a8d8690",
+    "skillId": "act-multi-step-rate-proportion",
+    "prompt": "A cyclist rides at 9 miles per hour for 4 hours, then at 9 miles per hour for 4 hours. What is the total distance traveled, in miles?",
+    "answer": {
+      "type": "auto",
+      "value": "72",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "26"
+      },
+      {
+        "label": "B",
+        "text": "72"
+      },
+      {
+        "label": "C",
+        "text": "81"
+      },
+      {
+        "label": "D",
+        "text": "36"
+      },
+      {
+        "label": "E",
+        "text": "144"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-multi-step-rate-proportion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "9e8a8d869023d7bf6b32a2706176126c788ee9eb616a133bf2f6e810adfc5888",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-multi-step-rate-proportion-2d0603d4ed",
+    "skillId": "act-multi-step-rate-proportion",
+    "prompt": "A cyclist rides at 5 miles per hour for 2 hours, then at 3 miles per hour for 4 hours. What is the total distance traveled, in miles?",
+    "answer": {
+      "type": "auto",
+      "value": "22",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "48"
+      },
+      {
+        "label": "B",
+        "text": "22"
+      },
+      {
+        "label": "C",
+        "text": "27"
+      },
+      {
+        "label": "D",
+        "text": "10"
+      },
+      {
+        "label": "E",
+        "text": "14"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-multi-step-rate-proportion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "2d0603d4edb6ef41fdae941b72fc461c667d7b0784c91df591b12de5943b54bc",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-multi-step-rate-proportion-24fad99b7d",
+    "skillId": "act-multi-step-rate-proportion",
+    "prompt": "A cyclist rides at 9 miles per hour for 4 hours, then at 5 miles per hour for 2 hours. What is the total distance traveled, in miles?",
+    "answer": {
+      "type": "auto",
+      "value": "46",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "36"
+      },
+      {
+        "label": "B",
+        "text": "38"
+      },
+      {
+        "label": "C",
+        "text": "84"
+      },
+      {
+        "label": "D",
+        "text": "20"
+      },
+      {
+        "label": "E",
+        "text": "46"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-multi-step-rate-proportion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "24fad99b7d7433e1554ee4120b38f98a5752b50f7129f0833bfe84ee2bbcb0c1",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-multi-step-rate-proportion-337acd176d",
+    "skillId": "act-multi-step-rate-proportion",
+    "prompt": "A cyclist rides at 6 miles per hour for 4 hours, then at 3 miles per hour for 4 hours. What is the total distance traveled, in miles?",
+    "answer": {
+      "type": "auto",
+      "value": "36",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "17"
+      },
+      {
+        "label": "B",
+        "text": "24"
+      },
+      {
+        "label": "C",
+        "text": "72"
+      },
+      {
+        "label": "D",
+        "text": "36"
+      },
+      {
+        "label": "E",
+        "text": "42"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-multi-step-rate-proportion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "337acd176d827570a95e4bedd149164a36163033b62e2871cfca3c71b7745398",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-multi-step-rate-proportion-8dc707b068",
+    "skillId": "act-multi-step-rate-proportion",
+    "prompt": "A cyclist rides at 5 miles per hour for 3 hours, then at 6 miles per hour for 3 hours. What is the total distance traveled, in miles?",
+    "answer": {
+      "type": "auto",
+      "value": "33",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "15"
+      },
+      {
+        "label": "B",
+        "text": "38"
+      },
+      {
+        "label": "C",
+        "text": "17"
+      },
+      {
+        "label": "D",
+        "text": "66"
+      },
+      {
+        "label": "E",
+        "text": "33"
       }
     ],
     "correctOption": "E",
@@ -348,85 +348,40 @@
       "act-multi-step-rate-proportion"
     ],
     "source": "act-template-gen",
-    "contentHash": "baaf019d617ea6552b46f39b85efa9e6ad3f6921e7064beb64807df57f1c46c5",
+    "contentHash": "8dc707b068e2bc2e2e8f26f8848767623649d3685b26db93ebfaafa067962683",
     "isActive": true
   },
   {
-    "problemId": "act-act-area-perimeter-composite-4a7a2a14ee",
+    "problemId": "act-act-area-perimeter-composite-15e835a7dc",
     "skillId": "act-area-perimeter-composite",
-    "prompt": "In the figure shown, a square of side 2 has been cut from the corner of a 5-by-7 rectangle. What is the area of the remaining (shaded) region?",
-    "svg": "<svg viewBox=\"0 0 120 124\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 66,20 66,44 90,44 90,104 30,104\" stroke-linejoin=\"round\"/></svg>",
+    "prompt": "In the figure shown, a square of side 4 has been cut from the corner of a 7-by-6 rectangle. What is the area of the remaining (shaded) region?",
+    "svg": "<svg viewBox=\"0 0 144 112\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 66,20 66,68 114,68 114,92 30,92\" stroke-linejoin=\"round\"/></svg>",
     "answer": {
       "type": "auto",
-      "value": "31",
+      "value": "26",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "39"
-      },
-      {
-        "label": "B",
-        "text": "35"
-      },
-      {
-        "label": "C",
-        "text": "31"
-      },
-      {
-        "label": "D",
         "text": "22"
       },
       {
-        "label": "E",
-        "text": "33"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-area-perimeter-composite"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "4a7a2a14eeef3bc7ab7aa3c21764361b008b5cdb8a7f106e9424049c4429b913",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-area-perimeter-composite-0617d3733f",
-    "skillId": "act-area-perimeter-composite",
-    "prompt": "In the figure shown, a square of side 4 has been cut from the corner of a 6-by-4 rectangle. What is the area of the remaining (shaded) region?",
-    "svg": "<svg viewBox=\"0 0 132 88\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 54,20 54,68 102,68 102,68 30,68\" stroke-linejoin=\"round\"/></svg>",
-    "answer": {
-      "type": "auto",
-      "value": "8",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "20"
-      },
-      {
         "label": "B",
-        "text": "24"
+        "text": "58"
       },
       {
         "label": "C",
-        "text": "8"
+        "text": "26"
       },
       {
         "label": "D",
-        "text": "16"
+        "text": "42"
       },
       {
         "label": "E",
-        "text": "40"
+        "text": "38"
       }
     ],
     "correctOption": "C",
@@ -438,28 +393,28 @@
       "act-area-perimeter-composite"
     ],
     "source": "act-template-gen",
-    "contentHash": "0617d3733fadd9f9d0bbe5793a6e6727972de5f9e0065db910d8c870de379408",
+    "contentHash": "15e835a7dcc1013dc80dd20f6dfc2b5870ff79e77b6a6a74e9d77524b4ed8729",
     "isActive": true
   },
   {
-    "problemId": "act-act-area-perimeter-composite-1d7e5377d8",
+    "problemId": "act-act-area-perimeter-composite-d3a6ba83ac",
     "skillId": "act-area-perimeter-composite",
-    "prompt": "In the figure shown, a square of side 5 has been cut from the corner of a 7-by-5 rectangle. What is the area of the remaining (shaded) region?",
-    "svg": "<svg viewBox=\"0 0 144 100\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 54,20 54,80 114,80 114,80 30,80\" stroke-linejoin=\"round\"/></svg>",
+    "prompt": "In the figure shown, a square of side 3 has been cut from the corner of a 6-by-5 rectangle. What is the area of the remaining (shaded) region?",
+    "svg": "<svg viewBox=\"0 0 132 100\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 66,20 66,56 102,56 102,80 30,80\" stroke-linejoin=\"round\"/></svg>",
     "answer": {
       "type": "auto",
-      "value": "10",
+      "value": "21",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "35"
+        "text": "30"
       },
       {
         "label": "B",
-        "text": "10"
+        "text": "39"
       },
       {
         "label": "C",
@@ -467,15 +422,15 @@
       },
       {
         "label": "D",
-        "text": "60"
+        "text": "21"
       },
       {
         "label": "E",
-        "text": "30"
+        "text": "27"
       }
     ],
-    "correctOption": "B",
-    "difficulty": 3,
+    "correctOption": "D",
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -483,7 +438,7 @@
       "act-area-perimeter-composite"
     ],
     "source": "act-template-gen",
-    "contentHash": "1d7e5377d87c1e28256b41571f34ddfdc4152370dfe31ba486be21c6f522772d",
+    "contentHash": "d3a6ba83aca03792c54267ca59284340acf5fa95210c1239be30bd50c53bdb58",
     "isActive": true
   },
   {
@@ -610,7 +565,7 @@
       }
     ],
     "correctOption": "E",
-    "difficulty": 4,
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -700,7 +655,7 @@
       }
     ],
     "correctOption": "D",
-    "difficulty": 5,
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -712,79 +667,80 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-algebraic-reasoning-context-f45eb94c18",
-    "skillId": "act-algebraic-reasoning-context",
-    "prompt": "A plumber charges $18 plus $4 per hour. What is the total charge for a 4-hour job?",
+    "problemId": "act-act-area-perimeter-composite-aba5bffee8",
+    "skillId": "act-area-perimeter-composite",
+    "prompt": "In the figure shown, a square of side 3 has been cut from the corner of a 7-by-6 rectangle. What is the area of the remaining (shaded) region?",
+    "svg": "<svg viewBox=\"0 0 144 112\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 78,20 78,56 114,56 114,92 30,92\" stroke-linejoin=\"round\"/></svg>",
     "answer": {
       "type": "auto",
-      "value": "$34",
+      "value": "33",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "$38"
+        "text": "39"
       },
       {
         "label": "B",
-        "text": "$88"
+        "text": "42"
       },
       {
         "label": "C",
-        "text": "$34"
+        "text": "33"
       },
       {
         "label": "D",
-        "text": "$16"
+        "text": "51"
       },
       {
         "label": "E",
-        "text": "$22"
+        "text": "23"
       }
     ],
     "correctOption": "C",
-    "difficulty": 2,
+    "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-algebraic-reasoning-context"
+      "act-area-perimeter-composite"
     ],
     "source": "act-template-gen",
-    "contentHash": "f45eb94c18a073c3ffbf4302d1e6a4216281cde43c7ee044c3502ba9f3822ff5",
+    "contentHash": "aba5bffee87d8007c50eb69e3e7c96ab644373d33ae4e508f438c2b4eea5b6cd",
     "isActive": true
   },
   {
-    "problemId": "act-act-algebraic-reasoning-context-95fee355cc",
+    "problemId": "act-act-algebraic-reasoning-context-5e90bd329e",
     "skillId": "act-algebraic-reasoning-context",
-    "prompt": "A plumber charges $11 plus $6 per hour. What is the total charge for a 7-hour job?",
+    "prompt": "A gym charges a $35 one-time sign-up fee plus $8 each month. After how many months will a member have paid $107 in all?",
     "answer": {
       "type": "auto",
-      "value": "$53",
+      "value": "9",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "$17"
+        "text": "8"
       },
       {
         "label": "B",
-        "text": "$59"
+        "text": "2"
       },
       {
         "label": "C",
-        "text": "$119"
+        "text": "10"
       },
       {
         "label": "D",
-        "text": "$42"
+        "text": "13"
       },
       {
         "label": "E",
-        "text": "$53"
+        "text": "9"
       }
     ],
     "correctOption": "E",
@@ -796,39 +752,83 @@
       "act-algebraic-reasoning-context"
     ],
     "source": "act-template-gen",
-    "contentHash": "95fee355cc0b2af65b49378c7d0d1f94bb7f2a10389a793ca0dfe342ad1a47ae",
+    "contentHash": "5e90bd329e2b0405232cd11b0d73fd61575f21256d7dbafa46f0d825ad1c44b9",
     "isActive": true
   },
   {
-    "problemId": "act-act-algebraic-reasoning-context-6bdc16e552",
+    "problemId": "act-act-algebraic-reasoning-context-a1e6eda95f",
     "skillId": "act-algebraic-reasoning-context",
-    "prompt": "A plumber charges $12 plus $8 per hour. What is the total charge for a 8-hour job?",
+    "prompt": "A gym charges a $15 one-time sign-up fee plus $3 each month. After how many months will a member have paid $42 in all?",
     "answer": {
       "type": "auto",
-      "value": "$76",
+      "value": "9",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "$160"
+        "text": "9"
       },
       {
         "label": "B",
-        "text": "$20"
+        "text": "8"
       },
       {
         "label": "C",
-        "text": "$64"
+        "text": "10"
       },
       {
         "label": "D",
-        "text": "$76"
+        "text": "2"
       },
       {
         "label": "E",
-        "text": "$84"
+        "text": "14"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-algebraic-reasoning-context"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "a1e6eda95ffed1bca7dab5183a155b393c5c21b8f32aec7c75c5ec118d31b068",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-algebraic-reasoning-context-c2ce69366e",
+    "skillId": "act-algebraic-reasoning-context",
+    "prompt": "A gym charges a $10 one-time sign-up fee plus $5 each month. After how many months will a member have paid $55 in all?",
+    "answer": {
+      "type": "auto",
+      "value": "9",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "4"
+      },
+      {
+        "label": "B",
+        "text": "11"
+      },
+      {
+        "label": "C",
+        "text": "10"
+      },
+      {
+        "label": "D",
+        "text": "9"
+      },
+      {
+        "label": "E",
+        "text": "8"
       }
     ],
     "correctOption": "D",
@@ -840,42 +840,42 @@
       "act-algebraic-reasoning-context"
     ],
     "source": "act-template-gen",
-    "contentHash": "6bdc16e5525a90e5cb13885105a2a9ec010d76d16543c6310f916e85fceb55c8",
+    "contentHash": "c2ce69366ecdc1efa615c560e61868bd4513550b9c5da56ff2ae84020d5dd99e",
     "isActive": true
   },
   {
-    "problemId": "act-act-algebraic-reasoning-context-82371ecab5",
+    "problemId": "act-act-algebraic-reasoning-context-2cf0973b05",
     "skillId": "act-algebraic-reasoning-context",
-    "prompt": "A plumber charges $20 plus $8 per hour. What is the total charge for a 2-hour job?",
+    "prompt": "A gym charges a $20 one-time sign-up fee plus $7 each month. After how many months will a member have paid $69 in all?",
     "answer": {
       "type": "auto",
-      "value": "$36",
+      "value": "7",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "$16"
+        "text": "7"
       },
       {
         "label": "B",
-        "text": "$56"
+        "text": "8"
       },
       {
         "label": "C",
-        "text": "$36"
+        "text": "3"
       },
       {
         "label": "D",
-        "text": "$44"
+        "text": "6"
       },
       {
         "label": "E",
-        "text": "$28"
+        "text": "10"
       }
     ],
-    "correctOption": "C",
+    "correctOption": "A",
     "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
@@ -884,39 +884,39 @@
       "act-algebraic-reasoning-context"
     ],
     "source": "act-template-gen",
-    "contentHash": "82371ecab5d0eea9b0f8d62d8971282e87852c599793ffe8327d4799ea51a429",
+    "contentHash": "2cf0973b0595d781f17db49e133656c71a7f648b86c82fc000422014d28fcfcd",
     "isActive": true
   },
   {
-    "problemId": "act-act-algebraic-reasoning-context-0a32724bf3",
+    "problemId": "act-act-algebraic-reasoning-context-4d3f7422b6",
     "skillId": "act-algebraic-reasoning-context",
-    "prompt": "A plumber charges $20 plus $4 per hour. What is the total charge for a 4-hour job?",
+    "prompt": "A gym charges a $25 one-time sign-up fee plus $6 each month. After how many months will a member have paid $49 in all?",
     "answer": {
       "type": "auto",
-      "value": "$36",
+      "value": "4",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "$16"
+        "text": "3"
       },
       {
         "label": "B",
-        "text": "$36"
+        "text": "4"
       },
       {
         "label": "C",
-        "text": "$40"
+        "text": "5"
       },
       {
         "label": "D",
-        "text": "$96"
+        "text": "8"
       },
       {
         "label": "E",
-        "text": "$24"
+        "text": "2"
       }
     ],
     "correctOption": "B",
@@ -928,39 +928,39 @@
       "act-algebraic-reasoning-context"
     ],
     "source": "act-template-gen",
-    "contentHash": "0a32724bf30bae8d90175fb9c3e6b29d831ad3bbe8263591f933061569f82fd4",
+    "contentHash": "4d3f7422b67b82b1179e977183da22b5b5e2fe561e4aa8c7c310c15bde837918",
     "isActive": true
   },
   {
-    "problemId": "act-act-algebraic-reasoning-context-adebaf1700",
+    "problemId": "act-act-algebraic-reasoning-context-cad4a551b2",
     "skillId": "act-algebraic-reasoning-context",
-    "prompt": "A plumber charges $20 plus $3 per hour. What is the total charge for a 7-hour job?",
+    "prompt": "A gym charges a $15 one-time sign-up fee plus $4 each month. After how many months will a member have paid $31 in all?",
     "answer": {
       "type": "auto",
-      "value": "$41",
+      "value": "4",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "$161"
+        "text": "5"
       },
       {
         "label": "B",
-        "text": "$44"
+        "text": "12"
       },
       {
         "label": "C",
-        "text": "$21"
+        "text": "3"
       },
       {
         "label": "D",
-        "text": "$23"
+        "text": "8"
       },
       {
         "label": "E",
-        "text": "$41"
+        "text": "4"
       }
     ],
     "correctOption": "E",
@@ -972,42 +972,42 @@
       "act-algebraic-reasoning-context"
     ],
     "source": "act-template-gen",
-    "contentHash": "adebaf1700bd26cae9469372092201dd8a822e9396fa439d09da604b92c1b6d4",
+    "contentHash": "cad4a551b2601f3efa356c8b2d01f3525400492732c76e56866afcc5b9f97266",
     "isActive": true
   },
   {
-    "problemId": "act-act-algebraic-reasoning-context-edba0c8aed",
+    "problemId": "act-act-algebraic-reasoning-context-20fb2b8d32",
     "skillId": "act-algebraic-reasoning-context",
-    "prompt": "A plumber charges $15 plus $5 per hour. What is the total charge for a 3-hour job?",
+    "prompt": "A gym charges a $10 one-time sign-up fee plus $4 each month. After how many months will a member have paid $30 in all?",
     "answer": {
       "type": "auto",
-      "value": "$30",
+      "value": "5",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "$30"
+        "text": "8"
       },
       {
         "label": "B",
-        "text": "$15"
+        "text": "4"
       },
       {
         "label": "C",
-        "text": "$35"
+        "text": "6"
       },
       {
         "label": "D",
-        "text": "$20"
+        "text": "10"
       },
       {
         "label": "E",
-        "text": "$60"
+        "text": "5"
       }
     ],
-    "correctOption": "A",
+    "correctOption": "E",
     "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
@@ -1016,35 +1016,79 @@
       "act-algebraic-reasoning-context"
     ],
     "source": "act-template-gen",
-    "contentHash": "edba0c8aed0898a53da945db511faf88b6b0fba3c49db8cbe4660f12dcc06374",
+    "contentHash": "20fb2b8d328a632352a134d67447755e340638f217ae2d83ca83c3c5476a8d25",
     "isActive": true
   },
   {
-    "problemId": "act-act-algebraic-reasoning-context-be8918b596",
+    "problemId": "act-act-algebraic-reasoning-context-36f0759614",
     "skillId": "act-algebraic-reasoning-context",
-    "prompt": "A plumber charges $8 plus $6 per hour. What is the total charge for a 8-hour job?",
+    "prompt": "A gym charges a $20 one-time sign-up fee plus $8 each month. After how many months will a member have paid $44 in all?",
     "answer": {
       "type": "auto",
-      "value": "$56",
+      "value": "3",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "$112"
+        "text": "3"
       },
       {
         "label": "B",
-        "text": "$14"
+        "text": "8"
       },
       {
         "label": "C",
-        "text": "$56"
+        "text": "2"
       },
       {
         "label": "D",
-        "text": "$62"
+        "text": "6"
+      },
+      {
+        "label": "E",
+        "text": "4"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-algebraic-reasoning-context"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "36f07596147a1c682fad1feccd835d8a191851f4eb6a6c9ebce20cbc976fecb6",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-percent-applications-a11c159089",
+    "skillId": "act-percent-applications",
+    "prompt": "A $60 jacket is 20% off. With 5% sales tax added to the discounted price, what is the final cost?",
+    "answer": {
+      "type": "auto",
+      "value": "$50.40",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$40"
+      },
+      {
+        "label": "B",
+        "text": "$12"
+      },
+      {
+        "label": "C",
+        "text": "$50.40"
+      },
+      {
+        "label": "D",
+        "text": "$63"
       },
       {
         "label": "E",
@@ -1052,50 +1096,6 @@
       }
     ],
     "correctOption": "C",
-    "difficulty": 5,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-algebraic-reasoning-context"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "be8918b596ba2a6692885481f3cd23d4c48ceecf98666de58a383f4a52ea7b79",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-percent-applications-1d7cccefa9",
-    "skillId": "act-percent-applications",
-    "prompt": "A $50 item is discounted 15%. What is the sale price?",
-    "answer": {
-      "type": "auto",
-      "value": "$42.50",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "$35"
-      },
-      {
-        "label": "B",
-        "text": "$7.50"
-      },
-      {
-        "label": "C",
-        "text": "$49.25"
-      },
-      {
-        "label": "D",
-        "text": "$57.50"
-      },
-      {
-        "label": "E",
-        "text": "$42.50"
-      }
-    ],
-    "correctOption": "E",
     "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
@@ -1104,263 +1104,43 @@
       "act-percent-applications"
     ],
     "source": "act-template-gen",
-    "contentHash": "1d7cccefa9ec6f764c128eb1e2b58749e0dfb55587ca0f39930c24ff1bc7f2b3",
+    "contentHash": "a11c1590899c4be230688a036076ede8ca3e953becc12ddea312031eee3f6ce1",
     "isActive": true
   },
   {
-    "problemId": "act-act-percent-applications-845a81ef98",
+    "problemId": "act-act-percent-applications-82c80e8eb5",
     "skillId": "act-percent-applications",
-    "prompt": "A $90 item is discounted 20%. What is the sale price?",
+    "prompt": "A $60 jacket is 25% off. With 10% sales tax added to the discounted price, what is the final cost?",
     "answer": {
       "type": "auto",
-      "value": "$72",
+      "value": "$49.50",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "$108"
+        "text": "$66"
       },
       {
         "label": "B",
-        "text": "$72"
-      },
-      {
-        "label": "C",
-        "text": "$88.20"
-      },
-      {
-        "label": "D",
-        "text": "$18"
-      },
-      {
-        "label": "E",
-        "text": "$70"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-percent-applications"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "845a81ef989b887f3bbcb2d9dda0131351331a717d09e4606efacd8ab4071abf",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-percent-applications-0a0bb23947",
-    "skillId": "act-percent-applications",
-    "prompt": "A $60 item is discounted 15%. What is the sale price?",
-    "answer": {
-      "type": "auto",
-      "value": "$51",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "$45"
-      },
-      {
-        "label": "B",
-        "text": "$69"
-      },
-      {
-        "label": "C",
-        "text": "$59.10"
-      },
-      {
-        "label": "D",
-        "text": "$9"
-      },
-      {
-        "label": "E",
-        "text": "$51"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-percent-applications"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "0a0bb23947af99d3c281714cb77beb79f05b673a0a82a5e530dc996b0417ecfd",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-percent-applications-da4ec4530c",
-    "skillId": "act-percent-applications",
-    "prompt": "A $70 item is discounted 15%. What is the sale price?",
-    "answer": {
-      "type": "auto",
-      "value": "$59.50",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "$80.50"
-      },
-      {
-        "label": "B",
-        "text": "$68.95"
-      },
-      {
-        "label": "C",
-        "text": "$59.50"
-      },
-      {
-        "label": "D",
-        "text": "$10.50"
-      },
-      {
-        "label": "E",
-        "text": "$55"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-percent-applications"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "da4ec4530c4a84d87d4001eca5436d4cfa89ca6aa98d94f89a5db0ace3de9f42",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-percent-applications-b8dea580ba",
-    "skillId": "act-percent-applications",
-    "prompt": "A $80 item is discounted 30%. What is the sale price?",
-    "answer": {
-      "type": "auto",
-      "value": "$56",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "$104"
-      },
-      {
-        "label": "B",
-        "text": "$56"
-      },
-      {
-        "label": "C",
-        "text": "$50"
-      },
-      {
-        "label": "D",
-        "text": "$24"
-      },
-      {
-        "label": "E",
-        "text": "$77.60"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-percent-applications"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "b8dea580bac184ba861ec06623b7145c1fc2e382bec5ea9062a9516ed6c13d56",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-percent-applications-1af2c0976d",
-    "skillId": "act-percent-applications",
-    "prompt": "A $60 item is discounted 25%. What is the sale price?",
-    "answer": {
-      "type": "auto",
-      "value": "$45",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "$45"
-      },
-      {
-        "label": "B",
-        "text": "$75"
-      },
-      {
-        "label": "C",
-        "text": "$58.50"
-      },
-      {
-        "label": "D",
         "text": "$35"
       },
       {
-        "label": "E",
+        "label": "C",
         "text": "$15"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-percent-applications"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "1af2c0976de3f8a091172fe075cc18a472e93c111d03e76a089838204dcbc6ad",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-percent-applications-3ba8da09be",
-    "skillId": "act-percent-applications",
-    "prompt": "A $110 item is discounted 10%. What is the sale price?",
-    "answer": {
-      "type": "auto",
-      "value": "$99",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "$121"
-      },
-      {
-        "label": "B",
-        "text": "$100"
-      },
-      {
-        "label": "C",
-        "text": "$108.90"
       },
       {
         "label": "D",
-        "text": "$99"
+        "text": "$45"
       },
       {
         "label": "E",
-        "text": "$11"
+        "text": "$49.50"
       }
     ],
-    "correctOption": "D",
-    "difficulty": 4,
+    "correctOption": "E",
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -1368,39 +1148,259 @@
       "act-percent-applications"
     ],
     "source": "act-template-gen",
-    "contentHash": "3ba8da09be88b75a71d0b9982096f062b97356598bb15586d429d6f3a727428a",
+    "contentHash": "82c80e8eb536eacfcdd20fbc699e3234eac37b70bd09d6de150f9256570e2a86",
     "isActive": true
   },
   {
-    "problemId": "act-act-percent-applications-930e95cf05",
+    "problemId": "act-act-percent-applications-9c3a5d7476",
     "skillId": "act-percent-applications",
-    "prompt": "A $120 item is discounted 30%. What is the sale price?",
+    "prompt": "A $120 jacket is 25% off. With 8% sales tax added to the discounted price, what is the final cost?",
     "answer": {
       "type": "auto",
-      "value": "$84",
+      "value": "$97.20",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "$36"
+        "text": "$129.60"
       },
       {
         "label": "B",
-        "text": "$84"
+        "text": "$97.20"
       },
       {
         "label": "C",
-        "text": "$116.40"
-      },
-      {
-        "label": "D",
         "text": "$90"
       },
       {
+        "label": "D",
+        "text": "$95"
+      },
+      {
         "label": "E",
-        "text": "$156"
+        "text": "$30"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-percent-applications"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "9c3a5d74767c9514df8e38ecda95104ee172d2d18d841f153812ee2bab13c153",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-percent-applications-599e100e8b",
+    "skillId": "act-percent-applications",
+    "prompt": "A $40 jacket is 25% off. With 8% sales tax added to the discounted price, what is the final cost?",
+    "answer": {
+      "type": "auto",
+      "value": "$32.40",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$15"
+      },
+      {
+        "label": "B",
+        "text": "$10"
+      },
+      {
+        "label": "C",
+        "text": "$43.20"
+      },
+      {
+        "label": "D",
+        "text": "$30"
+      },
+      {
+        "label": "E",
+        "text": "$32.40"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-percent-applications"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "599e100e8b0cfe4fdf2c11803dc184fd281dde4b2cf8ae5794cfbe3fbea63709",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-percent-applications-bfdf0ff081",
+    "skillId": "act-percent-applications",
+    "prompt": "A $50 jacket is 20% off. With 10% sales tax added to the discounted price, what is the final cost?",
+    "answer": {
+      "type": "auto",
+      "value": "$44",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$40"
+      },
+      {
+        "label": "B",
+        "text": "$55"
+      },
+      {
+        "label": "C",
+        "text": "$10"
+      },
+      {
+        "label": "D",
+        "text": "$30"
+      },
+      {
+        "label": "E",
+        "text": "$44"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-percent-applications"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "bfdf0ff081dabf066e325d1390a8d31ed7109c025a7f8c2d39eeb3db7a607eec",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-percent-applications-202b2575c4",
+    "skillId": "act-percent-applications",
+    "prompt": "A $80 jacket is 20% off. With 5% sales tax added to the discounted price, what is the final cost?",
+    "answer": {
+      "type": "auto",
+      "value": "$67.20",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$84"
+      },
+      {
+        "label": "B",
+        "text": "$60"
+      },
+      {
+        "label": "C",
+        "text": "$64"
+      },
+      {
+        "label": "D",
+        "text": "$68"
+      },
+      {
+        "label": "E",
+        "text": "$67.20"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-percent-applications"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "202b2575c4a6b747ea6e991bcc02b5031f32dd6461b8777f9c5dd0cf287596b6",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-percent-applications-2680623f86",
+    "skillId": "act-percent-applications",
+    "prompt": "A $40 jacket is 25% off. With 10% sales tax added to the discounted price, what is the final cost?",
+    "answer": {
+      "type": "auto",
+      "value": "$33",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$44"
+      },
+      {
+        "label": "B",
+        "text": "$33"
+      },
+      {
+        "label": "C",
+        "text": "$15"
+      },
+      {
+        "label": "D",
+        "text": "$30"
+      },
+      {
+        "label": "E",
+        "text": "$34"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-percent-applications"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "2680623f86e444fcd2b28358d4b376fca1d2fac4f900b2c6ddb4e2af2c8533df",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-percent-applications-5e8ef1c2e8",
+    "skillId": "act-percent-applications",
+    "prompt": "A $40 jacket is 10% off. With 5% sales tax added to the discounted price, what is the final cost?",
+    "answer": {
+      "type": "auto",
+      "value": "$37.80",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$42"
+      },
+      {
+        "label": "B",
+        "text": "$37.80"
+      },
+      {
+        "label": "C",
+        "text": "$30"
+      },
+      {
+        "label": "D",
+        "text": "$36"
+      },
+      {
+        "label": "E",
+        "text": "$38"
       }
     ],
     "correctOption": "B",
@@ -1412,7 +1412,51 @@
       "act-percent-applications"
     ],
     "source": "act-template-gen",
-    "contentHash": "930e95cf05d3bc3382445dd7d8c7d1adf2830ee8384ce28d3c029fe878a6677f",
+    "contentHash": "5e8ef1c2e816a1247e113d414f1e44a777bda4ecddee91660bb164ece766a04c",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-measurement-unit-conversion-6828ac9d72",
+    "skillId": "act-measurement-unit-conversion",
+    "prompt": "How many ounces are in 5 pounds?",
+    "answer": {
+      "type": "auto",
+      "value": "80",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "40"
+      },
+      {
+        "label": "B",
+        "text": "21"
+      },
+      {
+        "label": "C",
+        "text": "80"
+      },
+      {
+        "label": "D",
+        "text": "75"
+      },
+      {
+        "label": "E",
+        "text": "160"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-measurement-unit-conversion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "6828ac9d72288372ac0e981f0eb44558533cace341d6ae0b28f76a31ef335490",
     "isActive": true
   },
   {
@@ -1428,26 +1472,26 @@
     "options": [
       {
         "label": "A",
-        "text": "14"
-      },
-      {
-        "label": "B",
-        "text": "48"
-      },
-      {
-        "label": "C",
         "text": "24"
       },
       {
+        "label": "B",
+        "text": "12"
+      },
+      {
+        "label": "C",
+        "text": "48"
+      },
+      {
         "label": "D",
-        "text": "1"
+        "text": "22"
       },
       {
         "label": "E",
-        "text": "22"
+        "text": "14"
       }
     ],
-    "correctOption": "C",
+    "correctOption": "A",
     "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
@@ -1457,6 +1501,182 @@
     ],
     "source": "act-template-gen",
     "contentHash": "e2d0aae66d74b3673d823ece66e20791f58a19e56687d9d277be5cc0aa7ac853",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-measurement-unit-conversion-a70340ed08",
+    "skillId": "act-measurement-unit-conversion",
+    "prompt": "How many inches are in 2 yards?",
+    "answer": {
+      "type": "auto",
+      "value": "72",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "72"
+      },
+      {
+        "label": "B",
+        "text": "38"
+      },
+      {
+        "label": "C",
+        "text": "144"
+      },
+      {
+        "label": "D",
+        "text": "70"
+      },
+      {
+        "label": "E",
+        "text": "36"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-measurement-unit-conversion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "a70340ed084f8cb0a279b0227f80b8c8f281d96ba90025fcfaa4fcfab9c4678f",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-measurement-unit-conversion-1a47958926",
+    "skillId": "act-measurement-unit-conversion",
+    "prompt": "How many ounces are in 3 pounds?",
+    "answer": {
+      "type": "auto",
+      "value": "48",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "96"
+      },
+      {
+        "label": "B",
+        "text": "48"
+      },
+      {
+        "label": "C",
+        "text": "45"
+      },
+      {
+        "label": "D",
+        "text": "24"
+      },
+      {
+        "label": "E",
+        "text": "19"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-measurement-unit-conversion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "1a4795892673c3e8d1744487ae4057b379ea4e17e34e4f3cbcd432d60c9c7b88",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-measurement-unit-conversion-e0cc892cc4",
+    "skillId": "act-measurement-unit-conversion",
+    "prompt": "How many seconds are in 5 hours?",
+    "answer": {
+      "type": "auto",
+      "value": "18000",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "36000"
+      },
+      {
+        "label": "B",
+        "text": "3605"
+      },
+      {
+        "label": "C",
+        "text": "17995"
+      },
+      {
+        "label": "D",
+        "text": "18000"
+      },
+      {
+        "label": "E",
+        "text": "9000"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-measurement-unit-conversion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "e0cc892cc40626653ca800b775c1e8f155ceaff9eef152e3a2d7cb3fc9726aeb",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-measurement-unit-conversion-6079209f62",
+    "skillId": "act-measurement-unit-conversion",
+    "prompt": "How many ounces are in 7 pounds?",
+    "answer": {
+      "type": "auto",
+      "value": "112",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "56"
+      },
+      {
+        "label": "B",
+        "text": "105"
+      },
+      {
+        "label": "C",
+        "text": "224"
+      },
+      {
+        "label": "D",
+        "text": "112"
+      },
+      {
+        "label": "E",
+        "text": "23"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-measurement-unit-conversion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "6079209f62eab69e54db81f3e5e3edf3b75e7ee36c7f9ae6960f17a3b046c4bb",
     "isActive": true
   },
   {
@@ -1480,19 +1700,19 @@
       },
       {
         "label": "C",
-        "text": "60"
+        "text": "64"
       },
       {
         "label": "D",
-        "text": "1"
+        "text": "32"
       },
       {
         "label": "E",
-        "text": "64"
+        "text": "60"
       }
     ],
-    "correctOption": "E",
-    "difficulty": 2,
+    "correctOption": "C",
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -1504,115 +1724,27 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-measurement-unit-conversion-1a47958926",
+    "problemId": "act-act-measurement-unit-conversion-3da981fe2c",
     "skillId": "act-measurement-unit-conversion",
-    "prompt": "How many ounces are in 3 pounds?",
+    "prompt": "How many ounces are in 2 pounds?",
     "answer": {
       "type": "auto",
-      "value": "48",
+      "value": "32",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "45"
+        "text": "18"
       },
       {
         "label": "B",
-        "text": "48"
+        "text": "30"
       },
       {
         "label": "C",
-        "text": "96"
-      },
-      {
-        "label": "D",
-        "text": "1"
-      },
-      {
-        "label": "E",
-        "text": "19"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-measurement-unit-conversion"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "1a4795892673c3e8d1744487ae4057b379ea4e17e34e4f3cbcd432d60c9c7b88",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-measurement-unit-conversion-0a9f3cea78",
-    "skillId": "act-measurement-unit-conversion",
-    "prompt": "How many inches are in 4 feet?",
-    "answer": {
-      "type": "auto",
-      "value": "48",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "1"
-      },
-      {
-        "label": "B",
-        "text": "44"
-      },
-      {
-        "label": "C",
-        "text": "48"
-      },
-      {
-        "label": "D",
-        "text": "16"
-      },
-      {
-        "label": "E",
-        "text": "96"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-measurement-unit-conversion"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "0a9f3cea7832234745bbf05767d4ad12ad05b13a8d10e0d2238865c53bb9872a",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-measurement-unit-conversion-1bd5fd1dd3",
-    "skillId": "act-measurement-unit-conversion",
-    "prompt": "How many minutes are in 4 hours?",
-    "answer": {
-      "type": "auto",
-      "value": "240",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "480"
-      },
-      {
-        "label": "B",
-        "text": "1"
-      },
-      {
-        "label": "C",
-        "text": "240"
+        "text": "32"
       },
       {
         "label": "D",
@@ -1620,142 +1752,10 @@
       },
       {
         "label": "E",
-        "text": "236"
+        "text": "16"
       }
     ],
     "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-measurement-unit-conversion"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "1bd5fd1dd3b62fd77bd8d0f905d29870d09ab2ba217bbc52a807921c5c9b2e36",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-measurement-unit-conversion-3c7228aa73",
-    "skillId": "act-measurement-unit-conversion",
-    "prompt": "How many feet are in 6 yards?",
-    "answer": {
-      "type": "auto",
-      "value": "18",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "12"
-      },
-      {
-        "label": "B",
-        "text": "18"
-      },
-      {
-        "label": "C",
-        "text": "36"
-      },
-      {
-        "label": "D",
-        "text": "9"
-      },
-      {
-        "label": "E",
-        "text": "2"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-measurement-unit-conversion"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "3c7228aa73459eae5dc28de16ffdf195244b321c0877036992a68982516a06ad",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-measurement-unit-conversion-4facf1079d",
-    "skillId": "act-measurement-unit-conversion",
-    "prompt": "How many ounces are in 6 pounds?",
-    "answer": {
-      "type": "auto",
-      "value": "96",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "90"
-      },
-      {
-        "label": "B",
-        "text": "192"
-      },
-      {
-        "label": "C",
-        "text": "22"
-      },
-      {
-        "label": "D",
-        "text": "1"
-      },
-      {
-        "label": "E",
-        "text": "96"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-measurement-unit-conversion"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "4facf1079d85a3968cd20b4635816802c3204017e6934572ab874f1310778db4",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-measurement-unit-conversion-4c47ba3044",
-    "skillId": "act-measurement-unit-conversion",
-    "prompt": "How many feet are in 8 yards?",
-    "answer": {
-      "type": "auto",
-      "value": "24",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "16"
-      },
-      {
-        "label": "B",
-        "text": "48"
-      },
-      {
-        "label": "C",
-        "text": "3"
-      },
-      {
-        "label": "D",
-        "text": "11"
-      },
-      {
-        "label": "E",
-        "text": "24"
-      }
-    ],
-    "correctOption": "E",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -1764,27 +1764,27 @@
       "act-measurement-unit-conversion"
     ],
     "source": "act-template-gen",
-    "contentHash": "4c47ba3044ea84a4a1305f1c5151c6c776c48b5cf1327272d2c225d97f8617d7",
+    "contentHash": "3da981fe2cc5ad7025cde8038af9d0658c379e6d50b77ed5f9b63b855406a561",
     "isActive": true
   },
   {
-    "problemId": "act-act-angles-lines-triangles-28c3e12ef1",
+    "problemId": "act-act-angles-lines-triangles-6befe651f9",
     "skillId": "act-angles-lines-triangles",
-    "prompt": "Two angles of a triangle measure 42° and 45°. What is the measure of the third angle?",
+    "prompt": "Two angles of a triangle measure 43° and 45°. What is the measure of the third angle?",
     "answer": {
       "type": "auto",
-      "value": "93°",
+      "value": "92°",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "135°"
+        "text": "137°"
       },
       {
         "label": "B",
-        "text": "93°"
+        "text": "88°"
       },
       {
         "label": "C",
@@ -1792,14 +1792,14 @@
       },
       {
         "label": "D",
-        "text": "138°"
+        "text": "92°"
       },
       {
         "label": "E",
-        "text": "87°"
+        "text": "135°"
       }
     ],
-    "correctOption": "B",
+    "correctOption": "D",
     "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
@@ -1808,13 +1808,13 @@
       "act-angles-lines-triangles"
     ],
     "source": "act-template-gen",
-    "contentHash": "28c3e12ef1c075ad5c3f2206f612d51f900a8db25988fc0196eda945eeaf5db7",
+    "contentHash": "6befe651f90cc65ee92e1bc5cf651df039ee06c6b1a223bace5e16d6cbdc8797",
     "isActive": true
   },
   {
-    "problemId": "act-act-angles-lines-triangles-7eee5ea143",
+    "problemId": "act-act-angles-lines-triangles-cc72dba960",
     "skillId": "act-angles-lines-triangles",
-    "prompt": "Two angles of a triangle measure 76° and 32°. What is the measure of the third angle?",
+    "prompt": "Two angles of a triangle measure 58° and 50°. What is the measure of the third angle?",
     "answer": {
       "type": "auto",
       "value": "72°",
@@ -1824,11 +1824,11 @@
     "options": [
       {
         "label": "A",
-        "text": "72°"
+        "text": "90°"
       },
       {
         "label": "B",
-        "text": "104°"
+        "text": "72°"
       },
       {
         "label": "C",
@@ -1836,14 +1836,14 @@
       },
       {
         "label": "D",
-        "text": "148°"
+        "text": "122°"
       },
       {
         "label": "E",
-        "text": "90°"
+        "text": "130°"
       }
     ],
-    "correctOption": "A",
+    "correctOption": "B",
     "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
@@ -1852,175 +1852,43 @@
       "act-angles-lines-triangles"
     ],
     "source": "act-template-gen",
-    "contentHash": "7eee5ea143bb6922ed9c3f3e0e7301291aaafbf331bf1dd47a2ee428a17f1a89",
+    "contentHash": "cc72dba9603cb796effd2f70f8a473d2e707c1b6235f7beb16d75240ce3b05df",
     "isActive": true
   },
   {
-    "problemId": "act-act-angles-lines-triangles-bf82e6b9be",
+    "problemId": "act-act-angles-lines-triangles-4c249c9cfc",
     "skillId": "act-angles-lines-triangles",
-    "prompt": "Two angles of a triangle measure 43° and 35°. What is the measure of the third angle?",
+    "prompt": "Two angles of a triangle measure 39° and 40°. What is the measure of the third angle?",
     "answer": {
       "type": "auto",
-      "value": "102°",
+      "value": "101°",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "90°"
+        "text": "101°"
       },
       {
         "label": "B",
-        "text": "78°"
-      },
-      {
-        "label": "C",
-        "text": "145°"
-      },
-      {
-        "label": "D",
-        "text": "102°"
-      },
-      {
-        "label": "E",
-        "text": "137°"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-angles-lines-triangles"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "bf82e6b9bee10a787336d7f3915b49f380520b37a8033747ca71e35cf137b751",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-angles-lines-triangles-a337967c2d",
-    "skillId": "act-angles-lines-triangles",
-    "prompt": "Two angles of a triangle measure 55° and 66°. What is the measure of the third angle?",
-    "answer": {
-      "type": "auto",
-      "value": "59°",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "114°"
-      },
-      {
-        "label": "B",
-        "text": "121°"
-      },
-      {
-        "label": "C",
-        "text": "125°"
-      },
-      {
-        "label": "D",
         "text": "90°"
       },
       {
-        "label": "E",
-        "text": "59°"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-angles-lines-triangles"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "a337967c2d63ff7103d99a883fdf44836ac29bbf2b3073adb931416a8e0b0f2e",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-angles-lines-triangles-78db4a7d9c",
-    "skillId": "act-angles-lines-triangles",
-    "prompt": "Two angles of a triangle measure 80° and 70°. What is the measure of the third angle?",
-    "answer": {
-      "type": "auto",
-      "value": "30°",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "150°"
-      },
-      {
-        "label": "B",
-        "text": "110°"
-      },
-      {
         "label": "C",
-        "text": "90°"
-      },
-      {
-        "label": "D",
-        "text": "100°"
-      },
-      {
-        "label": "E",
-        "text": "30°"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-angles-lines-triangles"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "78db4a7d9c623aabf48b29d47e60b6ec79ed1adb2f02206c092abb451d4325e6",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-angles-lines-triangles-8ef4fb986e",
-    "skillId": "act-angles-lines-triangles",
-    "prompt": "Two angles of a triangle measure 50° and 40°. What is the measure of the third angle?",
-    "answer": {
-      "type": "auto",
-      "value": "90°",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
         "text": "140°"
       },
       {
-        "label": "B",
-        "text": "80°"
-      },
-      {
-        "label": "C",
-        "text": "130°"
-      },
-      {
         "label": "D",
-        "text": "90°"
+        "text": "79°"
       },
       {
         "label": "E",
-        "text": "100°"
+        "text": "141°"
       }
     ],
-    "correctOption": "D",
-    "difficulty": 4,
+    "correctOption": "A",
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -2028,16 +1896,16 @@
       "act-angles-lines-triangles"
     ],
     "source": "act-template-gen",
-    "contentHash": "8ef4fb986edca30490e1d525d6b07261b5b081c2ae5091dd58d520d93a8ea522",
+    "contentHash": "4c249c9cfcd8ccbd4bfb1c0e35837b68d31f83a256888f842b7115c278bce2e0",
     "isActive": true
   },
   {
-    "problemId": "act-act-angles-lines-triangles-f1f2c753dd",
+    "problemId": "act-act-angles-lines-triangles-6a0f0a9238",
     "skillId": "act-angles-lines-triangles",
-    "prompt": "Two angles of a triangle measure 56° and 50°. What is the measure of the third angle?",
+    "prompt": "Two angles of a triangle measure 37° and 31°. What is the measure of the third angle?",
     "answer": {
       "type": "auto",
-      "value": "74°",
+      "value": "112°",
       "equivalents": []
     },
     "answerType": "multiple-choice",
@@ -2048,23 +1916,23 @@
       },
       {
         "label": "B",
-        "text": "130°"
+        "text": "68°"
       },
       {
         "label": "C",
-        "text": "106°"
+        "text": "112°"
       },
       {
         "label": "D",
-        "text": "74°"
+        "text": "149°"
       },
       {
         "label": "E",
-        "text": "124°"
+        "text": "143°"
       }
     ],
-    "correctOption": "D",
-    "difficulty": 4,
+    "correctOption": "C",
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -2072,23 +1940,23 @@
       "act-angles-lines-triangles"
     ],
     "source": "act-template-gen",
-    "contentHash": "f1f2c753dd7dd58c71cf66025d1d2efc31920c1f160dc5489431b19c15daf2b6",
+    "contentHash": "6a0f0a92388f8a3c2932bfca9bd1addfba1a6d84a269ba9a8506038d8998d480",
     "isActive": true
   },
   {
-    "problemId": "act-act-angles-lines-triangles-a1ded5774c",
+    "problemId": "act-act-angles-lines-triangles-541d725d47",
     "skillId": "act-angles-lines-triangles",
-    "prompt": "Two angles of a triangle measure 47° and 79°. What is the measure of the third angle?",
+    "prompt": "Two angles of a triangle measure 79° and 76°. What is the measure of the third angle?",
     "answer": {
       "type": "auto",
-      "value": "54°",
+      "value": "25°",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "133°"
+        "text": "155°"
       },
       {
         "label": "B",
@@ -2096,7 +1964,7 @@
       },
       {
         "label": "C",
-        "text": "54°"
+        "text": "25°"
       },
       {
         "label": "D",
@@ -2104,10 +1972,142 @@
       },
       {
         "label": "E",
-        "text": "126°"
+        "text": "104°"
       }
     ],
     "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-angles-lines-triangles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "541d725d47249152d9e9409cb6e5c6e8fbfdd50385cb9f65fc10d4b1084f4130",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-angles-lines-triangles-4b3bd712e1",
+    "skillId": "act-angles-lines-triangles",
+    "prompt": "Two angles of a triangle measure 65° and 77°. What is the measure of the third angle?",
+    "answer": {
+      "type": "auto",
+      "value": "38°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "90°"
+      },
+      {
+        "label": "B",
+        "text": "38°"
+      },
+      {
+        "label": "C",
+        "text": "103°"
+      },
+      {
+        "label": "D",
+        "text": "115°"
+      },
+      {
+        "label": "E",
+        "text": "142°"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-angles-lines-triangles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "4b3bd712e146a21bb9e1470287c237489d721015dc269e89469fb1eccf93fc8a",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-angles-lines-triangles-ab195559bb",
+    "skillId": "act-angles-lines-triangles",
+    "prompt": "Two angles of a triangle measure 79° and 60°. What is the measure of the third angle?",
+    "answer": {
+      "type": "auto",
+      "value": "41°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "139°"
+      },
+      {
+        "label": "B",
+        "text": "101°"
+      },
+      {
+        "label": "C",
+        "text": "90°"
+      },
+      {
+        "label": "D",
+        "text": "41°"
+      },
+      {
+        "label": "E",
+        "text": "120°"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-angles-lines-triangles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "ab195559bb89e9ed5cc4907bf854b3a2bdded41e3f4a3028b9f7d942ab3735ba",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-angles-lines-triangles-0392524b57",
+    "skillId": "act-angles-lines-triangles",
+    "prompt": "Two angles of a triangle measure 31° and 76°. What is the measure of the third angle?",
+    "answer": {
+      "type": "auto",
+      "value": "73°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "73°"
+      },
+      {
+        "label": "B",
+        "text": "90°"
+      },
+      {
+        "label": "C",
+        "text": "107°"
+      },
+      {
+        "label": "D",
+        "text": "104°"
+      },
+      {
+        "label": "E",
+        "text": "149°"
+      }
+    ],
+    "correctOption": "A",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -2116,185 +2116,7 @@
       "act-angles-lines-triangles"
     ],
     "source": "act-template-gen",
-    "contentHash": "a1ded5774cb62e1bfb38cc11bc70724417d63c6eae792f0a4682f0d34ab8a6f5",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-polygons-circles-db43864a60",
-    "skillId": "act-polygons-circles",
-    "prompt": "What is the measure of one interior angle of the regular 10-gon shown?",
-    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"100.0,17.0 134.1,28.1 155.2,57.1 155.2,92.9 134.1,121.9 100.0,133.0 65.9,121.9 44.8,92.9 44.8,57.1 65.9,28.1\" stroke-linejoin=\"round\"/></svg>",
-    "answer": {
-      "type": "auto",
-      "value": "144°",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "36°"
-      },
-      {
-        "label": "B",
-        "text": "180°"
-      },
-      {
-        "label": "C",
-        "text": "144°"
-      },
-      {
-        "label": "D",
-        "text": "1440°"
-      },
-      {
-        "label": "E",
-        "text": "18°"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-polygons-circles"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "db43864a60f9ee91815d5dc908104ff7e89aa3605ec2ba484a69b683c6e49b7e",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-polygons-circles-68e6432c74",
-    "skillId": "act-polygons-circles",
-    "prompt": "What is the measure of one interior angle of the regular 24-gon shown?",
-    "answer": {
-      "type": "auto",
-      "value": "165°",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "7.5°"
-      },
-      {
-        "label": "B",
-        "text": "3960°"
-      },
-      {
-        "label": "C",
-        "text": "165°"
-      },
-      {
-        "label": "D",
-        "text": "180°"
-      },
-      {
-        "label": "E",
-        "text": "15°"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-polygons-circles"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "68e6432c743ca7b87f760ef9aa22445da68875e9ee341bd158936a2daf0b4c72",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-polygons-circles-1b11ff8e8a",
-    "skillId": "act-polygons-circles",
-    "prompt": "What is the measure of one interior angle of the regular 18-gon shown?",
-    "answer": {
-      "type": "auto",
-      "value": "160°",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "160°"
-      },
-      {
-        "label": "B",
-        "text": "10°"
-      },
-      {
-        "label": "C",
-        "text": "2880°"
-      },
-      {
-        "label": "D",
-        "text": "20°"
-      },
-      {
-        "label": "E",
-        "text": "180°"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-polygons-circles"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "1b11ff8e8ab46c2a650de720034211e941cf238a2aeec83396dcde04a040b8f5",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-polygons-circles-7beecb7077",
-    "skillId": "act-polygons-circles",
-    "prompt": "What is the measure of one interior angle of the regular 5-gon shown?",
-    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"100.0,17.0 155.2,57.1 134.1,121.9 65.9,121.9 44.8,57.1\" stroke-linejoin=\"round\"/></svg>",
-    "answer": {
-      "type": "auto",
-      "value": "108°",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "36°"
-      },
-      {
-        "label": "B",
-        "text": "108°"
-      },
-      {
-        "label": "C",
-        "text": "540°"
-      },
-      {
-        "label": "D",
-        "text": "72°"
-      },
-      {
-        "label": "E",
-        "text": "180°"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-polygons-circles"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "7beecb7077129efd69b3a3471795d300dc179ce2cd7ccdebc86a6f64b322b19f",
+    "contentHash": "0392524b57ee53978b567f17f3af576bdda58666060f2669e2dd784ca15fb5a8",
     "isActive": true
   },
   {
@@ -2310,27 +2132,27 @@
     "options": [
       {
         "label": "A",
-        "text": "180°"
+        "text": "12°"
       },
       {
         "label": "B",
-        "text": "156°"
+        "text": "180°"
       },
       {
         "label": "C",
-        "text": "2340°"
-      },
-      {
-        "label": "D",
         "text": "24°"
       },
       {
+        "label": "D",
+        "text": "2340°"
+      },
+      {
         "label": "E",
-        "text": "12°"
+        "text": "156°"
       }
     ],
-    "correctOption": "B",
-    "difficulty": 3,
+    "correctOption": "E",
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -2339,6 +2161,50 @@
     ],
     "source": "act-template-gen",
     "contentHash": "d01292a4a9212f7f36f0f44cffe66ea27e58606438a122d3a8d34f52b3bdcf6d",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polygons-circles-b68f36c479",
+    "skillId": "act-polygons-circles",
+    "prompt": "What is the measure of one interior angle of the regular 20-gon shown?",
+    "answer": {
+      "type": "auto",
+      "value": "162°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "3240°"
+      },
+      {
+        "label": "B",
+        "text": "180°"
+      },
+      {
+        "label": "C",
+        "text": "9°"
+      },
+      {
+        "label": "D",
+        "text": "18°"
+      },
+      {
+        "label": "E",
+        "text": "162°"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polygons-circles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "b68f36c479a3afa356ff30f1af51f3882475ced0c2e6c8e6905fb7380e887449",
     "isActive": true
   },
   {
@@ -2367,15 +2233,15 @@
       },
       {
         "label": "D",
-        "text": "1800°"
+        "text": "180°"
       },
       {
         "label": "E",
-        "text": "180°"
+        "text": "1800°"
       }
     ],
     "correctOption": "B",
-    "difficulty": 4,
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -2387,28 +2253,28 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-polygons-circles-a438fc4cf0",
+    "problemId": "act-act-polygons-circles-db43864a60",
     "skillId": "act-polygons-circles",
-    "prompt": "What is the measure of one interior angle of the regular 6-gon shown?",
-    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"100.0,17.0 150.2,46.0 150.2,104.0 100.0,133.0 49.8,104.0 49.8,46.0\" stroke-linejoin=\"round\"/></svg>",
+    "prompt": "What is the measure of one interior angle of the regular 10-gon shown?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"100.0,17.0 134.1,28.1 155.2,57.1 155.2,92.9 134.1,121.9 100.0,133.0 65.9,121.9 44.8,92.9 44.8,57.1 65.9,28.1\" stroke-linejoin=\"round\"/></svg>",
     "answer": {
       "type": "auto",
-      "value": "120°",
+      "value": "144°",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "60°"
+        "text": "36°"
       },
       {
         "label": "B",
-        "text": "30°"
+        "text": "18°"
       },
       {
         "label": "C",
-        "text": "720°"
+        "text": "144°"
       },
       {
         "label": "D",
@@ -2416,11 +2282,11 @@
       },
       {
         "label": "E",
-        "text": "120°"
+        "text": "1440°"
       }
     ],
-    "correctOption": "E",
-    "difficulty": 4,
+    "correctOption": "C",
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -2428,7 +2294,52 @@
       "act-polygons-circles"
     ],
     "source": "act-template-gen",
-    "contentHash": "a438fc4cf03173115b31662107f6bd8657e9ac360d2b4694ca48bc51e5d4cb3f",
+    "contentHash": "db43864a60f9ee91815d5dc908104ff7e89aa3605ec2ba484a69b683c6e49b7e",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polygons-circles-7beecb7077",
+    "skillId": "act-polygons-circles",
+    "prompt": "What is the measure of one interior angle of the regular 5-gon shown?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"100.0,17.0 155.2,57.1 134.1,121.9 65.9,121.9 44.8,57.1\" stroke-linejoin=\"round\"/></svg>",
+    "answer": {
+      "type": "auto",
+      "value": "108°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "72°"
+      },
+      {
+        "label": "B",
+        "text": "36°"
+      },
+      {
+        "label": "C",
+        "text": "108°"
+      },
+      {
+        "label": "D",
+        "text": "180°"
+      },
+      {
+        "label": "E",
+        "text": "540°"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polygons-circles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "7beecb7077129efd69b3a3471795d300dc179ce2cd7ccdebc86a6f64b322b19f",
     "isActive": true
   },
   {
@@ -2445,7 +2356,7 @@
     "options": [
       {
         "label": "A",
-        "text": "40°"
+        "text": "140°"
       },
       {
         "label": "B",
@@ -2453,11 +2364,100 @@
       },
       {
         "label": "C",
-        "text": "1260°"
+        "text": "40°"
       },
       {
         "label": "D",
-        "text": "140°"
+        "text": "180°"
+      },
+      {
+        "label": "E",
+        "text": "1260°"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polygons-circles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "5167a2fc11904d6472e10059da24ffb68139257bc7afd6d9877d8e95328216cc",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polygons-circles-e9063bbaea",
+    "skillId": "act-polygons-circles",
+    "prompt": "What is the measure of one interior angle of the regular 36-gon shown?",
+    "answer": {
+      "type": "auto",
+      "value": "170°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "170°"
+      },
+      {
+        "label": "B",
+        "text": "6120°"
+      },
+      {
+        "label": "C",
+        "text": "10°"
+      },
+      {
+        "label": "D",
+        "text": "180°"
+      },
+      {
+        "label": "E",
+        "text": "5°"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polygons-circles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "e9063bbaea131d620460fab1c162d76d67c50aece68476519e125613cccfbb86",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polygons-circles-a438fc4cf0",
+    "skillId": "act-polygons-circles",
+    "prompt": "What is the measure of one interior angle of the regular 6-gon shown?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"100.0,17.0 150.2,46.0 150.2,104.0 100.0,133.0 49.8,104.0 49.8,46.0\" stroke-linejoin=\"round\"/></svg>",
+    "answer": {
+      "type": "auto",
+      "value": "120°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "30°"
+      },
+      {
+        "label": "B",
+        "text": "720°"
+      },
+      {
+        "label": "C",
+        "text": "60°"
+      },
+      {
+        "label": "D",
+        "text": "120°"
       },
       {
         "label": "E",
@@ -2473,42 +2473,42 @@
       "act-polygons-circles"
     ],
     "source": "act-template-gen",
-    "contentHash": "5167a2fc11904d6472e10059da24ffb68139257bc7afd6d9877d8e95328216cc",
+    "contentHash": "a438fc4cf03173115b31662107f6bd8657e9ac360d2b4694ca48bc51e5d4cb3f",
     "isActive": true
   },
   {
-    "problemId": "act-act-area-volume-surface-area-ec73684fd6",
+    "problemId": "act-act-area-volume-surface-area-596879dc61",
     "skillId": "act-area-volume-surface-area",
-    "prompt": "What is the area of a triangle with base 6 and height 8?",
+    "prompt": "What is the area of a triangle with base 12 and height 5?",
     "answer": {
       "type": "auto",
-      "value": "24",
+      "value": "30",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "14"
+        "text": "8.5"
       },
       {
         "label": "B",
-        "text": "16"
+        "text": "20"
       },
       {
         "label": "C",
-        "text": "7"
+        "text": "30"
       },
       {
         "label": "D",
-        "text": "48"
+        "text": "17"
       },
       {
         "label": "E",
-        "text": "24"
+        "text": "60"
       }
     ],
-    "correctOption": "E",
+    "correctOption": "C",
     "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
@@ -2517,86 +2517,86 @@
       "act-area-volume-surface-area"
     ],
     "source": "act-template-gen",
-    "contentHash": "ec73684fd6777771f85ef2cbab32c375b8b9ef734ee79f50f98c758cf7836e91",
+    "contentHash": "596879dc612bbba654dc8580c8ce01063c98b489c47edb3f2f6551efa0bb27bb",
     "isActive": true
   },
   {
-    "problemId": "act-act-area-volume-surface-area-9a246c1c51",
+    "problemId": "act-act-area-volume-surface-area-8523dc6def",
     "skillId": "act-area-volume-surface-area",
-    "prompt": "What is the volume of a box with dimensions 3 × 2 × 3?",
+    "prompt": "What is the area of a rectangle with length 7 and width 4?",
     "answer": {
       "type": "auto",
-      "value": "18",
+      "value": "28",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "8"
+        "text": "28"
       },
       {
         "label": "B",
+        "text": "11"
+      },
+      {
+        "label": "C",
+        "text": "56"
+      },
+      {
+        "label": "D",
+        "text": "14"
+      },
+      {
+        "label": "E",
+        "text": "22"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-volume-surface-area"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "8523dc6def7ec91fc6dd9bc3f87979df628059d0e36e1969bddf1b785dcde7a8",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-volume-surface-area-9ba9a538fc",
+    "skillId": "act-area-volume-surface-area",
+    "prompt": "What is the area of a triangle with base 6 and height 7?",
+    "answer": {
+      "type": "auto",
+      "value": "21",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "6.5"
+      },
+      {
+        "label": "B",
+        "text": "21"
+      },
+      {
+        "label": "C",
+        "text": "13"
+      },
+      {
+        "label": "D",
+        "text": "14"
+      },
+      {
+        "label": "E",
         "text": "42"
-      },
-      {
-        "label": "C",
-        "text": "18"
-      },
-      {
-        "label": "D",
-        "text": "36"
-      },
-      {
-        "label": "E",
-        "text": "9"
       }
     ],
-    "correctOption": "C",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-area-volume-surface-area"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "9a246c1c51c552c3133b8b70cec8886187ed88fe3c26bb3c88934bf3ef11fa9c",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-area-volume-surface-area-c35421fc9c",
-    "skillId": "act-area-volume-surface-area",
-    "prompt": "What is the area of a triangle with base 9 and height 3?",
-    "answer": {
-      "type": "auto",
-      "value": "13.5",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "12"
-      },
-      {
-        "label": "B",
-        "text": "9"
-      },
-      {
-        "label": "C",
-        "text": "27"
-      },
-      {
-        "label": "D",
-        "text": "6"
-      },
-      {
-        "label": "E",
-        "text": "13.5"
-      }
-    ],
-    "correctOption": "E",
+    "correctOption": "B",
     "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
@@ -2605,43 +2605,175 @@
       "act-area-volume-surface-area"
     ],
     "source": "act-template-gen",
-    "contentHash": "c35421fc9c4e1bcaa532b59332cd960939b7ef52889c8b8049ff07dba853fb9b",
+    "contentHash": "9ba9a538fc929fd77e80a0cc3ca55fbafe45ccb655533f43ee758b74f170746b",
     "isActive": true
   },
   {
-    "problemId": "act-act-area-volume-surface-area-e239b70e97",
+    "problemId": "act-act-area-volume-surface-area-42491fd93a",
     "skillId": "act-area-volume-surface-area",
-    "prompt": "What is the volume of a box with dimensions 5 × 4 × 5?",
+    "prompt": "What is the volume of a box with dimensions 2 × 5 × 3?",
     "answer": {
       "type": "auto",
-      "value": "100",
+      "value": "30",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "25"
+        "text": "60"
       },
       {
         "label": "B",
-        "text": "130"
+        "text": "62"
       },
       {
         "label": "C",
-        "text": "100"
+        "text": "30"
       },
       {
         "label": "D",
+        "text": "13"
+      },
+      {
+        "label": "E",
+        "text": "10"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-volume-surface-area"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "42491fd93a24a2e5c05f144292f17a49cd4e9055955c282ee6aef780eb27b2b0",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-volume-surface-area-c729f324b8",
+    "skillId": "act-area-volume-surface-area",
+    "prompt": "What is the area of a rectangle with length 8 and width 7?",
+    "answer": {
+      "type": "auto",
+      "value": "56",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "56"
+      },
+      {
+        "label": "B",
+        "text": "15"
+      },
+      {
+        "label": "C",
+        "text": "112"
+      },
+      {
+        "label": "D",
+        "text": "28"
+      },
+      {
+        "label": "E",
+        "text": "30"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-volume-surface-area"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "c729f324b8f64f2159391c8be421a6a534d9f99e2813668db317e90d37e9ebb5",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-volume-surface-area-2f0c15a25b",
+    "skillId": "act-area-volume-surface-area",
+    "prompt": "What is the volume of a box with dimensions 5 × 4 × 2?",
+    "answer": {
+      "type": "auto",
+      "value": "40",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "40"
+      },
+      {
+        "label": "B",
+        "text": "76"
+      },
+      {
+        "label": "C",
+        "text": "22"
+      },
+      {
+        "label": "D",
+        "text": "11"
+      },
+      {
+        "label": "E",
+        "text": "80"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-volume-surface-area"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "2f0c15a25b7daa86ed85696eddaccb2d72c4595eec94e9557799202d4510fb95",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-volume-surface-area-2dc96a9146",
+    "skillId": "act-area-volume-surface-area",
+    "prompt": "What is the area of a triangle with base 4 and height 7?",
+    "answer": {
+      "type": "auto",
+      "value": "14",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
         "text": "14"
       },
       {
+        "label": "B",
+        "text": "28"
+      },
+      {
+        "label": "C",
+        "text": "11"
+      },
+      {
+        "label": "D",
+        "text": "9.333333333333334"
+      },
+      {
         "label": "E",
-        "text": "200"
+        "text": "5.5"
       }
     ],
-    "correctOption": "C",
-    "difficulty": 3,
+    "correctOption": "A",
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -2649,27 +2781,27 @@
       "act-area-volume-surface-area"
     ],
     "source": "act-template-gen",
-    "contentHash": "e239b70e97d4d0194f106e3e32d5e4e2c5dc655f87d7821c78dc708526c2c62a",
+    "contentHash": "2dc96a91468306edf86d453588fb281aa52213ecce5766acb1090f9d4ea149c2",
     "isActive": true
   },
   {
-    "problemId": "act-act-area-volume-surface-area-e0fa9d0f25",
+    "problemId": "act-act-area-volume-surface-area-e50aedcef5",
     "skillId": "act-area-volume-surface-area",
-    "prompt": "What is the area of a rectangle with length 8 and width 9?",
+    "prompt": "What is the volume of a box with dimensions 4 × 3 × 3?",
     "answer": {
       "type": "auto",
-      "value": "72",
+      "value": "36",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "34"
+        "text": "15"
       },
       {
         "label": "B",
-        "text": "36"
+        "text": "10"
       },
       {
         "label": "C",
@@ -2677,143 +2809,11 @@
       },
       {
         "label": "D",
-        "text": "144"
+        "text": "36"
       },
       {
         "label": "E",
-        "text": "17"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-area-volume-surface-area"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "e0fa9d0f25baa527680cb8ae2dbf46cb1e979ab21ad2eb6280921aa15514eead",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-area-volume-surface-area-188378f66b",
-    "skillId": "act-area-volume-surface-area",
-    "prompt": "What is the area of a triangle with base 5 and height 7?",
-    "answer": {
-      "type": "auto",
-      "value": "17.5",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "35"
-      },
-      {
-        "label": "B",
-        "text": "6"
-      },
-      {
-        "label": "C",
-        "text": "11.666666666666666"
-      },
-      {
-        "label": "D",
-        "text": "12"
-      },
-      {
-        "label": "E",
-        "text": "17.5"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-area-volume-surface-area"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "188378f66b4a245fbd3f17683b402d9e73aa301bf18d3e42deac562b1b7c0374",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-area-volume-surface-area-c12ad0387d",
-    "skillId": "act-area-volume-surface-area",
-    "prompt": "What is the area of a triangle with base 9 and height 7?",
-    "answer": {
-      "type": "auto",
-      "value": "31.5",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "16"
-      },
-      {
-        "label": "B",
-        "text": "31.5"
-      },
-      {
-        "label": "C",
-        "text": "21"
-      },
-      {
-        "label": "D",
-        "text": "63"
-      },
-      {
-        "label": "E",
-        "text": "8"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-area-volume-surface-area"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "c12ad0387dc373baf8fee082067a409d3d1de1d91ef7a310054dafd6ecda36c2",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-area-volume-surface-area-0c54fd5d75",
-    "skillId": "act-area-volume-surface-area",
-    "prompt": "What is the area of a rectangle with length 9 and width 6?",
-    "answer": {
-      "type": "auto",
-      "value": "54",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "30"
-      },
-      {
-        "label": "B",
-        "text": "108"
-      },
-      {
-        "label": "C",
-        "text": "15"
-      },
-      {
-        "label": "D",
-        "text": "54"
-      },
-      {
-        "label": "E",
-        "text": "27"
+        "text": "66"
       }
     ],
     "correctOption": "D",
@@ -2825,43 +2825,43 @@
       "act-area-volume-surface-area"
     ],
     "source": "act-template-gen",
-    "contentHash": "0c54fd5d75f458c5cb286e165508a16f5caa8f36ee78a6decb5d59131aa4d40c",
+    "contentHash": "e50aedcef57623e61d480ace198f15afb31c317e7f44191c1d33e8a68d30c677",
     "isActive": true
   },
   {
-    "problemId": "act-act-coordinate-geometry-a9a5022bcb",
+    "problemId": "act-act-coordinate-geometry-89d8eac1f2",
     "skillId": "act-coordinate-geometry",
-    "prompt": "What is the midpoint of the segment joining the two points shown, (1, -2) and (2, -2)?",
-    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><line x1=\"20\" y1=\"75\" x2=\"180\" y2=\"75\" stroke=\"#bbb\" stroke-width=\"1\"/><line x1=\"100\" y1=\"15\" x2=\"100\" y2=\"140\" stroke=\"#bbb\" stroke-width=\"1\"/><circle cx=\"112\" cy=\"93\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"118\" y=\"87\" fill=\"#7c5cff\" stroke=\"none\">(1, -2)</text><circle cx=\"124\" cy=\"93\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"130\" y=\"87\" fill=\"#7c5cff\" stroke=\"none\">(2, -2)</text></svg>",
+    "prompt": "What is the midpoint of the segment joining the two points shown, (-3, 5) and (0, 0)?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><line x1=\"20\" y1=\"75\" x2=\"180\" y2=\"75\" stroke=\"#bbb\" stroke-width=\"1\"/><line x1=\"100\" y1=\"15\" x2=\"100\" y2=\"140\" stroke=\"#bbb\" stroke-width=\"1\"/><circle cx=\"64\" cy=\"30\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"70\" y=\"24\" fill=\"#7c5cff\" stroke=\"none\">(-3, 5)</text><circle cx=\"100\" cy=\"75\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"106\" y=\"69\" fill=\"#7c5cff\" stroke=\"none\">(0, 0)</text></svg>",
     "answer": {
       "type": "auto",
-      "value": "(1.5, -2)",
+      "value": "(-1.5, 2.5)",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "(3, -4)"
+        "text": "(-1.5, 2.5)"
       },
       {
         "label": "B",
-        "text": "(-2, 1.5)"
+        "text": "(3, -5)"
       },
       {
         "label": "C",
-        "text": "(1.5, -2)"
+        "text": "(-0.5, 2.5)"
       },
       {
         "label": "D",
-        "text": "(1, 0)"
+        "text": "(-3, 5)"
       },
       {
         "label": "E",
-        "text": "(2.5, -2)"
+        "text": "(2.5, -1.5)"
       }
     ],
-    "correctOption": "C",
+    "correctOption": "A",
     "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
@@ -2870,42 +2870,43 @@
       "act-coordinate-geometry"
     ],
     "source": "act-template-gen",
-    "contentHash": "a9a5022bcb35c1a710496d0438be6278c175f4f572f7366b8be7b1f15a5edcc3",
+    "contentHash": "89d8eac1f200c6a2810cd36e2198315b73583ae85dad7ac5a9c4fc3c6777fb8b",
     "isActive": true
   },
   {
-    "problemId": "act-act-coordinate-geometry-454ced9ff5",
+    "problemId": "act-act-coordinate-geometry-9dc207e7dc",
     "skillId": "act-coordinate-geometry",
-    "prompt": "What is the distance between (5, 5) and (8, 9)?",
+    "prompt": "What is the midpoint of the segment joining the two points shown, (-4, 0) and (2, 0)?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><line x1=\"20\" y1=\"75\" x2=\"180\" y2=\"75\" stroke=\"#bbb\" stroke-width=\"1\"/><line x1=\"100\" y1=\"15\" x2=\"100\" y2=\"140\" stroke=\"#bbb\" stroke-width=\"1\"/><circle cx=\"52\" cy=\"75\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"58\" y=\"69\" fill=\"#7c5cff\" stroke=\"none\">(-4, 0)</text><circle cx=\"124\" cy=\"75\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"130\" y=\"69\" fill=\"#7c5cff\" stroke=\"none\">(2, 0)</text></svg>",
     "answer": {
       "type": "auto",
-      "value": "5",
+      "value": "(-1, 0)",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "6"
+        "text": "(0, 0)"
       },
       {
         "label": "B",
-        "text": "7"
+        "text": "(-1, 0)"
       },
       {
         "label": "C",
-        "text": "3"
+        "text": "(6, 0)"
       },
       {
         "label": "D",
-        "text": "12"
+        "text": "(0, -1)"
       },
       {
         "label": "E",
-        "text": "5"
+        "text": "(-2, 0)"
       }
     ],
-    "correctOption": "E",
+    "correctOption": "B",
     "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
@@ -2914,40 +2915,40 @@
       "act-coordinate-geometry"
     ],
     "source": "act-template-gen",
-    "contentHash": "454ced9ff533f2ea9502a10cbbbf39ac3b27031932b5476728610f49c8e6cd49",
+    "contentHash": "9dc207e7dc3c567816b1a3734e29567bc7123fffd6cd9d2341be1150943e48a4",
     "isActive": true
   },
   {
-    "problemId": "act-act-coordinate-geometry-d0b05612a3",
+    "problemId": "act-act-coordinate-geometry-8a610c691e",
     "skillId": "act-coordinate-geometry",
-    "prompt": "What is the midpoint of the segment joining the two points shown, (-5, 2) and (1, 3)?",
-    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><line x1=\"20\" y1=\"75\" x2=\"180\" y2=\"75\" stroke=\"#bbb\" stroke-width=\"1\"/><line x1=\"100\" y1=\"15\" x2=\"100\" y2=\"140\" stroke=\"#bbb\" stroke-width=\"1\"/><circle cx=\"40\" cy=\"57\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"46\" y=\"51\" fill=\"#7c5cff\" stroke=\"none\">(-5, 2)</text><circle cx=\"112\" cy=\"48\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"118\" y=\"42\" fill=\"#7c5cff\" stroke=\"none\">(1, 3)</text></svg>",
+    "prompt": "What is the midpoint of the segment joining the two points shown, (1, 1) and (2, -1)?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><line x1=\"20\" y1=\"75\" x2=\"180\" y2=\"75\" stroke=\"#bbb\" stroke-width=\"1\"/><line x1=\"100\" y1=\"15\" x2=\"100\" y2=\"140\" stroke=\"#bbb\" stroke-width=\"1\"/><circle cx=\"112\" cy=\"66\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"118\" y=\"60\" fill=\"#7c5cff\" stroke=\"none\">(1, 1)</text><circle cx=\"124\" cy=\"84\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"130\" y=\"78\" fill=\"#7c5cff\" stroke=\"none\">(2, -1)</text></svg>",
     "answer": {
       "type": "auto",
-      "value": "(-2, 2.5)",
+      "value": "(1.5, 0)",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "(2.5, -2)"
+        "text": "(2.5, 0)"
       },
       {
         "label": "B",
-        "text": "(-4, 5)"
+        "text": "(1, -2)"
       },
       {
         "label": "C",
-        "text": "(-2, 2.5)"
+        "text": "(1.5, 0)"
       },
       {
         "label": "D",
-        "text": "(-1, 2.5)"
+        "text": "(3, 0)"
       },
       {
         "label": "E",
-        "text": "(6, 1)"
+        "text": "(0, 1.5)"
       }
     ],
     "correctOption": "C",
@@ -2959,40 +2960,39 @@
       "act-coordinate-geometry"
     ],
     "source": "act-template-gen",
-    "contentHash": "d0b05612a3335488107aa2356ba5b7355452a4e5d9f6db82d501c73938a36e61",
+    "contentHash": "8a610c691e9a19a8f491ef2ef9d4c8d228e559c21607e67224e858f2310ded32",
     "isActive": true
   },
   {
-    "problemId": "act-act-coordinate-geometry-44164cb634",
+    "problemId": "act-act-coordinate-geometry-2367c7e31e",
     "skillId": "act-coordinate-geometry",
-    "prompt": "What is the midpoint of the segment joining the two points shown, (5, 5) and (1, 2)?",
-    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><line x1=\"20\" y1=\"75\" x2=\"180\" y2=\"75\" stroke=\"#bbb\" stroke-width=\"1\"/><line x1=\"100\" y1=\"15\" x2=\"100\" y2=\"140\" stroke=\"#bbb\" stroke-width=\"1\"/><circle cx=\"160\" cy=\"30\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"166\" y=\"24\" fill=\"#7c5cff\" stroke=\"none\">(5, 5)</text><circle cx=\"112\" cy=\"57\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"118\" y=\"51\" fill=\"#7c5cff\" stroke=\"none\">(1, 2)</text></svg>",
+    "prompt": "What is the distance between (0, 0) and (8, 15)?",
     "answer": {
       "type": "auto",
-      "value": "(3, 3.5)",
+      "value": "17",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "(4, 3.5)"
+        "text": "11"
       },
       {
         "label": "B",
-        "text": "(3, 3.5)"
+        "text": "17"
       },
       {
         "label": "C",
-        "text": "(3.5, 3)"
+        "text": "18"
       },
       {
         "label": "D",
-        "text": "(6, 7)"
+        "text": "120"
       },
       {
         "label": "E",
-        "text": "(-4, -3)"
+        "text": "23"
       }
     ],
     "correctOption": "B",
@@ -3004,102 +3004,13 @@
       "act-coordinate-geometry"
     ],
     "source": "act-template-gen",
-    "contentHash": "44164cb63410091e895c3d77727d882fc5bcc7a10302ed7a79fb7ef59dc054e3",
+    "contentHash": "2367c7e31ee898f6dab5b20c2c3634b2c5b98a6c2da4f62d73a1492bfd880b4b",
     "isActive": true
   },
   {
-    "problemId": "act-act-coordinate-geometry-e6fdbde599",
+    "problemId": "act-act-coordinate-geometry-f6c2a6cc4a",
     "skillId": "act-coordinate-geometry",
-    "prompt": "What is the distance between (-4, -3) and (1, 9)?",
-    "answer": {
-      "type": "auto",
-      "value": "13",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "60"
-      },
-      {
-        "label": "B",
-        "text": "14"
-      },
-      {
-        "label": "C",
-        "text": "17"
-      },
-      {
-        "label": "D",
-        "text": "8"
-      },
-      {
-        "label": "E",
-        "text": "13"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-coordinate-geometry"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "e6fdbde599085eb300f3278e9f55c10b06536680edb94641aef289fc7e253057",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-coordinate-geometry-c400987432",
-    "skillId": "act-coordinate-geometry",
-    "prompt": "What is the midpoint of the segment joining the two points shown, (-1, 1) and (1, 2)?",
-    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><line x1=\"20\" y1=\"75\" x2=\"180\" y2=\"75\" stroke=\"#bbb\" stroke-width=\"1\"/><line x1=\"100\" y1=\"15\" x2=\"100\" y2=\"140\" stroke=\"#bbb\" stroke-width=\"1\"/><circle cx=\"88\" cy=\"66\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"94\" y=\"60\" fill=\"#7c5cff\" stroke=\"none\">(-1, 1)</text><circle cx=\"112\" cy=\"57\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"118\" y=\"51\" fill=\"#7c5cff\" stroke=\"none\">(1, 2)</text></svg>",
-    "answer": {
-      "type": "auto",
-      "value": "(0, 1.5)",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "(1, 1.5)"
-      },
-      {
-        "label": "B",
-        "text": "(0, 3)"
-      },
-      {
-        "label": "C",
-        "text": "(1.5, 0)"
-      },
-      {
-        "label": "D",
-        "text": "(2, 1)"
-      },
-      {
-        "label": "E",
-        "text": "(0, 1.5)"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-coordinate-geometry"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "c400987432d9e104ab111a39d905a0d37aea583320d92288955c177b76795336",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-coordinate-geometry-a48b5b3585",
-    "skillId": "act-coordinate-geometry",
-    "prompt": "What is the distance between (3, 4) and (6, 8)?",
+    "prompt": "What is the distance between (5, 2) and (8, 6)?",
     "answer": {
       "type": "auto",
       "value": "5",
@@ -3109,23 +3020,67 @@
     "options": [
       {
         "label": "A",
-        "text": "5"
-      },
-      {
-        "label": "B",
-        "text": "6"
-      },
-      {
-        "label": "C",
         "text": "7"
       },
       {
-        "label": "D",
+        "label": "B",
+        "text": "5"
+      },
+      {
+        "label": "C",
         "text": "12"
       },
       {
-        "label": "E",
+        "label": "D",
         "text": "3"
+      },
+      {
+        "label": "E",
+        "text": "6"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-coordinate-geometry"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "f6c2a6cc4a0ad808c7278e2c934bf27b3f36000879ab6198fd391c0fb48a9e30",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-coordinate-geometry-d5698c5e89",
+    "skillId": "act-coordinate-geometry",
+    "prompt": "What is the distance between (-3, 5) and (2, 17)?",
+    "answer": {
+      "type": "auto",
+      "value": "13",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "13"
+      },
+      {
+        "label": "B",
+        "text": "17"
+      },
+      {
+        "label": "C",
+        "text": "14"
+      },
+      {
+        "label": "D",
+        "text": "60"
+      },
+      {
+        "label": "E",
+        "text": "8"
       }
     ],
     "correctOption": "A",
@@ -3137,59 +3092,13 @@
       "act-coordinate-geometry"
     ],
     "source": "act-template-gen",
-    "contentHash": "a48b5b3585535e3c9fda6d889b36c422a55c5d320b3819bf31ee07d086d07b17",
+    "contentHash": "d5698c5e8977763eb2f05afff2a1ccdac243775cc92a92df9ea1b8ab6ea65ac6",
     "isActive": true
   },
   {
-    "problemId": "act-act-coordinate-geometry-62e2af7c1f",
+    "problemId": "act-act-coordinate-geometry-e5cd812399",
     "skillId": "act-coordinate-geometry",
-    "prompt": "What is the midpoint of the segment joining the two points shown, (4, 1) and (1, 2)?",
-    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><line x1=\"20\" y1=\"75\" x2=\"180\" y2=\"75\" stroke=\"#bbb\" stroke-width=\"1\"/><line x1=\"100\" y1=\"15\" x2=\"100\" y2=\"140\" stroke=\"#bbb\" stroke-width=\"1\"/><circle cx=\"148\" cy=\"66\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"154\" y=\"60\" fill=\"#7c5cff\" stroke=\"none\">(4, 1)</text><circle cx=\"112\" cy=\"57\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"118\" y=\"51\" fill=\"#7c5cff\" stroke=\"none\">(1, 2)</text></svg>",
-    "answer": {
-      "type": "auto",
-      "value": "(2.5, 1.5)",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "(5, 3)"
-      },
-      {
-        "label": "B",
-        "text": "(1.5, 2.5)"
-      },
-      {
-        "label": "C",
-        "text": "(2.5, 1.5)"
-      },
-      {
-        "label": "D",
-        "text": "(3.5, 1.5)"
-      },
-      {
-        "label": "E",
-        "text": "(-3, 1)"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 5,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-coordinate-geometry"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "62e2af7c1fc4bc682a87a2079447b9d86477348684b5128f59610622852b3f68",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-right-triangle-trig-7fff992dd7",
-    "skillId": "act-right-triangle-trig",
-    "prompt": "In the right triangle shown, the legs have length 5 and 12. What is the length of the hypotenuse?",
-    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\">\n      <polygon points=\"30,120 170,120 30,30\" stroke-linejoin=\"round\"/>\n      <rect x=\"30\" y=\"108\" width=\"12\" height=\"12\" stroke-width=\"1.5\"/>\n      <text x=\"100\" y=\"138\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">5</text>\n      <text x=\"16\" y=\"78\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">12</text></svg>",
+    "prompt": "What is the distance between (-1, 5) and (4, 17)?",
     "answer": {
       "type": "auto",
       "value": "13",
@@ -3199,42 +3108,41 @@
     "options": [
       {
         "label": "A",
-        "text": "8"
+        "text": "13"
       },
       {
         "label": "B",
-        "text": "14"
+        "text": "8"
       },
       {
         "label": "C",
-        "text": "17"
+        "text": "60"
       },
       {
         "label": "D",
-        "text": "12"
+        "text": "17"
       },
       {
         "label": "E",
-        "text": "13"
+        "text": "14"
       }
     ],
-    "correctOption": "E",
-    "difficulty": 2,
+    "correctOption": "A",
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-right-triangle-trig"
+      "act-coordinate-geometry"
     ],
     "source": "act-template-gen",
-    "contentHash": "7fff992dd736f447a26ec3f3d141f84866f7eaa4ee4b9f64f83f498dabb64d4c",
+    "contentHash": "e5cd812399e0a253d82dbdb108e3d090d9378e2871935c482db2e4444f4f7227",
     "isActive": true
   },
   {
-    "problemId": "act-act-right-triangle-trig-d569434159",
-    "skillId": "act-right-triangle-trig",
-    "prompt": "In the right triangle shown, the legs have length 6 and 8. What is the length of the hypotenuse?",
-    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\">\n      <polygon points=\"30,120 170,120 30,30\" stroke-linejoin=\"round\"/>\n      <rect x=\"30\" y=\"108\" width=\"12\" height=\"12\" stroke-width=\"1.5\"/>\n      <text x=\"100\" y=\"138\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">6</text>\n      <text x=\"16\" y=\"78\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">8</text></svg>",
+    "problemId": "act-act-coordinate-geometry-66ab6c2f43",
+    "skillId": "act-coordinate-geometry",
+    "prompt": "What is the distance between (-3, -4) and (3, 4)?",
     "answer": {
       "type": "auto",
       "value": "10",
@@ -3260,19 +3168,19 @@
       },
       {
         "label": "E",
-        "text": "9"
+        "text": "48"
       }
     ],
     "correctOption": "C",
-    "difficulty": 2,
+    "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-right-triangle-trig"
+      "act-coordinate-geometry"
     ],
     "source": "act-template-gen",
-    "contentHash": "d56943415991ca0a0e0711a6de8bc811bc830a4d5f329be9023a9f0bf217e864",
+    "contentHash": "66ab6c2f43415a201017784d2fb8bee261bb6f803b0d70cd47da5c9818278ffc",
     "isActive": true
   },
   {
@@ -3293,11 +3201,11 @@
       },
       {
         "label": "B",
-        "text": "21"
+        "text": "14"
       },
       {
         "label": "C",
-        "text": "14"
+        "text": "21"
       },
       {
         "label": "D",
@@ -3309,7 +3217,7 @@
       }
     ],
     "correctOption": "D",
-    "difficulty": 3,
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -3321,40 +3229,40 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-right-triangle-trig-ca750442c2",
+    "problemId": "act-act-right-triangle-trig-7fff992dd7",
     "skillId": "act-right-triangle-trig",
-    "prompt": "In the right triangle shown, the legs have length 3 and 4. What is the length of the hypotenuse?",
-    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\">\n      <polygon points=\"30,120 170,120 30,30\" stroke-linejoin=\"round\"/>\n      <rect x=\"30\" y=\"108\" width=\"12\" height=\"12\" stroke-width=\"1.5\"/>\n      <text x=\"100\" y=\"138\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">3</text>\n      <text x=\"16\" y=\"78\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">4</text></svg>",
+    "prompt": "In the right triangle shown, the legs have length 5 and 12. What is the length of the hypotenuse?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\">\n      <polygon points=\"30,120 170,120 30,30\" stroke-linejoin=\"round\"/>\n      <rect x=\"30\" y=\"108\" width=\"12\" height=\"12\" stroke-width=\"1.5\"/>\n      <text x=\"100\" y=\"138\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">5</text>\n      <text x=\"16\" y=\"78\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">12</text></svg>",
     "answer": {
       "type": "auto",
-      "value": "5",
+      "value": "13",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "7"
+        "text": "17"
       },
       {
         "label": "B",
-        "text": "5"
+        "text": "8"
       },
       {
         "label": "C",
-        "text": "6"
+        "text": "13"
       },
       {
         "label": "D",
-        "text": "3"
+        "text": "12"
       },
       {
         "label": "E",
-        "text": "4"
+        "text": "14"
       }
     ],
-    "correctOption": "B",
-    "difficulty": 3,
+    "correctOption": "C",
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -3362,7 +3270,7 @@
       "act-right-triangle-trig"
     ],
     "source": "act-template-gen",
-    "contentHash": "ca750442c29abcc887ace36e4fdb84be1aeac1d0b233b6b48b6881971ca6646a",
+    "contentHash": "7fff992dd736f447a26ec3f3d141f84866f7eaa4ee4b9f64f83f498dabb64d4c",
     "isActive": true
   },
   {
@@ -3379,26 +3287,26 @@
     "options": [
       {
         "label": "A",
-        "text": "18"
-      },
-      {
-        "label": "B",
         "text": "17"
       },
       {
-        "label": "C",
+        "label": "B",
         "text": "23"
       },
       {
-        "label": "D",
+        "label": "C",
         "text": "11"
+      },
+      {
+        "label": "D",
+        "text": "18"
       },
       {
         "label": "E",
         "text": "16"
       }
     ],
-    "correctOption": "B",
+    "correctOption": "A",
     "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
@@ -3411,141 +3319,10 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-congruence-similarity-eb22153ae2",
-    "skillId": "act-congruence-similarity",
-    "prompt": "Two triangles are similar. A side of length 5 corresponds to a side of length 10. What length corresponds to a side of length 4?",
-    "answer": {
-      "type": "auto",
-      "value": "8",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "8"
-      },
-      {
-        "label": "B",
-        "text": "2"
-      },
-      {
-        "label": "C",
-        "text": "6"
-      },
-      {
-        "label": "D",
-        "text": "9"
-      },
-      {
-        "label": "E",
-        "text": "12"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-congruence-similarity"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "eb22153ae2d1523ac5338b77dabe8dca2eab7e1eaca6b55c66674a93b9ac716a",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-congruence-similarity-afe3b8b9da",
-    "skillId": "act-congruence-similarity",
-    "prompt": "Two triangles are similar. A side of length 7 corresponds to a side of length 21. What length corresponds to a side of length 8?",
-    "answer": {
-      "type": "auto",
-      "value": "24",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "32"
-      },
-      {
-        "label": "B",
-        "text": "22"
-      },
-      {
-        "label": "C",
-        "text": "11"
-      },
-      {
-        "label": "D",
-        "text": "24"
-      },
-      {
-        "label": "E",
-        "text": "3"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-congruence-similarity"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "afe3b8b9da171995d60919b1775f1697abf79b9b0682b9f39f0691c3a074074a",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-congruence-similarity-e405d98625",
-    "skillId": "act-congruence-similarity",
-    "prompt": "Two triangles are similar. A side of length 5 corresponds to a side of length 20. What length corresponds to a side of length 7?",
-    "answer": {
-      "type": "auto",
-      "value": "28",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "11"
-      },
-      {
-        "label": "B",
-        "text": "2"
-      },
-      {
-        "label": "C",
-        "text": "35"
-      },
-      {
-        "label": "D",
-        "text": "28"
-      },
-      {
-        "label": "E",
-        "text": "22"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-congruence-similarity"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "e405d986255c57c078363674d2ef3e004693cfcbdf7f42ba22ef6042c8af2541",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-congruence-similarity-ee4da28956",
-    "skillId": "act-congruence-similarity",
-    "prompt": "Two triangles are similar. A side of length 6 corresponds to a side of length 12. What length corresponds to a side of length 5?",
+    "problemId": "act-act-right-triangle-trig-d569434159",
+    "skillId": "act-right-triangle-trig",
+    "prompt": "In the right triangle shown, the legs have length 6 and 8. What is the length of the hypotenuse?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\">\n      <polygon points=\"30,120 170,120 30,30\" stroke-linejoin=\"round\"/>\n      <rect x=\"30\" y=\"108\" width=\"12\" height=\"12\" stroke-width=\"1.5\"/>\n      <text x=\"100\" y=\"138\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">6</text>\n      <text x=\"16\" y=\"78\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">8</text></svg>",
     "answer": {
       "type": "auto",
       "value": "10",
@@ -3559,125 +3336,82 @@
       },
       {
         "label": "B",
-        "text": "10"
-      },
-      {
-        "label": "C",
-        "text": "15"
-      },
-      {
-        "label": "D",
-        "text": "3"
-      },
-      {
-        "label": "E",
-        "text": "7"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-congruence-similarity"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "ee4da28956105bff54781dbd53db89c59dcbf822cd596191bcd3fce9ded6d8fa",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-congruence-similarity-3f836d1aaa",
-    "skillId": "act-congruence-similarity",
-    "prompt": "Two triangles are similar. A side of length 4 corresponds to a side of length 8. What length corresponds to a side of length 7?",
-    "answer": {
-      "type": "auto",
-      "value": "14",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "4"
-      },
-      {
-        "label": "B",
         "text": "14"
       },
       {
         "label": "C",
-        "text": "21"
+        "text": "10"
       },
       {
         "label": "D",
-        "text": "9"
+        "text": "7"
       },
       {
         "label": "E",
-        "text": "11"
+        "text": "9"
       }
     ],
-    "correctOption": "B",
+    "correctOption": "C",
     "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-congruence-similarity"
+      "act-right-triangle-trig"
     ],
     "source": "act-template-gen",
-    "contentHash": "3f836d1aaa3878122dbbd4e873af45567a87cec06734a8802e98206ca76f3e53",
+    "contentHash": "d56943415991ca0a0e0711a6de8bc811bc830a4d5f329be9023a9f0bf217e864",
     "isActive": true
   },
   {
-    "problemId": "act-act-congruence-similarity-ef2ba59e5f",
-    "skillId": "act-congruence-similarity",
-    "prompt": "Two triangles are similar. A side of length 8 corresponds to a side of length 24. What length corresponds to a side of length 7?",
+    "problemId": "act-act-right-triangle-trig-ca750442c2",
+    "skillId": "act-right-triangle-trig",
+    "prompt": "In the right triangle shown, the legs have length 3 and 4. What is the length of the hypotenuse?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\">\n      <polygon points=\"30,120 170,120 30,30\" stroke-linejoin=\"round\"/>\n      <rect x=\"30\" y=\"108\" width=\"12\" height=\"12\" stroke-width=\"1.5\"/>\n      <text x=\"100\" y=\"138\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">3</text>\n      <text x=\"16\" y=\"78\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">4</text></svg>",
     "answer": {
       "type": "auto",
-      "value": "21",
+      "value": "5",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "2"
+        "text": "3"
       },
       {
         "label": "B",
-        "text": "23"
+        "text": "6"
       },
       {
         "label": "C",
-        "text": "21"
+        "text": "7"
       },
       {
         "label": "D",
-        "text": "10"
+        "text": "4"
       },
       {
         "label": "E",
-        "text": "28"
+        "text": "5"
       }
     ],
-    "correctOption": "C",
-    "difficulty": 4,
+    "correctOption": "E",
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-congruence-similarity"
+      "act-right-triangle-trig"
     ],
     "source": "act-template-gen",
-    "contentHash": "ef2ba59e5fe2fcc78296d343b0f8cd1e67e6c3bf4e57ceb357f94ccba179f65a",
+    "contentHash": "ca750442c29abcc887ace36e4fdb84be1aeac1d0b233b6b48b6881971ca6646a",
     "isActive": true
   },
   {
-    "problemId": "act-act-congruence-similarity-ea8f32db72",
+    "problemId": "act-act-congruence-similarity-eaed7cf073",
     "skillId": "act-congruence-similarity",
-    "prompt": "Two triangles are similar. A side of length 4 corresponds to a side of length 16. What length corresponds to a side of length 8?",
+    "prompt": "Two triangles are similar. A side of length 3 corresponds to a side of length 12. What length corresponds to a side of length 8?",
     "answer": {
       "type": "auto",
       "value": "32",
@@ -3687,7 +3421,7 @@
     "options": [
       {
         "label": "A",
-        "text": "2"
+        "text": "12"
       },
       {
         "label": "B",
@@ -3695,19 +3429,19 @@
       },
       {
         "label": "C",
-        "text": "12"
+        "text": "32"
       },
       {
         "label": "D",
-        "text": "20"
+        "text": "2"
       },
       {
         "label": "E",
-        "text": "32"
+        "text": "17"
       }
     ],
-    "correctOption": "E",
-    "difficulty": 4,
+    "correctOption": "C",
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -3715,13 +3449,145 @@
       "act-congruence-similarity"
     ],
     "source": "act-template-gen",
-    "contentHash": "ea8f32db725f9a9827c56fe8c8430e03bc618b736a0bc3e2258f1f07c2020a0e",
+    "contentHash": "eaed7cf0736c76afb98528949b7cdff1721e724ac2586ff7c0d49c7ea94ae9b1",
     "isActive": true
   },
   {
-    "problemId": "act-act-congruence-similarity-e184128ba0",
+    "problemId": "act-act-congruence-similarity-45c8405f7f",
     "skillId": "act-congruence-similarity",
-    "prompt": "Two triangles are similar. A side of length 3 corresponds to a side of length 6. What length corresponds to a side of length 8?",
+    "prompt": "Two triangles are similar. A side of length 8 corresponds to a side of length 24. What length corresponds to a side of length 5?",
+    "answer": {
+      "type": "auto",
+      "value": "15",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "2"
+      },
+      {
+        "label": "B",
+        "text": "8"
+      },
+      {
+        "label": "C",
+        "text": "20"
+      },
+      {
+        "label": "D",
+        "text": "21"
+      },
+      {
+        "label": "E",
+        "text": "15"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-congruence-similarity"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "45c8405f7f41c81e7b424ffb93b59ddccd32821e1f5b0c6ba3f1918ddc45691d",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-congruence-similarity-de538b28d6",
+    "skillId": "act-congruence-similarity",
+    "prompt": "Two triangles are similar. A side of length 6 corresponds to a side of length 12. What length corresponds to a side of length 9?",
+    "answer": {
+      "type": "auto",
+      "value": "18",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "15"
+      },
+      {
+        "label": "B",
+        "text": "27"
+      },
+      {
+        "label": "C",
+        "text": "11"
+      },
+      {
+        "label": "D",
+        "text": "18"
+      },
+      {
+        "label": "E",
+        "text": "5"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-congruence-similarity"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "de538b28d6717485c8eff07cf4a358304cb77245b487af9b1e9904910d87ab38",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-congruence-similarity-cfcf2416c5",
+    "skillId": "act-congruence-similarity",
+    "prompt": "Two triangles are similar. A side of length 8 corresponds to a side of length 16. What length corresponds to a side of length 5?",
+    "answer": {
+      "type": "auto",
+      "value": "10",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "15"
+      },
+      {
+        "label": "B",
+        "text": "10"
+      },
+      {
+        "label": "C",
+        "text": "7"
+      },
+      {
+        "label": "D",
+        "text": "3"
+      },
+      {
+        "label": "E",
+        "text": "13"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-congruence-similarity"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "cfcf2416c5f57b90637dbd770e35a1dfbddc204b070c3d4a5558e19f5dba784d",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-congruence-similarity-c2f0f3864d",
+    "skillId": "act-congruence-similarity",
+    "prompt": "Two triangles are similar. A side of length 5 corresponds to a side of length 10. What length corresponds to a side of length 8?",
     "answer": {
       "type": "auto",
       "value": "16",
@@ -3731,23 +3597,155 @@
     "options": [
       {
         "label": "A",
-        "text": "11"
-      },
-      {
-        "label": "B",
-        "text": "24"
-      },
-      {
-        "label": "C",
-        "text": "10"
-      },
-      {
-        "label": "D",
         "text": "4"
       },
       {
-        "label": "E",
+        "label": "B",
         "text": "16"
+      },
+      {
+        "label": "C",
+        "text": "24"
+      },
+      {
+        "label": "D",
+        "text": "10"
+      },
+      {
+        "label": "E",
+        "text": "13"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-congruence-similarity"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "c2f0f3864d8da009bba52fe608cfc02dac69b939527c3d25ab2a2270888029a0",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-congruence-similarity-b285ef65b0",
+    "skillId": "act-congruence-similarity",
+    "prompt": "Two triangles are similar. A side of length 8 corresponds to a side of length 16. What length corresponds to a side of length 6?",
+    "answer": {
+      "type": "auto",
+      "value": "12",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "18"
+      },
+      {
+        "label": "B",
+        "text": "12"
+      },
+      {
+        "label": "C",
+        "text": "14"
+      },
+      {
+        "label": "D",
+        "text": "3"
+      },
+      {
+        "label": "E",
+        "text": "8"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-congruence-similarity"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "b285ef65b0536cefe772a67c31b0beb9ccf269b8385f3cc8a9c3a658124888a4",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-congruence-similarity-188cbe4d01",
+    "skillId": "act-congruence-similarity",
+    "prompt": "Two triangles are similar. A side of length 8 corresponds to a side of length 32. What length corresponds to a side of length 5?",
+    "answer": {
+      "type": "auto",
+      "value": "20",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "1"
+      },
+      {
+        "label": "B",
+        "text": "25"
+      },
+      {
+        "label": "C",
+        "text": "9"
+      },
+      {
+        "label": "D",
+        "text": "20"
+      },
+      {
+        "label": "E",
+        "text": "29"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-congruence-similarity"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "188cbe4d01eff90275a6cb09855f28874fae3b0ae14fb6d9822224efca956010",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-congruence-similarity-fb89d9f19a",
+    "skillId": "act-congruence-similarity",
+    "prompt": "Two triangles are similar. A side of length 7 corresponds to a side of length 14. What length corresponds to a side of length 6?",
+    "answer": {
+      "type": "auto",
+      "value": "12",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "13"
+      },
+      {
+        "label": "B",
+        "text": "18"
+      },
+      {
+        "label": "C",
+        "text": "3"
+      },
+      {
+        "label": "D",
+        "text": "8"
+      },
+      {
+        "label": "E",
+        "text": "12"
       }
     ],
     "correctOption": "E",
@@ -3759,39 +3757,39 @@
       "act-congruence-similarity"
     ],
     "source": "act-template-gen",
-    "contentHash": "e184128ba0ed077f11d6683862d8ed6e67cff94804ff27e732ca2da09e9e532a",
+    "contentHash": "fb89d9f19a944685c82a2487b36dd631be99f56d93f515a264ba047779ca2e48",
     "isActive": true
   },
   {
-    "problemId": "act-act-linear-equations-62c6560209",
+    "problemId": "act-act-linear-equations-c823d35b2a",
     "skillId": "act-linear-equations",
-    "prompt": "If 2x + 7 = 4x - 5, then x = ?",
+    "prompt": "If 3x - 6 = -2x - 21, then x = ?",
     "answer": {
       "type": "auto",
-      "value": "6",
+      "value": "-3",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "-6"
+        "text": "-4"
       },
       {
         "label": "B",
-        "text": "-12"
+        "text": "-2"
       },
       {
         "label": "C",
-        "text": "5"
+        "text": "-15"
       },
       {
         "label": "D",
-        "text": "7"
+        "text": "3"
       },
       {
         "label": "E",
-        "text": "6"
+        "text": "-3"
       }
     ],
     "correctOption": "E",
@@ -3803,42 +3801,42 @@
       "act-linear-equations"
     ],
     "source": "act-template-gen",
-    "contentHash": "62c65602094c526346e666d2b8de9b2cd8226ae94c24233ed4545b17b7d6bbee",
+    "contentHash": "c823d35b2a65f958e7d35f465927dfd53e694364b4447e514ec627ba95926ab0",
     "isActive": true
   },
   {
-    "problemId": "act-act-linear-equations-d99c7a9c5f",
+    "problemId": "act-act-linear-equations-1845bb3f94",
     "skillId": "act-linear-equations",
-    "prompt": "If 4x + 5 = 2x + 19, then x = ?",
+    "prompt": "If 2x + 7 = -x + 31, then x = ?",
     "answer": {
       "type": "auto",
-      "value": "7",
+      "value": "8",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "-7"
+        "text": "7"
       },
       {
         "label": "B",
-        "text": "14"
+        "text": "-8"
       },
       {
         "label": "C",
-        "text": "6"
+        "text": "24"
       },
       {
         "label": "D",
-        "text": "7"
+        "text": "9"
       },
       {
         "label": "E",
         "text": "8"
       }
     ],
-    "correctOption": "D",
+    "correctOption": "E",
     "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
@@ -3847,16 +3845,60 @@
       "act-linear-equations"
     ],
     "source": "act-template-gen",
-    "contentHash": "d99c7a9c5f264455fc5f104fc1140ec6dfdd745e6989786a4081225ff52031ba",
+    "contentHash": "1845bb3f942ffd3364efbeebd5125b1e59e03a68e198afa5dea2213e9083abc9",
     "isActive": true
   },
   {
-    "problemId": "act-act-linear-equations-146b303f2a",
+    "problemId": "act-act-linear-equations-03a18e6d12",
     "skillId": "act-linear-equations",
-    "prompt": "If 6x + 5 = -2x + 53, then x = ?",
+    "prompt": "If 2x - 7 = -4x + 11, then x = ?",
     "answer": {
       "type": "auto",
-      "value": "6",
+      "value": "3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-3"
+      },
+      {
+        "label": "B",
+        "text": "2"
+      },
+      {
+        "label": "C",
+        "text": "18"
+      },
+      {
+        "label": "D",
+        "text": "3"
+      },
+      {
+        "label": "E",
+        "text": "4"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "03a18e6d12522ec42d0610d3eac80e8f8178507584223dcaf0fcd0e0354dc0e7",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-equations-042bb75324",
+    "skillId": "act-linear-equations",
+    "prompt": "If 5x + 8 = -x + 56, then x = ?",
+    "answer": {
+      "type": "auto",
+      "value": "8",
       "equivalents": []
     },
     "answerType": "multiple-choice",
@@ -3867,63 +3909,19 @@
       },
       {
         "label": "B",
-        "text": "5"
-      },
-      {
-        "label": "C",
         "text": "7"
       },
       {
-        "label": "D",
-        "text": "6"
-      },
-      {
-        "label": "E",
-        "text": "-6"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-linear-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "146b303f2a82c8eb256a7c328ca73a401023863890ff78aa8dfc5e5d412a8f44",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-linear-equations-c7a8fff9f5",
-    "skillId": "act-linear-equations",
-    "prompt": "If 5x - 1 = -x - 19, then x = ?",
-    "answer": {
-      "type": "auto",
-      "value": "-3",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "-2"
-      },
-      {
-        "label": "B",
-        "text": "3"
-      },
-      {
         "label": "C",
-        "text": "-3"
+        "text": "8"
       },
       {
         "label": "D",
-        "text": "-18"
+        "text": "9"
       },
       {
         "label": "E",
-        "text": "-4"
+        "text": "-8"
       }
     ],
     "correctOption": "C",
@@ -3935,13 +3933,145 @@
       "act-linear-equations"
     ],
     "source": "act-template-gen",
-    "contentHash": "c7a8fff9f556e144843eea3db3959a47947e8b449cd2fbee20529184ed71df25",
+    "contentHash": "042bb753247418d0fbc123f6e1f364c5c544f5fb0f2aee7411cef9724a8f660c",
     "isActive": true
   },
   {
-    "problemId": "act-act-linear-equations-b54fdacecb",
+    "problemId": "act-act-linear-equations-dc9ee19c85",
     "skillId": "act-linear-equations",
-    "prompt": "If 6x - 8 = 3x - 26, then x = ?",
+    "prompt": "If 5x - 4 = x - 24, then x = ?",
+    "answer": {
+      "type": "auto",
+      "value": "-5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-6"
+      },
+      {
+        "label": "B",
+        "text": "-5"
+      },
+      {
+        "label": "C",
+        "text": "-4"
+      },
+      {
+        "label": "D",
+        "text": "-20"
+      },
+      {
+        "label": "E",
+        "text": "5"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "dc9ee19c8586117b2fbadce4eee352438544f2fe08c1ef0a94407621b738467b",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-equations-cb6b4510fa",
+    "skillId": "act-linear-equations",
+    "prompt": "If 5x + 0 = -x + 18, then x = ?",
+    "answer": {
+      "type": "auto",
+      "value": "3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "18"
+      },
+      {
+        "label": "B",
+        "text": "3"
+      },
+      {
+        "label": "C",
+        "text": "2"
+      },
+      {
+        "label": "D",
+        "text": "4"
+      },
+      {
+        "label": "E",
+        "text": "-3"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "cb6b4510fad3d65df5ccb81b79e26824529ae6387acda92350322866b6b40ba7",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-equations-6d850644fb",
+    "skillId": "act-linear-equations",
+    "prompt": "If 9x - 7 = 3x - 31, then x = ?",
+    "answer": {
+      "type": "auto",
+      "value": "-4",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "4"
+      },
+      {
+        "label": "B",
+        "text": "-4"
+      },
+      {
+        "label": "C",
+        "text": "-24"
+      },
+      {
+        "label": "D",
+        "text": "-3"
+      },
+      {
+        "label": "E",
+        "text": "-5"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "6d850644fb60d64a7ac5e9c91a0fb3f524fe2a82d38f4da5b477aae5083e930b",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-equations-5d853f9cf3",
+    "skillId": "act-linear-equations",
+    "prompt": "If 4x + 3 = 2x - 9, then x = ?",
     "answer": {
       "type": "auto",
       "value": "-6",
@@ -3951,15 +4081,15 @@
     "options": [
       {
         "label": "A",
-        "text": "-18"
+        "text": "-12"
       },
       {
         "label": "B",
-        "text": "-5"
+        "text": "-6"
       },
       {
         "label": "C",
-        "text": "-6"
+        "text": "-5"
       },
       {
         "label": "D",
@@ -3970,8 +4100,8 @@
         "text": "-7"
       }
     ],
-    "correctOption": "C",
-    "difficulty": 3,
+    "correctOption": "B",
+    "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -3979,104 +4109,16 @@
       "act-linear-equations"
     ],
     "source": "act-template-gen",
-    "contentHash": "b54fdacecba66d585d235e46f52972243d23246dbf1e62a7bc6f219f09ca26ce",
+    "contentHash": "5d853f9cf32c3d5995f82b1f6b53598bbff8d160db7bc4a4bbbb4e7ff34138c0",
     "isActive": true
   },
   {
-    "problemId": "act-act-linear-equations-ac8890f994",
-    "skillId": "act-linear-equations",
-    "prompt": "If 2x - 4 = -3x - 14, then x = ?",
+    "problemId": "act-act-systems-of-equations-e6b8c817a7",
+    "skillId": "act-systems-of-equations",
+    "prompt": "If 3x + 4y = 24 and 4x + 4y = 28, what is x + y?",
     "answer": {
       "type": "auto",
-      "value": "-2",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "-10"
-      },
-      {
-        "label": "B",
-        "text": "-1"
-      },
-      {
-        "label": "C",
-        "text": "-3"
-      },
-      {
-        "label": "D",
-        "text": "-2"
-      },
-      {
-        "label": "E",
-        "text": "2"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-linear-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "ac8890f994f693b0228f8b544febef772b4a831651a21b55a9fc6b0a013b2504",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-linear-equations-78c5c134a4",
-    "skillId": "act-linear-equations",
-    "prompt": "If 4x - 1 = -3x - 29, then x = ?",
-    "answer": {
-      "type": "auto",
-      "value": "-4",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "-3"
-      },
-      {
-        "label": "B",
-        "text": "-5"
-      },
-      {
-        "label": "C",
-        "text": "4"
-      },
-      {
-        "label": "D",
-        "text": "-4"
-      },
-      {
-        "label": "E",
-        "text": "-28"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-linear-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "78c5c134a4453e9b12d0cfe22711e036e0c7f6f202b8e95e9e6bad824d08d781",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-linear-equations-ac42e969ea",
-    "skillId": "act-linear-equations",
-    "prompt": "If 7x - 8 = -4x + 58, then x = ?",
-    "answer": {
-      "type": "auto",
-      "value": "6",
+      "value": "7",
       "equivalents": []
     },
     "answerType": "multiple-choice",
@@ -4087,63 +4129,63 @@
       },
       {
         "label": "B",
-        "text": "5"
+        "text": "1"
       },
       {
         "label": "C",
-        "text": "66"
+        "text": "4"
       },
       {
         "label": "D",
-        "text": "-6"
+        "text": "12"
       },
       {
         "label": "E",
-        "text": "6"
+        "text": "3"
       }
     ],
-    "correctOption": "E",
-    "difficulty": 5,
+    "correctOption": "A",
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-linear-equations"
+      "act-systems-of-equations"
     ],
     "source": "act-template-gen",
-    "contentHash": "ac42e969ea99a9c893de4f4df7ce84a6e7ae68a270c35e668c4517faa33dd89e",
+    "contentHash": "e6b8c817a75c86b739fe3f38661dca0297c4e1e2e604354f9578d09399517538",
     "isActive": true
   },
   {
-    "problemId": "act-act-systems-of-equations-7b6d4409fa",
+    "problemId": "act-act-systems-of-equations-0d74e6b752",
     "skillId": "act-systems-of-equations",
-    "prompt": "If 3x + 3y = 15 and 2x + 4y = 22, what is x + y?",
+    "prompt": "If 3x + y = 12 and 2x + 2y = 16, what is x + y?",
     "answer": {
       "type": "auto",
-      "value": "5",
+      "value": "8",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "-6"
+        "text": "2"
       },
       {
         "label": "B",
-        "text": "6"
+        "text": "12"
       },
       {
         "label": "C",
-        "text": "5"
+        "text": "8"
       },
       {
         "label": "D",
-        "text": "-1"
+        "text": "6"
       },
       {
         "label": "E",
-        "text": "-7"
+        "text": "-4"
       }
     ],
     "correctOption": "C",
@@ -4155,57 +4197,13 @@
       "act-systems-of-equations"
     ],
     "source": "act-template-gen",
-    "contentHash": "7b6d4409fa5c5f457d79870c95ec07e1c965c7ce7029c6f224b970a2057e1d06",
+    "contentHash": "0d74e6b752980a118b71163ea05577ef9be18b0354d923a6e8a9fce139fc55be",
     "isActive": true
   },
   {
-    "problemId": "act-act-systems-of-equations-9778b40d6a",
+    "problemId": "act-act-systems-of-equations-d53240f373",
     "skillId": "act-systems-of-equations",
-    "prompt": "If 2x + y = 7 and 4x + 3y = 17, what is x + y?",
-    "answer": {
-      "type": "auto",
-      "value": "5",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "3"
-      },
-      {
-        "label": "B",
-        "text": "2"
-      },
-      {
-        "label": "C",
-        "text": "-1"
-      },
-      {
-        "label": "D",
-        "text": "5"
-      },
-      {
-        "label": "E",
-        "text": "6"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-systems-of-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "9778b40d6ab2e7ec36d4f011e7c28161cf1a475fd1c2649676c8b31f39dc68c7",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-systems-of-equations-a8fee6626f",
-    "skillId": "act-systems-of-equations",
-    "prompt": "If x + 2y = -2 and 2x + 3y = -1, what is x + y?",
+    "prompt": "If 2x + 4y = -4 and 4x + 4y = 4, what is x + y?",
     "answer": {
       "type": "auto",
       "value": "1",
@@ -4215,11 +4213,11 @@
     "options": [
       {
         "label": "A",
-        "text": "1"
+        "text": "-12"
       },
       {
         "label": "B",
-        "text": "4"
+        "text": "1"
       },
       {
         "label": "C",
@@ -4227,7 +4225,95 @@
       },
       {
         "label": "D",
-        "text": "-12"
+        "text": "4"
+      },
+      {
+        "label": "E",
+        "text": "-3"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-systems-of-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "d53240f3738751d81a06f241f0a796d5827aff8d752c402cf03101683e1ce6bc",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-systems-of-equations-199c5075f9",
+    "skillId": "act-systems-of-equations",
+    "prompt": "If 4x + y = 11 and 3x + 2y = 2, what is x + y?",
+    "answer": {
+      "type": "auto",
+      "value": "-1",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "9"
+      },
+      {
+        "label": "B",
+        "text": "-1"
+      },
+      {
+        "label": "C",
+        "text": "4"
+      },
+      {
+        "label": "D",
+        "text": "-5"
+      },
+      {
+        "label": "E",
+        "text": "-20"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-systems-of-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "199c5075f93d34e139c53c7fa5837dcabd56248cd4ef62ca1e2fe3bce6e9019c",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-systems-of-equations-6f2837dbd6",
+    "skillId": "act-systems-of-equations",
+    "prompt": "If 3x + 2y = 12 and 2x + 3y = 3, what is x + y?",
+    "answer": {
+      "type": "auto",
+      "value": "3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "3"
+      },
+      {
+        "label": "B",
+        "text": "-18"
+      },
+      {
+        "label": "C",
+        "text": "6"
+      },
+      {
+        "label": "D",
+        "text": "9"
       },
       {
         "label": "E",
@@ -4243,16 +4329,60 @@
       "act-systems-of-equations"
     ],
     "source": "act-template-gen",
-    "contentHash": "a8fee6626f124c20f0618758f74d9706b5c0fcf7c1866c23ca9c7deb36adb16c",
+    "contentHash": "6f2837dbd62560064818f1b00191db3d4506f2be8b6c34c3cb582ba6922fba44",
     "isActive": true
   },
   {
-    "problemId": "act-act-systems-of-equations-b6a414f47a",
+    "problemId": "act-act-systems-of-equations-ccd9aa5f45",
     "skillId": "act-systems-of-equations",
-    "prompt": "If 4x + 4y = 40 and 4x + 3y = 36, what is x + y?",
+    "prompt": "If 3x + 3y = 24 and 3x + y = 14, what is x + y?",
     "answer": {
       "type": "auto",
-      "value": "10",
+      "value": "8",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-2"
+      },
+      {
+        "label": "B",
+        "text": "3"
+      },
+      {
+        "label": "C",
+        "text": "15"
+      },
+      {
+        "label": "D",
+        "text": "5"
+      },
+      {
+        "label": "E",
+        "text": "8"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-systems-of-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "ccd9aa5f45da3f2f914fc6062c0148baa63e1f7cf6f0caca5780f4fe744b2886",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-systems-of-equations-252b489112",
+    "skillId": "act-systems-of-equations",
+    "prompt": "If 3x + 2y = 2 and 4x + 3y = 4, what is x + y?",
+    "answer": {
+      "type": "auto",
+      "value": "2",
       "equivalents": []
     },
     "answerType": "multiple-choice",
@@ -4263,198 +4393,66 @@
       },
       {
         "label": "B",
-        "text": "4"
+        "text": "-6"
       },
       {
         "label": "C",
-        "text": "10"
-      },
-      {
-        "label": "D",
-        "text": "6"
-      },
-      {
-        "label": "E",
-        "text": "24"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-systems-of-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "b6a414f47abba09ae20ca16ff9fc30628fd012850fe061f9cb1485858d396d94",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-systems-of-equations-a69a54d9bc",
-    "skillId": "act-systems-of-equations",
-    "prompt": "If 4x + 4y = -16 and 4x + 3y = -15, what is x + y?",
-    "answer": {
-      "type": "auto",
-      "value": "-4",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "3"
-      },
-      {
-        "label": "B",
         "text": "-2"
       },
       {
-        "label": "C",
-        "text": "-4"
-      },
-      {
         "label": "D",
-        "text": "-3"
-      },
-      {
-        "label": "E",
-        "text": "-1"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-systems-of-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "a69a54d9bcb8e1e740ca33c5d8cf625cc8d9d9818528dbcd3243cd19ee1b7cff",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-systems-of-equations-1ecbd212a7",
-    "skillId": "act-systems-of-equations",
-    "prompt": "If x + 3y = 10 and 2x + 4y = 10, what is x + y?",
-    "answer": {
-      "type": "auto",
-      "value": "0",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "0"
-      },
-      {
-        "label": "B",
-        "text": "5"
-      },
-      {
-        "label": "C",
-        "text": "-10"
-      },
-      {
-        "label": "D",
-        "text": "-5"
-      },
-      {
-        "label": "E",
-        "text": "-25"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-systems-of-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "1ecbd212a7b1f500efeaf682afc2a36811fef56ca10122cb9a1d94ed2e208ce1",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-systems-of-equations-310c7d92e2",
-    "skillId": "act-systems-of-equations",
-    "prompt": "If 4x + y = -13 and 2x + 3y = 1, what is x + y?",
-    "answer": {
-      "type": "auto",
-      "value": "-1",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "-4"
-      },
-      {
-        "label": "B",
-        "text": "-7"
-      },
-      {
-        "label": "C",
-        "text": "-1"
-      },
-      {
-        "label": "D",
-        "text": "-12"
-      },
-      {
-        "label": "E",
-        "text": "3"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-systems-of-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "310c7d92e2259f401cfc751f5c20caf26d8a307c3d09f4d592cb4bddab73d0d5",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-systems-of-equations-d461c79d92",
-    "skillId": "act-systems-of-equations",
-    "prompt": "If x + 3y = -8 and 2x + 2y = 0, what is x + y?",
-    "answer": {
-      "type": "auto",
-      "value": "0",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "0"
-      },
-      {
-        "label": "B",
         "text": "4"
       },
       {
-        "label": "C",
-        "text": "8"
-      },
-      {
-        "label": "D",
-        "text": "-4"
-      },
-      {
         "label": "E",
-        "text": "-16"
+        "text": "-8"
       }
     ],
     "correctOption": "A",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-systems-of-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "252b489112ef1c69cace0a276bf5cd8c9038afd356e5c4158b27c069c1cdea36",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-systems-of-equations-a3da93c892",
+    "skillId": "act-systems-of-equations",
+    "prompt": "If 4x + 4y = 12 and x + 3y = -1, what is x + y?",
+    "answer": {
+      "type": "auto",
+      "value": "3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "7"
+      },
+      {
+        "label": "B",
+        "text": "-10"
+      },
+      {
+        "label": "C",
+        "text": "3"
+      },
+      {
+        "label": "D",
+        "text": "-2"
+      },
+      {
+        "label": "E",
+        "text": "5"
+      }
+    ],
+    "correctOption": "C",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -4463,139 +4461,7 @@
       "act-systems-of-equations"
     ],
     "source": "act-template-gen",
-    "contentHash": "d461c79d92a9a12c2387615db4190cd457718d4bcd167ff41e176781cbf1e52f",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-quadratic-equations-18326da622",
-    "skillId": "act-quadratic-equations",
-    "prompt": "Which of the following is a solution to x² - 1x - 12 = 0?",
-    "answer": {
-      "type": "auto",
-      "value": "4",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "4"
-      },
-      {
-        "label": "B",
-        "text": "1"
-      },
-      {
-        "label": "C",
-        "text": "-4"
-      },
-      {
-        "label": "D",
-        "text": "3"
-      },
-      {
-        "label": "E",
-        "text": "-12"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-quadratic-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "18326da62282c7f782d56d372ca3ab3531ea3de47cd6be1ee01fea01128adde1",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-quadratic-equations-aec16618dd",
-    "skillId": "act-quadratic-equations",
-    "prompt": "Which of the following is a solution to x² - 9x + 20 = 0?",
-    "answer": {
-      "type": "auto",
-      "value": "5",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "-5"
-      },
-      {
-        "label": "B",
-        "text": "5"
-      },
-      {
-        "label": "C",
-        "text": "-4"
-      },
-      {
-        "label": "D",
-        "text": "20"
-      },
-      {
-        "label": "E",
-        "text": "9"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-quadratic-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "aec16618dd9cc77c91fdb52de98d5fd1c38b8a8d74d632f75fc91e0ade3883df",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-quadratic-equations-ff5716b0b2",
-    "skillId": "act-quadratic-equations",
-    "prompt": "Which of the following is a solution to x² - 10x + 24 = 0?",
-    "answer": {
-      "type": "auto",
-      "value": "6",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "6"
-      },
-      {
-        "label": "B",
-        "text": "24"
-      },
-      {
-        "label": "C",
-        "text": "10"
-      },
-      {
-        "label": "D",
-        "text": "-6"
-      },
-      {
-        "label": "E",
-        "text": "-4"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-quadratic-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "ff5716b0b23c091f2c8b30cccdb2eb535d222f7dc3cb456d4d447ff9d92c202f",
+    "contentHash": "a3da93c8928ea100de08560ff39ab56f0b8acf2097101c0f0a10e971ac0207a9",
     "isActive": true
   },
   {
@@ -4631,7 +4497,7 @@
       }
     ],
     "correctOption": "E",
-    "difficulty": 3,
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -4675,7 +4541,7 @@
       }
     ],
     "correctOption": "D",
-    "difficulty": 3,
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -4719,7 +4585,7 @@
       }
     ],
     "correctOption": "A",
-    "difficulty": 4,
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -4763,7 +4629,7 @@
       }
     ],
     "correctOption": "A",
-    "difficulty": 4,
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -4807,7 +4673,7 @@
       }
     ],
     "correctOption": "D",
-    "difficulty": 5,
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -4819,135 +4685,135 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-polynomial-expressions-ab63901d91",
-    "skillId": "act-polynomial-expressions",
-    "prompt": "Expand: (x + 5)(x + 6)",
+    "problemId": "act-act-quadratic-equations-cc12b30c0c",
+    "skillId": "act-quadratic-equations",
+    "prompt": "Which of the following is a solution to x² - 11x + 30 = 0?",
     "answer": {
       "type": "auto",
-      "value": "x^2 + 11x + 30",
+      "value": "6",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "x^2 + 11"
+        "text": "11"
       },
       {
         "label": "B",
-        "text": "x^2 + 11x + 30"
+        "text": "6"
       },
       {
         "label": "C",
-        "text": "x^2 + 31"
+        "text": "30"
       },
       {
         "label": "D",
-        "text": "x^2 + 11x - 30"
+        "text": "-6"
       },
       {
         "label": "E",
-        "text": "x^2 + 30x + 11"
+        "text": "-5"
       }
     ],
     "correctOption": "B",
-    "difficulty": 2,
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-polynomial-expressions"
+      "act-quadratic-equations"
     ],
     "source": "act-template-gen",
-    "contentHash": "ab63901d916d84c9bac8e9b8d72acb84fd15ea90f26260493d311592680d470e",
+    "contentHash": "cc12b30c0cff1d2d7afdb77e48f20d9667aec5f1e4fdcadf34f1612bcfa9d820",
     "isActive": true
   },
   {
-    "problemId": "act-act-polynomial-expressions-0d1fb0c578",
-    "skillId": "act-polynomial-expressions",
-    "prompt": "Expand: (x + 6)(x + 3)",
+    "problemId": "act-act-quadratic-equations-e51a649025",
+    "skillId": "act-quadratic-equations",
+    "prompt": "Which of the following is a solution to x² - 9x + 18 = 0?",
     "answer": {
       "type": "auto",
-      "value": "x^2 + 9x + 18",
+      "value": "6",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "x^2 + 18x + 9"
+        "text": "-6"
       },
       {
         "label": "B",
-        "text": "x^2 + 9x + 18"
+        "text": "6"
       },
       {
         "label": "C",
-        "text": "x^2 + 9"
+        "text": "9"
       },
       {
         "label": "D",
-        "text": "x^2 + 9x - 18"
+        "text": "-3"
       },
       {
         "label": "E",
-        "text": "x^2 + 19"
+        "text": "18"
       }
     ],
     "correctOption": "B",
-    "difficulty": 2,
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-polynomial-expressions"
+      "act-quadratic-equations"
     ],
     "source": "act-template-gen",
-    "contentHash": "0d1fb0c57882c08918b7e377daaa538f9d23c7261b919061193864b7d604555f",
+    "contentHash": "e51a64902548a3d96b83c40198a01d446557ede264c4146bba72ece920a6bda9",
     "isActive": true
   },
   {
-    "problemId": "act-act-polynomial-expressions-c4a479504c",
-    "skillId": "act-polynomial-expressions",
-    "prompt": "Expand: (x - 6)(x - 5)",
+    "problemId": "act-act-quadratic-equations-0dbb9fc166",
+    "skillId": "act-quadratic-equations",
+    "prompt": "Which of the following is a solution to x² + 11x + 30 = 0?",
     "answer": {
       "type": "auto",
-      "value": "x^2 - 11x + 30",
+      "value": "-5",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "x^2 + 31"
+        "text": "30"
       },
       {
         "label": "B",
-        "text": "x^2 - 11"
+        "text": "-11"
       },
       {
         "label": "C",
-        "text": "x^2 + 30x - 11"
+        "text": "6"
       },
       {
         "label": "D",
-        "text": "x^2 - 11x + 30"
+        "text": "-5"
       },
       {
         "label": "E",
-        "text": "x^2 - 11x - 30"
+        "text": "5"
       }
     ],
     "correctOption": "D",
-    "difficulty": 3,
+    "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-polynomial-expressions"
+      "act-quadratic-equations"
     ],
     "source": "act-template-gen",
-    "contentHash": "c4a479504c7bd03ec58ec6d0577e3e88afd1ff5fc8bc2f0033ffb53719af6a84",
+    "contentHash": "0dbb9fc166c52a2a26360c55d7a56b766f8f3571046ea6aba07164e99bcaf9ea",
     "isActive": true
   },
   {
@@ -4983,7 +4849,7 @@
       }
     ],
     "correctOption": "D",
-    "difficulty": 3,
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -5027,7 +4893,7 @@
       }
     ],
     "correctOption": "E",
-    "difficulty": 3,
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -5071,7 +4937,7 @@
       }
     ],
     "correctOption": "D",
-    "difficulty": 4,
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -5115,7 +4981,7 @@
       }
     ],
     "correctOption": "C",
-    "difficulty": 4,
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -5159,7 +5025,7 @@
       }
     ],
     "correctOption": "A",
-    "difficulty": 5,
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -5171,135 +5037,135 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-radical-rational-expressions-27fe7500f7",
-    "skillId": "act-radical-rational-expressions",
-    "prompt": "Simplify: √80",
+    "problemId": "act-act-polynomial-expressions-f04538c081",
+    "skillId": "act-polynomial-expressions",
+    "prompt": "Expand: (x - 1)(x + 3)",
     "answer": {
       "type": "auto",
-      "value": "4√5",
+      "value": "x^2 + 2x - 3",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "4√5"
+        "text": "x^2 + 2x - 3"
       },
       {
         "label": "B",
-        "text": "20√1"
+        "text": "x^2 - 3x + 2"
       },
       {
         "label": "C",
-        "text": "80"
+        "text": "x^2 + 2"
       },
       {
         "label": "D",
-        "text": "9√5"
+        "text": "x^2 - 2"
       },
       {
         "label": "E",
-        "text": "4√10"
+        "text": "x^2 + 2x + 3"
       }
     ],
     "correctOption": "A",
-    "difficulty": 2,
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-radical-rational-expressions"
+      "act-polynomial-expressions"
     ],
     "source": "act-template-gen",
-    "contentHash": "27fe7500f77d31e7d5249f4e4cbf166fbcc1fd016bcfce346ef8c39906a52871",
+    "contentHash": "f04538c0816e28aa6876349f6d8e1a5bbfff31038564c2fd423bbaa037acd4ef",
     "isActive": true
   },
   {
-    "problemId": "act-act-radical-rational-expressions-63cc21f580",
-    "skillId": "act-radical-rational-expressions",
-    "prompt": "Simplify: √75",
+    "problemId": "act-act-polynomial-expressions-3cc5275086",
+    "skillId": "act-polynomial-expressions",
+    "prompt": "Expand: (x - 3)(x + 6)",
     "answer": {
       "type": "auto",
-      "value": "5√3",
+      "value": "x^2 + 3x - 18",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "75"
+        "text": "x^2 + 3"
       },
       {
         "label": "B",
-        "text": "5√3"
+        "text": "x^2 + 3x - 18"
       },
       {
         "label": "C",
-        "text": "5√6"
+        "text": "x^2 + 3x + 18"
       },
       {
         "label": "D",
-        "text": "8√3"
+        "text": "x^2 - 17"
       },
       {
         "label": "E",
-        "text": "15√1"
+        "text": "x^2 - 18x + 3"
       }
     ],
     "correctOption": "B",
-    "difficulty": 2,
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-radical-rational-expressions"
+      "act-polynomial-expressions"
     ],
     "source": "act-template-gen",
-    "contentHash": "63cc21f5805c334e62df23ae862b0d1b95233de588e3b6713c09b0c6f23257a9",
+    "contentHash": "3cc527508616f6df9ccc75efc87fc30e91e68d05bd6a07bbeec6101808c1ee42",
     "isActive": true
   },
   {
-    "problemId": "act-act-radical-rational-expressions-281e03dcfa",
-    "skillId": "act-radical-rational-expressions",
-    "prompt": "Simplify: √18",
+    "problemId": "act-act-polynomial-expressions-91481e1c01",
+    "skillId": "act-polynomial-expressions",
+    "prompt": "Expand: (x - 4)(x - 2)",
     "answer": {
       "type": "auto",
-      "value": "3√2",
+      "value": "x^2 - 6x + 8",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "3√2"
+        "text": "x^2 - 6x + 8"
       },
       {
         "label": "B",
-        "text": "5√2"
+        "text": "x^2 + 9"
       },
       {
         "label": "C",
-        "text": "3√4"
+        "text": "x^2 - 6x - 8"
       },
       {
         "label": "D",
-        "text": "6√1"
+        "text": "x^2 + 8x - 6"
       },
       {
         "label": "E",
-        "text": "18"
+        "text": "x^2 - 6"
       }
     ],
     "correctOption": "A",
-    "difficulty": 3,
+    "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-radical-rational-expressions"
+      "act-polynomial-expressions"
     ],
     "source": "act-template-gen",
-    "contentHash": "281e03dcfa2fb4a02dd89ad955b4bdf726c6e292396548637609c3f1e2de62ac",
+    "contentHash": "91481e1c012eb4966b2ccf210b25316c73a74610410feb17d7ecc41c9866d352",
     "isActive": true
   },
   {
@@ -5335,7 +5201,7 @@
       }
     ],
     "correctOption": "A",
-    "difficulty": 3,
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -5379,7 +5245,7 @@
       }
     ],
     "correctOption": "E",
-    "difficulty": 3,
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -5423,7 +5289,7 @@
       }
     ],
     "correctOption": "C",
-    "difficulty": 4,
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -5467,7 +5333,7 @@
       }
     ],
     "correctOption": "B",
-    "difficulty": 4,
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -5479,35 +5345,167 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-radical-rational-expressions-0e59fca760",
+    "problemId": "act-act-radical-rational-expressions-3b5367f4ab",
     "skillId": "act-radical-rational-expressions",
-    "prompt": "Simplify: √180",
+    "prompt": "Simplify: √48",
     "answer": {
       "type": "auto",
-      "value": "6√5",
+      "value": "4√3",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "6√10"
+        "text": "12√1"
       },
       {
         "label": "B",
-        "text": "30√1"
+        "text": "4√6"
       },
       {
         "label": "C",
-        "text": "6√5"
+        "text": "48"
       },
       {
         "label": "D",
-        "text": "180"
+        "text": "4√3"
       },
       {
         "label": "E",
-        "text": "11√5"
+        "text": "7√3"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-radical-rational-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "3b5367f4ab67f79bee8495d64431f977467658f2df076e0d668acf5b040a7245",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-radical-rational-expressions-8eb9d160c9",
+    "skillId": "act-radical-rational-expressions",
+    "prompt": "Simplify: √125",
+    "answer": {
+      "type": "auto",
+      "value": "5√5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "5√10"
+      },
+      {
+        "label": "B",
+        "text": "25√1"
+      },
+      {
+        "label": "C",
+        "text": "5√5"
+      },
+      {
+        "label": "D",
+        "text": "125"
+      },
+      {
+        "label": "E",
+        "text": "10√5"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-radical-rational-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "8eb9d160c9074c0a1091db0a435ea5d0ee0f2e4a3525957fc03ce1036abfe968",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-radical-rational-expressions-94c1f4b75c",
+    "skillId": "act-radical-rational-expressions",
+    "prompt": "Simplify: √96",
+    "answer": {
+      "type": "auto",
+      "value": "4√6",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "4√12"
+      },
+      {
+        "label": "B",
+        "text": "4√6"
+      },
+      {
+        "label": "C",
+        "text": "24√1"
+      },
+      {
+        "label": "D",
+        "text": "10√6"
+      },
+      {
+        "label": "E",
+        "text": "96"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-radical-rational-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "94c1f4b75ca657721c28e674a6802d12093698881a34bcbc6477db54ce9a7287",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-radical-rational-expressions-457916c62d",
+    "skillId": "act-radical-rational-expressions",
+    "prompt": "Simplify: √50",
+    "answer": {
+      "type": "auto",
+      "value": "5√2",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "10√1"
+      },
+      {
+        "label": "B",
+        "text": "7√2"
+      },
+      {
+        "label": "C",
+        "text": "5√2"
+      },
+      {
+        "label": "D",
+        "text": "5√4"
+      },
+      {
+        "label": "E",
+        "text": "50"
       }
     ],
     "correctOption": "C",
@@ -5519,7 +5517,7 @@
       "act-radical-rational-expressions"
     ],
     "source": "act-template-gen",
-    "contentHash": "0e59fca760f006b0dadbe0686280f353588cef4ead67511edfb0b8500fd6c388",
+    "contentHash": "457916c62d3b50d6aff1f4c19d59513997461c7b869a2ce7d80dc4647c132e62",
     "isActive": true
   },
   {
@@ -5535,7 +5533,7 @@
     "options": [
       {
         "label": "A",
-        "text": "-19"
+        "text": "-16"
       },
       {
         "label": "B",
@@ -5543,18 +5541,18 @@
       },
       {
         "label": "C",
-        "text": "-16"
-      },
-      {
-        "label": "D",
         "text": "-17"
       },
       {
-        "label": "E",
+        "label": "D",
         "text": "-7"
+      },
+      {
+        "label": "E",
+        "text": "-19"
       }
     ],
-    "correctOption": "A",
+    "correctOption": "E",
     "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
@@ -5564,94 +5562,6 @@
     ],
     "source": "act-template-gen",
     "contentHash": "2aa842d1f028f75f6837c17f9f9ca8912aeed4c24bc8c69d6bade5b72980145d",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-function-notation-evaluation-a12e23d77b",
-    "skillId": "act-function-notation-evaluation",
-    "prompt": "If f(x) = 4x² + 1, what is f(-4)?",
-    "answer": {
-      "type": "auto",
-      "value": "65",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "257"
-      },
-      {
-        "label": "B",
-        "text": "63"
-      },
-      {
-        "label": "C",
-        "text": "68"
-      },
-      {
-        "label": "D",
-        "text": "-15"
-      },
-      {
-        "label": "E",
-        "text": "65"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-function-notation-evaluation"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "a12e23d77b5c6b3c8a676ee30db8b896800d21547c6630ce37694acd75660b67",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-function-notation-evaluation-3793a97ccc",
-    "skillId": "act-function-notation-evaluation",
-    "prompt": "If f(x) = -4x² - 3, what is f(3)?",
-    "answer": {
-      "type": "auto",
-      "value": "-39",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "-15"
-      },
-      {
-        "label": "B",
-        "text": "-24"
-      },
-      {
-        "label": "C",
-        "text": "141"
-      },
-      {
-        "label": "D",
-        "text": "-33"
-      },
-      {
-        "label": "E",
-        "text": "-39"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-function-notation-evaluation"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "3793a97cccd085b6f8e417dda5fc299695a40cd6880e8e8c676b6c83f96a138f",
     "isActive": true
   },
   {
@@ -5687,7 +5597,7 @@
       }
     ],
     "correctOption": "C",
-    "difficulty": 3,
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -5775,7 +5685,7 @@
       }
     ],
     "correctOption": "B",
-    "difficulty": 4,
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -5819,7 +5729,7 @@
       }
     ],
     "correctOption": "D",
-    "difficulty": 4,
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -5863,7 +5773,7 @@
       }
     ],
     "correctOption": "A",
-    "difficulty": 5,
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -5875,91 +5785,91 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-linear-functions-972f1bfb70",
-    "skillId": "act-linear-functions",
-    "prompt": "What is the slope of the line through (-2, 4) and (-5, 3)?",
+    "problemId": "act-act-function-notation-evaluation-96b4a131e5",
+    "skillId": "act-function-notation-evaluation",
+    "prompt": "If f(x) = 3x² - 1, what is f(-1)?",
     "answer": {
       "type": "auto",
-      "value": "-1/-3",
+      "value": "2",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "-3"
-      },
-      {
-        "label": "B",
-        "text": "-1/-3"
-      },
-      {
-        "label": "C",
-        "text": "-0.3333333333333333"
-      },
-      {
-        "label": "D",
-        "text": "3"
-      },
-      {
-        "label": "E",
-        "text": "-1"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-linear-functions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "972f1bfb70727f5c5c640a43c7c9d6a167227b5981ed53af4c3e233ba8734baf",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-linear-functions-df7a2edf32",
-    "skillId": "act-linear-functions",
-    "prompt": "What is the slope of the line through (-3, -3) and (1, 2)?",
-    "answer": {
-      "type": "auto",
-      "value": "5/4",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "4/5"
-      },
-      {
-        "label": "B",
-        "text": "-1.25"
-      },
-      {
-        "label": "C",
         "text": "4"
       },
       {
+        "label": "B",
+        "text": "0"
+      },
+      {
+        "label": "C",
+        "text": "2"
+      },
+      {
         "label": "D",
-        "text": "5"
+        "text": "-4"
       },
       {
         "label": "E",
-        "text": "5/4"
+        "text": "8"
       }
     ],
-    "correctOption": "E",
-    "difficulty": 2,
+    "correctOption": "C",
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-linear-functions"
+      "act-function-notation-evaluation"
     ],
     "source": "act-template-gen",
-    "contentHash": "df7a2edf32ed0627b275164ee96e1a3e969a52af0656f858656beeb96d8f351c",
+    "contentHash": "96b4a131e5f02607cabd59e788b9e1e34e1f7469ff5bef12368572f206cba5b5",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-notation-evaluation-94f40d87e7",
+    "skillId": "act-function-notation-evaluation",
+    "prompt": "If f(x) = -2x² + 2, what is f(-3)?",
+    "answer": {
+      "type": "auto",
+      "value": "-16",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-22"
+      },
+      {
+        "label": "B",
+        "text": "-16"
+      },
+      {
+        "label": "C",
+        "text": "8"
+      },
+      {
+        "label": "D",
+        "text": "38"
+      },
+      {
+        "label": "E",
+        "text": "-20"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-notation-evaluation"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "94f40d87e7c06e6b4861044f8ba29776da7969130dd16139529825a09bcc4c7d",
     "isActive": true
   },
   {
@@ -5995,7 +5905,7 @@
       }
     ],
     "correctOption": "D",
-    "difficulty": 3,
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -6039,7 +5949,7 @@
       }
     ],
     "correctOption": "E",
-    "difficulty": 3,
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -6127,7 +6037,7 @@
       }
     ],
     "correctOption": "E",
-    "difficulty": 4,
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -6171,7 +6081,7 @@
       }
     ],
     "correctOption": "A",
-    "difficulty": 4,
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -6215,7 +6125,7 @@
       }
     ],
     "correctOption": "D",
-    "difficulty": 5,
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -6227,79 +6137,123 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-quadratic-functions-fbd665509e",
-    "skillId": "act-quadratic-functions",
-    "prompt": "What is the vertex of the parabola y = 2(x - 4)² - 6?",
+    "problemId": "act-act-linear-functions-c1f77355c5",
+    "skillId": "act-linear-functions",
+    "prompt": "What is the slope of the line through (-2, 0) and (1, 4)?",
     "answer": {
       "type": "auto",
-      "value": "(4, -6)",
+      "value": "4/3",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "(4, -6)"
+        "text": "4/3"
       },
       {
         "label": "B",
-        "text": "(-6, 4)"
+        "text": "3/4"
       },
       {
         "label": "C",
-        "text": "(-4, 6)"
+        "text": "3"
       },
       {
         "label": "D",
-        "text": "(-4, -6)"
+        "text": "-1.3333333333333333"
       },
       {
         "label": "E",
-        "text": "(4, 6)"
+        "text": "4"
       }
     ],
     "correctOption": "A",
-    "difficulty": 2,
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-quadratic-functions"
+      "act-linear-functions"
     ],
     "source": "act-template-gen",
-    "contentHash": "fbd665509e56a65ce259cf9a0f2c794c82487f4cdbafb93f753ad90f010cbb47",
+    "contentHash": "c1f77355c5dbf524d0e85fafe7dc8b3e1a8f943392cae40ee40ce4b57d697d2c",
     "isActive": true
   },
   {
-    "problemId": "act-act-quadratic-functions-1bf22db683",
-    "skillId": "act-quadratic-functions",
-    "prompt": "What is the vertex of the parabola y = 1(x + 2)² - 3?",
+    "problemId": "act-act-linear-functions-c0b0a4403a",
+    "skillId": "act-linear-functions",
+    "prompt": "What is the slope of the line through (1, -6) and (5, -1)?",
     "answer": {
       "type": "auto",
-      "value": "(-2, -3)",
+      "value": "5/4",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "(2, -3)"
+        "text": "4"
       },
       {
         "label": "B",
-        "text": "(-3, -2)"
+        "text": "5/4"
       },
       {
         "label": "C",
-        "text": "(2, 3)"
+        "text": "-1.25"
       },
       {
         "label": "D",
-        "text": "(-2, -3)"
+        "text": "5"
       },
       {
         "label": "E",
-        "text": "(-2, 3)"
+        "text": "4/5"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "c0b0a4403a4bd5259f54ce2ee398e117efd8e1c0e8247f8972d57fe5e36e959e",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-functions-41f74f98b2",
+    "skillId": "act-quadratic-functions",
+    "prompt": "What is the vertex of the parabola y = 1(x + 2)² + 5?",
+    "answer": {
+      "type": "auto",
+      "value": "(-2, 5)",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "(-2, -5)"
+      },
+      {
+        "label": "B",
+        "text": "(2, 5)"
+      },
+      {
+        "label": "C",
+        "text": "(5, -2)"
+      },
+      {
+        "label": "D",
+        "text": "(-2, 5)"
+      },
+      {
+        "label": "E",
+        "text": "(2, -5)"
       }
     ],
     "correctOption": "D",
@@ -6311,7 +6265,7 @@
       "act-quadratic-functions"
     ],
     "source": "act-template-gen",
-    "contentHash": "1bf22db68335604c314c7da6287263eb0dd28d8b4730f13a8d74af16085e3277",
+    "contentHash": "41f74f98b2e3516108b2dbf746126ba6c3c180c9817454b2be5db1f41894cac3",
     "isActive": true
   },
   {
@@ -6347,7 +6301,7 @@
       }
     ],
     "correctOption": "B",
-    "difficulty": 3,
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -6400,6 +6354,50 @@
     ],
     "source": "act-template-gen",
     "contentHash": "c744d428be4f4db2f273a35009f8ef1d61bbe39eab05f2cf0c6e78f577915726",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-functions-fbd665509e",
+    "skillId": "act-quadratic-functions",
+    "prompt": "What is the vertex of the parabola y = 2(x - 4)² - 6?",
+    "answer": {
+      "type": "auto",
+      "value": "(4, -6)",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "(-4, 6)"
+      },
+      {
+        "label": "B",
+        "text": "(4, 6)"
+      },
+      {
+        "label": "C",
+        "text": "(-4, -6)"
+      },
+      {
+        "label": "D",
+        "text": "(4, -6)"
+      },
+      {
+        "label": "E",
+        "text": "(-6, 4)"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "fbd665509e56a65ce259cf9a0f2c794c82487f4cdbafb93f753ad90f010cbb47",
     "isActive": true
   },
   {

--- a/seeds/act-math-items.generated.json
+++ b/seeds/act-math-items.generated.json
@@ -1,0 +1,10782 @@
+[
+  {
+    "problemId": "act-act-multi-step-rate-proportion-a13fe1d7ce",
+    "skillId": "act-multi-step-rate-proportion",
+    "prompt": "A machine produces 3 parts per hour. How many parts does it produce in 5 hours?",
+    "answer": {
+      "type": "auto",
+      "value": "15",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "30"
+      },
+      {
+        "label": "B",
+        "text": "18"
+      },
+      {
+        "label": "C",
+        "text": "8"
+      },
+      {
+        "label": "D",
+        "text": "15"
+      },
+      {
+        "label": "E",
+        "text": "10"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-multi-step-rate-proportion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "a13fe1d7ce79d5df6c95418b349ad8116d7893c8b7738e340eea8c95ead95ca7",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-multi-step-rate-proportion-0d98d54d72",
+    "skillId": "act-multi-step-rate-proportion",
+    "prompt": "A machine produces 8 parts per hour. How many parts does it produce in 5 hours?",
+    "answer": {
+      "type": "auto",
+      "value": "40",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "40"
+      },
+      {
+        "label": "B",
+        "text": "13"
+      },
+      {
+        "label": "C",
+        "text": "80"
+      },
+      {
+        "label": "D",
+        "text": "35"
+      },
+      {
+        "label": "E",
+        "text": "48"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-multi-step-rate-proportion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "0d98d54d727ccefbc07e315ee44b9a2f53a7f3fbf0aef2487575a9ef9853ad0a",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-multi-step-rate-proportion-f08ac06ff8",
+    "skillId": "act-multi-step-rate-proportion",
+    "prompt": "A machine produces 7 parts per hour. How many parts does it produce in 8 hours?",
+    "answer": {
+      "type": "auto",
+      "value": "56",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "112"
+      },
+      {
+        "label": "B",
+        "text": "56"
+      },
+      {
+        "label": "C",
+        "text": "48"
+      },
+      {
+        "label": "D",
+        "text": "15"
+      },
+      {
+        "label": "E",
+        "text": "63"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-multi-step-rate-proportion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "f08ac06ff84cc55c4e9fe2bde8c1af5687998db23c4db5123187270cbd39ffd0",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-multi-step-rate-proportion-22ca676850",
+    "skillId": "act-multi-step-rate-proportion",
+    "prompt": "A machine produces 4 parts per hour. How many parts does it produce in 2 hours?",
+    "answer": {
+      "type": "auto",
+      "value": "8",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "12"
+      },
+      {
+        "label": "B",
+        "text": "16"
+      },
+      {
+        "label": "C",
+        "text": "8"
+      },
+      {
+        "label": "D",
+        "text": "10"
+      },
+      {
+        "label": "E",
+        "text": "6"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-multi-step-rate-proportion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "22ca67685099d2e96ecc1161f5603263c4e92005f71b8678c6e83b66b6a23365",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-multi-step-rate-proportion-2bb0f1f8bd",
+    "skillId": "act-multi-step-rate-proportion",
+    "prompt": "A machine produces 8 parts per hour. How many parts does it produce in 8 hours?",
+    "answer": {
+      "type": "auto",
+      "value": "64",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "72"
+      },
+      {
+        "label": "B",
+        "text": "64"
+      },
+      {
+        "label": "C",
+        "text": "16"
+      },
+      {
+        "label": "D",
+        "text": "56"
+      },
+      {
+        "label": "E",
+        "text": "128"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-multi-step-rate-proportion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "2bb0f1f8bd6831a50e31b95a9ba39fbed79ab66b3a878ab1b539daf89b1f4c3d",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-multi-step-rate-proportion-64076677fc",
+    "skillId": "act-multi-step-rate-proportion",
+    "prompt": "A machine produces 9 parts per hour. How many parts does it produce in 5 hours?",
+    "answer": {
+      "type": "auto",
+      "value": "45",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "54"
+      },
+      {
+        "label": "B",
+        "text": "40"
+      },
+      {
+        "label": "C",
+        "text": "45"
+      },
+      {
+        "label": "D",
+        "text": "90"
+      },
+      {
+        "label": "E",
+        "text": "14"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-multi-step-rate-proportion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "64076677fcd8e42c3783d3965160b6f9a61f651b5d755562ed3a5d6460e2b545",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-multi-step-rate-proportion-6dcb91b119",
+    "skillId": "act-multi-step-rate-proportion",
+    "prompt": "A machine produces 8 parts per hour. How many parts does it produce in 6 hours?",
+    "answer": {
+      "type": "auto",
+      "value": "48",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "42"
+      },
+      {
+        "label": "B",
+        "text": "14"
+      },
+      {
+        "label": "C",
+        "text": "96"
+      },
+      {
+        "label": "D",
+        "text": "48"
+      },
+      {
+        "label": "E",
+        "text": "56"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-multi-step-rate-proportion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "6dcb91b1197c533f2c986731ec5f585cdf87c5f740321200dd422961a358d722",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-multi-step-rate-proportion-baaf019d61",
+    "skillId": "act-multi-step-rate-proportion",
+    "prompt": "A machine produces 4 parts per hour. How many parts does it produce in 4 hours?",
+    "answer": {
+      "type": "auto",
+      "value": "16",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "20"
+      },
+      {
+        "label": "B",
+        "text": "8"
+      },
+      {
+        "label": "C",
+        "text": "12"
+      },
+      {
+        "label": "D",
+        "text": "32"
+      },
+      {
+        "label": "E",
+        "text": "16"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-multi-step-rate-proportion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "baaf019d617ea6552b46f39b85efa9e6ad3f6921e7064beb64807df57f1c46c5",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-perimeter-composite-1d55897189",
+    "skillId": "act-area-perimeter-composite",
+    "prompt": "A rectangle 5 by 7 has a square of side 2 cut from one corner. What is the remaining area?",
+    "answer": {
+      "type": "auto",
+      "value": "31",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "39"
+      },
+      {
+        "label": "B",
+        "text": "35"
+      },
+      {
+        "label": "C",
+        "text": "31"
+      },
+      {
+        "label": "D",
+        "text": "22"
+      },
+      {
+        "label": "E",
+        "text": "33"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-perimeter-composite"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "1d5589718941fc99335e18f3e5412960ce57b819aabbfc99400c1470f64f52a1",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-perimeter-composite-59079adf70",
+    "skillId": "act-area-perimeter-composite",
+    "prompt": "A rectangle 6 by 4 has a square of side 4 cut from one corner. What is the remaining area?",
+    "answer": {
+      "type": "auto",
+      "value": "8",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "20"
+      },
+      {
+        "label": "B",
+        "text": "24"
+      },
+      {
+        "label": "C",
+        "text": "8"
+      },
+      {
+        "label": "D",
+        "text": "16"
+      },
+      {
+        "label": "E",
+        "text": "40"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-perimeter-composite"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "59079adf70b2766f19b02084e546cb8c780f21050e8c504e7025904235447b1f",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-perimeter-composite-c6f7e9ab43",
+    "skillId": "act-area-perimeter-composite",
+    "prompt": "A rectangle 7 by 5 has a square of side 5 cut from one corner. What is the remaining area?",
+    "answer": {
+      "type": "auto",
+      "value": "10",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "35"
+      },
+      {
+        "label": "B",
+        "text": "10"
+      },
+      {
+        "label": "C",
+        "text": "19"
+      },
+      {
+        "label": "D",
+        "text": "60"
+      },
+      {
+        "label": "E",
+        "text": "30"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-perimeter-composite"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "c6f7e9ab43af66a1fc511e78771a07d2c9c1d63615cc9b5ec6d7752f2d29a97e",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-perimeter-composite-e89543acfa",
+    "skillId": "act-area-perimeter-composite",
+    "prompt": "A rectangle 5 by 7 has a square of side 5 cut from one corner. What is the remaining area?",
+    "answer": {
+      "type": "auto",
+      "value": "10",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "30"
+      },
+      {
+        "label": "B",
+        "text": "60"
+      },
+      {
+        "label": "C",
+        "text": "19"
+      },
+      {
+        "label": "D",
+        "text": "35"
+      },
+      {
+        "label": "E",
+        "text": "10"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-perimeter-composite"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "e89543acfa49c8ab4a56ce64f9e72dac85a761ba7d18e82d417d94dce74eeabc",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-perimeter-composite-6c171564ab",
+    "skillId": "act-area-perimeter-composite",
+    "prompt": "A rectangle 4 by 3 has a square of side 3 cut from one corner. What is the remaining area?",
+    "answer": {
+      "type": "auto",
+      "value": "3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "21"
+      },
+      {
+        "label": "B",
+        "text": "3"
+      },
+      {
+        "label": "C",
+        "text": "11"
+      },
+      {
+        "label": "D",
+        "text": "9"
+      },
+      {
+        "label": "E",
+        "text": "12"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-perimeter-composite"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "6c171564ab90ef4da785bfcef805292b60aa0d8b149aaa89a219b7db3d5578ea",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-perimeter-composite-ed414179c3",
+    "skillId": "act-area-perimeter-composite",
+    "prompt": "A rectangle 5 by 7 has a square of side 3 cut from one corner. What is the remaining area?",
+    "answer": {
+      "type": "auto",
+      "value": "26",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "21"
+      },
+      {
+        "label": "B",
+        "text": "32"
+      },
+      {
+        "label": "C",
+        "text": "35"
+      },
+      {
+        "label": "D",
+        "text": "44"
+      },
+      {
+        "label": "E",
+        "text": "26"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-perimeter-composite"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "ed414179c305c665c78785ce05f1e9958e7bb19ea600c8f758e345780aad1cf0",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-perimeter-composite-a4e327425c",
+    "skillId": "act-area-perimeter-composite",
+    "prompt": "A rectangle 5 by 5 has a square of side 2 cut from one corner. What is the remaining area?",
+    "answer": {
+      "type": "auto",
+      "value": "21",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "23"
+      },
+      {
+        "label": "B",
+        "text": "25"
+      },
+      {
+        "label": "C",
+        "text": "21"
+      },
+      {
+        "label": "D",
+        "text": "29"
+      },
+      {
+        "label": "E",
+        "text": "18"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-perimeter-composite"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "a4e327425c099eb1e2470f99301655cd5185cf5556812d5a91d57c6a6d3b53d4",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-perimeter-composite-9aff74273e",
+    "skillId": "act-area-perimeter-composite",
+    "prompt": "A rectangle 4 by 6 has a square of side 4 cut from one corner. What is the remaining area?",
+    "answer": {
+      "type": "auto",
+      "value": "8",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "20"
+      },
+      {
+        "label": "B",
+        "text": "16"
+      },
+      {
+        "label": "C",
+        "text": "40"
+      },
+      {
+        "label": "D",
+        "text": "8"
+      },
+      {
+        "label": "E",
+        "text": "24"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-perimeter-composite"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "9aff74273e058af97eaf3086b7a4f6d3b8128f3d6aaba43c8a7543469a341319",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-algebraic-reasoning-context-f45eb94c18",
+    "skillId": "act-algebraic-reasoning-context",
+    "prompt": "A plumber charges $18 plus $4 per hour. What is the total charge for a 4-hour job?",
+    "answer": {
+      "type": "auto",
+      "value": "$34",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$38"
+      },
+      {
+        "label": "B",
+        "text": "$88"
+      },
+      {
+        "label": "C",
+        "text": "$34"
+      },
+      {
+        "label": "D",
+        "text": "$16"
+      },
+      {
+        "label": "E",
+        "text": "$22"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-algebraic-reasoning-context"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "f45eb94c18a073c3ffbf4302d1e6a4216281cde43c7ee044c3502ba9f3822ff5",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-algebraic-reasoning-context-95fee355cc",
+    "skillId": "act-algebraic-reasoning-context",
+    "prompt": "A plumber charges $11 plus $6 per hour. What is the total charge for a 7-hour job?",
+    "answer": {
+      "type": "auto",
+      "value": "$53",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$17"
+      },
+      {
+        "label": "B",
+        "text": "$59"
+      },
+      {
+        "label": "C",
+        "text": "$119"
+      },
+      {
+        "label": "D",
+        "text": "$42"
+      },
+      {
+        "label": "E",
+        "text": "$53"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-algebraic-reasoning-context"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "95fee355cc0b2af65b49378c7d0d1f94bb7f2a10389a793ca0dfe342ad1a47ae",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-algebraic-reasoning-context-6bdc16e552",
+    "skillId": "act-algebraic-reasoning-context",
+    "prompt": "A plumber charges $12 plus $8 per hour. What is the total charge for a 8-hour job?",
+    "answer": {
+      "type": "auto",
+      "value": "$76",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$160"
+      },
+      {
+        "label": "B",
+        "text": "$20"
+      },
+      {
+        "label": "C",
+        "text": "$64"
+      },
+      {
+        "label": "D",
+        "text": "$76"
+      },
+      {
+        "label": "E",
+        "text": "$84"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-algebraic-reasoning-context"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "6bdc16e5525a90e5cb13885105a2a9ec010d76d16543c6310f916e85fceb55c8",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-algebraic-reasoning-context-82371ecab5",
+    "skillId": "act-algebraic-reasoning-context",
+    "prompt": "A plumber charges $20 plus $8 per hour. What is the total charge for a 2-hour job?",
+    "answer": {
+      "type": "auto",
+      "value": "$36",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$16"
+      },
+      {
+        "label": "B",
+        "text": "$56"
+      },
+      {
+        "label": "C",
+        "text": "$36"
+      },
+      {
+        "label": "D",
+        "text": "$44"
+      },
+      {
+        "label": "E",
+        "text": "$28"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-algebraic-reasoning-context"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "82371ecab5d0eea9b0f8d62d8971282e87852c599793ffe8327d4799ea51a429",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-algebraic-reasoning-context-0a32724bf3",
+    "skillId": "act-algebraic-reasoning-context",
+    "prompt": "A plumber charges $20 plus $4 per hour. What is the total charge for a 4-hour job?",
+    "answer": {
+      "type": "auto",
+      "value": "$36",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$16"
+      },
+      {
+        "label": "B",
+        "text": "$36"
+      },
+      {
+        "label": "C",
+        "text": "$40"
+      },
+      {
+        "label": "D",
+        "text": "$96"
+      },
+      {
+        "label": "E",
+        "text": "$24"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-algebraic-reasoning-context"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "0a32724bf30bae8d90175fb9c3e6b29d831ad3bbe8263591f933061569f82fd4",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-algebraic-reasoning-context-adebaf1700",
+    "skillId": "act-algebraic-reasoning-context",
+    "prompt": "A plumber charges $20 plus $3 per hour. What is the total charge for a 7-hour job?",
+    "answer": {
+      "type": "auto",
+      "value": "$41",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$161"
+      },
+      {
+        "label": "B",
+        "text": "$44"
+      },
+      {
+        "label": "C",
+        "text": "$21"
+      },
+      {
+        "label": "D",
+        "text": "$23"
+      },
+      {
+        "label": "E",
+        "text": "$41"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-algebraic-reasoning-context"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "adebaf1700bd26cae9469372092201dd8a822e9396fa439d09da604b92c1b6d4",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-algebraic-reasoning-context-edba0c8aed",
+    "skillId": "act-algebraic-reasoning-context",
+    "prompt": "A plumber charges $15 plus $5 per hour. What is the total charge for a 3-hour job?",
+    "answer": {
+      "type": "auto",
+      "value": "$30",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$30"
+      },
+      {
+        "label": "B",
+        "text": "$15"
+      },
+      {
+        "label": "C",
+        "text": "$35"
+      },
+      {
+        "label": "D",
+        "text": "$20"
+      },
+      {
+        "label": "E",
+        "text": "$60"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-algebraic-reasoning-context"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "edba0c8aed0898a53da945db511faf88b6b0fba3c49db8cbe4660f12dcc06374",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-algebraic-reasoning-context-be8918b596",
+    "skillId": "act-algebraic-reasoning-context",
+    "prompt": "A plumber charges $8 plus $6 per hour. What is the total charge for a 8-hour job?",
+    "answer": {
+      "type": "auto",
+      "value": "$56",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$112"
+      },
+      {
+        "label": "B",
+        "text": "$14"
+      },
+      {
+        "label": "C",
+        "text": "$56"
+      },
+      {
+        "label": "D",
+        "text": "$62"
+      },
+      {
+        "label": "E",
+        "text": "$48"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-algebraic-reasoning-context"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "be8918b596ba2a6692885481f3cd23d4c48ceecf98666de58a383f4a52ea7b79",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-percent-applications-1d7cccefa9",
+    "skillId": "act-percent-applications",
+    "prompt": "A $50 item is discounted 15%. What is the sale price?",
+    "answer": {
+      "type": "auto",
+      "value": "$42.50",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$35"
+      },
+      {
+        "label": "B",
+        "text": "$7.50"
+      },
+      {
+        "label": "C",
+        "text": "$49.25"
+      },
+      {
+        "label": "D",
+        "text": "$57.50"
+      },
+      {
+        "label": "E",
+        "text": "$42.50"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-percent-applications"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "1d7cccefa9ec6f764c128eb1e2b58749e0dfb55587ca0f39930c24ff1bc7f2b3",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-percent-applications-845a81ef98",
+    "skillId": "act-percent-applications",
+    "prompt": "A $90 item is discounted 20%. What is the sale price?",
+    "answer": {
+      "type": "auto",
+      "value": "$72",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$108"
+      },
+      {
+        "label": "B",
+        "text": "$72"
+      },
+      {
+        "label": "C",
+        "text": "$88.20"
+      },
+      {
+        "label": "D",
+        "text": "$18"
+      },
+      {
+        "label": "E",
+        "text": "$70"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-percent-applications"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "845a81ef989b887f3bbcb2d9dda0131351331a717d09e4606efacd8ab4071abf",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-percent-applications-0a0bb23947",
+    "skillId": "act-percent-applications",
+    "prompt": "A $60 item is discounted 15%. What is the sale price?",
+    "answer": {
+      "type": "auto",
+      "value": "$51",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$45"
+      },
+      {
+        "label": "B",
+        "text": "$69"
+      },
+      {
+        "label": "C",
+        "text": "$59.10"
+      },
+      {
+        "label": "D",
+        "text": "$9"
+      },
+      {
+        "label": "E",
+        "text": "$51"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-percent-applications"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "0a0bb23947af99d3c281714cb77beb79f05b673a0a82a5e530dc996b0417ecfd",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-percent-applications-da4ec4530c",
+    "skillId": "act-percent-applications",
+    "prompt": "A $70 item is discounted 15%. What is the sale price?",
+    "answer": {
+      "type": "auto",
+      "value": "$59.50",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$80.50"
+      },
+      {
+        "label": "B",
+        "text": "$68.95"
+      },
+      {
+        "label": "C",
+        "text": "$59.50"
+      },
+      {
+        "label": "D",
+        "text": "$10.50"
+      },
+      {
+        "label": "E",
+        "text": "$55"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-percent-applications"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "da4ec4530c4a84d87d4001eca5436d4cfa89ca6aa98d94f89a5db0ace3de9f42",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-percent-applications-b8dea580ba",
+    "skillId": "act-percent-applications",
+    "prompt": "A $80 item is discounted 30%. What is the sale price?",
+    "answer": {
+      "type": "auto",
+      "value": "$56",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$104"
+      },
+      {
+        "label": "B",
+        "text": "$56"
+      },
+      {
+        "label": "C",
+        "text": "$50"
+      },
+      {
+        "label": "D",
+        "text": "$24"
+      },
+      {
+        "label": "E",
+        "text": "$77.60"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-percent-applications"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "b8dea580bac184ba861ec06623b7145c1fc2e382bec5ea9062a9516ed6c13d56",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-percent-applications-1af2c0976d",
+    "skillId": "act-percent-applications",
+    "prompt": "A $60 item is discounted 25%. What is the sale price?",
+    "answer": {
+      "type": "auto",
+      "value": "$45",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$45"
+      },
+      {
+        "label": "B",
+        "text": "$75"
+      },
+      {
+        "label": "C",
+        "text": "$58.50"
+      },
+      {
+        "label": "D",
+        "text": "$35"
+      },
+      {
+        "label": "E",
+        "text": "$15"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-percent-applications"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "1af2c0976de3f8a091172fe075cc18a472e93c111d03e76a089838204dcbc6ad",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-percent-applications-3ba8da09be",
+    "skillId": "act-percent-applications",
+    "prompt": "A $110 item is discounted 10%. What is the sale price?",
+    "answer": {
+      "type": "auto",
+      "value": "$99",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$121"
+      },
+      {
+        "label": "B",
+        "text": "$100"
+      },
+      {
+        "label": "C",
+        "text": "$108.90"
+      },
+      {
+        "label": "D",
+        "text": "$99"
+      },
+      {
+        "label": "E",
+        "text": "$11"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-percent-applications"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "3ba8da09be88b75a71d0b9982096f062b97356598bb15586d429d6f3a727428a",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-percent-applications-930e95cf05",
+    "skillId": "act-percent-applications",
+    "prompt": "A $120 item is discounted 30%. What is the sale price?",
+    "answer": {
+      "type": "auto",
+      "value": "$84",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$36"
+      },
+      {
+        "label": "B",
+        "text": "$84"
+      },
+      {
+        "label": "C",
+        "text": "$116.40"
+      },
+      {
+        "label": "D",
+        "text": "$90"
+      },
+      {
+        "label": "E",
+        "text": "$156"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-percent-applications"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "930e95cf05d3bc3382445dd7d8c7d1adf2830ee8384ce28d3c029fe878a6677f",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-measurement-unit-conversion-e2d0aae66d",
+    "skillId": "act-measurement-unit-conversion",
+    "prompt": "How many inches are in 2 feet?",
+    "answer": {
+      "type": "auto",
+      "value": "24",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "14"
+      },
+      {
+        "label": "B",
+        "text": "48"
+      },
+      {
+        "label": "C",
+        "text": "24"
+      },
+      {
+        "label": "D",
+        "text": "1"
+      },
+      {
+        "label": "E",
+        "text": "22"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-measurement-unit-conversion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "e2d0aae66d74b3673d823ece66e20791f58a19e56687d9d277be5cc0aa7ac853",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-measurement-unit-conversion-2cc6ec7307",
+    "skillId": "act-measurement-unit-conversion",
+    "prompt": "How many ounces are in 4 pounds?",
+    "answer": {
+      "type": "auto",
+      "value": "64",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "20"
+      },
+      {
+        "label": "B",
+        "text": "128"
+      },
+      {
+        "label": "C",
+        "text": "60"
+      },
+      {
+        "label": "D",
+        "text": "1"
+      },
+      {
+        "label": "E",
+        "text": "64"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-measurement-unit-conversion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "2cc6ec7307b34f13c74d2fd5a032c7a7e590905d99f4ef4bed9d6b6fe88a9887",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-measurement-unit-conversion-1a47958926",
+    "skillId": "act-measurement-unit-conversion",
+    "prompt": "How many ounces are in 3 pounds?",
+    "answer": {
+      "type": "auto",
+      "value": "48",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "45"
+      },
+      {
+        "label": "B",
+        "text": "48"
+      },
+      {
+        "label": "C",
+        "text": "96"
+      },
+      {
+        "label": "D",
+        "text": "1"
+      },
+      {
+        "label": "E",
+        "text": "19"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-measurement-unit-conversion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "1a4795892673c3e8d1744487ae4057b379ea4e17e34e4f3cbcd432d60c9c7b88",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-measurement-unit-conversion-0a9f3cea78",
+    "skillId": "act-measurement-unit-conversion",
+    "prompt": "How many inches are in 4 feet?",
+    "answer": {
+      "type": "auto",
+      "value": "48",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "1"
+      },
+      {
+        "label": "B",
+        "text": "44"
+      },
+      {
+        "label": "C",
+        "text": "48"
+      },
+      {
+        "label": "D",
+        "text": "16"
+      },
+      {
+        "label": "E",
+        "text": "96"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-measurement-unit-conversion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "0a9f3cea7832234745bbf05767d4ad12ad05b13a8d10e0d2238865c53bb9872a",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-measurement-unit-conversion-1bd5fd1dd3",
+    "skillId": "act-measurement-unit-conversion",
+    "prompt": "How many minutes are in 4 hours?",
+    "answer": {
+      "type": "auto",
+      "value": "240",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "480"
+      },
+      {
+        "label": "B",
+        "text": "1"
+      },
+      {
+        "label": "C",
+        "text": "240"
+      },
+      {
+        "label": "D",
+        "text": "64"
+      },
+      {
+        "label": "E",
+        "text": "236"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-measurement-unit-conversion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "1bd5fd1dd3b62fd77bd8d0f905d29870d09ab2ba217bbc52a807921c5c9b2e36",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-measurement-unit-conversion-3c7228aa73",
+    "skillId": "act-measurement-unit-conversion",
+    "prompt": "How many feet are in 6 yards?",
+    "answer": {
+      "type": "auto",
+      "value": "18",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "12"
+      },
+      {
+        "label": "B",
+        "text": "18"
+      },
+      {
+        "label": "C",
+        "text": "36"
+      },
+      {
+        "label": "D",
+        "text": "9"
+      },
+      {
+        "label": "E",
+        "text": "2"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-measurement-unit-conversion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "3c7228aa73459eae5dc28de16ffdf195244b321c0877036992a68982516a06ad",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-measurement-unit-conversion-4facf1079d",
+    "skillId": "act-measurement-unit-conversion",
+    "prompt": "How many ounces are in 6 pounds?",
+    "answer": {
+      "type": "auto",
+      "value": "96",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "90"
+      },
+      {
+        "label": "B",
+        "text": "192"
+      },
+      {
+        "label": "C",
+        "text": "22"
+      },
+      {
+        "label": "D",
+        "text": "1"
+      },
+      {
+        "label": "E",
+        "text": "96"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-measurement-unit-conversion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "4facf1079d85a3968cd20b4635816802c3204017e6934572ab874f1310778db4",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-measurement-unit-conversion-4c47ba3044",
+    "skillId": "act-measurement-unit-conversion",
+    "prompt": "How many feet are in 8 yards?",
+    "answer": {
+      "type": "auto",
+      "value": "24",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "16"
+      },
+      {
+        "label": "B",
+        "text": "48"
+      },
+      {
+        "label": "C",
+        "text": "3"
+      },
+      {
+        "label": "D",
+        "text": "11"
+      },
+      {
+        "label": "E",
+        "text": "24"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-measurement-unit-conversion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "4c47ba3044ea84a4a1305f1c5151c6c776c48b5cf1327272d2c225d97f8617d7",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-angles-lines-triangles-28c3e12ef1",
+    "skillId": "act-angles-lines-triangles",
+    "prompt": "Two angles of a triangle measure 42° and 45°. What is the measure of the third angle?",
+    "answer": {
+      "type": "auto",
+      "value": "93°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "135°"
+      },
+      {
+        "label": "B",
+        "text": "93°"
+      },
+      {
+        "label": "C",
+        "text": "90°"
+      },
+      {
+        "label": "D",
+        "text": "138°"
+      },
+      {
+        "label": "E",
+        "text": "87°"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-angles-lines-triangles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "28c3e12ef1c075ad5c3f2206f612d51f900a8db25988fc0196eda945eeaf5db7",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-angles-lines-triangles-7eee5ea143",
+    "skillId": "act-angles-lines-triangles",
+    "prompt": "Two angles of a triangle measure 76° and 32°. What is the measure of the third angle?",
+    "answer": {
+      "type": "auto",
+      "value": "72°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "72°"
+      },
+      {
+        "label": "B",
+        "text": "104°"
+      },
+      {
+        "label": "C",
+        "text": "108°"
+      },
+      {
+        "label": "D",
+        "text": "148°"
+      },
+      {
+        "label": "E",
+        "text": "90°"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-angles-lines-triangles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "7eee5ea143bb6922ed9c3f3e0e7301291aaafbf331bf1dd47a2ee428a17f1a89",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-angles-lines-triangles-bf82e6b9be",
+    "skillId": "act-angles-lines-triangles",
+    "prompt": "Two angles of a triangle measure 43° and 35°. What is the measure of the third angle?",
+    "answer": {
+      "type": "auto",
+      "value": "102°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "90°"
+      },
+      {
+        "label": "B",
+        "text": "78°"
+      },
+      {
+        "label": "C",
+        "text": "145°"
+      },
+      {
+        "label": "D",
+        "text": "102°"
+      },
+      {
+        "label": "E",
+        "text": "137°"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-angles-lines-triangles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "bf82e6b9bee10a787336d7f3915b49f380520b37a8033747ca71e35cf137b751",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-angles-lines-triangles-a337967c2d",
+    "skillId": "act-angles-lines-triangles",
+    "prompt": "Two angles of a triangle measure 55° and 66°. What is the measure of the third angle?",
+    "answer": {
+      "type": "auto",
+      "value": "59°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "114°"
+      },
+      {
+        "label": "B",
+        "text": "121°"
+      },
+      {
+        "label": "C",
+        "text": "125°"
+      },
+      {
+        "label": "D",
+        "text": "90°"
+      },
+      {
+        "label": "E",
+        "text": "59°"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-angles-lines-triangles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "a337967c2d63ff7103d99a883fdf44836ac29bbf2b3073adb931416a8e0b0f2e",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-angles-lines-triangles-78db4a7d9c",
+    "skillId": "act-angles-lines-triangles",
+    "prompt": "Two angles of a triangle measure 80° and 70°. What is the measure of the third angle?",
+    "answer": {
+      "type": "auto",
+      "value": "30°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "150°"
+      },
+      {
+        "label": "B",
+        "text": "110°"
+      },
+      {
+        "label": "C",
+        "text": "90°"
+      },
+      {
+        "label": "D",
+        "text": "100°"
+      },
+      {
+        "label": "E",
+        "text": "30°"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-angles-lines-triangles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "78db4a7d9c623aabf48b29d47e60b6ec79ed1adb2f02206c092abb451d4325e6",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-angles-lines-triangles-8ef4fb986e",
+    "skillId": "act-angles-lines-triangles",
+    "prompt": "Two angles of a triangle measure 50° and 40°. What is the measure of the third angle?",
+    "answer": {
+      "type": "auto",
+      "value": "90°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "140°"
+      },
+      {
+        "label": "B",
+        "text": "80°"
+      },
+      {
+        "label": "C",
+        "text": "130°"
+      },
+      {
+        "label": "D",
+        "text": "90°"
+      },
+      {
+        "label": "E",
+        "text": "100°"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-angles-lines-triangles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "8ef4fb986edca30490e1d525d6b07261b5b081c2ae5091dd58d520d93a8ea522",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-angles-lines-triangles-f1f2c753dd",
+    "skillId": "act-angles-lines-triangles",
+    "prompt": "Two angles of a triangle measure 56° and 50°. What is the measure of the third angle?",
+    "answer": {
+      "type": "auto",
+      "value": "74°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "90°"
+      },
+      {
+        "label": "B",
+        "text": "130°"
+      },
+      {
+        "label": "C",
+        "text": "106°"
+      },
+      {
+        "label": "D",
+        "text": "74°"
+      },
+      {
+        "label": "E",
+        "text": "124°"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-angles-lines-triangles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "f1f2c753dd7dd58c71cf66025d1d2efc31920c1f160dc5489431b19c15daf2b6",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-angles-lines-triangles-a1ded5774c",
+    "skillId": "act-angles-lines-triangles",
+    "prompt": "Two angles of a triangle measure 47° and 79°. What is the measure of the third angle?",
+    "answer": {
+      "type": "auto",
+      "value": "54°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "133°"
+      },
+      {
+        "label": "B",
+        "text": "101°"
+      },
+      {
+        "label": "C",
+        "text": "54°"
+      },
+      {
+        "label": "D",
+        "text": "90°"
+      },
+      {
+        "label": "E",
+        "text": "126°"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-angles-lines-triangles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "a1ded5774cb62e1bfb38cc11bc70724417d63c6eae792f0a4682f0d34ab8a6f5",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polygons-circles-4ab299e776",
+    "skillId": "act-polygons-circles",
+    "prompt": "What is the measure of one interior angle of a regular 10-gon?",
+    "answer": {
+      "type": "auto",
+      "value": "144°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "36°"
+      },
+      {
+        "label": "B",
+        "text": "180°"
+      },
+      {
+        "label": "C",
+        "text": "144°"
+      },
+      {
+        "label": "D",
+        "text": "1440°"
+      },
+      {
+        "label": "E",
+        "text": "18°"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polygons-circles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "4ab299e77637854e19137bed3867d2bf64842bc48a2d85fde4bc6ec20eae229d",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polygons-circles-cf209d6f30",
+    "skillId": "act-polygons-circles",
+    "prompt": "What is the measure of one interior angle of a regular 24-gon?",
+    "answer": {
+      "type": "auto",
+      "value": "165°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "7.5°"
+      },
+      {
+        "label": "B",
+        "text": "3960°"
+      },
+      {
+        "label": "C",
+        "text": "165°"
+      },
+      {
+        "label": "D",
+        "text": "180°"
+      },
+      {
+        "label": "E",
+        "text": "15°"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polygons-circles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "cf209d6f30e738cf46fa695f4f21080246b1feb3cbfee4427f94705b6cd05167",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polygons-circles-d338b52a11",
+    "skillId": "act-polygons-circles",
+    "prompt": "What is the measure of one interior angle of a regular 18-gon?",
+    "answer": {
+      "type": "auto",
+      "value": "160°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "160°"
+      },
+      {
+        "label": "B",
+        "text": "10°"
+      },
+      {
+        "label": "C",
+        "text": "2880°"
+      },
+      {
+        "label": "D",
+        "text": "20°"
+      },
+      {
+        "label": "E",
+        "text": "180°"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polygons-circles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "d338b52a11713444d5c41a8b79f33bb94df01426a4f302995a29afdcb622d5fd",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polygons-circles-2c31981a43",
+    "skillId": "act-polygons-circles",
+    "prompt": "What is the measure of one interior angle of a regular 5-gon?",
+    "answer": {
+      "type": "auto",
+      "value": "108°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "36°"
+      },
+      {
+        "label": "B",
+        "text": "108°"
+      },
+      {
+        "label": "C",
+        "text": "540°"
+      },
+      {
+        "label": "D",
+        "text": "72°"
+      },
+      {
+        "label": "E",
+        "text": "180°"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polygons-circles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "2c31981a4357cfd1721ef045bcc83be9f77dffb5974a18d9827a9c67da1985ab",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polygons-circles-089cb9115f",
+    "skillId": "act-polygons-circles",
+    "prompt": "What is the measure of one interior angle of a regular 15-gon?",
+    "answer": {
+      "type": "auto",
+      "value": "156°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "180°"
+      },
+      {
+        "label": "B",
+        "text": "156°"
+      },
+      {
+        "label": "C",
+        "text": "2340°"
+      },
+      {
+        "label": "D",
+        "text": "24°"
+      },
+      {
+        "label": "E",
+        "text": "12°"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polygons-circles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "089cb9115fc28b7e3f539472922d476748a67c3fc5651798ae940a1d8dd19324",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polygons-circles-f23ad59710",
+    "skillId": "act-polygons-circles",
+    "prompt": "What is the measure of one interior angle of a regular 12-gon?",
+    "answer": {
+      "type": "auto",
+      "value": "150°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "15°"
+      },
+      {
+        "label": "B",
+        "text": "150°"
+      },
+      {
+        "label": "C",
+        "text": "30°"
+      },
+      {
+        "label": "D",
+        "text": "1800°"
+      },
+      {
+        "label": "E",
+        "text": "180°"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polygons-circles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "f23ad597101c9f8d32c6f0a974fbb36005718a4fe2b827932ce0b2df4d93708b",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polygons-circles-f1afd19014",
+    "skillId": "act-polygons-circles",
+    "prompt": "What is the measure of one interior angle of a regular 6-gon?",
+    "answer": {
+      "type": "auto",
+      "value": "120°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "60°"
+      },
+      {
+        "label": "B",
+        "text": "30°"
+      },
+      {
+        "label": "C",
+        "text": "720°"
+      },
+      {
+        "label": "D",
+        "text": "180°"
+      },
+      {
+        "label": "E",
+        "text": "120°"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polygons-circles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "f1afd19014fba1cae18af44f58beceb6cbaa493601ab98c68f0efb6ef19953b1",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polygons-circles-974bba90e9",
+    "skillId": "act-polygons-circles",
+    "prompt": "What is the measure of one interior angle of a regular 9-gon?",
+    "answer": {
+      "type": "auto",
+      "value": "140°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "40°"
+      },
+      {
+        "label": "B",
+        "text": "20°"
+      },
+      {
+        "label": "C",
+        "text": "1260°"
+      },
+      {
+        "label": "D",
+        "text": "140°"
+      },
+      {
+        "label": "E",
+        "text": "180°"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polygons-circles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "974bba90e978c77464782ad03971858313f75dcdfcc439dc553e7d102f7a5d56",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-volume-surface-area-ec73684fd6",
+    "skillId": "act-area-volume-surface-area",
+    "prompt": "What is the area of a triangle with base 6 and height 8?",
+    "answer": {
+      "type": "auto",
+      "value": "24",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "14"
+      },
+      {
+        "label": "B",
+        "text": "16"
+      },
+      {
+        "label": "C",
+        "text": "7"
+      },
+      {
+        "label": "D",
+        "text": "48"
+      },
+      {
+        "label": "E",
+        "text": "24"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-volume-surface-area"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "ec73684fd6777771f85ef2cbab32c375b8b9ef734ee79f50f98c758cf7836e91",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-volume-surface-area-9a246c1c51",
+    "skillId": "act-area-volume-surface-area",
+    "prompt": "What is the volume of a box with dimensions 3 × 2 × 3?",
+    "answer": {
+      "type": "auto",
+      "value": "18",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "8"
+      },
+      {
+        "label": "B",
+        "text": "42"
+      },
+      {
+        "label": "C",
+        "text": "18"
+      },
+      {
+        "label": "D",
+        "text": "36"
+      },
+      {
+        "label": "E",
+        "text": "9"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-volume-surface-area"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "9a246c1c51c552c3133b8b70cec8886187ed88fe3c26bb3c88934bf3ef11fa9c",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-volume-surface-area-c35421fc9c",
+    "skillId": "act-area-volume-surface-area",
+    "prompt": "What is the area of a triangle with base 9 and height 3?",
+    "answer": {
+      "type": "auto",
+      "value": "13.5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "12"
+      },
+      {
+        "label": "B",
+        "text": "9"
+      },
+      {
+        "label": "C",
+        "text": "27"
+      },
+      {
+        "label": "D",
+        "text": "6"
+      },
+      {
+        "label": "E",
+        "text": "13.5"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-volume-surface-area"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "c35421fc9c4e1bcaa532b59332cd960939b7ef52889c8b8049ff07dba853fb9b",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-volume-surface-area-e239b70e97",
+    "skillId": "act-area-volume-surface-area",
+    "prompt": "What is the volume of a box with dimensions 5 × 4 × 5?",
+    "answer": {
+      "type": "auto",
+      "value": "100",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "25"
+      },
+      {
+        "label": "B",
+        "text": "130"
+      },
+      {
+        "label": "C",
+        "text": "100"
+      },
+      {
+        "label": "D",
+        "text": "14"
+      },
+      {
+        "label": "E",
+        "text": "200"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-volume-surface-area"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "e239b70e97d4d0194f106e3e32d5e4e2c5dc655f87d7821c78dc708526c2c62a",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-volume-surface-area-e0fa9d0f25",
+    "skillId": "act-area-volume-surface-area",
+    "prompt": "What is the area of a rectangle with length 8 and width 9?",
+    "answer": {
+      "type": "auto",
+      "value": "72",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "34"
+      },
+      {
+        "label": "B",
+        "text": "36"
+      },
+      {
+        "label": "C",
+        "text": "72"
+      },
+      {
+        "label": "D",
+        "text": "144"
+      },
+      {
+        "label": "E",
+        "text": "17"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-volume-surface-area"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "e0fa9d0f25baa527680cb8ae2dbf46cb1e979ab21ad2eb6280921aa15514eead",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-volume-surface-area-188378f66b",
+    "skillId": "act-area-volume-surface-area",
+    "prompt": "What is the area of a triangle with base 5 and height 7?",
+    "answer": {
+      "type": "auto",
+      "value": "17.5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "35"
+      },
+      {
+        "label": "B",
+        "text": "6"
+      },
+      {
+        "label": "C",
+        "text": "11.666666666666666"
+      },
+      {
+        "label": "D",
+        "text": "12"
+      },
+      {
+        "label": "E",
+        "text": "17.5"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-volume-surface-area"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "188378f66b4a245fbd3f17683b402d9e73aa301bf18d3e42deac562b1b7c0374",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-volume-surface-area-c12ad0387d",
+    "skillId": "act-area-volume-surface-area",
+    "prompt": "What is the area of a triangle with base 9 and height 7?",
+    "answer": {
+      "type": "auto",
+      "value": "31.5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "16"
+      },
+      {
+        "label": "B",
+        "text": "31.5"
+      },
+      {
+        "label": "C",
+        "text": "21"
+      },
+      {
+        "label": "D",
+        "text": "63"
+      },
+      {
+        "label": "E",
+        "text": "8"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-volume-surface-area"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "c12ad0387dc373baf8fee082067a409d3d1de1d91ef7a310054dafd6ecda36c2",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-volume-surface-area-0c54fd5d75",
+    "skillId": "act-area-volume-surface-area",
+    "prompt": "What is the area of a rectangle with length 9 and width 6?",
+    "answer": {
+      "type": "auto",
+      "value": "54",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "30"
+      },
+      {
+        "label": "B",
+        "text": "108"
+      },
+      {
+        "label": "C",
+        "text": "15"
+      },
+      {
+        "label": "D",
+        "text": "54"
+      },
+      {
+        "label": "E",
+        "text": "27"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-volume-surface-area"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "0c54fd5d75f458c5cb286e165508a16f5caa8f36ee78a6decb5d59131aa4d40c",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-coordinate-geometry-d4256b0d73",
+    "skillId": "act-coordinate-geometry",
+    "prompt": "What is the midpoint of the segment from (1, -2) to (2, -2)?",
+    "answer": {
+      "type": "auto",
+      "value": "(1.5, -2)",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "(3, -4)"
+      },
+      {
+        "label": "B",
+        "text": "(-2, 1.5)"
+      },
+      {
+        "label": "C",
+        "text": "(1.5, -2)"
+      },
+      {
+        "label": "D",
+        "text": "(1, 0)"
+      },
+      {
+        "label": "E",
+        "text": "(2.5, -2)"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-coordinate-geometry"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "d4256b0d7325d51d126129c9de8d4743dc349d0e569d4801dd8918986a01b569",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-coordinate-geometry-454ced9ff5",
+    "skillId": "act-coordinate-geometry",
+    "prompt": "What is the distance between (5, 5) and (8, 9)?",
+    "answer": {
+      "type": "auto",
+      "value": "5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "6"
+      },
+      {
+        "label": "B",
+        "text": "7"
+      },
+      {
+        "label": "C",
+        "text": "3"
+      },
+      {
+        "label": "D",
+        "text": "12"
+      },
+      {
+        "label": "E",
+        "text": "5"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-coordinate-geometry"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "454ced9ff533f2ea9502a10cbbbf39ac3b27031932b5476728610f49c8e6cd49",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-coordinate-geometry-385d010d3c",
+    "skillId": "act-coordinate-geometry",
+    "prompt": "What is the midpoint of the segment from (-5, 2) to (1, 3)?",
+    "answer": {
+      "type": "auto",
+      "value": "(-2, 2.5)",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "(2.5, -2)"
+      },
+      {
+        "label": "B",
+        "text": "(-4, 5)"
+      },
+      {
+        "label": "C",
+        "text": "(-2, 2.5)"
+      },
+      {
+        "label": "D",
+        "text": "(-1, 2.5)"
+      },
+      {
+        "label": "E",
+        "text": "(6, 1)"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-coordinate-geometry"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "385d010d3c92863c93f5534f56810a4073af6c83409163ee85ddb42c7d99c545",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-coordinate-geometry-b396a42ecc",
+    "skillId": "act-coordinate-geometry",
+    "prompt": "What is the midpoint of the segment from (5, 5) to (1, 2)?",
+    "answer": {
+      "type": "auto",
+      "value": "(3, 3.5)",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "(4, 3.5)"
+      },
+      {
+        "label": "B",
+        "text": "(3, 3.5)"
+      },
+      {
+        "label": "C",
+        "text": "(3.5, 3)"
+      },
+      {
+        "label": "D",
+        "text": "(6, 7)"
+      },
+      {
+        "label": "E",
+        "text": "(-4, -3)"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-coordinate-geometry"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "b396a42eccecf455311c3c4242e6de18246b7ebf886ce8148007ddf9f9f818f1",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-coordinate-geometry-e6fdbde599",
+    "skillId": "act-coordinate-geometry",
+    "prompt": "What is the distance between (-4, -3) and (1, 9)?",
+    "answer": {
+      "type": "auto",
+      "value": "13",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "60"
+      },
+      {
+        "label": "B",
+        "text": "14"
+      },
+      {
+        "label": "C",
+        "text": "17"
+      },
+      {
+        "label": "D",
+        "text": "8"
+      },
+      {
+        "label": "E",
+        "text": "13"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-coordinate-geometry"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "e6fdbde599085eb300f3278e9f55c10b06536680edb94641aef289fc7e253057",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-coordinate-geometry-4f33f9e984",
+    "skillId": "act-coordinate-geometry",
+    "prompt": "What is the midpoint of the segment from (-1, 1) to (1, 2)?",
+    "answer": {
+      "type": "auto",
+      "value": "(0, 1.5)",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "(1, 1.5)"
+      },
+      {
+        "label": "B",
+        "text": "(0, 3)"
+      },
+      {
+        "label": "C",
+        "text": "(1.5, 0)"
+      },
+      {
+        "label": "D",
+        "text": "(2, 1)"
+      },
+      {
+        "label": "E",
+        "text": "(0, 1.5)"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-coordinate-geometry"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "4f33f9e984b650f077baf7a72a4e3aa81f5f86057fd81dbfa58a0499ca20467f",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-coordinate-geometry-a48b5b3585",
+    "skillId": "act-coordinate-geometry",
+    "prompt": "What is the distance between (3, 4) and (6, 8)?",
+    "answer": {
+      "type": "auto",
+      "value": "5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "5"
+      },
+      {
+        "label": "B",
+        "text": "6"
+      },
+      {
+        "label": "C",
+        "text": "7"
+      },
+      {
+        "label": "D",
+        "text": "12"
+      },
+      {
+        "label": "E",
+        "text": "3"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-coordinate-geometry"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "a48b5b3585535e3c9fda6d889b36c422a55c5d320b3819bf31ee07d086d07b17",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-coordinate-geometry-579ce4d46a",
+    "skillId": "act-coordinate-geometry",
+    "prompt": "What is the midpoint of the segment from (4, 1) to (1, 2)?",
+    "answer": {
+      "type": "auto",
+      "value": "(2.5, 1.5)",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "(5, 3)"
+      },
+      {
+        "label": "B",
+        "text": "(1.5, 2.5)"
+      },
+      {
+        "label": "C",
+        "text": "(2.5, 1.5)"
+      },
+      {
+        "label": "D",
+        "text": "(3.5, 1.5)"
+      },
+      {
+        "label": "E",
+        "text": "(-3, 1)"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-coordinate-geometry"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "579ce4d46a35cbe45cae281d1b4e86b1fdb1600249c1ee7060dcf05abc7fc64c",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-right-triangle-trig-25b128c82b",
+    "skillId": "act-right-triangle-trig",
+    "prompt": "A right triangle has legs of length 5 and 12. What is the length of the hypotenuse?",
+    "answer": {
+      "type": "auto",
+      "value": "13",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "8"
+      },
+      {
+        "label": "B",
+        "text": "14"
+      },
+      {
+        "label": "C",
+        "text": "17"
+      },
+      {
+        "label": "D",
+        "text": "12"
+      },
+      {
+        "label": "E",
+        "text": "13"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-right-triangle-trig"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "25b128c82bad1dda4198eefbde40b74c3984e2715c904317aa45a159d61232d4",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-right-triangle-trig-e486f2fd8f",
+    "skillId": "act-right-triangle-trig",
+    "prompt": "A right triangle has legs of length 6 and 8. What is the length of the hypotenuse?",
+    "answer": {
+      "type": "auto",
+      "value": "10",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "14"
+      },
+      {
+        "label": "B",
+        "text": "11"
+      },
+      {
+        "label": "C",
+        "text": "10"
+      },
+      {
+        "label": "D",
+        "text": "7"
+      },
+      {
+        "label": "E",
+        "text": "9"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-right-triangle-trig"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "e486f2fd8f88da9c09dedda90979c722fefc4c8e3e3244d8f3c32a2b5e8bf767",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-right-triangle-trig-1b2da9b036",
+    "skillId": "act-right-triangle-trig",
+    "prompt": "A right triangle has legs of length 9 and 12. What is the length of the hypotenuse?",
+    "answer": {
+      "type": "auto",
+      "value": "15",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "10"
+      },
+      {
+        "label": "B",
+        "text": "21"
+      },
+      {
+        "label": "C",
+        "text": "14"
+      },
+      {
+        "label": "D",
+        "text": "15"
+      },
+      {
+        "label": "E",
+        "text": "16"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-right-triangle-trig"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "1b2da9b03619156597f2f9ee2ed999d62f3d07bb0a50128bdaad2f98da2cc40e",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-right-triangle-trig-ea45682b37",
+    "skillId": "act-right-triangle-trig",
+    "prompt": "A right triangle has legs of length 3 and 4. What is the length of the hypotenuse?",
+    "answer": {
+      "type": "auto",
+      "value": "5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "7"
+      },
+      {
+        "label": "B",
+        "text": "5"
+      },
+      {
+        "label": "C",
+        "text": "6"
+      },
+      {
+        "label": "D",
+        "text": "3"
+      },
+      {
+        "label": "E",
+        "text": "4"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-right-triangle-trig"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "ea45682b3726fe6bf1f68c842e4a16db3d3187d13610366736b384460b43badc",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-right-triangle-trig-4a89dcc568",
+    "skillId": "act-right-triangle-trig",
+    "prompt": "A right triangle has legs of length 8 and 15. What is the length of the hypotenuse?",
+    "answer": {
+      "type": "auto",
+      "value": "17",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "18"
+      },
+      {
+        "label": "B",
+        "text": "17"
+      },
+      {
+        "label": "C",
+        "text": "23"
+      },
+      {
+        "label": "D",
+        "text": "11"
+      },
+      {
+        "label": "E",
+        "text": "16"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-right-triangle-trig"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "4a89dcc56881db2a7465958f1b5cddaa6fe2d1fe3eaa7a13bfe8a3f8eedd592c",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-congruence-similarity-eb22153ae2",
+    "skillId": "act-congruence-similarity",
+    "prompt": "Two triangles are similar. A side of length 5 corresponds to a side of length 10. What length corresponds to a side of length 4?",
+    "answer": {
+      "type": "auto",
+      "value": "8",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "8"
+      },
+      {
+        "label": "B",
+        "text": "2"
+      },
+      {
+        "label": "C",
+        "text": "6"
+      },
+      {
+        "label": "D",
+        "text": "9"
+      },
+      {
+        "label": "E",
+        "text": "12"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-congruence-similarity"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "eb22153ae2d1523ac5338b77dabe8dca2eab7e1eaca6b55c66674a93b9ac716a",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-congruence-similarity-afe3b8b9da",
+    "skillId": "act-congruence-similarity",
+    "prompt": "Two triangles are similar. A side of length 7 corresponds to a side of length 21. What length corresponds to a side of length 8?",
+    "answer": {
+      "type": "auto",
+      "value": "24",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "32"
+      },
+      {
+        "label": "B",
+        "text": "22"
+      },
+      {
+        "label": "C",
+        "text": "11"
+      },
+      {
+        "label": "D",
+        "text": "24"
+      },
+      {
+        "label": "E",
+        "text": "3"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-congruence-similarity"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "afe3b8b9da171995d60919b1775f1697abf79b9b0682b9f39f0691c3a074074a",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-congruence-similarity-e405d98625",
+    "skillId": "act-congruence-similarity",
+    "prompt": "Two triangles are similar. A side of length 5 corresponds to a side of length 20. What length corresponds to a side of length 7?",
+    "answer": {
+      "type": "auto",
+      "value": "28",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "11"
+      },
+      {
+        "label": "B",
+        "text": "2"
+      },
+      {
+        "label": "C",
+        "text": "35"
+      },
+      {
+        "label": "D",
+        "text": "28"
+      },
+      {
+        "label": "E",
+        "text": "22"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-congruence-similarity"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "e405d986255c57c078363674d2ef3e004693cfcbdf7f42ba22ef6042c8af2541",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-congruence-similarity-ee4da28956",
+    "skillId": "act-congruence-similarity",
+    "prompt": "Two triangles are similar. A side of length 6 corresponds to a side of length 12. What length corresponds to a side of length 5?",
+    "answer": {
+      "type": "auto",
+      "value": "10",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "11"
+      },
+      {
+        "label": "B",
+        "text": "10"
+      },
+      {
+        "label": "C",
+        "text": "15"
+      },
+      {
+        "label": "D",
+        "text": "3"
+      },
+      {
+        "label": "E",
+        "text": "7"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-congruence-similarity"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "ee4da28956105bff54781dbd53db89c59dcbf822cd596191bcd3fce9ded6d8fa",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-congruence-similarity-3f836d1aaa",
+    "skillId": "act-congruence-similarity",
+    "prompt": "Two triangles are similar. A side of length 4 corresponds to a side of length 8. What length corresponds to a side of length 7?",
+    "answer": {
+      "type": "auto",
+      "value": "14",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "4"
+      },
+      {
+        "label": "B",
+        "text": "14"
+      },
+      {
+        "label": "C",
+        "text": "21"
+      },
+      {
+        "label": "D",
+        "text": "9"
+      },
+      {
+        "label": "E",
+        "text": "11"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-congruence-similarity"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "3f836d1aaa3878122dbbd4e873af45567a87cec06734a8802e98206ca76f3e53",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-congruence-similarity-ef2ba59e5f",
+    "skillId": "act-congruence-similarity",
+    "prompt": "Two triangles are similar. A side of length 8 corresponds to a side of length 24. What length corresponds to a side of length 7?",
+    "answer": {
+      "type": "auto",
+      "value": "21",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "2"
+      },
+      {
+        "label": "B",
+        "text": "23"
+      },
+      {
+        "label": "C",
+        "text": "21"
+      },
+      {
+        "label": "D",
+        "text": "10"
+      },
+      {
+        "label": "E",
+        "text": "28"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-congruence-similarity"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "ef2ba59e5fe2fcc78296d343b0f8cd1e67e6c3bf4e57ceb357f94ccba179f65a",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-congruence-similarity-ea8f32db72",
+    "skillId": "act-congruence-similarity",
+    "prompt": "Two triangles are similar. A side of length 4 corresponds to a side of length 16. What length corresponds to a side of length 8?",
+    "answer": {
+      "type": "auto",
+      "value": "32",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "2"
+      },
+      {
+        "label": "B",
+        "text": "40"
+      },
+      {
+        "label": "C",
+        "text": "12"
+      },
+      {
+        "label": "D",
+        "text": "20"
+      },
+      {
+        "label": "E",
+        "text": "32"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-congruence-similarity"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "ea8f32db725f9a9827c56fe8c8430e03bc618b736a0bc3e2258f1f07c2020a0e",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-congruence-similarity-e184128ba0",
+    "skillId": "act-congruence-similarity",
+    "prompt": "Two triangles are similar. A side of length 3 corresponds to a side of length 6. What length corresponds to a side of length 8?",
+    "answer": {
+      "type": "auto",
+      "value": "16",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "11"
+      },
+      {
+        "label": "B",
+        "text": "24"
+      },
+      {
+        "label": "C",
+        "text": "10"
+      },
+      {
+        "label": "D",
+        "text": "4"
+      },
+      {
+        "label": "E",
+        "text": "16"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-congruence-similarity"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "e184128ba0ed077f11d6683862d8ed6e67cff94804ff27e732ca2da09e9e532a",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-equations-62c6560209",
+    "skillId": "act-linear-equations",
+    "prompt": "If 2x + 7 = 4x - 5, then x = ?",
+    "answer": {
+      "type": "auto",
+      "value": "6",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-6"
+      },
+      {
+        "label": "B",
+        "text": "-12"
+      },
+      {
+        "label": "C",
+        "text": "5"
+      },
+      {
+        "label": "D",
+        "text": "7"
+      },
+      {
+        "label": "E",
+        "text": "6"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "62c65602094c526346e666d2b8de9b2cd8226ae94c24233ed4545b17b7d6bbee",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-equations-d99c7a9c5f",
+    "skillId": "act-linear-equations",
+    "prompt": "If 4x + 5 = 2x + 19, then x = ?",
+    "answer": {
+      "type": "auto",
+      "value": "7",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-7"
+      },
+      {
+        "label": "B",
+        "text": "14"
+      },
+      {
+        "label": "C",
+        "text": "6"
+      },
+      {
+        "label": "D",
+        "text": "7"
+      },
+      {
+        "label": "E",
+        "text": "8"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "d99c7a9c5f264455fc5f104fc1140ec6dfdd745e6989786a4081225ff52031ba",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-equations-146b303f2a",
+    "skillId": "act-linear-equations",
+    "prompt": "If 6x + 5 = -2x + 53, then x = ?",
+    "answer": {
+      "type": "auto",
+      "value": "6",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "48"
+      },
+      {
+        "label": "B",
+        "text": "5"
+      },
+      {
+        "label": "C",
+        "text": "7"
+      },
+      {
+        "label": "D",
+        "text": "6"
+      },
+      {
+        "label": "E",
+        "text": "-6"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "146b303f2a82c8eb256a7c328ca73a401023863890ff78aa8dfc5e5d412a8f44",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-equations-c7a8fff9f5",
+    "skillId": "act-linear-equations",
+    "prompt": "If 5x - 1 = -x - 19, then x = ?",
+    "answer": {
+      "type": "auto",
+      "value": "-3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-2"
+      },
+      {
+        "label": "B",
+        "text": "3"
+      },
+      {
+        "label": "C",
+        "text": "-3"
+      },
+      {
+        "label": "D",
+        "text": "-18"
+      },
+      {
+        "label": "E",
+        "text": "-4"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "c7a8fff9f556e144843eea3db3959a47947e8b449cd2fbee20529184ed71df25",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-equations-b54fdacecb",
+    "skillId": "act-linear-equations",
+    "prompt": "If 6x - 8 = 3x - 26, then x = ?",
+    "answer": {
+      "type": "auto",
+      "value": "-6",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-18"
+      },
+      {
+        "label": "B",
+        "text": "-5"
+      },
+      {
+        "label": "C",
+        "text": "-6"
+      },
+      {
+        "label": "D",
+        "text": "6"
+      },
+      {
+        "label": "E",
+        "text": "-7"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "b54fdacecba66d585d235e46f52972243d23246dbf1e62a7bc6f219f09ca26ce",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-equations-ac8890f994",
+    "skillId": "act-linear-equations",
+    "prompt": "If 2x - 4 = -3x - 14, then x = ?",
+    "answer": {
+      "type": "auto",
+      "value": "-2",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-10"
+      },
+      {
+        "label": "B",
+        "text": "-1"
+      },
+      {
+        "label": "C",
+        "text": "-3"
+      },
+      {
+        "label": "D",
+        "text": "-2"
+      },
+      {
+        "label": "E",
+        "text": "2"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "ac8890f994f693b0228f8b544febef772b4a831651a21b55a9fc6b0a013b2504",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-equations-78c5c134a4",
+    "skillId": "act-linear-equations",
+    "prompt": "If 4x - 1 = -3x - 29, then x = ?",
+    "answer": {
+      "type": "auto",
+      "value": "-4",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-3"
+      },
+      {
+        "label": "B",
+        "text": "-5"
+      },
+      {
+        "label": "C",
+        "text": "4"
+      },
+      {
+        "label": "D",
+        "text": "-4"
+      },
+      {
+        "label": "E",
+        "text": "-28"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "78c5c134a4453e9b12d0cfe22711e036e0c7f6f202b8e95e9e6bad824d08d781",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-equations-ac42e969ea",
+    "skillId": "act-linear-equations",
+    "prompt": "If 7x - 8 = -4x + 58, then x = ?",
+    "answer": {
+      "type": "auto",
+      "value": "6",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "7"
+      },
+      {
+        "label": "B",
+        "text": "5"
+      },
+      {
+        "label": "C",
+        "text": "66"
+      },
+      {
+        "label": "D",
+        "text": "-6"
+      },
+      {
+        "label": "E",
+        "text": "6"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "ac42e969ea99a9c893de4f4df7ce84a6e7ae68a270c35e668c4517faa33dd89e",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-systems-of-equations-7b6d4409fa",
+    "skillId": "act-systems-of-equations",
+    "prompt": "If 3x + 3y = 15 and 2x + 4y = 22, what is x + y?",
+    "answer": {
+      "type": "auto",
+      "value": "5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-6"
+      },
+      {
+        "label": "B",
+        "text": "6"
+      },
+      {
+        "label": "C",
+        "text": "5"
+      },
+      {
+        "label": "D",
+        "text": "-1"
+      },
+      {
+        "label": "E",
+        "text": "-7"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-systems-of-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "7b6d4409fa5c5f457d79870c95ec07e1c965c7ce7029c6f224b970a2057e1d06",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-systems-of-equations-9778b40d6a",
+    "skillId": "act-systems-of-equations",
+    "prompt": "If 2x + y = 7 and 4x + 3y = 17, what is x + y?",
+    "answer": {
+      "type": "auto",
+      "value": "5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "3"
+      },
+      {
+        "label": "B",
+        "text": "2"
+      },
+      {
+        "label": "C",
+        "text": "-1"
+      },
+      {
+        "label": "D",
+        "text": "5"
+      },
+      {
+        "label": "E",
+        "text": "6"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-systems-of-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "9778b40d6ab2e7ec36d4f011e7c28161cf1a475fd1c2649676c8b31f39dc68c7",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-systems-of-equations-a8fee6626f",
+    "skillId": "act-systems-of-equations",
+    "prompt": "If x + 2y = -2 and 2x + 3y = -1, what is x + y?",
+    "answer": {
+      "type": "auto",
+      "value": "1",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "1"
+      },
+      {
+        "label": "B",
+        "text": "4"
+      },
+      {
+        "label": "C",
+        "text": "7"
+      },
+      {
+        "label": "D",
+        "text": "-12"
+      },
+      {
+        "label": "E",
+        "text": "-3"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-systems-of-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "a8fee6626f124c20f0618758f74d9706b5c0fcf7c1866c23ca9c7deb36adb16c",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-systems-of-equations-b6a414f47a",
+    "skillId": "act-systems-of-equations",
+    "prompt": "If 4x + 4y = 40 and 4x + 3y = 36, what is x + y?",
+    "answer": {
+      "type": "auto",
+      "value": "10",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "2"
+      },
+      {
+        "label": "B",
+        "text": "4"
+      },
+      {
+        "label": "C",
+        "text": "10"
+      },
+      {
+        "label": "D",
+        "text": "6"
+      },
+      {
+        "label": "E",
+        "text": "24"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-systems-of-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "b6a414f47abba09ae20ca16ff9fc30628fd012850fe061f9cb1485858d396d94",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-systems-of-equations-a69a54d9bc",
+    "skillId": "act-systems-of-equations",
+    "prompt": "If 4x + 4y = -16 and 4x + 3y = -15, what is x + y?",
+    "answer": {
+      "type": "auto",
+      "value": "-4",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "3"
+      },
+      {
+        "label": "B",
+        "text": "-2"
+      },
+      {
+        "label": "C",
+        "text": "-4"
+      },
+      {
+        "label": "D",
+        "text": "-3"
+      },
+      {
+        "label": "E",
+        "text": "-1"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-systems-of-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "a69a54d9bcb8e1e740ca33c5d8cf625cc8d9d9818528dbcd3243cd19ee1b7cff",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-systems-of-equations-1ecbd212a7",
+    "skillId": "act-systems-of-equations",
+    "prompt": "If x + 3y = 10 and 2x + 4y = 10, what is x + y?",
+    "answer": {
+      "type": "auto",
+      "value": "0",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "0"
+      },
+      {
+        "label": "B",
+        "text": "5"
+      },
+      {
+        "label": "C",
+        "text": "-10"
+      },
+      {
+        "label": "D",
+        "text": "-5"
+      },
+      {
+        "label": "E",
+        "text": "-25"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-systems-of-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "1ecbd212a7b1f500efeaf682afc2a36811fef56ca10122cb9a1d94ed2e208ce1",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-systems-of-equations-310c7d92e2",
+    "skillId": "act-systems-of-equations",
+    "prompt": "If 4x + y = -13 and 2x + 3y = 1, what is x + y?",
+    "answer": {
+      "type": "auto",
+      "value": "-1",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-4"
+      },
+      {
+        "label": "B",
+        "text": "-7"
+      },
+      {
+        "label": "C",
+        "text": "-1"
+      },
+      {
+        "label": "D",
+        "text": "-12"
+      },
+      {
+        "label": "E",
+        "text": "3"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-systems-of-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "310c7d92e2259f401cfc751f5c20caf26d8a307c3d09f4d592cb4bddab73d0d5",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-systems-of-equations-d461c79d92",
+    "skillId": "act-systems-of-equations",
+    "prompt": "If x + 3y = -8 and 2x + 2y = 0, what is x + y?",
+    "answer": {
+      "type": "auto",
+      "value": "0",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "0"
+      },
+      {
+        "label": "B",
+        "text": "4"
+      },
+      {
+        "label": "C",
+        "text": "8"
+      },
+      {
+        "label": "D",
+        "text": "-4"
+      },
+      {
+        "label": "E",
+        "text": "-16"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-systems-of-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "d461c79d92a9a12c2387615db4190cd457718d4bcd167ff41e176781cbf1e52f",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-equations-18326da622",
+    "skillId": "act-quadratic-equations",
+    "prompt": "Which of the following is a solution to x² - 1x - 12 = 0?",
+    "answer": {
+      "type": "auto",
+      "value": "4",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "4"
+      },
+      {
+        "label": "B",
+        "text": "1"
+      },
+      {
+        "label": "C",
+        "text": "-4"
+      },
+      {
+        "label": "D",
+        "text": "3"
+      },
+      {
+        "label": "E",
+        "text": "-12"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "18326da62282c7f782d56d372ca3ab3531ea3de47cd6be1ee01fea01128adde1",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-equations-aec16618dd",
+    "skillId": "act-quadratic-equations",
+    "prompt": "Which of the following is a solution to x² - 9x + 20 = 0?",
+    "answer": {
+      "type": "auto",
+      "value": "5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-5"
+      },
+      {
+        "label": "B",
+        "text": "5"
+      },
+      {
+        "label": "C",
+        "text": "-4"
+      },
+      {
+        "label": "D",
+        "text": "20"
+      },
+      {
+        "label": "E",
+        "text": "9"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "aec16618dd9cc77c91fdb52de98d5fd1c38b8a8d74d632f75fc91e0ade3883df",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-equations-ff5716b0b2",
+    "skillId": "act-quadratic-equations",
+    "prompt": "Which of the following is a solution to x² - 10x + 24 = 0?",
+    "answer": {
+      "type": "auto",
+      "value": "6",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "6"
+      },
+      {
+        "label": "B",
+        "text": "24"
+      },
+      {
+        "label": "C",
+        "text": "10"
+      },
+      {
+        "label": "D",
+        "text": "-6"
+      },
+      {
+        "label": "E",
+        "text": "-4"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "ff5716b0b23c091f2c8b30cccdb2eb535d222f7dc3cb456d4d447ff9d92c202f",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-equations-e4ce4fb629",
+    "skillId": "act-quadratic-equations",
+    "prompt": "Which of the following is a solution to x² + 8x + 15 = 0?",
+    "answer": {
+      "type": "auto",
+      "value": "-3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "15"
+      },
+      {
+        "label": "B",
+        "text": "3"
+      },
+      {
+        "label": "C",
+        "text": "5"
+      },
+      {
+        "label": "D",
+        "text": "-8"
+      },
+      {
+        "label": "E",
+        "text": "-3"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "e4ce4fb6299de2369493613af28f1a69852536222c20fa39fa6db7ba43bef107",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-equations-9144d958a9",
+    "skillId": "act-quadratic-equations",
+    "prompt": "Which of the following is a solution to x² + 1x - 20 = 0?",
+    "answer": {
+      "type": "auto",
+      "value": "4",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-20"
+      },
+      {
+        "label": "B",
+        "text": "-1"
+      },
+      {
+        "label": "C",
+        "text": "5"
+      },
+      {
+        "label": "D",
+        "text": "4"
+      },
+      {
+        "label": "E",
+        "text": "-4"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "9144d958a90c4914bc68d01c41ebe652f440f959e173621d0a9f2829036ee467",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-equations-234380b521",
+    "skillId": "act-quadratic-equations",
+    "prompt": "Which of the following is a solution to x² + 4x - 5 = 0?",
+    "answer": {
+      "type": "auto",
+      "value": "1",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "1"
+      },
+      {
+        "label": "B",
+        "text": "5"
+      },
+      {
+        "label": "C",
+        "text": "-4"
+      },
+      {
+        "label": "D",
+        "text": "-1"
+      },
+      {
+        "label": "E",
+        "text": "-5"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "234380b521211fc9d0f32da0d4786e45134b4590e2ff00e0fb724dfaeedbdcc7",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-equations-3ed6dfcbe5",
+    "skillId": "act-quadratic-equations",
+    "prompt": "Which of the following is a solution to x² + 10x + 24 = 0?",
+    "answer": {
+      "type": "auto",
+      "value": "-4",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-4"
+      },
+      {
+        "label": "B",
+        "text": "-10"
+      },
+      {
+        "label": "C",
+        "text": "4"
+      },
+      {
+        "label": "D",
+        "text": "6"
+      },
+      {
+        "label": "E",
+        "text": "24"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "3ed6dfcbe55631c2fb5cb26cd197d5e84523dface616f20a3304fbed6c9db4c7",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-equations-34250e0e10",
+    "skillId": "act-quadratic-equations",
+    "prompt": "Which of the following is a solution to x² + 8x + 12 = 0?",
+    "answer": {
+      "type": "auto",
+      "value": "-2",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "6"
+      },
+      {
+        "label": "B",
+        "text": "12"
+      },
+      {
+        "label": "C",
+        "text": "2"
+      },
+      {
+        "label": "D",
+        "text": "-2"
+      },
+      {
+        "label": "E",
+        "text": "-8"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "34250e0e106f0577d82e6786ac4eeda5e63c3d8eb7dbe9470641cd99fab336b3",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polynomial-expressions-ab63901d91",
+    "skillId": "act-polynomial-expressions",
+    "prompt": "Expand: (x + 5)(x + 6)",
+    "answer": {
+      "type": "auto",
+      "value": "x^2 + 11x + 30",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "x^2 + 11"
+      },
+      {
+        "label": "B",
+        "text": "x^2 + 11x + 30"
+      },
+      {
+        "label": "C",
+        "text": "x^2 + 31"
+      },
+      {
+        "label": "D",
+        "text": "x^2 + 11x - 30"
+      },
+      {
+        "label": "E",
+        "text": "x^2 + 30x + 11"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polynomial-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "ab63901d916d84c9bac8e9b8d72acb84fd15ea90f26260493d311592680d470e",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polynomial-expressions-0d1fb0c578",
+    "skillId": "act-polynomial-expressions",
+    "prompt": "Expand: (x + 6)(x + 3)",
+    "answer": {
+      "type": "auto",
+      "value": "x^2 + 9x + 18",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "x^2 + 18x + 9"
+      },
+      {
+        "label": "B",
+        "text": "x^2 + 9x + 18"
+      },
+      {
+        "label": "C",
+        "text": "x^2 + 9"
+      },
+      {
+        "label": "D",
+        "text": "x^2 + 9x - 18"
+      },
+      {
+        "label": "E",
+        "text": "x^2 + 19"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polynomial-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "0d1fb0c57882c08918b7e377daaa538f9d23c7261b919061193864b7d604555f",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polynomial-expressions-c4a479504c",
+    "skillId": "act-polynomial-expressions",
+    "prompt": "Expand: (x - 6)(x - 5)",
+    "answer": {
+      "type": "auto",
+      "value": "x^2 - 11x + 30",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "x^2 + 31"
+      },
+      {
+        "label": "B",
+        "text": "x^2 - 11"
+      },
+      {
+        "label": "C",
+        "text": "x^2 + 30x - 11"
+      },
+      {
+        "label": "D",
+        "text": "x^2 - 11x + 30"
+      },
+      {
+        "label": "E",
+        "text": "x^2 - 11x - 30"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polynomial-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "c4a479504c7bd03ec58ec6d0577e3e88afd1ff5fc8bc2f0033ffb53719af6a84",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polynomial-expressions-c5e5a238f9",
+    "skillId": "act-polynomial-expressions",
+    "prompt": "Expand: (x - 3)(x - 1)",
+    "answer": {
+      "type": "auto",
+      "value": "x^2 - 4x + 3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "x^2 + 4"
+      },
+      {
+        "label": "B",
+        "text": "x^2 - 4"
+      },
+      {
+        "label": "C",
+        "text": "x^2 + 3x - 4"
+      },
+      {
+        "label": "D",
+        "text": "x^2 - 4x + 3"
+      },
+      {
+        "label": "E",
+        "text": "x^2 - 4x - 3"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polynomial-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "c5e5a238f9c0b5e7cc84a890363cdf721cc809350e6aff963f0ccf9112ce1b33",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polynomial-expressions-321446d37d",
+    "skillId": "act-polynomial-expressions",
+    "prompt": "Expand: (x + 2)(x - 6)",
+    "answer": {
+      "type": "auto",
+      "value": "x^2 - 4x - 12",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "x^2 - 12x - 4"
+      },
+      {
+        "label": "B",
+        "text": "x^2 - 4x + 12"
+      },
+      {
+        "label": "C",
+        "text": "x^2 - 4"
+      },
+      {
+        "label": "D",
+        "text": "x^2 - 11"
+      },
+      {
+        "label": "E",
+        "text": "x^2 - 4x - 12"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polynomial-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "321446d37d8f560e5ee58a2147c7bacc08c279ce9523846e708d0a80eda1438f",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polynomial-expressions-7737d9b6ad",
+    "skillId": "act-polynomial-expressions",
+    "prompt": "Expand: (x - 4)(x + 3)",
+    "answer": {
+      "type": "auto",
+      "value": "x^2 - 1x - 12",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "x^2 - 1x + 12"
+      },
+      {
+        "label": "B",
+        "text": "x^2 - 11"
+      },
+      {
+        "label": "C",
+        "text": "x^2 - 12x - 1"
+      },
+      {
+        "label": "D",
+        "text": "x^2 - 1x - 12"
+      },
+      {
+        "label": "E",
+        "text": "x^2 - 1"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polynomial-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "7737d9b6ad68428c42bd279d03cf2a676dfa300c25970b40de5b5e2ebe933bb8",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polynomial-expressions-db1c7c22f1",
+    "skillId": "act-polynomial-expressions",
+    "prompt": "Expand: (x - 4)(x - 4)",
+    "answer": {
+      "type": "auto",
+      "value": "x^2 - 8x + 16",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "x^2 - 8"
+      },
+      {
+        "label": "B",
+        "text": "x^2 + 17"
+      },
+      {
+        "label": "C",
+        "text": "x^2 - 8x + 16"
+      },
+      {
+        "label": "D",
+        "text": "x^2 + 16x - 8"
+      },
+      {
+        "label": "E",
+        "text": "x^2 - 8x - 16"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polynomial-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "db1c7c22f1a0110762b14d4822bcd60774d8e816ab00e0179669eed6c1e5cb21",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polynomial-expressions-c76ba9dc0f",
+    "skillId": "act-polynomial-expressions",
+    "prompt": "Expand: (x - 1)(x + 4)",
+    "answer": {
+      "type": "auto",
+      "value": "x^2 + 3x - 4",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "x^2 + 3x - 4"
+      },
+      {
+        "label": "B",
+        "text": "x^2 + 3"
+      },
+      {
+        "label": "C",
+        "text": "x^2 - 3"
+      },
+      {
+        "label": "D",
+        "text": "x^2 + 3x + 4"
+      },
+      {
+        "label": "E",
+        "text": "x^2 - 4x + 3"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polynomial-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "c76ba9dc0f7c6223fa698fa29110b09df2737752486713ec8296b70767314bf8",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-radical-rational-expressions-27fe7500f7",
+    "skillId": "act-radical-rational-expressions",
+    "prompt": "Simplify: √80",
+    "answer": {
+      "type": "auto",
+      "value": "4√5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "4√5"
+      },
+      {
+        "label": "B",
+        "text": "20√1"
+      },
+      {
+        "label": "C",
+        "text": "80"
+      },
+      {
+        "label": "D",
+        "text": "9√5"
+      },
+      {
+        "label": "E",
+        "text": "4√10"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-radical-rational-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "27fe7500f77d31e7d5249f4e4cbf166fbcc1fd016bcfce346ef8c39906a52871",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-radical-rational-expressions-63cc21f580",
+    "skillId": "act-radical-rational-expressions",
+    "prompt": "Simplify: √75",
+    "answer": {
+      "type": "auto",
+      "value": "5√3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "75"
+      },
+      {
+        "label": "B",
+        "text": "5√3"
+      },
+      {
+        "label": "C",
+        "text": "5√6"
+      },
+      {
+        "label": "D",
+        "text": "8√3"
+      },
+      {
+        "label": "E",
+        "text": "15√1"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-radical-rational-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "63cc21f5805c334e62df23ae862b0d1b95233de588e3b6713c09b0c6f23257a9",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-radical-rational-expressions-281e03dcfa",
+    "skillId": "act-radical-rational-expressions",
+    "prompt": "Simplify: √18",
+    "answer": {
+      "type": "auto",
+      "value": "3√2",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "3√2"
+      },
+      {
+        "label": "B",
+        "text": "5√2"
+      },
+      {
+        "label": "C",
+        "text": "3√4"
+      },
+      {
+        "label": "D",
+        "text": "6√1"
+      },
+      {
+        "label": "E",
+        "text": "18"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-radical-rational-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "281e03dcfa2fb4a02dd89ad955b4bdf726c6e292396548637609c3f1e2de62ac",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-radical-rational-expressions-dc4ef895c9",
+    "skillId": "act-radical-rational-expressions",
+    "prompt": "Simplify: √63",
+    "answer": {
+      "type": "auto",
+      "value": "3√7",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "3√7"
+      },
+      {
+        "label": "B",
+        "text": "63"
+      },
+      {
+        "label": "C",
+        "text": "10√7"
+      },
+      {
+        "label": "D",
+        "text": "21√1"
+      },
+      {
+        "label": "E",
+        "text": "3√14"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-radical-rational-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "dc4ef895c934f7012ea411359754f180121d4f6c3b197603ebbdc16f0431e5a8",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-radical-rational-expressions-dfde70e812",
+    "skillId": "act-radical-rational-expressions",
+    "prompt": "Simplify: √32",
+    "answer": {
+      "type": "auto",
+      "value": "4√2",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "4√4"
+      },
+      {
+        "label": "B",
+        "text": "8√1"
+      },
+      {
+        "label": "C",
+        "text": "6√2"
+      },
+      {
+        "label": "D",
+        "text": "32"
+      },
+      {
+        "label": "E",
+        "text": "4√2"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-radical-rational-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "dfde70e8123d295ef4efc090b89fff569c1f1c4c6099e42d8332e0cc538fcaa1",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-radical-rational-expressions-87927c8c7c",
+    "skillId": "act-radical-rational-expressions",
+    "prompt": "Simplify: √24",
+    "answer": {
+      "type": "auto",
+      "value": "2√6",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "24"
+      },
+      {
+        "label": "B",
+        "text": "8√6"
+      },
+      {
+        "label": "C",
+        "text": "2√6"
+      },
+      {
+        "label": "D",
+        "text": "2√12"
+      },
+      {
+        "label": "E",
+        "text": "12√1"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-radical-rational-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "87927c8c7c975a367e3c302ab07f98b7d09be369ec56860b3dc45b2acc5d6777",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-radical-rational-expressions-bc45d35737",
+    "skillId": "act-radical-rational-expressions",
+    "prompt": "Simplify: √12",
+    "answer": {
+      "type": "auto",
+      "value": "2√3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "5√3"
+      },
+      {
+        "label": "B",
+        "text": "2√3"
+      },
+      {
+        "label": "C",
+        "text": "2√6"
+      },
+      {
+        "label": "D",
+        "text": "6√1"
+      },
+      {
+        "label": "E",
+        "text": "12"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-radical-rational-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "bc45d35737a4267130a69ba8fc315fde8f510f2e0ca2e327bf4e6501a0a8b41f",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-radical-rational-expressions-0e59fca760",
+    "skillId": "act-radical-rational-expressions",
+    "prompt": "Simplify: √180",
+    "answer": {
+      "type": "auto",
+      "value": "6√5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "6√10"
+      },
+      {
+        "label": "B",
+        "text": "30√1"
+      },
+      {
+        "label": "C",
+        "text": "6√5"
+      },
+      {
+        "label": "D",
+        "text": "180"
+      },
+      {
+        "label": "E",
+        "text": "11√5"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-radical-rational-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "0e59fca760f006b0dadbe0686280f353588cef4ead67511edfb0b8500fd6c388",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-notation-evaluation-2aa842d1f0",
+    "skillId": "act-function-notation-evaluation",
+    "prompt": "If f(x) = -2x² - 1, what is f(3)?",
+    "answer": {
+      "type": "auto",
+      "value": "-19",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-19"
+      },
+      {
+        "label": "B",
+        "text": "35"
+      },
+      {
+        "label": "C",
+        "text": "-16"
+      },
+      {
+        "label": "D",
+        "text": "-17"
+      },
+      {
+        "label": "E",
+        "text": "-7"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-notation-evaluation"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "2aa842d1f028f75f6837c17f9f9ca8912aeed4c24bc8c69d6bade5b72980145d",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-notation-evaluation-a12e23d77b",
+    "skillId": "act-function-notation-evaluation",
+    "prompt": "If f(x) = 4x² + 1, what is f(-4)?",
+    "answer": {
+      "type": "auto",
+      "value": "65",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "257"
+      },
+      {
+        "label": "B",
+        "text": "63"
+      },
+      {
+        "label": "C",
+        "text": "68"
+      },
+      {
+        "label": "D",
+        "text": "-15"
+      },
+      {
+        "label": "E",
+        "text": "65"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-notation-evaluation"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "a12e23d77b5c6b3c8a676ee30db8b896800d21547c6630ce37694acd75660b67",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-notation-evaluation-3793a97ccc",
+    "skillId": "act-function-notation-evaluation",
+    "prompt": "If f(x) = -4x² - 3, what is f(3)?",
+    "answer": {
+      "type": "auto",
+      "value": "-39",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-15"
+      },
+      {
+        "label": "B",
+        "text": "-24"
+      },
+      {
+        "label": "C",
+        "text": "141"
+      },
+      {
+        "label": "D",
+        "text": "-33"
+      },
+      {
+        "label": "E",
+        "text": "-39"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-notation-evaluation"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "3793a97cccd085b6f8e417dda5fc299695a40cd6880e8e8c676b6c83f96a138f",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-notation-evaluation-4f426cd1db",
+    "skillId": "act-function-notation-evaluation",
+    "prompt": "If f(x) = 3x² + 3, what is f(4)?",
+    "answer": {
+      "type": "auto",
+      "value": "51",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "15"
+      },
+      {
+        "label": "B",
+        "text": "57"
+      },
+      {
+        "label": "C",
+        "text": "51"
+      },
+      {
+        "label": "D",
+        "text": "147"
+      },
+      {
+        "label": "E",
+        "text": "45"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-notation-evaluation"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "4f426cd1dbbc12f944302dded7d07ef229a43764f3e1a152bd0ce6e97159d45a",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-notation-evaluation-aedc4ffe25",
+    "skillId": "act-function-notation-evaluation",
+    "prompt": "If f(x) = -2x² - 2, what is f(-4)?",
+    "answer": {
+      "type": "auto",
+      "value": "-34",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-28"
+      },
+      {
+        "label": "B",
+        "text": "-30"
+      },
+      {
+        "label": "C",
+        "text": "6"
+      },
+      {
+        "label": "D",
+        "text": "-34"
+      },
+      {
+        "label": "E",
+        "text": "62"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-notation-evaluation"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "aedc4ffe2503e52474b8f85262099bd2a46a0276a3b117d996ca5cd3cdee5942",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-notation-evaluation-11f2babc51",
+    "skillId": "act-function-notation-evaluation",
+    "prompt": "If f(x) = -2x² + 6, what is f(-4)?",
+    "answer": {
+      "type": "auto",
+      "value": "-26",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-44"
+      },
+      {
+        "label": "B",
+        "text": "-26"
+      },
+      {
+        "label": "C",
+        "text": "70"
+      },
+      {
+        "label": "D",
+        "text": "-38"
+      },
+      {
+        "label": "E",
+        "text": "14"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-notation-evaluation"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "11f2babc5132ba278a6c20a992eb1424a7c5679925e5f7860270f32c9111b981",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-notation-evaluation-9783314b62",
+    "skillId": "act-function-notation-evaluation",
+    "prompt": "If f(x) = -3x² - 1, what is f(-2)?",
+    "answer": {
+      "type": "auto",
+      "value": "-13",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "35"
+      },
+      {
+        "label": "B",
+        "text": "-11"
+      },
+      {
+        "label": "C",
+        "text": "-9"
+      },
+      {
+        "label": "D",
+        "text": "-13"
+      },
+      {
+        "label": "E",
+        "text": "5"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-notation-evaluation"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "9783314b62289ce6ccbe9fe5ab2778f6cf59db4a01b44b2463e8678b2afd6d86",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-notation-evaluation-4389ba46f7",
+    "skillId": "act-function-notation-evaluation",
+    "prompt": "If f(x) = 3x² + 2, what is f(-1)?",
+    "answer": {
+      "type": "auto",
+      "value": "5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "5"
+      },
+      {
+        "label": "B",
+        "text": "-1"
+      },
+      {
+        "label": "C",
+        "text": "11"
+      },
+      {
+        "label": "D",
+        "text": "9"
+      },
+      {
+        "label": "E",
+        "text": "1"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-notation-evaluation"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "4389ba46f77c5e24c8cbe9bdfe390abf7bdb5ab99df44c146bfa2aded22da06a",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-functions-972f1bfb70",
+    "skillId": "act-linear-functions",
+    "prompt": "What is the slope of the line through (-2, 4) and (-5, 3)?",
+    "answer": {
+      "type": "auto",
+      "value": "-1/-3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-3"
+      },
+      {
+        "label": "B",
+        "text": "-1/-3"
+      },
+      {
+        "label": "C",
+        "text": "-0.3333333333333333"
+      },
+      {
+        "label": "D",
+        "text": "3"
+      },
+      {
+        "label": "E",
+        "text": "-1"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "972f1bfb70727f5c5c640a43c7c9d6a167227b5981ed53af4c3e233ba8734baf",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-functions-df7a2edf32",
+    "skillId": "act-linear-functions",
+    "prompt": "What is the slope of the line through (-3, -3) and (1, 2)?",
+    "answer": {
+      "type": "auto",
+      "value": "5/4",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "4/5"
+      },
+      {
+        "label": "B",
+        "text": "-1.25"
+      },
+      {
+        "label": "C",
+        "text": "4"
+      },
+      {
+        "label": "D",
+        "text": "5"
+      },
+      {
+        "label": "E",
+        "text": "5/4"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "df7a2edf32ed0627b275164ee96e1a3e969a52af0656f858656beeb96d8f351c",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-functions-2c6f37db42",
+    "skillId": "act-linear-functions",
+    "prompt": "What is the slope of the line through (-3, -1) and (-1, -6)?",
+    "answer": {
+      "type": "auto",
+      "value": "-5/2",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "2"
+      },
+      {
+        "label": "B",
+        "text": "2/-5"
+      },
+      {
+        "label": "C",
+        "text": "2.5"
+      },
+      {
+        "label": "D",
+        "text": "-5/2"
+      },
+      {
+        "label": "E",
+        "text": "-5"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "2c6f37db4245c9c665ebfedc4c82cd10ad7490fec70031d8a39df100cc4a801e",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-functions-34f1b45ca4",
+    "skillId": "act-linear-functions",
+    "prompt": "What is the slope of the line through (-3, 4) and (0, 6)?",
+    "answer": {
+      "type": "auto",
+      "value": "2/3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "2"
+      },
+      {
+        "label": "B",
+        "text": "-0.6666666666666666"
+      },
+      {
+        "label": "C",
+        "text": "3/2"
+      },
+      {
+        "label": "D",
+        "text": "3"
+      },
+      {
+        "label": "E",
+        "text": "2/3"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "34f1b45ca4ab59a5bd048ad0567f10c0b6a34ae358359df4f56ebbb0f2c30028",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-functions-44cc32d2ca",
+    "skillId": "act-linear-functions",
+    "prompt": "What is the slope of the line through (4, -4) and (-3, -6)?",
+    "answer": {
+      "type": "auto",
+      "value": "-2/-7",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-2/-7"
+      },
+      {
+        "label": "B",
+        "text": "-2"
+      },
+      {
+        "label": "C",
+        "text": "-7"
+      },
+      {
+        "label": "D",
+        "text": "-0.2857142857142857"
+      },
+      {
+        "label": "E",
+        "text": "-7/-2"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "44cc32d2cab44b708aa84c2b06c54d89ca5b44ba94d617c08b96d56c020be46b",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-functions-165366d07c",
+    "skillId": "act-linear-functions",
+    "prompt": "What is the slope of the line through (5, 6) and (1, -4)?",
+    "answer": {
+      "type": "auto",
+      "value": "-5/-2",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-2/-5"
+      },
+      {
+        "label": "B",
+        "text": "-10"
+      },
+      {
+        "label": "C",
+        "text": "-2.5"
+      },
+      {
+        "label": "D",
+        "text": "-4"
+      },
+      {
+        "label": "E",
+        "text": "-5/-2"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "165366d07cc02abcb73656d1231d8aea08158e51b116aee816a0e7f1b0928186",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-functions-d26d94a560",
+    "skillId": "act-linear-functions",
+    "prompt": "What is the slope of the line through (-3, 2) and (3, 4)?",
+    "answer": {
+      "type": "auto",
+      "value": "1/3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "1/3"
+      },
+      {
+        "label": "B",
+        "text": "3"
+      },
+      {
+        "label": "C",
+        "text": "-0.3333333333333333"
+      },
+      {
+        "label": "D",
+        "text": "6"
+      },
+      {
+        "label": "E",
+        "text": "2"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "d26d94a560f0d718b3d8dd7e32963021da66ffa6e00f22c46ce3a75f1e18ad29",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-functions-778281e087",
+    "skillId": "act-linear-functions",
+    "prompt": "What is the slope of the line through (-4, 3) and (2, 6)?",
+    "answer": {
+      "type": "auto",
+      "value": "1/2",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "6"
+      },
+      {
+        "label": "B",
+        "text": "-0.5"
+      },
+      {
+        "label": "C",
+        "text": "3"
+      },
+      {
+        "label": "D",
+        "text": "1/2"
+      },
+      {
+        "label": "E",
+        "text": "2"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "778281e0872cfe67f1d801a51595f5756e9ee2b544c2fff29192b32bb45e4dc3",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-functions-fbd665509e",
+    "skillId": "act-quadratic-functions",
+    "prompt": "What is the vertex of the parabola y = 2(x - 4)² - 6?",
+    "answer": {
+      "type": "auto",
+      "value": "(4, -6)",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "(4, -6)"
+      },
+      {
+        "label": "B",
+        "text": "(-6, 4)"
+      },
+      {
+        "label": "C",
+        "text": "(-4, 6)"
+      },
+      {
+        "label": "D",
+        "text": "(-4, -6)"
+      },
+      {
+        "label": "E",
+        "text": "(4, 6)"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "fbd665509e56a65ce259cf9a0f2c794c82487f4cdbafb93f753ad90f010cbb47",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-functions-1bf22db683",
+    "skillId": "act-quadratic-functions",
+    "prompt": "What is the vertex of the parabola y = 1(x + 2)² - 3?",
+    "answer": {
+      "type": "auto",
+      "value": "(-2, -3)",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "(2, -3)"
+      },
+      {
+        "label": "B",
+        "text": "(-3, -2)"
+      },
+      {
+        "label": "C",
+        "text": "(2, 3)"
+      },
+      {
+        "label": "D",
+        "text": "(-2, -3)"
+      },
+      {
+        "label": "E",
+        "text": "(-2, 3)"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "1bf22db68335604c314c7da6287263eb0dd28d8b4730f13a8d74af16085e3277",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-functions-35fc35f88f",
+    "skillId": "act-quadratic-functions",
+    "prompt": "What is the vertex of the parabola y = 1(x - 3)² - 2?",
+    "answer": {
+      "type": "auto",
+      "value": "(3, -2)",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "(3, 2)"
+      },
+      {
+        "label": "B",
+        "text": "(3, -2)"
+      },
+      {
+        "label": "C",
+        "text": "(-3, 2)"
+      },
+      {
+        "label": "D",
+        "text": "(-2, 3)"
+      },
+      {
+        "label": "E",
+        "text": "(-3, -2)"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "35fc35f88f8b6970288bb4ee028e6ba7256d047be005eeb88f1681c04576a14a",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-functions-c744d428be",
+    "skillId": "act-quadratic-functions",
+    "prompt": "What is the vertex of the parabola y = 1(x + 2)² + 6?",
+    "answer": {
+      "type": "auto",
+      "value": "(-2, 6)",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "(2, -6)"
+      },
+      {
+        "label": "B",
+        "text": "(2, 6)"
+      },
+      {
+        "label": "C",
+        "text": "(-2, -6)"
+      },
+      {
+        "label": "D",
+        "text": "(-2, 6)"
+      },
+      {
+        "label": "E",
+        "text": "(6, -2)"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "c744d428be4f4db2f273a35009f8ef1d61bbe39eab05f2cf0c6e78f577915726",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-functions-06de2ba4f1",
+    "skillId": "act-quadratic-functions",
+    "prompt": "What is the vertex of the parabola y = 1(x + 3)² - 6?",
+    "answer": {
+      "type": "auto",
+      "value": "(-3, -6)",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "(-3, 6)"
+      },
+      {
+        "label": "B",
+        "text": "(3, -6)"
+      },
+      {
+        "label": "C",
+        "text": "(-6, -3)"
+      },
+      {
+        "label": "D",
+        "text": "(3, 6)"
+      },
+      {
+        "label": "E",
+        "text": "(-3, -6)"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "06de2ba4f1cb97aa12985a47f2a62251b2f26622a13344e3a25259e1614b9c1e",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-functions-c55b6cac28",
+    "skillId": "act-quadratic-functions",
+    "prompt": "What is the vertex of the parabola y = 3(x + 3)² - 4?",
+    "answer": {
+      "type": "auto",
+      "value": "(-3, -4)",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "(-4, -3)"
+      },
+      {
+        "label": "B",
+        "text": "(-3, -4)"
+      },
+      {
+        "label": "C",
+        "text": "(3, 4)"
+      },
+      {
+        "label": "D",
+        "text": "(-3, 4)"
+      },
+      {
+        "label": "E",
+        "text": "(3, -4)"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "c55b6cac286cf1c51b161bd728f642b2bf07e7ebfd90f007b2518a93a8e90696",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-functions-9c106efa00",
+    "skillId": "act-quadratic-functions",
+    "prompt": "What is the vertex of the parabola y = 2(x + 1)² - 3?",
+    "answer": {
+      "type": "auto",
+      "value": "(-1, -3)",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "(-1, -3)"
+      },
+      {
+        "label": "B",
+        "text": "(-1, 3)"
+      },
+      {
+        "label": "C",
+        "text": "(1, -3)"
+      },
+      {
+        "label": "D",
+        "text": "(1, 3)"
+      },
+      {
+        "label": "E",
+        "text": "(-3, -1)"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "9c106efa004500af0336c9d801a645f66ba1c38e3dee508419bc89f926abb6d4",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-functions-818f30f47e",
+    "skillId": "act-quadratic-functions",
+    "prompt": "What is the vertex of the parabola y = 3(x + 1)² - 6?",
+    "answer": {
+      "type": "auto",
+      "value": "(-1, -6)",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "(-1, -6)"
+      },
+      {
+        "label": "B",
+        "text": "(-1, 6)"
+      },
+      {
+        "label": "C",
+        "text": "(1, 6)"
+      },
+      {
+        "label": "D",
+        "text": "(-6, -1)"
+      },
+      {
+        "label": "E",
+        "text": "(1, -6)"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "818f30f47e489fa2d701f442533852c1597dfb3576a42e6c4dee04e8c97df7ba",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polynomial-exponential-log-81ef195d81",
+    "skillId": "act-polynomial-exponential-log",
+    "prompt": "What is log₍5₎(3125)?",
+    "answer": {
+      "type": "auto",
+      "value": "5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "3125"
+      },
+      {
+        "label": "B",
+        "text": "6"
+      },
+      {
+        "label": "C",
+        "text": "625"
+      },
+      {
+        "label": "D",
+        "text": "5"
+      },
+      {
+        "label": "E",
+        "text": "25"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polynomial-exponential-log"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "81ef195d8103a0cfbd2d7e288d7b3cf55b952ad24745262e850b018e7c8b2798",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polynomial-exponential-log-3b910f180a",
+    "skillId": "act-polynomial-exponential-log",
+    "prompt": "What is log₍5₎(125)?",
+    "answer": {
+      "type": "auto",
+      "value": "3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "125"
+      },
+      {
+        "label": "B",
+        "text": "25"
+      },
+      {
+        "label": "C",
+        "text": "3"
+      },
+      {
+        "label": "D",
+        "text": "4"
+      },
+      {
+        "label": "E",
+        "text": "15"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polynomial-exponential-log"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "3b910f180a8c3368e60d260702d752a2e00e645d03951421fb50a9dc0041fd52",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polynomial-exponential-log-016b61dd6d",
+    "skillId": "act-polynomial-exponential-log",
+    "prompt": "What is log₍3₎(243)?",
+    "answer": {
+      "type": "auto",
+      "value": "5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "81"
+      },
+      {
+        "label": "B",
+        "text": "6"
+      },
+      {
+        "label": "C",
+        "text": "15"
+      },
+      {
+        "label": "D",
+        "text": "243"
+      },
+      {
+        "label": "E",
+        "text": "5"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polynomial-exponential-log"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "016b61dd6d9671b97b7419bf8318fd0e23f02d349ec9d969cef81cd98b15f706",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polynomial-exponential-log-5068409189",
+    "skillId": "act-polynomial-exponential-log",
+    "prompt": "What is log₍5₎(15625)?",
+    "answer": {
+      "type": "auto",
+      "value": "6",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "7"
+      },
+      {
+        "label": "B",
+        "text": "3125"
+      },
+      {
+        "label": "C",
+        "text": "6"
+      },
+      {
+        "label": "D",
+        "text": "15625"
+      },
+      {
+        "label": "E",
+        "text": "30"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polynomial-exponential-log"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "5068409189103598e4643acfe362294c2f9551cba7f1373a833cf5f0a2751d5a",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polynomial-exponential-log-4acdea0ccb",
+    "skillId": "act-polynomial-exponential-log",
+    "prompt": "What is log₍3₎(81)?",
+    "answer": {
+      "type": "auto",
+      "value": "4",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "27"
+      },
+      {
+        "label": "B",
+        "text": "4"
+      },
+      {
+        "label": "C",
+        "text": "5"
+      },
+      {
+        "label": "D",
+        "text": "81"
+      },
+      {
+        "label": "E",
+        "text": "12"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polynomial-exponential-log"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "4acdea0ccb84cfda8dd8d3cc05a06952a38c56150eefb18e1e7f7bec02373696",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polynomial-exponential-log-31fe16250a",
+    "skillId": "act-polynomial-exponential-log",
+    "prompt": "What is log₍5₎(25)?",
+    "answer": {
+      "type": "auto",
+      "value": "2",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "3"
+      },
+      {
+        "label": "B",
+        "text": "5"
+      },
+      {
+        "label": "C",
+        "text": "25"
+      },
+      {
+        "label": "D",
+        "text": "2"
+      },
+      {
+        "label": "E",
+        "text": "10"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polynomial-exponential-log"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "31fe16250a926a8bc94fb1b3f859ba9e06f9382cf58bcdbaebb98a3bd18a8451",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polynomial-exponential-log-73789f00f0",
+    "skillId": "act-polynomial-exponential-log",
+    "prompt": "What is log₍3₎(729)?",
+    "answer": {
+      "type": "auto",
+      "value": "6",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "243"
+      },
+      {
+        "label": "B",
+        "text": "729"
+      },
+      {
+        "label": "C",
+        "text": "18"
+      },
+      {
+        "label": "D",
+        "text": "7"
+      },
+      {
+        "label": "E",
+        "text": "6"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polynomial-exponential-log"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "73789f00f0ddc1a6abd94bf02f6f313342718920f3e5a7618a8f50cd5c5b47cb",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polynomial-exponential-log-83cf5fdc4d",
+    "skillId": "act-polynomial-exponential-log",
+    "prompt": "What is log₍2₎(256)?",
+    "answer": {
+      "type": "auto",
+      "value": "8",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "8"
+      },
+      {
+        "label": "B",
+        "text": "128"
+      },
+      {
+        "label": "C",
+        "text": "256"
+      },
+      {
+        "label": "D",
+        "text": "16"
+      },
+      {
+        "label": "E",
+        "text": "9"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polynomial-exponential-log"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "83cf5fdc4d9febe190c692e07359c3de814b2e8ce136761d03bf5961493afec1",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-trig-functions-adcd7b2911",
+    "skillId": "act-trig-functions",
+    "prompt": "What is tan(30°)?",
+    "answer": {
+      "type": "auto",
+      "value": "√3/3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "√2/2"
+      },
+      {
+        "label": "B",
+        "text": "√3/2"
+      },
+      {
+        "label": "C",
+        "text": "1/2"
+      },
+      {
+        "label": "D",
+        "text": "√3"
+      },
+      {
+        "label": "E",
+        "text": "√3/3"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-trig-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "adcd7b2911af744aec9371797981708e2058f7a68125f248f18241fa9b64656b",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-trig-functions-15e6b1dbed",
+    "skillId": "act-trig-functions",
+    "prompt": "What is tan(60°)?",
+    "answer": {
+      "type": "auto",
+      "value": "√3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "√2/2"
+      },
+      {
+        "label": "B",
+        "text": "√3/2"
+      },
+      {
+        "label": "C",
+        "text": "√3"
+      },
+      {
+        "label": "D",
+        "text": "1"
+      },
+      {
+        "label": "E",
+        "text": "1/2"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-trig-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "15e6b1dbed27797708d26210d1b013a6efc39364c0c8216375656466147db1ca",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-trig-functions-8a998270b0",
+    "skillId": "act-trig-functions",
+    "prompt": "What is cos(45°)?",
+    "answer": {
+      "type": "auto",
+      "value": "√2/2",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "1"
+      },
+      {
+        "label": "B",
+        "text": "√3"
+      },
+      {
+        "label": "C",
+        "text": "√2/2"
+      },
+      {
+        "label": "D",
+        "text": "√3/2"
+      },
+      {
+        "label": "E",
+        "text": "1/2"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-trig-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "8a998270b0eebed240b38c07a9dca5ad517f975637e1e414afc732f9260a5be1",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-trig-functions-186797f58c",
+    "skillId": "act-trig-functions",
+    "prompt": "What is tan(45°)?",
+    "answer": {
+      "type": "auto",
+      "value": "1",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "1"
+      },
+      {
+        "label": "B",
+        "text": "√3/2"
+      },
+      {
+        "label": "C",
+        "text": "√2/2"
+      },
+      {
+        "label": "D",
+        "text": "√3"
+      },
+      {
+        "label": "E",
+        "text": "1/2"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-trig-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "186797f58caabf9593718504109738fe59e629bb6a325b9f85d333d9f732f838",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-trig-functions-874129888f",
+    "skillId": "act-trig-functions",
+    "prompt": "What is sin(45°)?",
+    "answer": {
+      "type": "auto",
+      "value": "√2/2",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "1/2"
+      },
+      {
+        "label": "B",
+        "text": "1"
+      },
+      {
+        "label": "C",
+        "text": "√2/2"
+      },
+      {
+        "label": "D",
+        "text": "√3/2"
+      },
+      {
+        "label": "E",
+        "text": "√3"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-trig-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "874129888fd008ee0ac20ca921cd40611e2843600230a8c0aca89f5caafe313f",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-trig-functions-a4d749b7f8",
+    "skillId": "act-trig-functions",
+    "prompt": "What is cos(60°)?",
+    "answer": {
+      "type": "auto",
+      "value": "1/2",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "√2/2"
+      },
+      {
+        "label": "B",
+        "text": "1"
+      },
+      {
+        "label": "C",
+        "text": "√3"
+      },
+      {
+        "label": "D",
+        "text": "1/2"
+      },
+      {
+        "label": "E",
+        "text": "√3/2"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-trig-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "a4d749b7f8778e28cadb1cc37de49152c930a0eb4bb3830723c8feac5d6bd5e2",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-trig-functions-2da5063d6e",
+    "skillId": "act-trig-functions",
+    "prompt": "What is sin(30°)?",
+    "answer": {
+      "type": "auto",
+      "value": "1/2",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "1"
+      },
+      {
+        "label": "B",
+        "text": "√2/2"
+      },
+      {
+        "label": "C",
+        "text": "√3"
+      },
+      {
+        "label": "D",
+        "text": "√3/2"
+      },
+      {
+        "label": "E",
+        "text": "1/2"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-trig-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "2da5063d6ef4b9451626bae425d96535ce3e9a08928806508b600c57bf8133e1",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-trig-functions-4832211b7a",
+    "skillId": "act-trig-functions",
+    "prompt": "What is sin(60°)?",
+    "answer": {
+      "type": "auto",
+      "value": "√3/2",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "1/2"
+      },
+      {
+        "label": "B",
+        "text": "1"
+      },
+      {
+        "label": "C",
+        "text": "√2/2"
+      },
+      {
+        "label": "D",
+        "text": "√3/2"
+      },
+      {
+        "label": "E",
+        "text": "√3"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-trig-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "4832211b7ad3359409eec5552bb7fbb23a0231da40daa5bd2ee692ae14b7b7fe",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-transformations-1d58f5b4a0",
+    "skillId": "act-function-transformations",
+    "prompt": "If f(x) = -3x - 4 and g(x) = f(x − 4) + 2, what is g(-3)?",
+    "answer": {
+      "type": "auto",
+      "value": "19",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "7"
+      },
+      {
+        "label": "B",
+        "text": "5"
+      },
+      {
+        "label": "C",
+        "text": "15"
+      },
+      {
+        "label": "D",
+        "text": "-5"
+      },
+      {
+        "label": "E",
+        "text": "19"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-transformations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "1d58f5b4a014164a18813435ae3405a6b869d2d847faffa54ac66906f280e814",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-transformations-fece4a2f20",
+    "skillId": "act-function-transformations",
+    "prompt": "If f(x) = 1x - 4 and g(x) = f(x − 2) + 1, what is g(-1)?",
+    "answer": {
+      "type": "auto",
+      "value": "-6",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-8"
+      },
+      {
+        "label": "B",
+        "text": "-4"
+      },
+      {
+        "label": "C",
+        "text": "-2"
+      },
+      {
+        "label": "D",
+        "text": "-6"
+      },
+      {
+        "label": "E",
+        "text": "-5"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-transformations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "fece4a2f20aa6cfe8891b083a038d4c07f95b8a5270ab397163b765e9221d5e1",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-transformations-8f84a298f4",
+    "skillId": "act-function-transformations",
+    "prompt": "If f(x) = 2x + 1 and g(x) = f(x − 3) + 3, what is g(-1)?",
+    "answer": {
+      "type": "auto",
+      "value": "-4",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "8"
+      },
+      {
+        "label": "B",
+        "text": "-4"
+      },
+      {
+        "label": "C",
+        "text": "-10"
+      },
+      {
+        "label": "D",
+        "text": "2"
+      },
+      {
+        "label": "E",
+        "text": "-1"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-transformations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "8f84a298f473abbe396a8af19dbc7f5c28dc0f8128a38d1447431b7583276c99",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-transformations-24f1b209a0",
+    "skillId": "act-function-transformations",
+    "prompt": "If f(x) = 4x - 1 and g(x) = f(x − 2) + 1, what is g(-1)?",
+    "answer": {
+      "type": "auto",
+      "value": "-12",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "4"
+      },
+      {
+        "label": "B",
+        "text": "-4"
+      },
+      {
+        "label": "C",
+        "text": "-14"
+      },
+      {
+        "label": "D",
+        "text": "-12"
+      },
+      {
+        "label": "E",
+        "text": "-5"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-transformations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "24f1b209a058e99e464bf72304f783c35a9f5987bd155a54de585a58780ce888",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-transformations-87878ee342",
+    "skillId": "act-function-transformations",
+    "prompt": "If f(x) = 2x + 6 and g(x) = f(x − 3) + 5, what is g(-3)?",
+    "answer": {
+      "type": "auto",
+      "value": "-1",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-11"
+      },
+      {
+        "label": "B",
+        "text": "0"
+      },
+      {
+        "label": "C",
+        "text": "11"
+      },
+      {
+        "label": "D",
+        "text": "5"
+      },
+      {
+        "label": "E",
+        "text": "-1"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-transformations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "87878ee3420d34289b45bb5c7a6387e5df205f79be6aeab4a4a4dde2c580dc3d",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-transformations-784ee149b6",
+    "skillId": "act-function-transformations",
+    "prompt": "If f(x) = -1x - 1 and g(x) = f(x − 3) + 5, what is g(3)?",
+    "answer": {
+      "type": "auto",
+      "value": "4",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-2"
+      },
+      {
+        "label": "B",
+        "text": "4"
+      },
+      {
+        "label": "C",
+        "text": "-6"
+      },
+      {
+        "label": "D",
+        "text": "1"
+      },
+      {
+        "label": "E",
+        "text": "-4"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-transformations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "784ee149b6fa287dfea80cfc6cb0874aca11269010cfea3002d4c1cc8963481c",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-transformations-088f501b84",
+    "skillId": "act-function-transformations",
+    "prompt": "If f(x) = -1x + 1 and g(x) = f(x − 3) + 4, what is g(4)?",
+    "answer": {
+      "type": "auto",
+      "value": "4",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "4"
+      },
+      {
+        "label": "B",
+        "text": "1"
+      },
+      {
+        "label": "C",
+        "text": "-3"
+      },
+      {
+        "label": "D",
+        "text": "-4"
+      },
+      {
+        "label": "E",
+        "text": "-2"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-transformations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "088f501b84a9a372022bcf6e0c64e1e9ff8c9649997f8d2aae08944f4fdae505",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-transformations-aa855a33b2",
+    "skillId": "act-function-transformations",
+    "prompt": "If f(x) = 3x - 1 and g(x) = f(x − 3) + 3, what is g(1)?",
+    "answer": {
+      "type": "auto",
+      "value": "-4",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "2"
+      },
+      {
+        "label": "B",
+        "text": "14"
+      },
+      {
+        "label": "C",
+        "text": "-4"
+      },
+      {
+        "label": "D",
+        "text": "-10"
+      },
+      {
+        "label": "E",
+        "text": "5"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-transformations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "aa855a33b245d786392a9b5187bed11fcf39ce831cddc7385bde88747861eca3",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-center-spread-b23c0b8f31",
+    "skillId": "act-center-spread",
+    "prompt": "What is the average (mean) of 10, 5, 12, 3, 15?",
+    "answer": {
+      "type": "auto",
+      "value": "9",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "12"
+      },
+      {
+        "label": "B",
+        "text": "11"
+      },
+      {
+        "label": "C",
+        "text": "45"
+      },
+      {
+        "label": "D",
+        "text": "9"
+      },
+      {
+        "label": "E",
+        "text": "10"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-center-spread"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "b23c0b8f317a8193ef043b24e8cd39bf61f567f69651f2684935b135837d87ef",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-center-spread-f23fdb88f2",
+    "skillId": "act-center-spread",
+    "prompt": "What is the average (mean) of 15, 5, 14, 8, 3?",
+    "answer": {
+      "type": "auto",
+      "value": "9",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "9"
+      },
+      {
+        "label": "B",
+        "text": "12"
+      },
+      {
+        "label": "C",
+        "text": "11"
+      },
+      {
+        "label": "D",
+        "text": "45"
+      },
+      {
+        "label": "E",
+        "text": "8"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-center-spread"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "f23fdb88f2546468381c7c5dfebd528e7e501d069d0241661952bcd37d6652a0",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-center-spread-aec1f9f696",
+    "skillId": "act-center-spread",
+    "prompt": "What is the average (mean) of 19, 10, 10, 16, 15?",
+    "answer": {
+      "type": "auto",
+      "value": "14",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "15"
+      },
+      {
+        "label": "B",
+        "text": "14"
+      },
+      {
+        "label": "C",
+        "text": "70"
+      },
+      {
+        "label": "D",
+        "text": "18"
+      },
+      {
+        "label": "E",
+        "text": "9"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-center-spread"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "aec1f9f696af0225ecfba999b934a4ebdf7db804bfd8bdf1733d768459b155c1",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-center-spread-73b06a12a3",
+    "skillId": "act-center-spread",
+    "prompt": "What is the average (mean) of 10, 11, 2, 14, 8?",
+    "answer": {
+      "type": "auto",
+      "value": "9",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "9"
+      },
+      {
+        "label": "B",
+        "text": "45"
+      },
+      {
+        "label": "C",
+        "text": "10"
+      },
+      {
+        "label": "D",
+        "text": "11"
+      },
+      {
+        "label": "E",
+        "text": "12"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-center-spread"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "73b06a12a3032827e8525b6415661d05d4aff5e32a935bee35fe5a692468fbbe",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-center-spread-bc371c5df3",
+    "skillId": "act-center-spread",
+    "prompt": "What is the average (mean) of 13, 6, 17, 15, 19?",
+    "answer": {
+      "type": "auto",
+      "value": "14",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "70"
+      },
+      {
+        "label": "B",
+        "text": "13"
+      },
+      {
+        "label": "C",
+        "text": "14"
+      },
+      {
+        "label": "D",
+        "text": "15"
+      },
+      {
+        "label": "E",
+        "text": "18"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-center-spread"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "bc371c5df3da086bdbf7b9a2b9e96b8c54547fdbc64e16b95927767f71dbf985",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-center-spread-6c03f694ad",
+    "skillId": "act-center-spread",
+    "prompt": "What is the average (mean) of 20, 8, 7, 5, 5?",
+    "answer": {
+      "type": "auto",
+      "value": "9",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "9"
+      },
+      {
+        "label": "B",
+        "text": "11"
+      },
+      {
+        "label": "C",
+        "text": "7"
+      },
+      {
+        "label": "D",
+        "text": "45"
+      },
+      {
+        "label": "E",
+        "text": "15"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-center-spread"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "6c03f694ada319c72e8ea24e4c8c74a78bce2e38bfd6a091367d0c033dd300dc",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-center-spread-71d1f96546",
+    "skillId": "act-center-spread",
+    "prompt": "What is the average (mean) of 9, 19, 12, 7, 8?",
+    "answer": {
+      "type": "auto",
+      "value": "11",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "12"
+      },
+      {
+        "label": "B",
+        "text": "11"
+      },
+      {
+        "label": "C",
+        "text": "9"
+      },
+      {
+        "label": "D",
+        "text": "14"
+      },
+      {
+        "label": "E",
+        "text": "55"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-center-spread"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "71d1f965463fdcc9641a384d1d2ce1d1a74069b4e1b37f971ad491d0a1920030",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-center-spread-a06a75418e",
+    "skillId": "act-center-spread",
+    "prompt": "What is the average (mean) of 9, 6, 6, 9, 20?",
+    "answer": {
+      "type": "auto",
+      "value": "10",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "50"
+      },
+      {
+        "label": "B",
+        "text": "13"
+      },
+      {
+        "label": "C",
+        "text": "9"
+      },
+      {
+        "label": "D",
+        "text": "10"
+      },
+      {
+        "label": "E",
+        "text": "14"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-center-spread"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "a06a75418e5d6a6e7922b11d447bc30ab1cb6588c0f7c28258f17f0857c3f0ff",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-data-representations-11712ffa3f",
+    "skillId": "act-data-representations",
+    "prompt": "A store's daily sales were Mon: 18, Tue: 18, Wed: 20, Thu: 19. What were the total sales?",
+    "answer": {
+      "type": "auto",
+      "value": "75",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "20"
+      },
+      {
+        "label": "B",
+        "text": "19"
+      },
+      {
+        "label": "C",
+        "text": "2"
+      },
+      {
+        "label": "D",
+        "text": "57"
+      },
+      {
+        "label": "E",
+        "text": "75"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-data-representations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "11712ffa3f3a0227722ad14d0bb54b027c5a8f7e365daf9fc2521e721fabf217",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-data-representations-1dd0142fd9",
+    "skillId": "act-data-representations",
+    "prompt": "A store's daily sales were Mon: 30, Tue: 7, Wed: 16, Thu: 16. What were the total sales?",
+    "answer": {
+      "type": "auto",
+      "value": "69",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "17"
+      },
+      {
+        "label": "B",
+        "text": "30"
+      },
+      {
+        "label": "C",
+        "text": "62"
+      },
+      {
+        "label": "D",
+        "text": "23"
+      },
+      {
+        "label": "E",
+        "text": "69"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-data-representations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "1dd0142fd988bcb87af6d5c4a15ffb6996ad7a65d4b27757cbd0df983ddc82a1",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-data-representations-cb7d5666fe",
+    "skillId": "act-data-representations",
+    "prompt": "A store's daily sales were Mon: 7, Tue: 22, Wed: 14, Thu: 21. What were the total sales?",
+    "answer": {
+      "type": "auto",
+      "value": "64",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "15"
+      },
+      {
+        "label": "B",
+        "text": "64"
+      },
+      {
+        "label": "C",
+        "text": "22"
+      },
+      {
+        "label": "D",
+        "text": "57"
+      },
+      {
+        "label": "E",
+        "text": "16"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-data-representations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "cb7d5666fee9c199c79d634b1f8bfd3ad3c64b9743ec1f2bd65523faacda1143",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-data-representations-9eede66e3b",
+    "skillId": "act-data-representations",
+    "prompt": "A store's daily sales were Mon: 9, Tue: 11, Wed: 16, Thu: 6. What were the total sales?",
+    "answer": {
+      "type": "auto",
+      "value": "42",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "16"
+      },
+      {
+        "label": "B",
+        "text": "36"
+      },
+      {
+        "label": "C",
+        "text": "42"
+      },
+      {
+        "label": "D",
+        "text": "11"
+      },
+      {
+        "label": "E",
+        "text": "10"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-data-representations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "9eede66e3b8738368263716b2af23490dca6c46efade525b8838447c785c3d24",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-data-representations-96f9d92f24",
+    "skillId": "act-data-representations",
+    "prompt": "A store's daily sales were Mon: 23, Tue: 19, Wed: 23, Thu: 21. What were the total sales?",
+    "answer": {
+      "type": "auto",
+      "value": "86",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "23"
+      },
+      {
+        "label": "B",
+        "text": "4"
+      },
+      {
+        "label": "C",
+        "text": "86"
+      },
+      {
+        "label": "D",
+        "text": "22"
+      },
+      {
+        "label": "E",
+        "text": "67"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-data-representations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "96f9d92f2480d0968c9ea5b70bd9c44eb97c6ccfe1b11233bd0d7da905e5d872",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-data-representations-85ca79611e",
+    "skillId": "act-data-representations",
+    "prompt": "A store's daily sales were Mon: 12, Tue: 8, Wed: 16, Thu: 24. What were the total sales?",
+    "answer": {
+      "type": "auto",
+      "value": "60",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "60"
+      },
+      {
+        "label": "B",
+        "text": "16"
+      },
+      {
+        "label": "C",
+        "text": "52"
+      },
+      {
+        "label": "D",
+        "text": "15"
+      },
+      {
+        "label": "E",
+        "text": "24"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-data-representations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "85ca79611eda4db2494283d20128129e966b28fa90cf323e0e8a19b5cb089b7f",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-data-representations-768fd1337b",
+    "skillId": "act-data-representations",
+    "prompt": "A store's daily sales were Mon: 25, Tue: 23, Wed: 26, Thu: 25. What were the total sales?",
+    "answer": {
+      "type": "auto",
+      "value": "99",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "26"
+      },
+      {
+        "label": "B",
+        "text": "3"
+      },
+      {
+        "label": "C",
+        "text": "76"
+      },
+      {
+        "label": "D",
+        "text": "99"
+      },
+      {
+        "label": "E",
+        "text": "25"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-data-representations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "768fd1337b3d9327086a89b693077ea0984c0e79512f55efc54adc2633673961",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-data-representations-102ea5e6ca",
+    "skillId": "act-data-representations",
+    "prompt": "A store's daily sales were Mon: 16, Tue: 6, Wed: 27, Thu: 5. What were the total sales?",
+    "answer": {
+      "type": "auto",
+      "value": "54",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "54"
+      },
+      {
+        "label": "B",
+        "text": "14"
+      },
+      {
+        "label": "C",
+        "text": "49"
+      },
+      {
+        "label": "D",
+        "text": "27"
+      },
+      {
+        "label": "E",
+        "text": "22"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-data-representations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "102ea5e6caa1a06330e965faac6a3f6182498bfbfbc844992d51901265a7a6b2",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-two-way-tables-57e009105c",
+    "skillId": "act-two-way-tables",
+    "prompt": "In a survey, 8 boys and 12 girls chose pizza; 10 boys and 7 girls chose tacos. How many boys were surveyed in total?",
+    "answer": {
+      "type": "auto",
+      "value": "8",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "18"
+      },
+      {
+        "label": "B",
+        "text": "20"
+      },
+      {
+        "label": "C",
+        "text": "8"
+      },
+      {
+        "label": "D",
+        "text": "19"
+      },
+      {
+        "label": "E",
+        "text": "37"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-two-way-tables"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "57e009105c46aa496bf78304874bcc0ce483bd9029f1f6194322efc4a7496467",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-two-way-tables-126a168f19",
+    "skillId": "act-two-way-tables",
+    "prompt": "In a survey, 6 boys and 14 girls chose pizza; 10 boys and 9 girls chose tacos. How many boys were surveyed in total?",
+    "answer": {
+      "type": "auto",
+      "value": "6",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "39"
+      },
+      {
+        "label": "B",
+        "text": "23"
+      },
+      {
+        "label": "C",
+        "text": "6"
+      },
+      {
+        "label": "D",
+        "text": "16"
+      },
+      {
+        "label": "E",
+        "text": "20"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-two-way-tables"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "126a168f19eca79b59071b0031ab44589c268f0d2094811ee610461cc19cfe1a",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-two-way-tables-18fddabd65",
+    "skillId": "act-two-way-tables",
+    "prompt": "In a survey, 13 boys and 11 girls chose pizza; 9 boys and 4 girls chose tacos. How many boys were surveyed in total?",
+    "answer": {
+      "type": "auto",
+      "value": "13",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "24"
+      },
+      {
+        "label": "B",
+        "text": "37"
+      },
+      {
+        "label": "C",
+        "text": "22"
+      },
+      {
+        "label": "D",
+        "text": "13"
+      },
+      {
+        "label": "E",
+        "text": "15"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-two-way-tables"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "18fddabd658ca0f4b5cfe8c66690868ae1ba68bd4d5bd0696cb38a45ae9698a9",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-two-way-tables-45e861aa36",
+    "skillId": "act-two-way-tables",
+    "prompt": "In a survey, 7 boys and 8 girls chose pizza; 11 boys and 6 girls chose tacos. How many boys were surveyed in total?",
+    "answer": {
+      "type": "auto",
+      "value": "7",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "32"
+      },
+      {
+        "label": "B",
+        "text": "15"
+      },
+      {
+        "label": "C",
+        "text": "7"
+      },
+      {
+        "label": "D",
+        "text": "18"
+      },
+      {
+        "label": "E",
+        "text": "14"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-two-way-tables"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "45e861aa36c402e4f08efec096f9b4b3689c772d98740e10ff78e25ab3ade866",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-two-way-tables-f7814ee7ed",
+    "skillId": "act-two-way-tables",
+    "prompt": "In a survey, 4 boys and 10 girls chose pizza; 9 boys and 8 girls chose tacos. How many boys were surveyed in total?",
+    "answer": {
+      "type": "auto",
+      "value": "4",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "31"
+      },
+      {
+        "label": "B",
+        "text": "18"
+      },
+      {
+        "label": "C",
+        "text": "4"
+      },
+      {
+        "label": "D",
+        "text": "13"
+      },
+      {
+        "label": "E",
+        "text": "14"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-two-way-tables"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "f7814ee7ed223433c2cdd6039ff16769ee7a232ad1d3e56f9abbfc52f9ef8421",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-two-way-tables-25f8addcc1",
+    "skillId": "act-two-way-tables",
+    "prompt": "In a survey, 9 boys and 15 girls chose pizza; 5 boys and 4 girls chose tacos. How many boys were surveyed in total?",
+    "answer": {
+      "type": "auto",
+      "value": "9",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "14"
+      },
+      {
+        "label": "B",
+        "text": "24"
+      },
+      {
+        "label": "C",
+        "text": "33"
+      },
+      {
+        "label": "D",
+        "text": "19"
+      },
+      {
+        "label": "E",
+        "text": "9"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-two-way-tables"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "25f8addcc15c25a7e6fed3b1d5a7de758b8c1636a898903b2984ddb5080e2e71",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-two-way-tables-c3fd14232b",
+    "skillId": "act-two-way-tables",
+    "prompt": "In a survey, 12 boys and 5 girls chose pizza; 11 boys and 5 girls chose tacos. How many boys were surveyed in total?",
+    "answer": {
+      "type": "auto",
+      "value": "12",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "23"
+      },
+      {
+        "label": "B",
+        "text": "12"
+      },
+      {
+        "label": "C",
+        "text": "33"
+      },
+      {
+        "label": "D",
+        "text": "10"
+      },
+      {
+        "label": "E",
+        "text": "17"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-two-way-tables"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "c3fd14232b04b911622dafcbc6eef8990ecd626eabbead438a6d5ffac29d6a2b",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-two-way-tables-c41f020a6e",
+    "skillId": "act-two-way-tables",
+    "prompt": "In a survey, 12 boys and 11 girls chose pizza; 12 boys and 7 girls chose tacos. How many boys were surveyed in total?",
+    "answer": {
+      "type": "auto",
+      "value": "12",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "12"
+      },
+      {
+        "label": "B",
+        "text": "18"
+      },
+      {
+        "label": "C",
+        "text": "42"
+      },
+      {
+        "label": "D",
+        "text": "24"
+      },
+      {
+        "label": "E",
+        "text": "23"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-two-way-tables"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "c41f020a6ebcf467cdd3fb18340b166f356a31c10a0698feea5bd95ae6655c47",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-probability-080a1d414f",
+    "skillId": "act-probability",
+    "prompt": "A bag has 3 red, 5 green, and 6 blue marbles. What is the probability of drawing a red marble?",
+    "answer": {
+      "type": "auto",
+      "value": "3/14",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "3/5"
+      },
+      {
+        "label": "B",
+        "text": "5/14"
+      },
+      {
+        "label": "C",
+        "text": "3/14"
+      },
+      {
+        "label": "D",
+        "text": "3/11"
+      },
+      {
+        "label": "E",
+        "text": "14/3"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-probability"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "080a1d414fb482a6fdff4934bbbff20c8fa5cb2abae41631433664622d9e4523",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-probability-b31ae01916",
+    "skillId": "act-probability",
+    "prompt": "A bag has 2 red, 4 green, and 5 blue marbles. What is the probability of drawing a red marble?",
+    "answer": {
+      "type": "auto",
+      "value": "2/11",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "11/2"
+      },
+      {
+        "label": "B",
+        "text": "2/11"
+      },
+      {
+        "label": "C",
+        "text": "2/4"
+      },
+      {
+        "label": "D",
+        "text": "4/11"
+      },
+      {
+        "label": "E",
+        "text": "2/9"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-probability"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "b31ae0191652dc3f08da11ed8e877509fe9749880655e3267928a0a979bfd77c",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-probability-58430fd45d",
+    "skillId": "act-probability",
+    "prompt": "A bag has 5 red, 6 green, and 5 blue marbles. What is the probability of drawing a red marble?",
+    "answer": {
+      "type": "auto",
+      "value": "5/16",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "5/16"
+      },
+      {
+        "label": "B",
+        "text": "3/8"
+      },
+      {
+        "label": "C",
+        "text": "16/5"
+      },
+      {
+        "label": "D",
+        "text": "5/6"
+      },
+      {
+        "label": "E",
+        "text": "5/11"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-probability"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "58430fd45de5c6dde60a8c9574625270902ef24a423eb06bbe2cd8dc208c16b2",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-probability-b97c85ac31",
+    "skillId": "act-probability",
+    "prompt": "A bag has 3 red, 2 green, and 2 blue marbles. What is the probability of drawing a red marble?",
+    "answer": {
+      "type": "auto",
+      "value": "3/7",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "3/2"
+      },
+      {
+        "label": "B",
+        "text": "3/7"
+      },
+      {
+        "label": "C",
+        "text": "3/4"
+      },
+      {
+        "label": "D",
+        "text": "7/3"
+      },
+      {
+        "label": "E",
+        "text": "2/7"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-probability"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "b97c85ac3154452fdc9a80394681fcfb4e4cda8565f9e651da57dd450b53726c",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-probability-ec8c70f987",
+    "skillId": "act-probability",
+    "prompt": "A bag has 5 red, 2 green, and 2 blue marbles. What is the probability of drawing a red marble?",
+    "answer": {
+      "type": "auto",
+      "value": "5/9",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "5/4"
+      },
+      {
+        "label": "B",
+        "text": "5/2"
+      },
+      {
+        "label": "C",
+        "text": "9/5"
+      },
+      {
+        "label": "D",
+        "text": "5/9"
+      },
+      {
+        "label": "E",
+        "text": "2/9"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-probability"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "ec8c70f98786038e1f49ba6841eff3efaf3dc040a8e2c645b5fca8dedf1040e9",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-probability-462c4221b8",
+    "skillId": "act-probability",
+    "prompt": "A bag has 4 red, 6 green, and 3 blue marbles. What is the probability of drawing a red marble?",
+    "answer": {
+      "type": "auto",
+      "value": "4/13",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "13/4"
+      },
+      {
+        "label": "B",
+        "text": "6/13"
+      },
+      {
+        "label": "C",
+        "text": "4/9"
+      },
+      {
+        "label": "D",
+        "text": "4/13"
+      },
+      {
+        "label": "E",
+        "text": "4/6"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-probability"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "462c4221b8d8a74dd72a1c8b6cc4b0868e5db140ee11640f5f88009fd3fe8715",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-probability-36d5102d1b",
+    "skillId": "act-probability",
+    "prompt": "A bag has 5 red, 3 green, and 4 blue marbles. What is the probability of drawing a red marble?",
+    "answer": {
+      "type": "auto",
+      "value": "5/12",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "5/12"
+      },
+      {
+        "label": "B",
+        "text": "5/3"
+      },
+      {
+        "label": "C",
+        "text": "1/4"
+      },
+      {
+        "label": "D",
+        "text": "5/7"
+      },
+      {
+        "label": "E",
+        "text": "12/5"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-probability"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "36d5102d1b88d232a3561fb6c3c59ad57529e1758aee64e7bf30c658a34a52f3",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-probability-fa1ca24378",
+    "skillId": "act-probability",
+    "prompt": "A bag has 5 red, 6 green, and 4 blue marbles. What is the probability of drawing a red marble?",
+    "answer": {
+      "type": "auto",
+      "value": "1/3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "1/3"
+      },
+      {
+        "label": "B",
+        "text": "5/6"
+      },
+      {
+        "label": "C",
+        "text": "15/5"
+      },
+      {
+        "label": "D",
+        "text": "2/5"
+      },
+      {
+        "label": "E",
+        "text": "5/10"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-probability"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "fa1ca243783613ddabe95a91a2fdac3927a997f439888fffc8c40b32141cd6a4",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-counting-techniques-34bea27ddc",
+    "skillId": "act-counting-techniques",
+    "prompt": "A meal has 4 appetizers, 4 entrées, and 2 desserts. How many different 3-course meals are possible?",
+    "answer": {
+      "type": "auto",
+      "value": "32",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "36"
+      },
+      {
+        "label": "B",
+        "text": "16"
+      },
+      {
+        "label": "C",
+        "text": "32"
+      },
+      {
+        "label": "D",
+        "text": "18"
+      },
+      {
+        "label": "E",
+        "text": "10"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-counting-techniques"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "34bea27ddc7a660c6e6fa54367eb86c1c4c15be500c8a8cd700f8a4ea0e0710f",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-counting-techniques-f30b48bed9",
+    "skillId": "act-counting-techniques",
+    "prompt": "A meal has 2 appetizers, 3 entrées, and 4 desserts. How many different 3-course meals are possible?",
+    "answer": {
+      "type": "auto",
+      "value": "24",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "26"
+      },
+      {
+        "label": "B",
+        "text": "10"
+      },
+      {
+        "label": "C",
+        "text": "24"
+      },
+      {
+        "label": "D",
+        "text": "12"
+      },
+      {
+        "label": "E",
+        "text": "9"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-counting-techniques"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "f30b48bed9f1ffacfc1afafaaea3f99068f4b4d9e624565cdeff25a3377b5536",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-counting-techniques-73368d60e1",
+    "skillId": "act-counting-techniques",
+    "prompt": "A meal has 4 appetizers, 2 entrées, and 3 desserts. How many different 3-course meals are possible?",
+    "answer": {
+      "type": "auto",
+      "value": "24",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "12"
+      },
+      {
+        "label": "B",
+        "text": "11"
+      },
+      {
+        "label": "C",
+        "text": "9"
+      },
+      {
+        "label": "D",
+        "text": "28"
+      },
+      {
+        "label": "E",
+        "text": "24"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-counting-techniques"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "73368d60e1fbaab72440f650f1aa9c07097f0f6af42f2fbe37843717b323fc8f",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-counting-techniques-40c5516e4a",
+    "skillId": "act-counting-techniques",
+    "prompt": "A meal has 2 appetizers, 3 entrées, and 2 desserts. How many different 3-course meals are possible?",
+    "answer": {
+      "type": "auto",
+      "value": "12",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "6"
+      },
+      {
+        "label": "B",
+        "text": "8"
+      },
+      {
+        "label": "C",
+        "text": "7"
+      },
+      {
+        "label": "D",
+        "text": "14"
+      },
+      {
+        "label": "E",
+        "text": "12"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-counting-techniques"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "40c5516e4ad49db65fba65e6ccc29e2237627857cb1c734a7bf84f357e3f5f26",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-counting-techniques-1a0fd51d29",
+    "skillId": "act-counting-techniques",
+    "prompt": "A meal has 3 appetizers, 5 entrées, and 4 desserts. How many different 3-course meals are possible?",
+    "answer": {
+      "type": "auto",
+      "value": "60",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "60"
+      },
+      {
+        "label": "B",
+        "text": "19"
+      },
+      {
+        "label": "C",
+        "text": "30"
+      },
+      {
+        "label": "D",
+        "text": "12"
+      },
+      {
+        "label": "E",
+        "text": "63"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-counting-techniques"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "1a0fd51d297d7d52322b0b3b136cd09dd4786c9267a41fad29367a1b0123c712",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-counting-techniques-0f4dc99f0e",
+    "skillId": "act-counting-techniques",
+    "prompt": "A meal has 2 appetizers, 5 entrées, and 4 desserts. How many different 3-course meals are possible?",
+    "answer": {
+      "type": "auto",
+      "value": "40",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "14"
+      },
+      {
+        "label": "B",
+        "text": "11"
+      },
+      {
+        "label": "C",
+        "text": "40"
+      },
+      {
+        "label": "D",
+        "text": "20"
+      },
+      {
+        "label": "E",
+        "text": "42"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-counting-techniques"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "0f4dc99f0e9ad45b32923c0064d0cadf824fa90b326ed8d8f92a0f4df9685d24",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-counting-techniques-9e7b2c276f",
+    "skillId": "act-counting-techniques",
+    "prompt": "A meal has 5 appetizers, 2 entrées, and 5 desserts. How many different 3-course meals are possible?",
+    "answer": {
+      "type": "auto",
+      "value": "50",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "50"
+      },
+      {
+        "label": "B",
+        "text": "25"
+      },
+      {
+        "label": "C",
+        "text": "15"
+      },
+      {
+        "label": "D",
+        "text": "12"
+      },
+      {
+        "label": "E",
+        "text": "55"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-counting-techniques"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "9e7b2c276f05f033ba98d17f63f2da87268e79c36396009649305313d39774b3",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-counting-techniques-3271778247",
+    "skillId": "act-counting-techniques",
+    "prompt": "A meal has 2 appetizers, 4 entrées, and 4 desserts. How many different 3-course meals are possible?",
+    "answer": {
+      "type": "auto",
+      "value": "32",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "16"
+      },
+      {
+        "label": "B",
+        "text": "34"
+      },
+      {
+        "label": "C",
+        "text": "10"
+      },
+      {
+        "label": "D",
+        "text": "32"
+      },
+      {
+        "label": "E",
+        "text": "12"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-counting-techniques"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "3271778247d5dbb0ff35d04c92001f9e0ba155b53e4f8f0bf2cfc899ae662e9d",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-real-complex-numbers-07f722d6e4",
+    "skillId": "act-real-complex-numbers",
+    "prompt": "(7 + 8i) + (-5 + 7i) = ?",
+    "answer": {
+      "type": "auto",
+      "value": "2+15i",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "2+15i"
+      },
+      {
+        "label": "B",
+        "text": "-35+56i"
+      },
+      {
+        "label": "C",
+        "text": "2+1i"
+      },
+      {
+        "label": "D",
+        "text": "15+2i"
+      },
+      {
+        "label": "E",
+        "text": "12+15i"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-real-complex-numbers"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "07f722d6e42c6f95b501956dcedb661f1cdbb40ecce89c0195491714ed6ffbf7",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-real-complex-numbers-7337417079",
+    "skillId": "act-real-complex-numbers",
+    "prompt": "(8 + 5i) + (2 + 2i) = ?",
+    "answer": {
+      "type": "auto",
+      "value": "10+7i",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "16+10i"
+      },
+      {
+        "label": "B",
+        "text": "10+3i"
+      },
+      {
+        "label": "C",
+        "text": "6+7i"
+      },
+      {
+        "label": "D",
+        "text": "10+7i"
+      },
+      {
+        "label": "E",
+        "text": "7+10i"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-real-complex-numbers"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "7337417079b6ee38558c09dece854a467b21bd3d450ed05f5777cc4f204f97ac",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-real-complex-numbers-c2c609fe81",
+    "skillId": "act-real-complex-numbers",
+    "prompt": "(-6 - 4i) + (-6 + 8i) = ?",
+    "answer": {
+      "type": "auto",
+      "value": "-12+4i",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "0+4i"
+      },
+      {
+        "label": "B",
+        "text": "-12+4i"
+      },
+      {
+        "label": "C",
+        "text": "36-32i"
+      },
+      {
+        "label": "D",
+        "text": "4-12i"
+      },
+      {
+        "label": "E",
+        "text": "-12-12i"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-real-complex-numbers"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "c2c609fe817fb54ca7a780244887a20161b52a6ffe1ddab899305e4ac1f00a20",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-real-complex-numbers-5e94b71d6d",
+    "skillId": "act-real-complex-numbers",
+    "prompt": "(-3 + 7i) + (-3 + 3i) = ?",
+    "answer": {
+      "type": "auto",
+      "value": "-6+10i",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "9+21i"
+      },
+      {
+        "label": "B",
+        "text": "10-6i"
+      },
+      {
+        "label": "C",
+        "text": "-6+10i"
+      },
+      {
+        "label": "D",
+        "text": "-6+4i"
+      },
+      {
+        "label": "E",
+        "text": "0+10i"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-real-complex-numbers"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "5e94b71d6d8b4cf1af82845d76fdf0568a17a94a2ff4ac147db044061bf27a56",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-real-complex-numbers-c1c802fba5",
+    "skillId": "act-real-complex-numbers",
+    "prompt": "(1 - 1i) + (-2 - 1i) = ?",
+    "answer": {
+      "type": "auto",
+      "value": "-1-2i",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-2+1i"
+      },
+      {
+        "label": "B",
+        "text": "-1+0i"
+      },
+      {
+        "label": "C",
+        "text": "-2-1i"
+      },
+      {
+        "label": "D",
+        "text": "3-2i"
+      },
+      {
+        "label": "E",
+        "text": "-1-2i"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-real-complex-numbers"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "c1c802fba56471965674cba8dca58fd478d7e7ca8da23e2be839cbb0bee2231f",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-real-complex-numbers-4f650878c4",
+    "skillId": "act-real-complex-numbers",
+    "prompt": "(2 + 2i) + (-3 + 6i) = ?",
+    "answer": {
+      "type": "auto",
+      "value": "-1+8i",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "5+8i"
+      },
+      {
+        "label": "B",
+        "text": "-6+12i"
+      },
+      {
+        "label": "C",
+        "text": "-1+8i"
+      },
+      {
+        "label": "D",
+        "text": "-1-4i"
+      },
+      {
+        "label": "E",
+        "text": "8-1i"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-real-complex-numbers"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "4f650878c49ce23f48bbdca22ad3acc112b89579274e788afe2a987fd74dee1a",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-real-complex-numbers-3b2418be1d",
+    "skillId": "act-real-complex-numbers",
+    "prompt": "(4 + 8i) + (-6 + 6i) = ?",
+    "answer": {
+      "type": "auto",
+      "value": "-2+14i",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "14-2i"
+      },
+      {
+        "label": "B",
+        "text": "-2+2i"
+      },
+      {
+        "label": "C",
+        "text": "-2+14i"
+      },
+      {
+        "label": "D",
+        "text": "10+14i"
+      },
+      {
+        "label": "E",
+        "text": "-24+48i"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-real-complex-numbers"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "3b2418be1d8ba0aa284e9bb13ba5650f698e45f8d5db3f0eca63260c19cf4ba8",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-real-complex-numbers-aefd19d5d8",
+    "skillId": "act-real-complex-numbers",
+    "prompt": "(-5 - 1i) + (5 - 5i) = ?",
+    "answer": {
+      "type": "auto",
+      "value": "0-6i",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "0-6i"
+      },
+      {
+        "label": "B",
+        "text": "0+4i"
+      },
+      {
+        "label": "C",
+        "text": "-25+5i"
+      },
+      {
+        "label": "D",
+        "text": "-6+0i"
+      },
+      {
+        "label": "E",
+        "text": "-10-6i"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-real-complex-numbers"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "aefd19d5d8b051846acc07dd8227c23003e22db73e068717edb82a0759047272",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-exponents-roots-1a90d818c8",
+    "skillId": "act-exponents-roots",
+    "prompt": "The expression 5^3 · 5^4 is equal to:",
+    "answer": {
+      "type": "auto",
+      "value": "78125",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "78125"
+      },
+      {
+        "label": "B",
+        "text": "244140625"
+      },
+      {
+        "label": "C",
+        "text": "35"
+      },
+      {
+        "label": "D",
+        "text": "390625"
+      },
+      {
+        "label": "E",
+        "text": "5"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-exponents-roots"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "1a90d818c89f4227c80ec09540e3d19ad3b1f874884d43b3410e29c3099c24a7",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-exponents-roots-956c2c0d5c",
+    "skillId": "act-exponents-roots",
+    "prompt": "The expression 2^4 · 2^2 is equal to:",
+    "answer": {
+      "type": "auto",
+      "value": "64",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "128"
+      },
+      {
+        "label": "B",
+        "text": "12"
+      },
+      {
+        "label": "C",
+        "text": "4"
+      },
+      {
+        "label": "D",
+        "text": "64"
+      },
+      {
+        "label": "E",
+        "text": "256"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-exponents-roots"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "956c2c0d5c0b5a3d8aee984f8a2f70d5b04c7d51585bfa0f5fbb410f54d43e89",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-exponents-roots-0ae4db6505",
+    "skillId": "act-exponents-roots",
+    "prompt": "The expression 5^3 · 5^3 is equal to:",
+    "answer": {
+      "type": "auto",
+      "value": "15625",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "1953125"
+      },
+      {
+        "label": "B",
+        "text": "1"
+      },
+      {
+        "label": "C",
+        "text": "30"
+      },
+      {
+        "label": "D",
+        "text": "15625"
+      },
+      {
+        "label": "E",
+        "text": "78125"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-exponents-roots"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "0ae4db6505f7d321c4f424eb20b6d68feea4c05a3939878b976d4958178522dc",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-exponents-roots-1ef41456de",
+    "skillId": "act-exponents-roots",
+    "prompt": "The expression 2^4 · 2^5 is equal to:",
+    "answer": {
+      "type": "auto",
+      "value": "512",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "512"
+      },
+      {
+        "label": "B",
+        "text": "18"
+      },
+      {
+        "label": "C",
+        "text": "1048576"
+      },
+      {
+        "label": "D",
+        "text": "2"
+      },
+      {
+        "label": "E",
+        "text": "1024"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-exponents-roots"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "1ef41456de1d2dd5d8458ce4cf0b51661a3e56763b5d725a6c2db220af9b93c7",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-exponents-roots-ff41723e1b",
+    "skillId": "act-exponents-roots",
+    "prompt": "The expression 5^3 · 5^5 is equal to:",
+    "answer": {
+      "type": "auto",
+      "value": "390625",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "390625"
+      },
+      {
+        "label": "B",
+        "text": "25"
+      },
+      {
+        "label": "C",
+        "text": "30517578125"
+      },
+      {
+        "label": "D",
+        "text": "1953125"
+      },
+      {
+        "label": "E",
+        "text": "40"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-exponents-roots"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "ff41723e1b2a49899e178284c67c505f3f72fa9a3bd5e634a0723be847a5ef6b",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-exponents-roots-aecd1b3d9d",
+    "skillId": "act-exponents-roots",
+    "prompt": "The expression 5^5 · 5^5 is equal to:",
+    "answer": {
+      "type": "auto",
+      "value": "9765625",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "50"
+      },
+      {
+        "label": "B",
+        "text": "1"
+      },
+      {
+        "label": "C",
+        "text": "48828125"
+      },
+      {
+        "label": "D",
+        "text": "298023223876953150"
+      },
+      {
+        "label": "E",
+        "text": "9765625"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-exponents-roots"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "aecd1b3d9d42b51e8b099a98ae99f83ee07f3238915a0f68e82d442ab4ee5b29",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-exponents-roots-ad88be80fc",
+    "skillId": "act-exponents-roots",
+    "prompt": "The expression 2^5 · 2^5 is equal to:",
+    "answer": {
+      "type": "auto",
+      "value": "1024",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "20"
+      },
+      {
+        "label": "B",
+        "text": "33554432"
+      },
+      {
+        "label": "C",
+        "text": "1"
+      },
+      {
+        "label": "D",
+        "text": "2048"
+      },
+      {
+        "label": "E",
+        "text": "1024"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-exponents-roots"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "ad88be80fcdf783fc5d36105af255fbe6dfd3256fd1664080f34bd88aa67b390",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-exponents-roots-96fa05e065",
+    "skillId": "act-exponents-roots",
+    "prompt": "The expression 5^5 · 5^3 is equal to:",
+    "answer": {
+      "type": "auto",
+      "value": "390625",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "40"
+      },
+      {
+        "label": "B",
+        "text": "390625"
+      },
+      {
+        "label": "C",
+        "text": "25"
+      },
+      {
+        "label": "D",
+        "text": "30517578125"
+      },
+      {
+        "label": "E",
+        "text": "1953125"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-exponents-roots"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "96fa05e065c91a43972b91ed65889e2f9fa2ef6d24f70982446ac4af16565210",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-ratios-proportions-percents-238abe121e",
+    "skillId": "act-ratios-proportions-percents",
+    "prompt": "What is 20% of 100?",
+    "answer": {
+      "type": "auto",
+      "value": "20",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "10"
+      },
+      {
+        "label": "B",
+        "text": "2"
+      },
+      {
+        "label": "C",
+        "text": "40"
+      },
+      {
+        "label": "D",
+        "text": "80"
+      },
+      {
+        "label": "E",
+        "text": "20"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-ratios-proportions-percents"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "238abe121ed22119f4c1a4adc61e137fc874b870050a50feda3771c9a0d67da5",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-ratios-proportions-percents-283d43137c",
+    "skillId": "act-ratios-proportions-percents",
+    "prompt": "What is 25% of 60?",
+    "answer": {
+      "type": "auto",
+      "value": "15",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "45"
+      },
+      {
+        "label": "B",
+        "text": "15"
+      },
+      {
+        "label": "C",
+        "text": "1.5"
+      },
+      {
+        "label": "D",
+        "text": "7.5"
+      },
+      {
+        "label": "E",
+        "text": "30"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-ratios-proportions-percents"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "283d43137c4b9332300da2580c2ee6ea56bf3824fbd74065164578be2f3311bb",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-ratios-proportions-percents-ebd9d82c9a",
+    "skillId": "act-ratios-proportions-percents",
+    "prompt": "What is 20% of 40?",
+    "answer": {
+      "type": "auto",
+      "value": "8",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "4"
+      },
+      {
+        "label": "B",
+        "text": "0.8"
+      },
+      {
+        "label": "C",
+        "text": "32"
+      },
+      {
+        "label": "D",
+        "text": "8"
+      },
+      {
+        "label": "E",
+        "text": "16"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-ratios-proportions-percents"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "ebd9d82c9a3a03327dedcafbb1500c0805b33e55b4b5b3562ea2103054d23c87",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-ratios-proportions-percents-12f38260a7",
+    "skillId": "act-ratios-proportions-percents",
+    "prompt": "What is 75% of 180?",
+    "answer": {
+      "type": "auto",
+      "value": "135",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "67.5"
+      },
+      {
+        "label": "B",
+        "text": "45"
+      },
+      {
+        "label": "C",
+        "text": "270"
+      },
+      {
+        "label": "D",
+        "text": "135"
+      },
+      {
+        "label": "E",
+        "text": "13.5"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-ratios-proportions-percents"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "12f38260a7b5f54909a962c100e19ecd9e40698a6de8d7c922261562a5b3e161",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-ratios-proportions-percents-9bd97b73bb",
+    "skillId": "act-ratios-proportions-percents",
+    "prompt": "What is 40% of 160?",
+    "answer": {
+      "type": "auto",
+      "value": "64",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "128"
+      },
+      {
+        "label": "B",
+        "text": "6.4"
+      },
+      {
+        "label": "C",
+        "text": "32"
+      },
+      {
+        "label": "D",
+        "text": "64"
+      },
+      {
+        "label": "E",
+        "text": "96"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-ratios-proportions-percents"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "9bd97b73bb0b0c8086d7784e3c62d020265fe6794f52537240aa86b4905ea821",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-ratios-proportions-percents-f8f59099b6",
+    "skillId": "act-ratios-proportions-percents",
+    "prompt": "What is 10% of 120?",
+    "answer": {
+      "type": "auto",
+      "value": "12",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "1.2"
+      },
+      {
+        "label": "B",
+        "text": "24"
+      },
+      {
+        "label": "C",
+        "text": "6"
+      },
+      {
+        "label": "D",
+        "text": "108"
+      },
+      {
+        "label": "E",
+        "text": "12"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-ratios-proportions-percents"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "f8f59099b62741b9376c294ecd70541fe06de68e065fdcb79bdf242607f58b9c",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-ratios-proportions-percents-8c4c5469ce",
+    "skillId": "act-ratios-proportions-percents",
+    "prompt": "What is 60% of 180?",
+    "answer": {
+      "type": "auto",
+      "value": "108",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "10.8"
+      },
+      {
+        "label": "B",
+        "text": "108"
+      },
+      {
+        "label": "C",
+        "text": "54"
+      },
+      {
+        "label": "D",
+        "text": "72"
+      },
+      {
+        "label": "E",
+        "text": "216"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-ratios-proportions-percents"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "8c4c5469cee9b4b2c114a0d2657c7225b04fd1d7033e647bc6051467edcceb1c",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-ratios-proportions-percents-6086307a62",
+    "skillId": "act-ratios-proportions-percents",
+    "prompt": "What is 75% of 100?",
+    "answer": {
+      "type": "auto",
+      "value": "75",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "7.5"
+      },
+      {
+        "label": "B",
+        "text": "150"
+      },
+      {
+        "label": "C",
+        "text": "75"
+      },
+      {
+        "label": "D",
+        "text": "25"
+      },
+      {
+        "label": "E",
+        "text": "37.5"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-ratios-proportions-percents"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "6086307a62f7bb8a1e39ce26a9818e140ca94e579c9048575ca54c0293981cec",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-matrices-vectors-2bfbb036ad",
+    "skillId": "act-matrices-vectors",
+    "prompt": "5 · [1, 3; 6, 2] = ? (scalar multiple of the 2×2 matrix)",
+    "answer": {
+      "type": "auto",
+      "value": "[5, 15; 30, 10]",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "[5, 3; 6, 10]"
+      },
+      {
+        "label": "B",
+        "text": "[1, 3; 6, 2]"
+      },
+      {
+        "label": "C",
+        "text": "[5, 15; 30, 10]"
+      },
+      {
+        "label": "D",
+        "text": "[5, 15; 6, 2]"
+      },
+      {
+        "label": "E",
+        "text": "[6, 8; 11, 7]"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-matrices-vectors"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "2bfbb036ad95e5846d1c948a7036a5ad32312ebe5f5006989d31f2148789bda4",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-matrices-vectors-7581f9867b",
+    "skillId": "act-matrices-vectors",
+    "prompt": "3 · [4, 2; 5, 3] = ? (scalar multiple of the 2×2 matrix)",
+    "answer": {
+      "type": "auto",
+      "value": "[12, 6; 15, 9]",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "[12, 6; 5, 3]"
+      },
+      {
+        "label": "B",
+        "text": "[12, 6; 15, 9]"
+      },
+      {
+        "label": "C",
+        "text": "[12, 2; 5, 9]"
+      },
+      {
+        "label": "D",
+        "text": "[4, 2; 5, 3]"
+      },
+      {
+        "label": "E",
+        "text": "[7, 5; 8, 6]"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-matrices-vectors"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "7581f9867b99c8137977f9c481ea1f6ae2711333c5b91915750fdb25daf8f589",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-matrices-vectors-5e5d114a81",
+    "skillId": "act-matrices-vectors",
+    "prompt": "3 · [3, 3; 6, 1] = ? (scalar multiple of the 2×2 matrix)",
+    "answer": {
+      "type": "auto",
+      "value": "[9, 9; 18, 3]",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "[9, 9; 6, 1]"
+      },
+      {
+        "label": "B",
+        "text": "[6, 6; 9, 4]"
+      },
+      {
+        "label": "C",
+        "text": "[9, 9; 18, 3]"
+      },
+      {
+        "label": "D",
+        "text": "[3, 3; 6, 1]"
+      },
+      {
+        "label": "E",
+        "text": "[9, 3; 6, 3]"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-matrices-vectors"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "5e5d114a81cd93d8d6ee0cc4923bdc51fd27768c791d7d203e318dbe6aebfbdc",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-matrices-vectors-dcaa0aae95",
+    "skillId": "act-matrices-vectors",
+    "prompt": "2 · [6, 3; 4, 6] = ? (scalar multiple of the 2×2 matrix)",
+    "answer": {
+      "type": "auto",
+      "value": "[12, 6; 8, 12]",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "[12, 6; 8, 12]"
+      },
+      {
+        "label": "B",
+        "text": "[12, 6; 4, 6]"
+      },
+      {
+        "label": "C",
+        "text": "[12, 3; 4, 12]"
+      },
+      {
+        "label": "D",
+        "text": "[6, 3; 4, 6]"
+      },
+      {
+        "label": "E",
+        "text": "[8, 5; 6, 8]"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-matrices-vectors"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "dcaa0aae952c375f4b8dac2c6468bed060497f705b898230bf7213c5249c177e",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-matrices-vectors-bbb44e4fa8",
+    "skillId": "act-matrices-vectors",
+    "prompt": "3 · [6, 6; 2, 1] = ? (scalar multiple of the 2×2 matrix)",
+    "answer": {
+      "type": "auto",
+      "value": "[18, 18; 6, 3]",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "[18, 6; 2, 3]"
+      },
+      {
+        "label": "B",
+        "text": "[18, 18; 6, 3]"
+      },
+      {
+        "label": "C",
+        "text": "[18, 18; 2, 1]"
+      },
+      {
+        "label": "D",
+        "text": "[9, 9; 5, 4]"
+      },
+      {
+        "label": "E",
+        "text": "[6, 6; 2, 1]"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-matrices-vectors"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "bbb44e4fa8bb7fcb4168329db6a9a715962dde5529bae3a554dfd1ea94931a68",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-matrices-vectors-c750c09bb5",
+    "skillId": "act-matrices-vectors",
+    "prompt": "2 · [2, 5; 1, 4] = ? (scalar multiple of the 2×2 matrix)",
+    "answer": {
+      "type": "auto",
+      "value": "[4, 10; 2, 8]",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "[4, 7; 3, 6]"
+      },
+      {
+        "label": "B",
+        "text": "[4, 10; 1, 4]"
+      },
+      {
+        "label": "C",
+        "text": "[4, 5; 1, 8]"
+      },
+      {
+        "label": "D",
+        "text": "[2, 5; 1, 4]"
+      },
+      {
+        "label": "E",
+        "text": "[4, 10; 2, 8]"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-matrices-vectors"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "c750c09bb5ed02a8a34f41e54c631f3fdaa3a9c6cc2c462026c64b056dee1fd4",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-matrices-vectors-ee0c862c0b",
+    "skillId": "act-matrices-vectors",
+    "prompt": "6 · [1, 6; 2, 6] = ? (scalar multiple of the 2×2 matrix)",
+    "answer": {
+      "type": "auto",
+      "value": "[6, 36; 12, 36]",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "[6, 6; 2, 36]"
+      },
+      {
+        "label": "B",
+        "text": "[6, 36; 12, 36]"
+      },
+      {
+        "label": "C",
+        "text": "[1, 6; 2, 6]"
+      },
+      {
+        "label": "D",
+        "text": "[7, 12; 8, 12]"
+      },
+      {
+        "label": "E",
+        "text": "[6, 36; 2, 6]"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-matrices-vectors"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "ee0c862c0baf50ceb874e0f530820222fe380ffaaa16ff323c2310aefe6436cc",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-matrices-vectors-4c0d7b8b50",
+    "skillId": "act-matrices-vectors",
+    "prompt": "2 · [2, 3; 3, 4] = ? (scalar multiple of the 2×2 matrix)",
+    "answer": {
+      "type": "auto",
+      "value": "[4, 6; 6, 8]",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "[4, 5; 5, 6]"
+      },
+      {
+        "label": "B",
+        "text": "[4, 3; 3, 8]"
+      },
+      {
+        "label": "C",
+        "text": "[4, 6; 3, 4]"
+      },
+      {
+        "label": "D",
+        "text": "[2, 3; 3, 4]"
+      },
+      {
+        "label": "E",
+        "text": "[4, 6; 6, 8]"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-matrices-vectors"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "4c0d7b8b50ebf5944f7d3255b1beb57566360c2b1babcfc12f9fc8dade0f94fd",
+    "isActive": true
+  }
+]

--- a/seeds/act-math-items.generated.json
+++ b/seeds/act-math-items.generated.json
@@ -352,9 +352,10 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-area-perimeter-composite-1d55897189",
+    "problemId": "act-act-area-perimeter-composite-4a7a2a14ee",
     "skillId": "act-area-perimeter-composite",
-    "prompt": "A rectangle 5 by 7 has a square of side 2 cut from one corner. What is the remaining area?",
+    "prompt": "In the figure shown, a square of side 2 has been cut from the corner of a 5-by-7 rectangle. What is the area of the remaining (shaded) region?",
+    "svg": "<svg viewBox=\"0 0 120 124\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 66,20 66,44 90,44 90,104 30,104\" stroke-linejoin=\"round\"/></svg>",
     "answer": {
       "type": "auto",
       "value": "31",
@@ -392,13 +393,14 @@
       "act-area-perimeter-composite"
     ],
     "source": "act-template-gen",
-    "contentHash": "1d5589718941fc99335e18f3e5412960ce57b819aabbfc99400c1470f64f52a1",
+    "contentHash": "4a7a2a14eeef3bc7ab7aa3c21764361b008b5cdb8a7f106e9424049c4429b913",
     "isActive": true
   },
   {
-    "problemId": "act-act-area-perimeter-composite-59079adf70",
+    "problemId": "act-act-area-perimeter-composite-0617d3733f",
     "skillId": "act-area-perimeter-composite",
-    "prompt": "A rectangle 6 by 4 has a square of side 4 cut from one corner. What is the remaining area?",
+    "prompt": "In the figure shown, a square of side 4 has been cut from the corner of a 6-by-4 rectangle. What is the area of the remaining (shaded) region?",
+    "svg": "<svg viewBox=\"0 0 132 88\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 54,20 54,68 102,68 102,68 30,68\" stroke-linejoin=\"round\"/></svg>",
     "answer": {
       "type": "auto",
       "value": "8",
@@ -436,13 +438,14 @@
       "act-area-perimeter-composite"
     ],
     "source": "act-template-gen",
-    "contentHash": "59079adf70b2766f19b02084e546cb8c780f21050e8c504e7025904235447b1f",
+    "contentHash": "0617d3733fadd9f9d0bbe5793a6e6727972de5f9e0065db910d8c870de379408",
     "isActive": true
   },
   {
-    "problemId": "act-act-area-perimeter-composite-c6f7e9ab43",
+    "problemId": "act-act-area-perimeter-composite-1d7e5377d8",
     "skillId": "act-area-perimeter-composite",
-    "prompt": "A rectangle 7 by 5 has a square of side 5 cut from one corner. What is the remaining area?",
+    "prompt": "In the figure shown, a square of side 5 has been cut from the corner of a 7-by-5 rectangle. What is the area of the remaining (shaded) region?",
+    "svg": "<svg viewBox=\"0 0 144 100\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 54,20 54,80 114,80 114,80 30,80\" stroke-linejoin=\"round\"/></svg>",
     "answer": {
       "type": "auto",
       "value": "10",
@@ -480,13 +483,14 @@
       "act-area-perimeter-composite"
     ],
     "source": "act-template-gen",
-    "contentHash": "c6f7e9ab43af66a1fc511e78771a07d2c9c1d63615cc9b5ec6d7752f2d29a97e",
+    "contentHash": "1d7e5377d87c1e28256b41571f34ddfdc4152370dfe31ba486be21c6f522772d",
     "isActive": true
   },
   {
-    "problemId": "act-act-area-perimeter-composite-e89543acfa",
+    "problemId": "act-act-area-perimeter-composite-15cf52b424",
     "skillId": "act-area-perimeter-composite",
-    "prompt": "A rectangle 5 by 7 has a square of side 5 cut from one corner. What is the remaining area?",
+    "prompt": "In the figure shown, a square of side 5 has been cut from the corner of a 5-by-7 rectangle. What is the area of the remaining (shaded) region?",
+    "svg": "<svg viewBox=\"0 0 120 124\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 30,20 30,80 90,80 90,104 30,104\" stroke-linejoin=\"round\"/></svg>",
     "answer": {
       "type": "auto",
       "value": "10",
@@ -524,13 +528,14 @@
       "act-area-perimeter-composite"
     ],
     "source": "act-template-gen",
-    "contentHash": "e89543acfa49c8ab4a56ce64f9e72dac85a761ba7d18e82d417d94dce74eeabc",
+    "contentHash": "15cf52b424382ab4ca9a939ca5c829995ab1debb393e1040a5695a383649be1f",
     "isActive": true
   },
   {
-    "problemId": "act-act-area-perimeter-composite-6c171564ab",
+    "problemId": "act-act-area-perimeter-composite-1f6b36110f",
     "skillId": "act-area-perimeter-composite",
-    "prompt": "A rectangle 4 by 3 has a square of side 3 cut from one corner. What is the remaining area?",
+    "prompt": "In the figure shown, a square of side 3 has been cut from the corner of a 4-by-3 rectangle. What is the area of the remaining (shaded) region?",
+    "svg": "<svg viewBox=\"0 0 108 76\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 42,20 42,56 78,56 78,56 30,56\" stroke-linejoin=\"round\"/></svg>",
     "answer": {
       "type": "auto",
       "value": "3",
@@ -568,13 +573,14 @@
       "act-area-perimeter-composite"
     ],
     "source": "act-template-gen",
-    "contentHash": "6c171564ab90ef4da785bfcef805292b60aa0d8b149aaa89a219b7db3d5578ea",
+    "contentHash": "1f6b36110fe5376d8291ccfeb7422b44065a5b3280163cfffd8f903b80152ce6",
     "isActive": true
   },
   {
-    "problemId": "act-act-area-perimeter-composite-ed414179c3",
+    "problemId": "act-act-area-perimeter-composite-05b1a8f284",
     "skillId": "act-area-perimeter-composite",
-    "prompt": "A rectangle 5 by 7 has a square of side 3 cut from one corner. What is the remaining area?",
+    "prompt": "In the figure shown, a square of side 3 has been cut from the corner of a 5-by-7 rectangle. What is the area of the remaining (shaded) region?",
+    "svg": "<svg viewBox=\"0 0 120 124\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 54,20 54,56 90,56 90,104 30,104\" stroke-linejoin=\"round\"/></svg>",
     "answer": {
       "type": "auto",
       "value": "26",
@@ -612,13 +618,14 @@
       "act-area-perimeter-composite"
     ],
     "source": "act-template-gen",
-    "contentHash": "ed414179c305c665c78785ce05f1e9958e7bb19ea600c8f758e345780aad1cf0",
+    "contentHash": "05b1a8f284863e9e334a2c8fd6977062c5fb741ecff7ab4c5b15f7c9f63beb32",
     "isActive": true
   },
   {
-    "problemId": "act-act-area-perimeter-composite-a4e327425c",
+    "problemId": "act-act-area-perimeter-composite-c9bf870119",
     "skillId": "act-area-perimeter-composite",
-    "prompt": "A rectangle 5 by 5 has a square of side 2 cut from one corner. What is the remaining area?",
+    "prompt": "In the figure shown, a square of side 2 has been cut from the corner of a 5-by-5 rectangle. What is the area of the remaining (shaded) region?",
+    "svg": "<svg viewBox=\"0 0 120 100\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 66,20 66,44 90,44 90,80 30,80\" stroke-linejoin=\"round\"/></svg>",
     "answer": {
       "type": "auto",
       "value": "21",
@@ -656,13 +663,14 @@
       "act-area-perimeter-composite"
     ],
     "source": "act-template-gen",
-    "contentHash": "a4e327425c099eb1e2470f99301655cd5185cf5556812d5a91d57c6a6d3b53d4",
+    "contentHash": "c9bf870119f926db47ecad6a1bab02468474e52bbc829f3fd5bb58eaeb0389de",
     "isActive": true
   },
   {
-    "problemId": "act-act-area-perimeter-composite-9aff74273e",
+    "problemId": "act-act-area-perimeter-composite-6dbfb14bc8",
     "skillId": "act-area-perimeter-composite",
-    "prompt": "A rectangle 4 by 6 has a square of side 4 cut from one corner. What is the remaining area?",
+    "prompt": "In the figure shown, a square of side 4 has been cut from the corner of a 4-by-6 rectangle. What is the area of the remaining (shaded) region?",
+    "svg": "<svg viewBox=\"0 0 108 112\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 30,20 30,68 78,68 78,92 30,92\" stroke-linejoin=\"round\"/></svg>",
     "answer": {
       "type": "auto",
       "value": "8",
@@ -700,7 +708,7 @@
       "act-area-perimeter-composite"
     ],
     "source": "act-template-gen",
-    "contentHash": "9aff74273e058af97eaf3086b7a4f6d3b8128f3d6aaba43c8a7543469a341319",
+    "contentHash": "6dbfb14bc85e38ad0555043ef12d1565040dc89adc8e246be7426a56eaa79265",
     "isActive": true
   },
   {
@@ -2112,9 +2120,10 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-polygons-circles-4ab299e776",
+    "problemId": "act-act-polygons-circles-db43864a60",
     "skillId": "act-polygons-circles",
-    "prompt": "What is the measure of one interior angle of a regular 10-gon?",
+    "prompt": "What is the measure of one interior angle of the regular 10-gon shown?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"100.0,17.0 134.1,28.1 155.2,57.1 155.2,92.9 134.1,121.9 100.0,133.0 65.9,121.9 44.8,92.9 44.8,57.1 65.9,28.1\" stroke-linejoin=\"round\"/></svg>",
     "answer": {
       "type": "auto",
       "value": "144°",
@@ -2152,13 +2161,13 @@
       "act-polygons-circles"
     ],
     "source": "act-template-gen",
-    "contentHash": "4ab299e77637854e19137bed3867d2bf64842bc48a2d85fde4bc6ec20eae229d",
+    "contentHash": "db43864a60f9ee91815d5dc908104ff7e89aa3605ec2ba484a69b683c6e49b7e",
     "isActive": true
   },
   {
-    "problemId": "act-act-polygons-circles-cf209d6f30",
+    "problemId": "act-act-polygons-circles-68e6432c74",
     "skillId": "act-polygons-circles",
-    "prompt": "What is the measure of one interior angle of a regular 24-gon?",
+    "prompt": "What is the measure of one interior angle of the regular 24-gon shown?",
     "answer": {
       "type": "auto",
       "value": "165°",
@@ -2196,13 +2205,13 @@
       "act-polygons-circles"
     ],
     "source": "act-template-gen",
-    "contentHash": "cf209d6f30e738cf46fa695f4f21080246b1feb3cbfee4427f94705b6cd05167",
+    "contentHash": "68e6432c743ca7b87f760ef9aa22445da68875e9ee341bd158936a2daf0b4c72",
     "isActive": true
   },
   {
-    "problemId": "act-act-polygons-circles-d338b52a11",
+    "problemId": "act-act-polygons-circles-1b11ff8e8a",
     "skillId": "act-polygons-circles",
-    "prompt": "What is the measure of one interior angle of a regular 18-gon?",
+    "prompt": "What is the measure of one interior angle of the regular 18-gon shown?",
     "answer": {
       "type": "auto",
       "value": "160°",
@@ -2240,13 +2249,14 @@
       "act-polygons-circles"
     ],
     "source": "act-template-gen",
-    "contentHash": "d338b52a11713444d5c41a8b79f33bb94df01426a4f302995a29afdcb622d5fd",
+    "contentHash": "1b11ff8e8ab46c2a650de720034211e941cf238a2aeec83396dcde04a040b8f5",
     "isActive": true
   },
   {
-    "problemId": "act-act-polygons-circles-2c31981a43",
+    "problemId": "act-act-polygons-circles-7beecb7077",
     "skillId": "act-polygons-circles",
-    "prompt": "What is the measure of one interior angle of a regular 5-gon?",
+    "prompt": "What is the measure of one interior angle of the regular 5-gon shown?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"100.0,17.0 155.2,57.1 134.1,121.9 65.9,121.9 44.8,57.1\" stroke-linejoin=\"round\"/></svg>",
     "answer": {
       "type": "auto",
       "value": "108°",
@@ -2284,13 +2294,13 @@
       "act-polygons-circles"
     ],
     "source": "act-template-gen",
-    "contentHash": "2c31981a4357cfd1721ef045bcc83be9f77dffb5974a18d9827a9c67da1985ab",
+    "contentHash": "7beecb7077129efd69b3a3471795d300dc179ce2cd7ccdebc86a6f64b322b19f",
     "isActive": true
   },
   {
-    "problemId": "act-act-polygons-circles-089cb9115f",
+    "problemId": "act-act-polygons-circles-d01292a4a9",
     "skillId": "act-polygons-circles",
-    "prompt": "What is the measure of one interior angle of a regular 15-gon?",
+    "prompt": "What is the measure of one interior angle of the regular 15-gon shown?",
     "answer": {
       "type": "auto",
       "value": "156°",
@@ -2328,13 +2338,14 @@
       "act-polygons-circles"
     ],
     "source": "act-template-gen",
-    "contentHash": "089cb9115fc28b7e3f539472922d476748a67c3fc5651798ae940a1d8dd19324",
+    "contentHash": "d01292a4a9212f7f36f0f44cffe66ea27e58606438a122d3a8d34f52b3bdcf6d",
     "isActive": true
   },
   {
-    "problemId": "act-act-polygons-circles-f23ad59710",
+    "problemId": "act-act-polygons-circles-f7031a29c3",
     "skillId": "act-polygons-circles",
-    "prompt": "What is the measure of one interior angle of a regular 12-gon?",
+    "prompt": "What is the measure of one interior angle of the regular 12-gon shown?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"100.0,17.0 129.0,24.8 150.2,46.0 158.0,75.0 150.2,104.0 129.0,125.2 100.0,133.0 71.0,125.2 49.8,104.0 42.0,75.0 49.8,46.0 71.0,24.8\" stroke-linejoin=\"round\"/></svg>",
     "answer": {
       "type": "auto",
       "value": "150°",
@@ -2372,13 +2383,14 @@
       "act-polygons-circles"
     ],
     "source": "act-template-gen",
-    "contentHash": "f23ad597101c9f8d32c6f0a974fbb36005718a4fe2b827932ce0b2df4d93708b",
+    "contentHash": "f7031a29c327cbae8a47feee82235b44d5476b0841eb5858e19ce6906dbcbd92",
     "isActive": true
   },
   {
-    "problemId": "act-act-polygons-circles-f1afd19014",
+    "problemId": "act-act-polygons-circles-a438fc4cf0",
     "skillId": "act-polygons-circles",
-    "prompt": "What is the measure of one interior angle of a regular 6-gon?",
+    "prompt": "What is the measure of one interior angle of the regular 6-gon shown?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"100.0,17.0 150.2,46.0 150.2,104.0 100.0,133.0 49.8,104.0 49.8,46.0\" stroke-linejoin=\"round\"/></svg>",
     "answer": {
       "type": "auto",
       "value": "120°",
@@ -2416,13 +2428,14 @@
       "act-polygons-circles"
     ],
     "source": "act-template-gen",
-    "contentHash": "f1afd19014fba1cae18af44f58beceb6cbaa493601ab98c68f0efb6ef19953b1",
+    "contentHash": "a438fc4cf03173115b31662107f6bd8657e9ac360d2b4694ca48bc51e5d4cb3f",
     "isActive": true
   },
   {
-    "problemId": "act-act-polygons-circles-974bba90e9",
+    "problemId": "act-act-polygons-circles-5167a2fc11",
     "skillId": "act-polygons-circles",
-    "prompt": "What is the measure of one interior angle of a regular 9-gon?",
+    "prompt": "What is the measure of one interior angle of the regular 9-gon shown?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"100.0,17.0 137.3,30.6 157.1,64.9 150.2,104.0 119.8,129.5 80.2,129.5 49.8,104.0 42.9,64.9 62.7,30.6\" stroke-linejoin=\"round\"/></svg>",
     "answer": {
       "type": "auto",
       "value": "140°",
@@ -2460,7 +2473,7 @@
       "act-polygons-circles"
     ],
     "source": "act-template-gen",
-    "contentHash": "974bba90e978c77464782ad03971858313f75dcdfcc439dc553e7d102f7a5d56",
+    "contentHash": "5167a2fc11904d6472e10059da24ffb68139257bc7afd6d9877d8e95328216cc",
     "isActive": true
   },
   {
@@ -2816,9 +2829,10 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-coordinate-geometry-d4256b0d73",
+    "problemId": "act-act-coordinate-geometry-a9a5022bcb",
     "skillId": "act-coordinate-geometry",
-    "prompt": "What is the midpoint of the segment from (1, -2) to (2, -2)?",
+    "prompt": "What is the midpoint of the segment joining the two points shown, (1, -2) and (2, -2)?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><line x1=\"20\" y1=\"75\" x2=\"180\" y2=\"75\" stroke=\"#bbb\" stroke-width=\"1\"/><line x1=\"100\" y1=\"15\" x2=\"100\" y2=\"140\" stroke=\"#bbb\" stroke-width=\"1\"/><circle cx=\"112\" cy=\"93\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"118\" y=\"87\" fill=\"#7c5cff\" stroke=\"none\">(1, -2)</text><circle cx=\"124\" cy=\"93\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"130\" y=\"87\" fill=\"#7c5cff\" stroke=\"none\">(2, -2)</text></svg>",
     "answer": {
       "type": "auto",
       "value": "(1.5, -2)",
@@ -2856,7 +2870,7 @@
       "act-coordinate-geometry"
     ],
     "source": "act-template-gen",
-    "contentHash": "d4256b0d7325d51d126129c9de8d4743dc349d0e569d4801dd8918986a01b569",
+    "contentHash": "a9a5022bcb35c1a710496d0438be6278c175f4f572f7366b8be7b1f15a5edcc3",
     "isActive": true
   },
   {
@@ -2904,9 +2918,10 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-coordinate-geometry-385d010d3c",
+    "problemId": "act-act-coordinate-geometry-d0b05612a3",
     "skillId": "act-coordinate-geometry",
-    "prompt": "What is the midpoint of the segment from (-5, 2) to (1, 3)?",
+    "prompt": "What is the midpoint of the segment joining the two points shown, (-5, 2) and (1, 3)?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><line x1=\"20\" y1=\"75\" x2=\"180\" y2=\"75\" stroke=\"#bbb\" stroke-width=\"1\"/><line x1=\"100\" y1=\"15\" x2=\"100\" y2=\"140\" stroke=\"#bbb\" stroke-width=\"1\"/><circle cx=\"40\" cy=\"57\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"46\" y=\"51\" fill=\"#7c5cff\" stroke=\"none\">(-5, 2)</text><circle cx=\"112\" cy=\"48\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"118\" y=\"42\" fill=\"#7c5cff\" stroke=\"none\">(1, 3)</text></svg>",
     "answer": {
       "type": "auto",
       "value": "(-2, 2.5)",
@@ -2944,13 +2959,14 @@
       "act-coordinate-geometry"
     ],
     "source": "act-template-gen",
-    "contentHash": "385d010d3c92863c93f5534f56810a4073af6c83409163ee85ddb42c7d99c545",
+    "contentHash": "d0b05612a3335488107aa2356ba5b7355452a4e5d9f6db82d501c73938a36e61",
     "isActive": true
   },
   {
-    "problemId": "act-act-coordinate-geometry-b396a42ecc",
+    "problemId": "act-act-coordinate-geometry-44164cb634",
     "skillId": "act-coordinate-geometry",
-    "prompt": "What is the midpoint of the segment from (5, 5) to (1, 2)?",
+    "prompt": "What is the midpoint of the segment joining the two points shown, (5, 5) and (1, 2)?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><line x1=\"20\" y1=\"75\" x2=\"180\" y2=\"75\" stroke=\"#bbb\" stroke-width=\"1\"/><line x1=\"100\" y1=\"15\" x2=\"100\" y2=\"140\" stroke=\"#bbb\" stroke-width=\"1\"/><circle cx=\"160\" cy=\"30\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"166\" y=\"24\" fill=\"#7c5cff\" stroke=\"none\">(5, 5)</text><circle cx=\"112\" cy=\"57\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"118\" y=\"51\" fill=\"#7c5cff\" stroke=\"none\">(1, 2)</text></svg>",
     "answer": {
       "type": "auto",
       "value": "(3, 3.5)",
@@ -2988,7 +3004,7 @@
       "act-coordinate-geometry"
     ],
     "source": "act-template-gen",
-    "contentHash": "b396a42eccecf455311c3c4242e6de18246b7ebf886ce8148007ddf9f9f818f1",
+    "contentHash": "44164cb63410091e895c3d77727d882fc5bcc7a10302ed7a79fb7ef59dc054e3",
     "isActive": true
   },
   {
@@ -3036,9 +3052,10 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-coordinate-geometry-4f33f9e984",
+    "problemId": "act-act-coordinate-geometry-c400987432",
     "skillId": "act-coordinate-geometry",
-    "prompt": "What is the midpoint of the segment from (-1, 1) to (1, 2)?",
+    "prompt": "What is the midpoint of the segment joining the two points shown, (-1, 1) and (1, 2)?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><line x1=\"20\" y1=\"75\" x2=\"180\" y2=\"75\" stroke=\"#bbb\" stroke-width=\"1\"/><line x1=\"100\" y1=\"15\" x2=\"100\" y2=\"140\" stroke=\"#bbb\" stroke-width=\"1\"/><circle cx=\"88\" cy=\"66\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"94\" y=\"60\" fill=\"#7c5cff\" stroke=\"none\">(-1, 1)</text><circle cx=\"112\" cy=\"57\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"118\" y=\"51\" fill=\"#7c5cff\" stroke=\"none\">(1, 2)</text></svg>",
     "answer": {
       "type": "auto",
       "value": "(0, 1.5)",
@@ -3076,7 +3093,7 @@
       "act-coordinate-geometry"
     ],
     "source": "act-template-gen",
-    "contentHash": "4f33f9e984b650f077baf7a72a4e3aa81f5f86057fd81dbfa58a0499ca20467f",
+    "contentHash": "c400987432d9e104ab111a39d905a0d37aea583320d92288955c177b76795336",
     "isActive": true
   },
   {
@@ -3124,9 +3141,10 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-coordinate-geometry-579ce4d46a",
+    "problemId": "act-act-coordinate-geometry-62e2af7c1f",
     "skillId": "act-coordinate-geometry",
-    "prompt": "What is the midpoint of the segment from (4, 1) to (1, 2)?",
+    "prompt": "What is the midpoint of the segment joining the two points shown, (4, 1) and (1, 2)?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><line x1=\"20\" y1=\"75\" x2=\"180\" y2=\"75\" stroke=\"#bbb\" stroke-width=\"1\"/><line x1=\"100\" y1=\"15\" x2=\"100\" y2=\"140\" stroke=\"#bbb\" stroke-width=\"1\"/><circle cx=\"148\" cy=\"66\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"154\" y=\"60\" fill=\"#7c5cff\" stroke=\"none\">(4, 1)</text><circle cx=\"112\" cy=\"57\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"118\" y=\"51\" fill=\"#7c5cff\" stroke=\"none\">(1, 2)</text></svg>",
     "answer": {
       "type": "auto",
       "value": "(2.5, 1.5)",
@@ -3164,13 +3182,14 @@
       "act-coordinate-geometry"
     ],
     "source": "act-template-gen",
-    "contentHash": "579ce4d46a35cbe45cae281d1b4e86b1fdb1600249c1ee7060dcf05abc7fc64c",
+    "contentHash": "62e2af7c1fc4bc682a87a2079447b9d86477348684b5128f59610622852b3f68",
     "isActive": true
   },
   {
-    "problemId": "act-act-right-triangle-trig-25b128c82b",
+    "problemId": "act-act-right-triangle-trig-7fff992dd7",
     "skillId": "act-right-triangle-trig",
-    "prompt": "A right triangle has legs of length 5 and 12. What is the length of the hypotenuse?",
+    "prompt": "In the right triangle shown, the legs have length 5 and 12. What is the length of the hypotenuse?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\">\n      <polygon points=\"30,120 170,120 30,30\" stroke-linejoin=\"round\"/>\n      <rect x=\"30\" y=\"108\" width=\"12\" height=\"12\" stroke-width=\"1.5\"/>\n      <text x=\"100\" y=\"138\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">5</text>\n      <text x=\"16\" y=\"78\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">12</text></svg>",
     "answer": {
       "type": "auto",
       "value": "13",
@@ -3208,13 +3227,14 @@
       "act-right-triangle-trig"
     ],
     "source": "act-template-gen",
-    "contentHash": "25b128c82bad1dda4198eefbde40b74c3984e2715c904317aa45a159d61232d4",
+    "contentHash": "7fff992dd736f447a26ec3f3d141f84866f7eaa4ee4b9f64f83f498dabb64d4c",
     "isActive": true
   },
   {
-    "problemId": "act-act-right-triangle-trig-e486f2fd8f",
+    "problemId": "act-act-right-triangle-trig-d569434159",
     "skillId": "act-right-triangle-trig",
-    "prompt": "A right triangle has legs of length 6 and 8. What is the length of the hypotenuse?",
+    "prompt": "In the right triangle shown, the legs have length 6 and 8. What is the length of the hypotenuse?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\">\n      <polygon points=\"30,120 170,120 30,30\" stroke-linejoin=\"round\"/>\n      <rect x=\"30\" y=\"108\" width=\"12\" height=\"12\" stroke-width=\"1.5\"/>\n      <text x=\"100\" y=\"138\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">6</text>\n      <text x=\"16\" y=\"78\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">8</text></svg>",
     "answer": {
       "type": "auto",
       "value": "10",
@@ -3252,13 +3272,14 @@
       "act-right-triangle-trig"
     ],
     "source": "act-template-gen",
-    "contentHash": "e486f2fd8f88da9c09dedda90979c722fefc4c8e3e3244d8f3c32a2b5e8bf767",
+    "contentHash": "d56943415991ca0a0e0711a6de8bc811bc830a4d5f329be9023a9f0bf217e864",
     "isActive": true
   },
   {
-    "problemId": "act-act-right-triangle-trig-1b2da9b036",
+    "problemId": "act-act-right-triangle-trig-54394e51d2",
     "skillId": "act-right-triangle-trig",
-    "prompt": "A right triangle has legs of length 9 and 12. What is the length of the hypotenuse?",
+    "prompt": "In the right triangle shown, the legs have length 9 and 12. What is the length of the hypotenuse?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\">\n      <polygon points=\"30,120 170,120 30,30\" stroke-linejoin=\"round\"/>\n      <rect x=\"30\" y=\"108\" width=\"12\" height=\"12\" stroke-width=\"1.5\"/>\n      <text x=\"100\" y=\"138\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">9</text>\n      <text x=\"16\" y=\"78\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">12</text></svg>",
     "answer": {
       "type": "auto",
       "value": "15",
@@ -3296,13 +3317,14 @@
       "act-right-triangle-trig"
     ],
     "source": "act-template-gen",
-    "contentHash": "1b2da9b03619156597f2f9ee2ed999d62f3d07bb0a50128bdaad2f98da2cc40e",
+    "contentHash": "54394e51d27e3f765b55a2aae3f19603ebf16bd4143c81e627e8bd61af21713c",
     "isActive": true
   },
   {
-    "problemId": "act-act-right-triangle-trig-ea45682b37",
+    "problemId": "act-act-right-triangle-trig-ca750442c2",
     "skillId": "act-right-triangle-trig",
-    "prompt": "A right triangle has legs of length 3 and 4. What is the length of the hypotenuse?",
+    "prompt": "In the right triangle shown, the legs have length 3 and 4. What is the length of the hypotenuse?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\">\n      <polygon points=\"30,120 170,120 30,30\" stroke-linejoin=\"round\"/>\n      <rect x=\"30\" y=\"108\" width=\"12\" height=\"12\" stroke-width=\"1.5\"/>\n      <text x=\"100\" y=\"138\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">3</text>\n      <text x=\"16\" y=\"78\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">4</text></svg>",
     "answer": {
       "type": "auto",
       "value": "5",
@@ -3340,13 +3362,14 @@
       "act-right-triangle-trig"
     ],
     "source": "act-template-gen",
-    "contentHash": "ea45682b3726fe6bf1f68c842e4a16db3d3187d13610366736b384460b43badc",
+    "contentHash": "ca750442c29abcc887ace36e4fdb84be1aeac1d0b233b6b48b6881971ca6646a",
     "isActive": true
   },
   {
-    "problemId": "act-act-right-triangle-trig-4a89dcc568",
+    "problemId": "act-act-right-triangle-trig-38ec4874db",
     "skillId": "act-right-triangle-trig",
-    "prompt": "A right triangle has legs of length 8 and 15. What is the length of the hypotenuse?",
+    "prompt": "In the right triangle shown, the legs have length 8 and 15. What is the length of the hypotenuse?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\">\n      <polygon points=\"30,120 170,120 30,30\" stroke-linejoin=\"round\"/>\n      <rect x=\"30\" y=\"108\" width=\"12\" height=\"12\" stroke-width=\"1.5\"/>\n      <text x=\"100\" y=\"138\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">8</text>\n      <text x=\"16\" y=\"78\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">15</text></svg>",
     "answer": {
       "type": "auto",
       "value": "17",
@@ -3384,7 +3407,7 @@
       "act-right-triangle-trig"
     ],
     "source": "act-template-gen",
-    "contentHash": "4a89dcc56881db2a7465958f1b5cddaa6fe2d1fe3eaa7a13bfe8a3f8eedd592c",
+    "contentHash": "38ec4874db46c5e4e45961c52b1646ab2220af543ee9dd807b68b6bd988524c9",
     "isActive": true
   },
   {

--- a/tests/unit/actTestAssembler.test.js
+++ b/tests/unit/actTestAssembler.test.js
@@ -1,0 +1,107 @@
+// tests/unit/actTestAssembler.test.js
+// Unit tests for the ACT practice-test assembler's pure logic (slot planning,
+// skill pool, scaled scoring). assembleForm() hits the DB and is covered by
+// integration tests; requiring this module does NOT load mongoose because the
+// Problem model is required lazily inside assembleForm.
+
+const A = require('../../utils/actTestAssembler');
+
+const bp = A.getBlueprint();
+const fixedRng = () => 0.5; // deterministic
+
+describe('actTestAssembler.buildSlots', () => {
+  test('produces exactly totalItems slots', () => {
+    const slots = A.buildSlots(bp, fixedRng);
+    expect(slots).toHaveLength(bp.totalItems);
+    expect(slots).toHaveLength(60);
+  });
+
+  test('category counts match the blueprint weights exactly', () => {
+    const slots = A.buildSlots(bp, fixedRng);
+    const counts = {};
+    slots.forEach(s => { counts[s.category] = (counts[s.category] || 0) + 1; });
+    expect(counts).toEqual(bp.categoryWeights);
+  });
+
+  test('assigns a skill to every slot', () => {
+    const slots = A.buildSlots(bp, fixedRng);
+    expect(slots.every(s => typeof s.skillId === 'string' && s.skillId.startsWith('act-'))).toBe(true);
+  });
+
+  test('positions are 1..60 in order', () => {
+    const slots = A.buildSlots(bp, fixedRng);
+    expect(slots.map(s => s.position)).toEqual(Array.from({ length: 60 }, (_, i) => i + 1));
+  });
+
+  test('applies the difficulty ramp by position', () => {
+    const slots = A.buildSlots(bp, fixedRng);
+    expect(slots[0].targetDifficulty).toBe(2);   // pos 1
+    expect(slots[19].targetDifficulty).toBe(2);  // pos 20
+    expect(slots[20].targetDifficulty).toBe(3);  // pos 21
+    expect(slots[39].targetDifficulty).toBe(3);  // pos 40
+    expect(slots[40].targetDifficulty).toBe(4);  // pos 41
+    expect(slots[59].targetDifficulty).toBe(4);  // pos 60
+  });
+
+  test('interleaves categories rather than blocking them', () => {
+    const slots = A.buildSlots(bp, fixedRng);
+    // No category should occupy a long contiguous run; check the first 6 slots
+    // touch several categories (real ACT mixes domains).
+    const firstSix = new Set(slots.slice(0, 6).map(s => s.category));
+    expect(firstSix.size).toBeGreaterThanOrEqual(4);
+  });
+
+  test('is deterministic for a fixed rng and varies skills across seeds', () => {
+    const a1 = A.buildSlots(bp, () => 0.5).map(s => s.skillId);
+    const a2 = A.buildSlots(bp, () => 0.5).map(s => s.skillId);
+    expect(a1).toEqual(a2);
+    // A different rng stream should change at least some skill assignments
+    let i = 0;
+    const varyRng = () => { i += 1; return (i % 7) / 7; };
+    const b = A.buildSlots(bp, varyRng).map(s => s.skillId);
+    expect(b).not.toEqual(a1);
+  });
+});
+
+describe('actTestAssembler.skillPool', () => {
+  test('returns the 31 ACT content skills, all act- prefixed', () => {
+    const pool = A.skillPool();
+    expect(pool).toHaveLength(31);
+    expect(pool.every(s => s.startsWith('act-'))).toBe(true);
+    // excludes test-strategy / modeling skills
+    expect(pool).not.toContain('act-pacing-strategy');
+    expect(pool).not.toContain('act-model-interpretation');
+  });
+});
+
+describe('actTestAssembler.rawToScaled', () => {
+  test('maps the endpoints and is monotonic non-decreasing', () => {
+    expect(A.rawToScaled(60).scaled).toBe(36);
+    expect(A.rawToScaled(0).scaled).toBe(1);
+    let prev = 0;
+    for (let raw = 0; raw <= 60; raw++) {
+      const s = A.rawToScaled(raw).scaled;
+      expect(s).toBeGreaterThanOrEqual(prev);
+      expect(s).toBeGreaterThanOrEqual(1);
+      expect(s).toBeLessThanOrEqual(36);
+      prev = s;
+    }
+  });
+
+  test('clamps out-of-range raw scores', () => {
+    expect(A.rawToScaled(999).scaled).toBe(36);
+    expect(A.rawToScaled(-5).scaled).toBe(1);
+  });
+
+  test('flags the estimate as approximate', () => {
+    expect(A.rawToScaled(40).approximate).toBe(true);
+  });
+});
+
+describe('actTestAssembler.difficultyForPosition', () => {
+  test('returns ramped difficulty per band', () => {
+    expect(A.difficultyForPosition(bp, 1)).toBe(2);
+    expect(A.difficultyForPosition(bp, 30)).toBe(3);
+    expect(A.difficultyForPosition(bp, 55)).toBe(4);
+  });
+});

--- a/tests/unit/generateActItems.test.js
+++ b/tests/unit/generateActItems.test.js
@@ -1,0 +1,51 @@
+// tests/unit/generateActItems.test.js
+// Correctness gate for the ACT item generator. Runs in CI without a DB
+// (generate()/assemblyProof() don't touch mongoose). If any template ever
+// emits an item whose key doesn't match its options, this fails loudly — the
+// whole point is that a wrong answer key cannot ship.
+
+const { generate, assemblyProof } = require('../../scripts/generateActItems');
+const blueprint = require('../../seeds/act-math-blueprint.json');
+
+describe('generateActItems', () => {
+  const { items } = generate(8);
+
+  test('produces items for every content skill in the blueprint', () => {
+    const expected = new Set(Object.values(blueprint.skillsByCategory).flat());
+    const got = new Set(items.map(i => i.skillId));
+    for (const s of expected) expect(got.has(s)).toBe(true);
+  });
+
+  test('every item is structurally valid and self-consistent', () => {
+    for (const it of items) {
+      expect(typeof it.problemId).toBe('string');
+      expect(it.skillId.startsWith('act-')).toBe(true);
+      expect(typeof it.prompt).toBe('string');
+      expect(it.prompt.length).toBeGreaterThan(0);
+      expect(it.answerType).toBe('multiple-choice');
+      expect(it.options).toHaveLength(5);
+      expect(it.difficulty).toBeGreaterThanOrEqual(1);
+      expect(it.difficulty).toBeLessThanOrEqual(5);
+      expect(it.gradeBand).toBe('8-12');
+
+      // The correct letter must exist and map to the stored answer value…
+      const chosen = it.options.find(o => o.label === it.correctOption);
+      expect(chosen).toBeDefined();
+      expect(chosen.text).toBe(it.answer.value);
+
+      // …and EXACTLY ONE option may equal the answer (no ambiguous keys).
+      const matches = it.options.filter(o => o.text === it.answer.value);
+      expect(matches).toHaveLength(1);
+
+      // Options are distinct.
+      const texts = new Set(it.options.map(o => o.text));
+      expect(texts.size).toBe(5);
+    }
+  });
+
+  test('the bank fills a complete 60-item form', () => {
+    const proof = assemblyProof(items);
+    expect(proof.filled).toBe(proof.total);
+    expect(proof.total).toBe(60);
+  });
+});

--- a/tests/unit/skillFocusBuilder.test.js
+++ b/tests/unit/skillFocusBuilder.test.js
@@ -1,0 +1,132 @@
+// tests/unit/skillFocusBuilder.test.js
+// Unit tests for the Phase 2 "structure everywhere" skill-focus seeder.
+// Uses plain objects for the plan (addSkillToFocus only needs an array) and a
+// Map for skillMastery — no DB required. TutorPlan statics (inferFamiliarity,
+// familiarityToMode) are pure and load without a connection.
+
+const { refreshSkillFocus, isStructuredFreeChatEnabled } = require('../../utils/skillFocusBuilder');
+
+function makePlan() {
+  return { skillFocus: [] };
+}
+
+// Fixed clock so review-due math is deterministic.
+const NOW = new Date('2026-07-15T12:00:00Z');
+const PAST = new Date('2026-07-10T12:00:00Z');   // due
+const FUTURE = new Date('2026-08-10T12:00:00Z'); // not due
+
+function masteryMap(entries) {
+  const m = new Map();
+  for (const [id, e] of Object.entries(entries)) m.set(id, e);
+  return m;
+}
+
+describe('skillFocusBuilder.refreshSkillFocus', () => {
+  const prevFlag = process.env.STRUCTURED_FREE_CHAT;
+  afterEach(() => {
+    if (prevFlag === undefined) delete process.env.STRUCTURED_FREE_CHAT;
+    else process.env.STRUCTURED_FREE_CHAT = prevFlag;
+  });
+
+  test('seeds an in-progress (developing) skill when the queue is empty', () => {
+    const plan = makePlan();
+    const user = { skillMastery: masteryMap({
+      'add-fractions': { status: 'learning', totalAttempts: 4 },
+    }) };
+    refreshSkillFocus(plan, user, { now: NOW });
+    expect(plan.skillFocus).toHaveLength(1);
+    expect(plan.skillFocus[0]).toMatchObject({
+      skillId: 'add-fractions',
+      reason: 'assessment-identified',
+      familiarity: 'developing',
+      instructionalMode: 'guide',
+      status: 'active',
+    });
+  });
+
+  test('bumps a review-due in-progress skill to review-due priority', () => {
+    const plan = makePlan();
+    const user = { skillMastery: masteryMap({
+      // developing + review due → jumps the queue
+      'one-step-eq': { status: 'practicing', masteryScore: 60, totalAttempts: 4, reviewSchedule: { nextReviewDate: PAST } },
+      'two-step-eq': { status: 'learning', totalAttempts: 3 },
+    }) };
+    refreshSkillFocus(plan, user, { now: NOW });
+    const due = plan.skillFocus.find(s => s.skillId === 'one-step-eq');
+    const dev = plan.skillFocus.find(s => s.skillId === 'two-step-eq');
+    expect(due).toMatchObject({ reason: 'review-due', priority: 8 });
+    // review-due outranks a not-due in-progress skill
+    expect(due.priority).toBeGreaterThan(dev.priority);
+  });
+
+  test('skips mastered skills (retired by resolveCurrentTarget; surfaced by the prompt layer)', () => {
+    const plan = makePlan();
+    const user = { skillMastery: masteryMap({
+      'slope': { status: 'mastered', masteredDate: PAST, reviewSchedule: { nextReviewDate: PAST } },
+    }) };
+    refreshSkillFocus(plan, user, { now: NOW });
+    expect(plan.skillFocus).toHaveLength(0);
+  });
+
+  test('skips never-seen skills (would trigger aggressive INSTRUCT)', () => {
+    const plan = makePlan();
+    const user = { skillMastery: masteryMap({
+      'limits': { status: 'locked', totalAttempts: 0 },
+    }) };
+    refreshSkillFocus(plan, user, { now: NOW });
+    expect(plan.skillFocus).toHaveLength(0);
+  });
+
+  test('skips a mastered skill that is not yet due for review', () => {
+    const plan = makePlan();
+    const user = { skillMastery: masteryMap({
+      'slope': { status: 'mastered', masteredDate: PAST, reviewSchedule: { nextReviewDate: FUTURE } },
+    }) };
+    refreshSkillFocus(plan, user, { now: NOW });
+    expect(plan.skillFocus).toHaveLength(0);
+  });
+
+  test('is a no-op when the queue already has active work', () => {
+    const plan = { skillFocus: [{ skillId: 'existing', status: 'in-progress', priority: 5 }] };
+    const user = { skillMastery: masteryMap({
+      'add-fractions': { status: 'learning', totalAttempts: 4 },
+    }) };
+    refreshSkillFocus(plan, user, { now: NOW });
+    expect(plan.skillFocus).toHaveLength(1);
+    expect(plan.skillFocus[0].skillId).toBe('existing');
+  });
+
+  test('is a no-op during a course session', () => {
+    const plan = makePlan();
+    const user = { skillMastery: masteryMap({
+      'add-fractions': { status: 'learning', totalAttempts: 4 },
+    }) };
+    refreshSkillFocus(plan, user, { now: NOW, inCourse: true });
+    expect(plan.skillFocus).toHaveLength(0);
+  });
+
+  test('is a no-op when the kill switch is set', () => {
+    process.env.STRUCTURED_FREE_CHAT = 'false';
+    expect(isStructuredFreeChatEnabled()).toBe(false);
+    const plan = makePlan();
+    const user = { skillMastery: masteryMap({
+      'add-fractions': { status: 'learning', totalAttempts: 4 },
+    }) };
+    refreshSkillFocus(plan, user, { now: NOW });
+    expect(plan.skillFocus).toHaveLength(0);
+  });
+
+  test('caps the seeded queue at 6 entries', () => {
+    const entries = {};
+    for (let i = 0; i < 12; i++) entries['skill-' + i] = { status: 'learning', totalAttempts: 4 };
+    const plan = makePlan();
+    refreshSkillFocus(plan, { skillMastery: masteryMap(entries) }, { now: NOW });
+    expect(plan.skillFocus.length).toBeLessThanOrEqual(6);
+  });
+
+  test('tolerates a missing or malformed skillMastery gracefully', () => {
+    const plan = makePlan();
+    expect(() => refreshSkillFocus(plan, {}, { now: NOW })).not.toThrow();
+    expect(plan.skillFocus).toHaveLength(0);
+  });
+});

--- a/utils/actTestAssembler.js
+++ b/utils/actTestAssembler.js
@@ -1,0 +1,200 @@
+/**
+ * ACT TEST ASSEMBLER — builds an ORIGINAL parallel ACT Math form from our own
+ * item bank, to a fixed blueprint (seeds/act-math-blueprint.json).
+ *
+ * The blueprint is derived from the ACT Math reporting-category structure — the
+ * *composition* of the exam (how many items per category, difficulty ramp), not
+ * any published test's questions. This assembler samples our own skill-tagged
+ * items (models/problem.js, the `act-*` skills) to hit that composition, so every
+ * assembled form is a fresh, original parallel test with the same measurement
+ * properties. No copyrighted items are ever stored or served.
+ *
+ * Two consumers:
+ *   - Fixed-form runner: take `items` in order, time it, score raw→scaled.
+ *   - Adaptive diagnostic (Starting Point rail): use `skillPool` /
+ *     `skillsByCategory` to constrain the CAT engine to the ACT skill set.
+ *
+ * Any slot the bank can't fill is reported in `gaps` with a `generationSpec`
+ * the problem generator (scripts/generate*.js) can fulfill — so the assembler
+ * is useful even before the bank is fully populated for ACT.
+ *
+ * @module utils/actTestAssembler
+ */
+
+const DEFAULT_BLUEPRINT = require('../seeds/act-math-blueprint.json');
+// models/problem (mongoose) is required lazily inside assembleForm so the pure
+// helpers (buildSlots / skillPool / rawToScaled) load without a DB connection.
+
+// ── Tiny seeded PRNG (mulberry32) so a given seed reproduces a form and
+// different seeds produce different — but balanced — forms. Runtime only;
+// never used inside workflow scripts (where Math.random is banned).
+function mulberry32(seed) {
+  let a = seed >>> 0;
+  return function () {
+    a |= 0; a = (a + 0x6D2B79F5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function hashSeed(str) {
+  let h = 2166136261 >>> 0;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+/** Target difficulty for a 1-based position, from the blueprint ramp. */
+function difficultyForPosition(blueprint, position) {
+  for (const band of blueprint.difficultyRamp || []) {
+    if (position >= band.fromPosition && position <= band.toPosition) return band.targetDifficulty;
+  }
+  return 3;
+}
+
+/**
+ * Expand category weights + ramp into an ordered list of 60 slots, with each
+ * category spread evenly across the form (interleaved like a real ACT, not
+ * blocked by category) and a rotating skill assignment for within-category
+ * coverage.
+ *
+ * @returns {Array<{position, category, skillId, targetDifficulty}>}
+ */
+function buildSlots(blueprint, rng) {
+  const weights = blueprint.categoryWeights || {};
+  const byCat = blueprint.skillsByCategory || {};
+
+  // Place each category's items at evenly spaced fractional positions so the
+  // final interleave spreads every category across the whole form.
+  const placed = [];
+  for (const [category, count] of Object.entries(weights)) {
+    const skills = byCat[category] || [];
+    // rotate the skill start point per form so different seeds vary coverage
+    const startOffset = skills.length ? Math.floor(rng() * skills.length) : 0;
+    for (let i = 0; i < count; i++) {
+      const frac = (i + 0.5) / count;               // even spread in [0,1)
+      const jitter = (rng() - 0.5) * (0.5 / count);  // tiny shuffle to avoid ties
+      const skillId = skills.length ? skills[(startOffset + i) % skills.length] : null;
+      placed.push({ category, skillId, sortKey: frac + jitter });
+    }
+  }
+
+  placed.sort((a, b) => a.sortKey - b.sortKey);
+
+  return placed.map((slot, idx) => ({
+    position: idx + 1,
+    category: slot.category,
+    skillId: slot.skillId,
+    targetDifficulty: difficultyForPosition(blueprint, idx + 1),
+  }));
+}
+
+/** Trim a Problem doc to the client-safe item payload (no answer key). */
+function toClientItem(slot, problem) {
+  return {
+    position: slot.position,
+    category: slot.category,
+    skillId: slot.skillId,
+    problemId: String(problem._id),
+    question: problem.question,
+    answerType: problem.answerType,
+    options: problem.answerType === 'multiple-choice' ? (problem.options || []) : undefined,
+    difficulty: problem.difficulty,
+  };
+}
+
+/** A spec the problem generator can fulfill for an unfillable slot. */
+function toGenerationSpec(slot) {
+  return {
+    position: slot.position,
+    skillId: slot.skillId,
+    category: slot.category,
+    targetDifficulty: slot.targetDifficulty,
+    answerType: 'multiple-choice',
+    optionCount: 5,
+  };
+}
+
+/**
+ * Assemble an original ACT Math form from the bank.
+ *
+ * @param {Object} [opts]
+ * @param {Object} [opts.blueprint] - Override blueprint (defaults to seeds file)
+ * @param {string|number} [opts.seed] - Reproducibility seed (string hashed)
+ * @param {number} [opts.difficultyRange=1] - ± band passed to findNearDifficulty
+ * @returns {Promise<{items, gaps, coverage, meta}>}
+ */
+async function assembleForm(opts = {}) {
+  const blueprint = opts.blueprint || DEFAULT_BLUEPRINT;
+  const seedInput = opts.seed != null ? opts.seed : `${Date.now()}`;
+  const seed = typeof seedInput === 'number' ? seedInput >>> 0 : hashSeed(String(seedInput));
+  const rng = mulberry32(seed);
+
+  const Problem = require('../models/problem');
+  const slots = buildSlots(blueprint, rng);
+  const usedProblemIds = [];
+  const items = [];
+  const gaps = [];
+
+  for (const slot of slots) {
+    if (!slot.skillId) { gaps.push(toGenerationSpec(slot)); continue; }
+    let problem = null;
+    try {
+      problem = await Problem.findNearDifficulty(
+        slot.skillId,
+        slot.targetDifficulty,
+        usedProblemIds,
+        { preferMultipleChoice: true }
+      );
+    } catch (err) {
+      // DB/query error — treat as a gap, keep assembling the rest.
+      problem = null;
+    }
+    if (!problem) { gaps.push(toGenerationSpec(slot)); continue; }
+    usedProblemIds.push(problem._id);
+    items.push(toClientItem(slot, problem));
+  }
+
+  return {
+    items,
+    gaps,
+    coverage: {
+      total: slots.length,
+      filled: items.length,
+      missing: gaps.length,
+      pct: slots.length ? Math.round((items.length / slots.length) * 100) : 0,
+    },
+    meta: {
+      testId: blueprint.testId,
+      title: blueprint.title,
+      totalItems: blueprint.totalItems,
+      timeLimitMinutes: blueprint.timeLimitMinutes,
+      seed,
+    },
+  };
+}
+
+/** Flat list of the ACT content skillIds (for constraining the CAT engine). */
+function skillPool(blueprint = DEFAULT_BLUEPRINT) {
+  return Object.values(blueprint.skillsByCategory || {}).flat();
+}
+
+/** Map a raw score (0..totalItems) to the approximate scaled 1-36 estimate. */
+function rawToScaled(raw, blueprint = DEFAULT_BLUEPRINT) {
+  const table = blueprint.scaledScore && blueprint.scaledScore.scaledByRaw;
+  if (!Array.isArray(table)) return null;
+  const r = Math.max(0, Math.min(table.length - 1, Math.round(raw)));
+  return { scaled: table[r], approximate: true };
+}
+
+module.exports = {
+  assembleForm,
+  buildSlots,
+  skillPool,
+  rawToScaled,
+  difficultyForPosition,
+  getBlueprint: () => DEFAULT_BLUEPRINT,
+};

--- a/utils/actTestAssembler.js
+++ b/utils/actTestAssembler.js
@@ -100,6 +100,7 @@ function toClientItem(slot, problem) {
     skillId: slot.skillId,
     problemId: problem.problemId,          // the string problemId (matches findNearDifficulty excludes)
     content: problem.prompt,               // field is `prompt`; screener sends it as `content`
+    svg: problem.svg || undefined,         // optional figure
     answerType: problem.answerType,
     options: problem.answerType === 'multiple-choice' ? (problem.options || []) : undefined,
     difficulty: problem.difficulty,

--- a/utils/actTestAssembler.js
+++ b/utils/actTestAssembler.js
@@ -98,8 +98,8 @@ function toClientItem(slot, problem) {
     position: slot.position,
     category: slot.category,
     skillId: slot.skillId,
-    problemId: String(problem._id),
-    question: problem.question,
+    problemId: problem.problemId,          // the string problemId (matches findNearDifficulty excludes)
+    content: problem.prompt,               // field is `prompt`; screener sends it as `content`
     answerType: problem.answerType,
     options: problem.answerType === 'multiple-choice' ? (problem.options || []) : undefined,
     difficulty: problem.difficulty,
@@ -154,7 +154,7 @@ async function assembleForm(opts = {}) {
       problem = null;
     }
     if (!problem) { gaps.push(toGenerationSpec(slot)); continue; }
-    usedProblemIds.push(problem._id);
+    usedProblemIds.push(problem.problemId);
     items.push(toClientItem(slot, problem));
   }
 

--- a/utils/pipeline/index.js
+++ b/utils/pipeline/index.js
@@ -213,6 +213,18 @@ async function runPipeline(message, ctx) {
     // chat.js already loads it for re-entry/override detection.
     tutorPlan = ctx.tutorPlan || await loadOrCreatePlan(ctx.user._id, { user: ctx.user });
 
+    // ── Phase 2: structure everywhere ──
+    // Seed the skill-focus queue from the student's own mastery signals so the
+    // structured-teaching machine runs in free chat too (not only in courses).
+    // Non-fatal, guarded to only act when the queue is empty and the student is
+    // not in a course. See utils/skillFocusBuilder.js.
+    try {
+      const { refreshSkillFocus } = require('../skillFocusBuilder');
+      refreshSkillFocus(tutorPlan, ctx.user, { inCourse: !!ctx.user.activeCourseSessionId });
+    } catch (seedErr) {
+      console.error('[Pipeline] skillFocus seed error (non-fatal):', seedErr.message);
+    }
+
     const resolved = await resolveCurrentTarget(tutorPlan, {
       user: ctx.user,
       activeSkillId: ctx.activeSkill?.skillId || null,

--- a/utils/skillFocusBuilder.js
+++ b/utils/skillFocusBuilder.js
@@ -1,0 +1,117 @@
+/**
+ * SKILL FOCUS BUILDER — makes structured teaching run in free chat.
+ *
+ * The tutor plan already has a full structured-teaching machine
+ * (skillFocus queue → currentTarget → instructional mode → gradual release),
+ * but in free chat the queue was never populated, so `decide` always fell
+ * through to the reactive Socratic default. This module feeds that queue from
+ * the student's OWN mastery signals so the tutor knows what to work on next —
+ * "structure everywhere" — without requiring a course enrolment.
+ *
+ * Safety posture (v1, "guided" — steer, don't cage):
+ *   - Seeds ONLY skills the student has already TOUCHED (review-due +
+ *     in-progress). These map to guide/strengthen/leverage modes, which stay
+ *     Socratic-compatible. It never seeds `never-seen` frontier skills, so it
+ *     can't trigger the answer-dumping INSTRUCT mode against an off-plan
+ *     question. Proactive brand-new-skill introduction stays reactive /
+ *     course-driven until the on-plan detector is proven (see
+ *     docs/COURSES_IN_FLOW_DESIGN.md, open question #2).
+ *   - Only runs when the active queue is EMPTY, so it never thrashes an
+ *     in-flight plan or overrides course / teacher / student-set focus.
+ *   - Skips course sessions entirely (the course drives its own queue).
+ *   - Non-fatal by contract: the caller wraps it in try/catch; on any bad
+ *     input it returns the plan untouched.
+ *
+ * Kill switch: set env STRUCTURED_FREE_CHAT=false to disable seeding globally.
+ *
+ * @module utils/skillFocusBuilder
+ */
+
+const TutorPlan = require('../models/tutorPlan');
+const { addSkillToFocus } = require('./tutorPlanManager');
+
+// Priority by familiarity for in-progress (not-yet-due) skills. Review-due
+// work outranks all of these so retention gets served first.
+const PRIORITY = { review_due: 8, developing: 6, introduced: 5, proficient: 4 };
+const MAX_SEED = 6;
+
+/**
+ * Whether structured free-chat seeding is enabled. Default ON; the env var is
+ * an explicit kill switch so a canary can turn it off without a code change.
+ * @returns {boolean}
+ */
+function isStructuredFreeChatEnabled() {
+  return process.env.STRUCTURED_FREE_CHAT !== 'false';
+}
+
+/**
+ * Populate `plan.skillFocus` from the student's mastery signals when the queue
+ * is empty and the student is in free chat. Mutates and returns the plan (does
+ * not save — the pipeline's persist stage saves it).
+ *
+ * @param {Object} plan - TutorPlan document
+ * @param {Object} user - User document (needs skillMastery)
+ * @param {Object} [opts]
+ * @param {boolean} [opts.inCourse] - True when the student is in a course session
+ * @param {Date}    [opts.now] - Injectable clock for tests
+ * @returns {Object} the same plan
+ */
+function refreshSkillFocus(plan, user, opts = {}) {
+  if (!isStructuredFreeChatEnabled()) return plan;
+  if (!plan || !user) return plan;
+  if (opts.inCourse) return plan; // course drives its own queue
+
+  // Don't touch a queue that already has active work.
+  const hasActive = (plan.skillFocus || []).some(
+    sf => sf.status === 'active' || sf.status === 'in-progress'
+  );
+  if (hasActive) return plan;
+
+  const mastery = user.skillMastery;
+  if (!mastery || typeof mastery.forEach !== 'function') return plan;
+
+  const now = opts.now || new Date();
+  const candidates = [];
+
+  mastery.forEach((entry, skillId) => {
+    if (!entry || !skillId) return;
+
+    const familiarity = TutorPlan.inferFamiliarity(entry);
+
+    // Skip never-seen (seeding it would trigger the answer-dumping INSTRUCT
+    // mode) and mastered. Mastered skills are auto-retired by
+    // resolveCurrentTarget, and mastered review-due is already surfaced by the
+    // prompt layer (buildSkillMasteryContext) — seeding them here is churn.
+    if (familiarity === 'never-seen' || familiarity === 'mastered') return;
+
+    const nextReview = entry.reviewSchedule && entry.reviewSchedule.nextReviewDate
+      ? new Date(entry.reviewSchedule.nextReviewDate)
+      : null;
+    const reviewDue = !!(nextReview && nextReview <= now);
+
+    // In-progress (developing / introduced / proficient). If a review is due,
+    // it jumps the queue; otherwise it's ordered by familiarity.
+    candidates.push({
+      skillId,
+      familiarity,
+      reason: reviewDue ? 'review-due' : 'assessment-identified',
+      priority: reviewDue ? PRIORITY.review_due : (PRIORITY[familiarity] || 5),
+    });
+  });
+
+  if (candidates.length === 0) return plan;
+
+  candidates.sort((a, b) => b.priority - a.priority);
+  for (const c of candidates.slice(0, MAX_SEED)) {
+    addSkillToFocus(plan, {
+      skillId: c.skillId,
+      reason: c.reason,
+      familiarity: c.familiarity,
+      priority: c.priority,
+    });
+  }
+
+  return plan;
+}
+
+module.exports = { refreshSkillFocus, isStructuredFreeChatEnabled };


### PR DESCRIPTION
Reworking "courses" into the main tutoring flow. Decision: **structure is the default for everyone, courses are a free on-ramp** (the AI-minute cap, not a paywall, converts to Mathmatix+), plus a full ACT boot-camp practice-test system.

## Courses-in-flow
- **Design record** — `docs/COURSES_IN_FLOW_DESIGN.md`.
- **Phase 1 — open the funnel:** drop `premiumFeatureGate('Courses')` + in-handler enrol gate; course-aware usage-cap message.
- **Un-shelve the course sidebar:** `MM_FEATURES.courses` (default on, `?courses=0` kill switch).
- **Phase 2 — structure in free chat:** `utils/skillFocusBuilder.js` seeds `tutorPlan.skillFocus` from mastery signals so `decide.js` runs structured teaching without a course. Conservative "guided" v1; `STRUCTURED_FREE_CHAT=false` to disable. Unit-tested.

## ACT boot-camp practice test (end-to-end)
- **Blueprint** — `seeds/act-math-blueprint.json`: 60-item composition (category weights + difficulty ramp + approximate raw→scaled 1–36), from the ACT reporting-category structure, not a copy of any published test.
- **Assembler** — `utils/actTestAssembler.js`: original parallel forms from our own bank; gaps become generation specs. Unit-tested.
- **Item generator + 245-item bank** — `scripts/generateActItems.js` + `seeds/act-math-items.generated.json`: template-generated, **correctness-by-construction** (every answer computed and a validator plugs it back in — a wrong key can't ship). Now includes **SVG figures** for geometry, **multi-step word problems** for the integrating-essential-skills category, and **trap distractors** that only surface at difficulty ≥4. `npm run act:gen | act:seed | act:coverage`. Test asserts every key valid + a form fills.
- **Delivery rail** — `routes/actTest.js` + `models/actTestSession.js`: fixed-form `/api/act-test` (`start`/`next-problem`/`submit-answer`/`complete`), raw + scaled + per-category breakdown. Free, no AI at request time.
- **Student UI** — `public/js/act-test.js`: timed runner, figures, results with the scaled score + per-category diagnostic. Verified in headless Chromium. Entry: `/chat.html?acttest=1`.

## Rollout / to make it live
- `MM_FEATURES.courses` and Phase 2 seeding default **on** (kill switches noted above).
- **Run `npm run act:seed`** to load the 245 ACT items into Mongo; then `/api/act-test` serves a full form. Add a boot-camp CTA linking to `?acttest=1`.
- **Adaptive ACT diagnostic** (reuse the CAT engine constrained to `skillPool()`) is documented as the next step (§6b).
- No integration test exercises `/api/act-test` yet (needs a seeded test DB); pure logic + item correctness are unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTm55BDVTnGaJm3DRVauGZ