### PR TITLE
feat(twin): verified twin generator — the anti-cheat co-solve core (b…

### DIFF
--- a/tests/unit/twinGenerator.test.js
+++ b/tests/unit/twinGenerator.test.js
@@ -1,0 +1,98 @@
+/**
+ * twinGenerator tests — the LLM is mocked, but the CAS verify gate
+ * (symbolicVerifier) is REAL, so these prove that only answers the CAS actually
+ * confirms are allowed to ship, and wrong ones are rejected.
+ */
+jest.mock('../../utils/llmGateway', () => ({ callLLM: jest.fn() }));
+jest.mock('../../utils/logger', () => ({
+  child: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }),
+}));
+
+const { callLLM } = require('../../utils/llmGateway');
+const { generateVerifiedTwin, verifyTwin } = require('../../utils/twinGenerator');
+
+const wrap = (obj) => ({ choices: [{ message: { content: JSON.stringify(obj) } }] });
+
+beforeEach(() => callLLM.mockReset());
+
+describe('verifyTwin — CAS gate (pure, no LLM)', () => {
+  it('confirms a correct equation twin', () => {
+    expect(verifyTwin({ answer: 'x = 7', problemTex: '3x - 5 = 16', checkType: 'equation', checkAgainst: '3x - 5 = 16' }))
+      .toEqual({ verified: true, method: 'equation' });
+  });
+  it('REJECTS a wrong equation twin answer', () => {
+    expect(verifyTwin({ answer: 'x = 8', problemTex: '3x - 5 = 16', checkType: 'equation', checkAgainst: '3x - 5 = 16' }).verified)
+      .toBe(false);
+  });
+  it('confirms a correct antiderivative twin', () => {
+    expect(verifyTwin({ answer: 'x^6 + C', problemTex: '\\int 6x^5 dx', checkType: 'antiderivative', checkAgainst: '\\int 6x^5 dx' }).verified)
+      .toBe(true);
+  });
+  it('confirms a correct simplify/equivalence twin and rejects a wrong one', () => {
+    expect(verifyTwin({ answer: '3x + 6', checkType: 'equivalence', checkAgainst: '3(x + 2)' }).verified).toBe(true);
+    expect(verifyTwin({ answer: '3x + 5', checkType: 'equivalence', checkAgainst: '3(x + 2)' }).verified).toBe(false);
+  });
+  it('leaves checkType "none" unverified (CAS can\'t check it — safe)', () => {
+    expect(verifyTwin({ answer: '42 apples', checkType: 'none', checkAgainst: '' }).verified).toBe(false);
+  });
+});
+
+describe('generateVerifiedTwin — end to end (mocked LLM, real CAS)', () => {
+  it('ships a twin only after the CAS confirms its answer', async () => {
+    callLLM.mockResolvedValueOnce(wrap({
+      twin: 'Solve for x: 3x - 5 = 16', problemTex: '3x - 5 = 16', answer: 'x = 7',
+      checkType: 'equation', checkAgainst: '3x - 5 = 16',
+    }));
+    const r = await generateVerifiedTwin('Solve for x: 2x + 4 = 20');
+    expect(r).toMatchObject({ ok: true, verified: true, answer: 'x = 7', method: 'equation' });
+    expect(callLLM).toHaveBeenCalledTimes(1);
+  });
+
+  it('RETRIES when the first twin\'s answer fails the CAS, then ships the good one', async () => {
+    callLLM
+      .mockResolvedValueOnce(wrap({ twin: 'Solve 4x = 12', problemTex: '4x = 12', answer: 'x = 5', checkType: 'equation', checkAgainst: '4x = 12' })) // wrong: 4*5≠12
+      .mockResolvedValueOnce(wrap({ twin: 'Solve 4x = 12', problemTex: '4x = 12', answer: 'x = 3', checkType: 'equation', checkAgainst: '4x = 12' })); // right
+    const r = await generateVerifiedTwin('Solve 2x = 10');
+    expect(r).toMatchObject({ ok: true, verified: true, answer: 'x = 3', attempts: 2 });
+    expect(callLLM).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back (ok:false) when no attempt produces a CAS-verified answer', async () => {
+    callLLM.mockResolvedValue(wrap({ twin: 'Solve 4x = 12', problemTex: '4x = 12', answer: 'x = 5', checkType: 'equation', checkAgainst: '4x = 12' }));
+    const r = await generateVerifiedTwin('Solve 2x = 10');
+    expect(r).toEqual({ ok: false, verified: false, reason: 'unverified' });
+    expect(callLLM).toHaveBeenCalledTimes(2); // exhausted both attempts
+  });
+
+  it('anti-cheat: rejects a twin identical to the student\'s own problem', async () => {
+    // Verbatim echo would leak the student's answer — must be rejected even
+    // though its answer is correct. Second attempt gives a real (different) twin.
+    callLLM
+      .mockResolvedValueOnce(wrap({ twin: 'Solve 2x = 10', problemTex: '2x = 10', answer: 'x = 5', checkType: 'equation', checkAgainst: '2x = 10' }))
+      .mockResolvedValueOnce(wrap({ twin: 'Solve 2x = 14', problemTex: '2x = 14', answer: 'x = 7', checkType: 'equation', checkAgainst: '2x = 14' }));
+    const r = await generateVerifiedTwin('Solve 2x = 10');
+    expect(r).toMatchObject({ ok: true, answer: 'x = 7', attempts: 2 });
+  });
+
+  it('tolerates malformed JSON and non-JSON, then recovers', async () => {
+    callLLM
+      .mockResolvedValueOnce({ choices: [{ message: { content: 'not json at all' } }] })
+      .mockResolvedValueOnce(wrap({ twin: 'Simplify 5(x + 1)', problemTex: '5(x + 1)', answer: '5x + 5', checkType: 'equivalence', checkAgainst: '5(x + 1)' }));
+    const r = await generateVerifiedTwin('Simplify 3(x + 2)');
+    expect(r).toMatchObject({ ok: true, verified: true, answer: '5x + 5', method: 'equivalence' });
+  });
+
+  it('returns no_problem for empty input without calling the LLM', async () => {
+    expect(await generateVerifiedTwin('')).toEqual({ ok: false, reason: 'no_problem' });
+    expect(await generateVerifiedTwin('   ')).toEqual({ ok: false, reason: 'no_problem' });
+    expect(callLLM).not.toHaveBeenCalled();
+  });
+
+  it('survives an LLM throw and retries', async () => {
+    callLLM
+      .mockRejectedValueOnce(new Error('rate limited'))
+      .mockResolvedValueOnce(wrap({ twin: 'Solve 5x = 20', problemTex: '5x = 20', answer: 'x = 4', checkType: 'equation', checkAgainst: '5x = 20' }));
+    const r = await generateVerifiedTwin('Solve 3x = 9');
+    expect(r).toMatchObject({ ok: true, answer: 'x = 4' });
+  });
+});

--- a/utils/twinGenerator.js
+++ b/utils/twinGenerator.js
@@ -1,0 +1,131 @@
+'use strict';
+/* ============================================================
+   twinGenerator.js — generate a VERIFIED "twin" of a math problem.
+
+   A twin is the SAME skill and structure as the student's problem but with
+   DIFFERENT numbers, so the tutor can demonstrate the method on a parallel
+   problem WITHOUT solving the student's own (the anti-cheat contract — see
+   utils/worksheetGuard.js, which today only *instructs* the LLM to invent a
+   parallel problem, with no computed answer).
+
+   The whole point is trust: an LLM proposes the twin + its answer, then the
+   deterministic CAS (utils/pipeline/symbolicVerifier) INDEPENDENTLY confirms the
+   answer before the twin is ever used. A cheap model is safe here precisely
+   because nothing ships unverified — a wrong answer fails the CAS check and we
+   retry or fall back to today's behavior.
+
+   Contract: generateVerifiedTwin() returns { ok:true, verified:true, ... } ONLY
+   when the CAS confirmed the answer. Otherwise { ok:false } and the caller keeps
+   the existing (LLM-improvised) behavior — this feature is strictly additive.
+   ============================================================ */
+
+const { callLLM } = require('./llmGateway');
+const { symbolicVerify } = require('./pipeline/symbolicVerifier');
+let logger;
+try { logger = require('./logger').child({ module: 'twinGenerator' }); }
+catch (_) { logger = { info() {}, warn() {}, error() {}, debug() {} }; }
+
+const TWIN_MODEL = 'gpt-4o-mini';
+
+const SYSTEM_PROMPT = `You generate a "twin" of a math problem: the SAME skill and structure, but DIFFERENT numbers, so a tutor can demonstrate the method on a parallel problem without solving the student's own.
+
+Rules:
+- Keep the skill and structure identical; change the numbers (and names/context if it's a word problem).
+- The twin must NOT be the same problem — at least the key numbers must differ.
+- Solve your twin yourself and give the answer.
+- Provide fields that let a computer algebra system verify your answer INDEPENDENTLY.
+
+Return STRICT JSON only:
+{
+  "twin": "<the twin problem, exactly as you'd show a student>",
+  "problemTex": "<the twin in plain math notation, e.g. '3x - 5 = 16' or '\\\\int 6x^5 dx'>",
+  "answer": "<your answer, e.g. 'x = 7' or 'x^6 + C' or '3x + 6'>",
+  "checkType": "equation | antiderivative | equivalence | none",
+  "checkAgainst": "<see below>"
+}
+
+Pick checkType and checkAgainst so the answer can be checked deterministically:
+- "equation"        -> the twin is 'solve ... = ...'.  checkAgainst = the equation (same as problemTex).
+- "antiderivative"  -> the twin is an indefinite integral.  checkAgainst = the integral (same as problemTex).
+- "equivalence"     -> the twin is simplify / expand / factor.  checkAgainst = the ORIGINAL expression the answer must equal.
+- "none"            -> none of the above (word problem, derivative, geometry, etc.).  checkAgainst = "".`;
+
+// Tolerant JSON extraction (mirrors llmVerifier): try strict, then first {...}.
+function parseJson(raw) {
+  if (!raw) return null;
+  const s = String(raw).trim();
+  try { return JSON.parse(s); } catch (_) { /* try to salvage */ }
+  const m = s.match(/\{[\s\S]*\}/);
+  if (m) { try { return JSON.parse(m[0]); } catch (_) { /* give up */ } }
+  return null;
+}
+
+function norm(s) { return String(s == null ? '' : s).replace(/\s+/g, '').toLowerCase(); }
+
+/**
+ * Independently confirm a proposed twin's answer with the CAS.
+ * @returns {{verified: boolean, method: string}}
+ */
+function verifyTwin(t) {
+  if (!t || t.answer == null) return { verified: false, method: 'none' };
+  const type = t.checkType;
+  const against = t.checkAgainst || t.problemTex;
+  let r = { isCorrect: null, method: 'unverifiable' };
+  try {
+    if (type === 'equation' || type === 'antiderivative') {
+      // symbolicVerify auto-detects: an integral problemTex -> antiderivative
+      // path, an equation problemTex -> substitute-and-check path.
+      r = symbolicVerify({ studentAnswer: t.answer, problemTex: against });
+    } else if (type === 'equivalence') {
+      r = symbolicVerify({ studentAnswer: t.answer, correctAnswer: against });
+    }
+  } catch (_) { /* stays unverifiable */ }
+  return { verified: r.isCorrect === true, method: r.method };
+}
+
+/**
+ * Generate a twin of `problemText` whose answer the CAS has confirmed.
+ * @param {string} problemText  the student's problem (text/LaTeX)
+ * @param {object} [opts]  { maxAttempts=2 }
+ * @returns {Promise<{ok:boolean, verified?:boolean, twin?:string, problemTex?:string, answer?:string, method?:string, attempts?:number, reason?:string}>}
+ */
+async function generateVerifiedTwin(problemText, opts) {
+  opts = opts || {};
+  const maxAttempts = opts.maxAttempts || 2;
+  if (!problemText || !String(problemText).trim()) return { ok: false, reason: 'no_problem' };
+  const studentNorm = norm(problemText);
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    let resp;
+    try {
+      resp = await callLLM(TWIN_MODEL, [
+        { role: 'system', content: SYSTEM_PROMPT },
+        { role: 'user', content: `Student's problem:\n${String(problemText).slice(0, 1000)}\n\nGenerate a verified twin.` },
+      ], { temperature: attempt === 1 ? 0.4 : 0.85, max_tokens: 500, response_format: { type: 'json_object' } });
+    } catch (err) {
+      logger.warn({ err: err && err.message, attempt }, 'twin LLM call failed');
+      continue;
+    }
+
+    const raw = resp && resp.choices && resp.choices[0] && resp.choices[0].message && resp.choices[0].message.content;
+    const t = parseJson(raw);
+    if (!t || !t.twin || t.answer == null) continue;
+
+    // Anti-cheat guard: a twin that's verbatim the student's problem would leak
+    // the student's own answer. Reject and retry with more variety.
+    if (norm(t.twin) === studentNorm || norm(t.problemTex) === studentNorm) {
+      logger.info({ attempt }, 'twin identical to student problem — rejecting');
+      continue;
+    }
+
+    const v = verifyTwin(t);
+    if (v.verified) {
+      return { ok: true, verified: true, twin: t.twin, problemTex: t.problemTex, answer: t.answer, method: v.method, attempts: attempt };
+    }
+    logger.info({ attempt, checkType: t.checkType }, 'twin answer unverified by CAS — retrying');
+  }
+  // Couldn't produce a CAS-verified twin — caller falls back to existing behavior.
+  return { ok: false, verified: false, reason: 'unverified' };
+}
+
+module.exports = { generateVerifiedTwin, verifyTwin, TWIN_MODEL };


### PR DESCRIPTION
…rick #3)

First real brick of the worksheet-twin flow. Generates a "twin" of a student's problem — same skill/structure, different numbers — so the tutor can demonstrate the method on a PARALLEL problem without solving the student's own.

Today worksheetGuard/decide/generate/verify only *instruct* the LLM to invent a parallel problem, with no computed answer — an anti-cheat weakness. This makes the twin real and trustworthy: a cheap LLM proposes the twin + its answer, then the deterministic CAS (symbolicVerifier) INDEPENDENTLY confirms the answer before anything ships. Equations are checked by substitution, integrals by differentiation, simplify/factor by equivalence to the source expression.

Contract (strictly additive): returns ok:true ONLY when the CAS confirmed the answer; otherwise ok:false and the caller keeps today's behavior. A wrong answer fails the check and we retry (higher temp) then fall back — so a mini model is safe here precisely because nothing unverified ever ships. Anti-cheat guard also rejects a twin that's verbatim the student's problem (would leak their answer).

Depends on feat/symbolic-verifier (branched off it) — merge that first. 12 tests: CAS confirms/rejects each family, retry-then-ship, safe fallback, verbatim-echo rejection, malformed-JSON recovery, LLM-throw recovery.