### PR TITLE
fix(act): trinomial distractors + scenario variety for the practice test

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "seed:playground:clear": "node scripts/seedPlaygroundAccounts.js --clear",
     "seed:skills": "node scripts/seed-pattern-skills.js",
     "act:gen": "node scripts/generateActItems.js",
-    "act:seed": "node scripts/generateActItems.js --seed-db",
+    "act:seed": "node scripts/generateActItems.js --seed-db --fresh",
     "act:coverage": "node scripts/actTestCoverage.js",
     "generate:fraction-problems": "node scripts/generate-fraction-problems.js",
     "generate:all-pattern-problems": "node scripts/generate-all-pattern-problems.js",

--- a/scripts/generateActItems.js
+++ b/scripts/generateActItems.js
@@ -37,6 +37,12 @@ const pick = (arr) => arr[Math.floor(RNG() * arr.length)];
 const co = (k, v) => (k === 1 ? v : k === -1 ? `-${v}` : `${k}${v}`);
 // Money: whole dollars plain, else two decimals.
 const money = (v) => (Number.isInteger(v) ? `$${v}` : `$${v.toFixed(2)}`);
+// Trinomial x^2 + Bx + C, cleanly formatted (handles ±1 coefficient and 0 terms).
+const trinomial = (B, C) => {
+  const bpart = B === 0 ? '' : B === 1 ? ' + x' : B === -1 ? ' - x' : (B > 0 ? ` + ${B}x` : ` - ${Math.abs(B)}x`);
+  const cpart = C === 0 ? '' : (C > 0 ? ` + ${C}` : ` - ${Math.abs(C)}`);
+  return `x^2${bpart}${cpart}`;
+};
 
 // ── MC assembler: takes correct value + distractor values, dedupes,
 //    shuffles, assigns the correct letter. Enforces exactly-one-correct. ──
@@ -212,12 +218,20 @@ G['act-quadratic-equations'] = (d) => {
 G['act-polynomial-expressions'] = (d) => {
   const a = nz(-6, 6), b = nz(-6, 6); // (x+a)(x+b) = x^2 + (a+b)x + ab
   const sum = a + b, prod = a * b;
-  const sgn = (n) => (n >= 0 ? `+ ${n}` : `- ${Math.abs(n)}`);
-  const correct = `x^2 ${sgn(sum)}x ${sgn(prod)}`;
+  if (sum === 0) return null; // avoid a degenerate answer with no middle term
+  const correct = trinomial(sum, prod);
   return {
     prompt: `Expand: (x ${a >= 0 ? '+' : '-'} ${Math.abs(a)})(x ${b >= 0 ? '+' : '-'} ${Math.abs(b)})`,
     correct, format: (v) => v,
-    distractors: [`x^2 ${sgn(prod)}x ${sgn(sum)}`, `x^2 ${sgn(sum)}x ${sgn(-prod)}`, `x^2 ${sgn(a * b + 1)}`, `x^2 ${sgn(sum)}`],
+    // Every distractor keeps the x^2 + Bx + C form — real sign/arithmetic errors,
+    // not degenerate shapes like "x^2 + 3".
+    distractors: [
+      trinomial(prod, sum),        // swapped middle & constant (added where they should multiply)
+      trinomial(-sum, prod),       // sign error on the middle term
+      trinomial(sum, -prod),       // sign error on the constant
+      trinomial(-sum, -prod),      // both signs flipped
+      trinomial(sum + a, prod),    // arithmetic slip combining the middle term
+    ],
     validate: () => (a + b === sum) && (a * b === prod),
   };
 };
@@ -356,11 +370,18 @@ G['act-congruence-similarity'] = (d) => {
 
 // integrating-essential-skills ----------------------------------
 G['act-multi-step-rate-proportion'] = (d) => {
-  // Two-leg trip — total distance = r1·h1 + r2·h2 (two computed steps).
+  // Two-leg problem — total = r1·h1 + r2·h2 (two computed steps). Scenario
+  // varies so repeated draws in one form don't read as the same question.
   const r1 = ri(3, 9), h1 = ri(2, 4), r2 = ri(3, 9), h2 = ri(2, 4);
   const correct = r1 * h1 + r2 * h2;
+  const ctx = pick([
+    ['A cyclist rides', 'miles per hour', 'hours', 'total distance traveled, in miles'],
+    ['A delivery van drives', 'miles per hour', 'hours', 'total distance driven, in miles'],
+    ['A printer prints', 'pages per minute', 'minutes', 'total number of pages printed'],
+    ['An assembly line produces', 'units per hour', 'hours', 'total number of units produced'],
+  ]);
   return {
-    prompt: `A cyclist rides at ${r1} miles per hour for ${h1} hours, then at ${r2} miles per hour for ${h2} hours. What is the total distance traveled, in miles?`,
+    prompt: `${ctx[0]} at ${r1} ${ctx[1]} for ${h1} ${ctx[2]}, then at ${r2} ${ctx[1]} for ${h2} ${ctx[2]}. What is the ${ctx[3]}?`,
     correct,
     distractors: [r1 * h1, (r1 + r2) * (h1 + h2), r1 + r2 + h1 + h2, correct + r1, correct - h2],
     trap: r1 * h2 + r2 * h1, // paired the wrong speed with the wrong time
@@ -376,8 +397,14 @@ G['act-algebraic-reasoning-context'] = (d) => {
   // Set up total = fixed + per·m, then SOLVE for the number of months m.
   const per = ri(3, 9), fixed = ri(2, 8) * 5, m = ri(3, 9);
   const total = fixed + per * m; const correct = m;
+  const ctx = pick([
+    ['A gym charges a', 'one-time sign-up fee plus', 'each month', 'months'],
+    ['A phone plan has a', 'activation fee plus', 'each month', 'months'],
+    ['A pool club charges a', 'membership fee plus', 'per visit', 'visits'],
+    ['A tool service has a', 'flat fee plus', 'per day', 'days'],
+  ]);
   return {
-    prompt: `A gym charges a $${fixed} one-time sign-up fee plus $${per} each month. After how many months will a member have paid $${total} in all?`,
+    prompt: `${ctx[0]} $${fixed} ${ctx[1]} $${per} ${ctx[2]}. After how many ${ctx[3]} will the total paid reach $${total}?`,
     correct,
     distractors: [Math.round(total / per), m + 1, m - 1, Math.round(total / (per + fixed)) || 1, total - fixed],
     trap: Math.round((total + fixed) / per), // ADDED the sign-up fee instead of subtracting it before dividing
@@ -389,8 +416,9 @@ G['act-percent-applications'] = (d) => {
   const price = pick([40, 50, 60, 80, 100, 120]); const disc = pick([10, 20, 25]); const tax = pick([5, 8, 10]);
   const sale = price * (1 - disc / 100);
   const correct = Math.round(sale * (1 + tax / 100) * 100) / 100;
+  const item = pick(['jacket', 'laptop', 'pair of shoes', 'backpack', 'desk lamp', 'bicycle']);
   return {
-    prompt: `A $${price} jacket is ${disc}% off. With ${tax}% sales tax added to the discounted price, what is the final cost?`,
+    prompt: `A $${price} ${item} is ${disc}% off. With ${tax}% sales tax added to the discounted price, what is the final cost?`,
     correct, format: money,
     distractors: [sale, Math.round(price * (1 + tax / 100) * 100) / 100, price - disc, Math.round(price * disc / 100 * 100) / 100],
     // TRAP: combined the percents on the original price — (1 − disc% + tax%) — instead of applying them in sequence.
@@ -511,12 +539,18 @@ function assemblyProof(items) {
   return { filled, total: slots.length, missing };
 }
 
-async function seedDb(items) {
+async function seedDb(items, fresh) {
   require('dotenv').config();
   const mongoose = require('mongoose');
   if (!process.env.MONGO_URI) { console.error('MONGO_URI not set — cannot --seed-db'); process.exit(1); }
   await mongoose.connect(process.env.MONGO_URI);
   const Problem = require('../models/problem');
+  // --fresh removes prior template-generated ACT items first, so regenerated
+  // prompts (new problemIds) don't leave stale copies behind.
+  if (fresh) {
+    const del = await Problem.deleteMany({ source: 'act-template-gen' });
+    console.log(`Cleared ${del.deletedCount} existing ACT items (--fresh).`);
+  }
   let up = 0;
   for (const it of items) {
     await Problem.updateOne({ problemId: it.problemId }, { $set: it }, { upsert: true });
@@ -540,7 +574,7 @@ async function main() {
   console.log(`\nAssembly proof: filled ${proof.filled}/${proof.total} slots of a full form.`);
   if (Object.keys(proof.missing).length) console.log('  short on:', proof.missing);
 
-  if (args.includes('--seed-db')) await seedDb(items);
+  if (args.includes('--seed-db')) await seedDb(items, args.includes('--fresh'));
 }
 
 if (require.main === module) main();

--- a/seeds/act-math-items.generated.json
+++ b/seeds/act-math-items.generated.json
@@ -1,8 +1,8 @@
 [
   {
-    "problemId": "act-act-multi-step-rate-proportion-507c6b353f",
+    "problemId": "act-act-multi-step-rate-proportion-345474ec3f",
     "skillId": "act-multi-step-rate-proportion",
-    "prompt": "A cyclist rides at 4 miles per hour for 3 hours, then at 8 miles per hour for 2 hours. What is the total distance traveled, in miles?",
+    "prompt": "A delivery van drives at 4 miles per hour for 3 hours, then at 8 miles per hour for 2 hours. What is the total distance driven, in miles?",
     "answer": {
       "type": "auto",
       "value": "28",
@@ -12,15 +12,15 @@
     "options": [
       {
         "label": "A",
-        "text": "12"
-      },
-      {
-        "label": "B",
         "text": "28"
       },
       {
+        "label": "B",
+        "text": "60"
+      },
+      {
         "label": "C",
-        "text": "17"
+        "text": "12"
       },
       {
         "label": "D",
@@ -28,7 +28,51 @@
       },
       {
         "label": "E",
-        "text": "60"
+        "text": "17"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-multi-step-rate-proportion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "345474ec3fc44f74f5f013c3ca331efd782f68db8ad9e84cce6e3144e471d3df",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-multi-step-rate-proportion-f0a6ee3754",
+    "skillId": "act-multi-step-rate-proportion",
+    "prompt": "An assembly line produces at 8 units per hour for 4 hours, then at 9 units per hour for 4 hours. What is the total number of units produced?",
+    "answer": {
+      "type": "auto",
+      "value": "68",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "76"
+      },
+      {
+        "label": "B",
+        "text": "68"
+      },
+      {
+        "label": "C",
+        "text": "25"
+      },
+      {
+        "label": "D",
+        "text": "32"
+      },
+      {
+        "label": "E",
+        "text": "136"
       }
     ],
     "correctOption": "B",
@@ -40,43 +84,43 @@
       "act-multi-step-rate-proportion"
     ],
     "source": "act-template-gen",
-    "contentHash": "507c6b353fdcbaf15f3494c12e9ab3753761e3f977f2c2c9a8799f61e942eb36",
+    "contentHash": "f0a6ee3754835dc543de07b3b2ada776156cd0995bfa37d338191f341a743194",
     "isActive": true
   },
   {
-    "problemId": "act-act-multi-step-rate-proportion-f373278627",
+    "problemId": "act-act-multi-step-rate-proportion-41c8fdb457",
     "skillId": "act-multi-step-rate-proportion",
-    "prompt": "A cyclist rides at 6 miles per hour for 4 hours, then at 9 miles per hour for 4 hours. What is the total distance traveled, in miles?",
+    "prompt": "A cyclist rides at 5 miles per hour for 2 hours, then at 4 miles per hour for 2 hours. What is the total distance traveled, in miles?",
     "answer": {
       "type": "auto",
-      "value": "60",
+      "value": "18",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "120"
+        "text": "18"
       },
       {
         "label": "B",
-        "text": "60"
+        "text": "10"
       },
       {
         "label": "C",
-        "text": "24"
+        "text": "36"
       },
       {
         "label": "D",
-        "text": "66"
+        "text": "13"
       },
       {
         "label": "E",
         "text": "23"
       }
     ],
-    "correctOption": "B",
-    "difficulty": 2,
+    "correctOption": "A",
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -84,39 +128,39 @@
       "act-multi-step-rate-proportion"
     ],
     "source": "act-template-gen",
-    "contentHash": "f373278627e5485c5516a36e1372b2da5d1b20281bdf81bb229da73a320a163a",
+    "contentHash": "41c8fdb4576644c6de203608c1a540c23a2ea693b42a522085f12034c1ef3d6c",
     "isActive": true
   },
   {
-    "problemId": "act-act-multi-step-rate-proportion-7b57bbb67b",
+    "problemId": "act-act-multi-step-rate-proportion-ea89885438",
     "skillId": "act-multi-step-rate-proportion",
-    "prompt": "A cyclist rides at 6 miles per hour for 3 hours, then at 5 miles per hour for 2 hours. What is the total distance traveled, in miles?",
+    "prompt": "A delivery van drives at 9 miles per hour for 3 hours, then at 5 miles per hour for 4 hours. What is the total distance driven, in miles?",
     "answer": {
       "type": "auto",
-      "value": "28",
+      "value": "47",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "55"
+        "text": "98"
       },
       {
         "label": "B",
-        "text": "16"
+        "text": "21"
       },
       {
         "label": "C",
-        "text": "28"
+        "text": "47"
       },
       {
         "label": "D",
-        "text": "34"
+        "text": "56"
       },
       {
         "label": "E",
-        "text": "18"
+        "text": "27"
       }
     ],
     "correctOption": "C",
@@ -128,42 +172,42 @@
       "act-multi-step-rate-proportion"
     ],
     "source": "act-template-gen",
-    "contentHash": "7b57bbb67b821bb55d6612be1d5c476805f17fe8188d70713ec05a60675024a5",
+    "contentHash": "ea89885438c2078f2a30bf8dc2e2793811d38711e2b75e7e8a9f106d0bed8d33",
     "isActive": true
   },
   {
-    "problemId": "act-act-multi-step-rate-proportion-9e8a8d8690",
+    "problemId": "act-act-multi-step-rate-proportion-9829e264a3",
     "skillId": "act-multi-step-rate-proportion",
-    "prompt": "A cyclist rides at 9 miles per hour for 4 hours, then at 9 miles per hour for 4 hours. What is the total distance traveled, in miles?",
+    "prompt": "An assembly line produces at 8 units per hour for 3 hours, then at 5 units per hour for 2 hours. What is the total number of units produced?",
     "answer": {
       "type": "auto",
-      "value": "72",
+      "value": "34",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "26"
+        "text": "18"
       },
       {
         "label": "B",
-        "text": "72"
+        "text": "65"
       },
       {
         "label": "C",
-        "text": "81"
+        "text": "34"
       },
       {
         "label": "D",
-        "text": "36"
+        "text": "24"
       },
       {
         "label": "E",
-        "text": "144"
+        "text": "42"
       }
     ],
-    "correctOption": "B",
+    "correctOption": "C",
     "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
@@ -172,83 +216,39 @@
       "act-multi-step-rate-proportion"
     ],
     "source": "act-template-gen",
-    "contentHash": "9e8a8d869023d7bf6b32a2706176126c788ee9eb616a133bf2f6e810adfc5888",
+    "contentHash": "9829e264a309afbb88375890a9b8390f73f21d24b988f59cf434a920d3100f08",
     "isActive": true
   },
   {
-    "problemId": "act-act-multi-step-rate-proportion-2d0603d4ed",
+    "problemId": "act-act-multi-step-rate-proportion-7096e991fc",
     "skillId": "act-multi-step-rate-proportion",
-    "prompt": "A cyclist rides at 5 miles per hour for 2 hours, then at 3 miles per hour for 4 hours. What is the total distance traveled, in miles?",
+    "prompt": "An assembly line produces at 3 units per hour for 2 hours, then at 7 units per hour for 3 hours. What is the total number of units produced?",
     "answer": {
       "type": "auto",
-      "value": "22",
+      "value": "27",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "48"
+        "text": "23"
       },
       {
         "label": "B",
-        "text": "22"
+        "text": "15"
       },
       {
         "label": "C",
+        "text": "6"
+      },
+      {
+        "label": "D",
+        "text": "50"
+      },
+      {
+        "label": "E",
         "text": "27"
-      },
-      {
-        "label": "D",
-        "text": "10"
-      },
-      {
-        "label": "E",
-        "text": "14"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-multi-step-rate-proportion"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "2d0603d4edb6ef41fdae941b72fc461c667d7b0784c91df591b12de5943b54bc",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-multi-step-rate-proportion-24fad99b7d",
-    "skillId": "act-multi-step-rate-proportion",
-    "prompt": "A cyclist rides at 9 miles per hour for 4 hours, then at 5 miles per hour for 2 hours. What is the total distance traveled, in miles?",
-    "answer": {
-      "type": "auto",
-      "value": "46",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "36"
-      },
-      {
-        "label": "B",
-        "text": "38"
-      },
-      {
-        "label": "C",
-        "text": "84"
-      },
-      {
-        "label": "D",
-        "text": "20"
-      },
-      {
-        "label": "E",
-        "text": "46"
       }
     ],
     "correctOption": "E",
@@ -260,39 +260,39 @@
       "act-multi-step-rate-proportion"
     ],
     "source": "act-template-gen",
-    "contentHash": "24fad99b7d7433e1554ee4120b38f98a5752b50f7129f0833bfe84ee2bbcb0c1",
+    "contentHash": "7096e991fc45f9457cfff756acc0775cdceac480837f04d5574c59c227b9da5a",
     "isActive": true
   },
   {
-    "problemId": "act-act-multi-step-rate-proportion-337acd176d",
+    "problemId": "act-act-multi-step-rate-proportion-05d7ba5fc7",
     "skillId": "act-multi-step-rate-proportion",
-    "prompt": "A cyclist rides at 6 miles per hour for 4 hours, then at 3 miles per hour for 4 hours. What is the total distance traveled, in miles?",
+    "prompt": "A printer prints at 9 pages per minute for 4 minutes, then at 5 pages per minute for 3 minutes. What is the total number of pages printed?",
     "answer": {
       "type": "auto",
-      "value": "36",
+      "value": "51",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "17"
+        "text": "98"
       },
       {
         "label": "B",
-        "text": "24"
+        "text": "21"
       },
       {
         "label": "C",
-        "text": "72"
+        "text": "47"
       },
       {
         "label": "D",
-        "text": "36"
+        "text": "51"
       },
       {
         "label": "E",
-        "text": "42"
+        "text": "36"
       }
     ],
     "correctOption": "D",
@@ -304,42 +304,42 @@
       "act-multi-step-rate-proportion"
     ],
     "source": "act-template-gen",
-    "contentHash": "337acd176d827570a95e4bedd149164a36163033b62e2871cfca3c71b7745398",
+    "contentHash": "05d7ba5fc7cac9bc4055ea2aa0eaef8b2815496f8416334c1ec7450d4c430d55",
     "isActive": true
   },
   {
-    "problemId": "act-act-multi-step-rate-proportion-8dc707b068",
+    "problemId": "act-act-multi-step-rate-proportion-b95de4e42a",
     "skillId": "act-multi-step-rate-proportion",
-    "prompt": "A cyclist rides at 5 miles per hour for 3 hours, then at 6 miles per hour for 3 hours. What is the total distance traveled, in miles?",
+    "prompt": "An assembly line produces at 5 units per hour for 4 hours, then at 8 units per hour for 3 hours. What is the total number of units produced?",
     "answer": {
       "type": "auto",
-      "value": "33",
+      "value": "44",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "15"
+        "text": "91"
       },
       {
         "label": "B",
-        "text": "38"
+        "text": "20"
       },
       {
         "label": "C",
-        "text": "17"
+        "text": "49"
       },
       {
         "label": "D",
-        "text": "66"
+        "text": "44"
       },
       {
         "label": "E",
-        "text": "33"
+        "text": "47"
       }
     ],
-    "correctOption": "E",
+    "correctOption": "D",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -348,97 +348,7 @@
       "act-multi-step-rate-proportion"
     ],
     "source": "act-template-gen",
-    "contentHash": "8dc707b068e2bc2e2e8f26f8848767623649d3685b26db93ebfaafa067962683",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-area-perimeter-composite-15e835a7dc",
-    "skillId": "act-area-perimeter-composite",
-    "prompt": "In the figure shown, a square of side 4 has been cut from the corner of a 7-by-6 rectangle. What is the area of the remaining (shaded) region?",
-    "svg": "<svg viewBox=\"0 0 144 112\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 66,20 66,68 114,68 114,92 30,92\" stroke-linejoin=\"round\"/></svg>",
-    "answer": {
-      "type": "auto",
-      "value": "26",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "22"
-      },
-      {
-        "label": "B",
-        "text": "58"
-      },
-      {
-        "label": "C",
-        "text": "26"
-      },
-      {
-        "label": "D",
-        "text": "42"
-      },
-      {
-        "label": "E",
-        "text": "38"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-area-perimeter-composite"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "15e835a7dcc1013dc80dd20f6dfc2b5870ff79e77b6a6a74e9d77524b4ed8729",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-area-perimeter-composite-d3a6ba83ac",
-    "skillId": "act-area-perimeter-composite",
-    "prompt": "In the figure shown, a square of side 3 has been cut from the corner of a 6-by-5 rectangle. What is the area of the remaining (shaded) region?",
-    "svg": "<svg viewBox=\"0 0 132 100\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 66,20 66,56 102,56 102,80 30,80\" stroke-linejoin=\"round\"/></svg>",
-    "answer": {
-      "type": "auto",
-      "value": "21",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "30"
-      },
-      {
-        "label": "B",
-        "text": "39"
-      },
-      {
-        "label": "C",
-        "text": "19"
-      },
-      {
-        "label": "D",
-        "text": "21"
-      },
-      {
-        "label": "E",
-        "text": "27"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-area-perimeter-composite"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "d3a6ba83aca03792c54267ca59284340acf5fa95210c1239be30bd50c53bdb58",
+    "contentHash": "b95de4e42a8fcbfd1b8bc79b3573fb64cb19147c2ce3718f1a8af694b9674b90",
     "isActive": true
   },
   {
@@ -475,7 +385,7 @@
       }
     ],
     "correctOption": "E",
-    "difficulty": 3,
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -520,7 +430,7 @@
       }
     ],
     "correctOption": "B",
-    "difficulty": 3,
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -610,7 +520,7 @@
       }
     ],
     "correctOption": "C",
-    "difficulty": 4,
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -655,7 +565,7 @@
       }
     ],
     "correctOption": "D",
-    "difficulty": 4,
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -700,7 +610,7 @@
       }
     ],
     "correctOption": "C",
-    "difficulty": 5,
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -712,100 +622,102 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-algebraic-reasoning-context-5e90bd329e",
-    "skillId": "act-algebraic-reasoning-context",
-    "prompt": "A gym charges a $35 one-time sign-up fee plus $8 each month. After how many months will a member have paid $107 in all?",
+    "problemId": "act-act-area-perimeter-composite-978eac015c",
+    "skillId": "act-area-perimeter-composite",
+    "prompt": "In the figure shown, a square of side 5 has been cut from the corner of a 6-by-7 rectangle. What is the area of the remaining (shaded) region?",
+    "svg": "<svg viewBox=\"0 0 132 124\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 42,20 42,80 102,80 102,104 30,104\" stroke-linejoin=\"round\"/></svg>",
     "answer": {
       "type": "auto",
-      "value": "9",
+      "value": "17",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "8"
+        "text": "37"
       },
       {
         "label": "B",
-        "text": "2"
+        "text": "21"
       },
       {
         "label": "C",
-        "text": "10"
+        "text": "67"
       },
       {
         "label": "D",
-        "text": "13"
+        "text": "42"
       },
       {
         "label": "E",
-        "text": "9"
+        "text": "17"
       }
     ],
     "correctOption": "E",
-    "difficulty": 2,
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-algebraic-reasoning-context"
+      "act-area-perimeter-composite"
     ],
     "source": "act-template-gen",
-    "contentHash": "5e90bd329e2b0405232cd11b0d73fd61575f21256d7dbafa46f0d825ad1c44b9",
+    "contentHash": "978eac015c1c0cad1f15fee8b91c84ce0e4936f5063486ca560ea0c1009d18b9",
     "isActive": true
   },
   {
-    "problemId": "act-act-algebraic-reasoning-context-a1e6eda95f",
-    "skillId": "act-algebraic-reasoning-context",
-    "prompt": "A gym charges a $15 one-time sign-up fee plus $3 each month. After how many months will a member have paid $42 in all?",
+    "problemId": "act-act-area-perimeter-composite-cea6e7feac",
+    "skillId": "act-area-perimeter-composite",
+    "prompt": "In the figure shown, a square of side 4 has been cut from the corner of a 4-by-5 rectangle. What is the area of the remaining (shaded) region?",
+    "svg": "<svg viewBox=\"0 0 108 100\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 30,20 30,68 78,68 78,80 30,80\" stroke-linejoin=\"round\"/></svg>",
     "answer": {
       "type": "auto",
-      "value": "9",
+      "value": "4",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "9"
+        "text": "36"
       },
       {
         "label": "B",
-        "text": "8"
+        "text": "16"
       },
       {
         "label": "C",
-        "text": "10"
+        "text": "4"
       },
       {
         "label": "D",
-        "text": "2"
+        "text": "20"
       },
       {
         "label": "E",
         "text": "14"
       }
     ],
-    "correctOption": "A",
-    "difficulty": 2,
+    "correctOption": "C",
+    "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-algebraic-reasoning-context"
+      "act-area-perimeter-composite"
     ],
     "source": "act-template-gen",
-    "contentHash": "a1e6eda95ffed1bca7dab5183a155b393c5c21b8f32aec7c75c5ec118d31b068",
+    "contentHash": "cea6e7feacf212bfa791adc677acbd6df3575a4936b1e630817a10ffa14d0df0",
     "isActive": true
   },
   {
-    "problemId": "act-act-algebraic-reasoning-context-c2ce69366e",
+    "problemId": "act-act-algebraic-reasoning-context-fc2f277d50",
     "skillId": "act-algebraic-reasoning-context",
-    "prompt": "A gym charges a $10 one-time sign-up fee plus $5 each month. After how many months will a member have paid $55 in all?",
+    "prompt": "A pool club charges a $10 membership fee plus $8 per visit. After how many visits will the total paid reach $66?",
     "answer": {
       "type": "auto",
-      "value": "9",
+      "value": "7",
       "equivalents": []
     },
     "answerType": "multiple-choice",
@@ -816,11 +728,55 @@
       },
       {
         "label": "B",
-        "text": "11"
+        "text": "7"
       },
       {
         "label": "C",
-        "text": "10"
+        "text": "56"
+      },
+      {
+        "label": "D",
+        "text": "8"
+      },
+      {
+        "label": "E",
+        "text": "6"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-algebraic-reasoning-context"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "fc2f277d503399d49f7cdab4ce877aa832df5672b85baf64c190360220528ba2",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-algebraic-reasoning-context-8f148748cf",
+    "skillId": "act-algebraic-reasoning-context",
+    "prompt": "A pool club charges a $30 membership fee plus $9 per visit. After how many visits will the total paid reach $111?",
+    "answer": {
+      "type": "auto",
+      "value": "9",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "12"
+      },
+      {
+        "label": "B",
+        "text": "8"
+      },
+      {
+        "label": "C",
+        "text": "3"
       },
       {
         "label": "D",
@@ -828,7 +784,51 @@
       },
       {
         "label": "E",
-        "text": "8"
+        "text": "10"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-algebraic-reasoning-context"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "8f148748cf1bd4be4cb0b03814d3ddf503334894ebc434aa5b24c3cded438176",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-algebraic-reasoning-context-17869de13b",
+    "skillId": "act-algebraic-reasoning-context",
+    "prompt": "A phone plan has a $10 activation fee plus $8 each month. After how many months will the total paid reach $42?",
+    "answer": {
+      "type": "auto",
+      "value": "4",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "32"
+      },
+      {
+        "label": "B",
+        "text": "2"
+      },
+      {
+        "label": "C",
+        "text": "3"
+      },
+      {
+        "label": "D",
+        "text": "4"
+      },
+      {
+        "label": "E",
+        "text": "5"
       }
     ],
     "correctOption": "D",
@@ -840,13 +840,101 @@
       "act-algebraic-reasoning-context"
     ],
     "source": "act-template-gen",
-    "contentHash": "c2ce69366ecdc1efa615c560e61868bd4513550b9c5da56ff2ae84020d5dd99e",
+    "contentHash": "17869de13b7862361888ea86d34a3b4bebeef6291cf303312cf775fd337b7fdb",
     "isActive": true
   },
   {
-    "problemId": "act-act-algebraic-reasoning-context-2cf0973b05",
+    "problemId": "act-act-algebraic-reasoning-context-257d5c8bff",
     "skillId": "act-algebraic-reasoning-context",
-    "prompt": "A gym charges a $20 one-time sign-up fee plus $7 each month. After how many months will a member have paid $69 in all?",
+    "prompt": "A pool club charges a $30 membership fee plus $8 per visit. After how many visits will the total paid reach $70?",
+    "answer": {
+      "type": "auto",
+      "value": "5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "9"
+      },
+      {
+        "label": "B",
+        "text": "4"
+      },
+      {
+        "label": "C",
+        "text": "5"
+      },
+      {
+        "label": "D",
+        "text": "2"
+      },
+      {
+        "label": "E",
+        "text": "6"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-algebraic-reasoning-context"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "257d5c8bffc8e0ecaac9b835872e30cd50c82bc53d3b4a78ada8ce878d224d78",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-algebraic-reasoning-context-be02a502f1",
+    "skillId": "act-algebraic-reasoning-context",
+    "prompt": "A gym charges a $10 one-time sign-up fee plus $4 each month. After how many months will the total paid reach $30?",
+    "answer": {
+      "type": "auto",
+      "value": "5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "6"
+      },
+      {
+        "label": "B",
+        "text": "4"
+      },
+      {
+        "label": "C",
+        "text": "5"
+      },
+      {
+        "label": "D",
+        "text": "2"
+      },
+      {
+        "label": "E",
+        "text": "8"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-algebraic-reasoning-context"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "be02a502f138702afb543c1cd901d29e39cfa69fdb4624b23d1d6c47dc180e49",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-algebraic-reasoning-context-815d75622a",
+    "skillId": "act-algebraic-reasoning-context",
+    "prompt": "A pool club charges a $10 membership fee plus $5 per visit. After how many visits will the total paid reach $45?",
     "answer": {
       "type": "auto",
       "value": "7",
@@ -860,11 +948,11 @@
       },
       {
         "label": "B",
-        "text": "8"
+        "text": "9"
       },
       {
         "label": "C",
-        "text": "3"
+        "text": "11"
       },
       {
         "label": "D",
@@ -872,11 +960,11 @@
       },
       {
         "label": "E",
-        "text": "10"
+        "text": "8"
       }
     ],
     "correctOption": "A",
-    "difficulty": 3,
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -884,13 +972,57 @@
       "act-algebraic-reasoning-context"
     ],
     "source": "act-template-gen",
-    "contentHash": "2cf0973b0595d781f17db49e133656c71a7f648b86c82fc000422014d28fcfcd",
+    "contentHash": "815d75622a85272d5e12729a221157f18623308d42f453d2fbd8d4ab604cb868",
     "isActive": true
   },
   {
-    "problemId": "act-act-algebraic-reasoning-context-4d3f7422b6",
+    "problemId": "act-act-algebraic-reasoning-context-0db596f0e4",
     "skillId": "act-algebraic-reasoning-context",
-    "prompt": "A gym charges a $25 one-time sign-up fee plus $6 each month. After how many months will a member have paid $49 in all?",
+    "prompt": "A phone plan has a $20 activation fee plus $3 each month. After how many months will the total paid reach $41?",
+    "answer": {
+      "type": "auto",
+      "value": "7",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "7"
+      },
+      {
+        "label": "B",
+        "text": "6"
+      },
+      {
+        "label": "C",
+        "text": "14"
+      },
+      {
+        "label": "D",
+        "text": "20"
+      },
+      {
+        "label": "E",
+        "text": "8"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-algebraic-reasoning-context"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "0db596f0e4f4ae4144ae550584656ac17e5308b25fd971574bf85f2c714ca54c",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-algebraic-reasoning-context-a8a85c22b3",
+    "skillId": "act-algebraic-reasoning-context",
+    "prompt": "A pool club charges a $20 membership fee plus $3 per visit. After how many visits will the total paid reach $32?",
     "answer": {
       "type": "auto",
       "value": "4",
@@ -900,158 +1032,26 @@
     "options": [
       {
         "label": "A",
-        "text": "3"
-      },
-      {
-        "label": "B",
-        "text": "4"
-      },
-      {
-        "label": "C",
-        "text": "5"
-      },
-      {
-        "label": "D",
-        "text": "8"
-      },
-      {
-        "label": "E",
-        "text": "2"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-algebraic-reasoning-context"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "4d3f7422b67b82b1179e977183da22b5b5e2fe561e4aa8c7c310c15bde837918",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-algebraic-reasoning-context-cad4a551b2",
-    "skillId": "act-algebraic-reasoning-context",
-    "prompt": "A gym charges a $15 one-time sign-up fee plus $4 each month. After how many months will a member have paid $31 in all?",
-    "answer": {
-      "type": "auto",
-      "value": "4",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
         "text": "5"
       },
       {
         "label": "B",
-        "text": "12"
+        "text": "17"
       },
       {
         "label": "C",
+        "text": "4"
+      },
+      {
+        "label": "D",
         "text": "3"
       },
       {
-        "label": "D",
-        "text": "8"
-      },
-      {
         "label": "E",
-        "text": "4"
+        "text": "11"
       }
     ],
-    "correctOption": "E",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-algebraic-reasoning-context"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "cad4a551b2601f3efa356c8b2d01f3525400492732c76e56866afcc5b9f97266",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-algebraic-reasoning-context-20fb2b8d32",
-    "skillId": "act-algebraic-reasoning-context",
-    "prompt": "A gym charges a $10 one-time sign-up fee plus $4 each month. After how many months will a member have paid $30 in all?",
-    "answer": {
-      "type": "auto",
-      "value": "5",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "8"
-      },
-      {
-        "label": "B",
-        "text": "4"
-      },
-      {
-        "label": "C",
-        "text": "6"
-      },
-      {
-        "label": "D",
-        "text": "10"
-      },
-      {
-        "label": "E",
-        "text": "5"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-algebraic-reasoning-context"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "20fb2b8d328a632352a134d67447755e340638f217ae2d83ca83c3c5476a8d25",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-algebraic-reasoning-context-36f0759614",
-    "skillId": "act-algebraic-reasoning-context",
-    "prompt": "A gym charges a $20 one-time sign-up fee plus $8 each month. After how many months will a member have paid $44 in all?",
-    "answer": {
-      "type": "auto",
-      "value": "3",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "3"
-      },
-      {
-        "label": "B",
-        "text": "8"
-      },
-      {
-        "label": "C",
-        "text": "2"
-      },
-      {
-        "label": "D",
-        "text": "6"
-      },
-      {
-        "label": "E",
-        "text": "4"
-      }
-    ],
-    "correctOption": "A",
+    "correctOption": "C",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -1060,86 +1060,42 @@
       "act-algebraic-reasoning-context"
     ],
     "source": "act-template-gen",
-    "contentHash": "36f07596147a1c682fad1feccd835d8a191851f4eb6a6c9ebce20cbc976fecb6",
+    "contentHash": "a8a85c22b3eef3a68c04feb6d00a67466034ca9d2b2f8e0f4c5c1dc0ad95c0f5",
     "isActive": true
   },
   {
-    "problemId": "act-act-percent-applications-a11c159089",
+    "problemId": "act-act-percent-applications-42a7fc21e2",
     "skillId": "act-percent-applications",
-    "prompt": "A $60 jacket is 20% off. With 5% sales tax added to the discounted price, what is the final cost?",
+    "prompt": "A $50 bicycle is 10% off. With 5% sales tax added to the discounted price, what is the final cost?",
     "answer": {
       "type": "auto",
-      "value": "$50.40",
+      "value": "$47.25",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "$40"
+        "text": "$47.25"
       },
       {
         "label": "B",
-        "text": "$12"
-      },
-      {
-        "label": "C",
-        "text": "$50.40"
-      },
-      {
-        "label": "D",
-        "text": "$63"
-      },
-      {
-        "label": "E",
-        "text": "$48"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-percent-applications"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "a11c1590899c4be230688a036076ede8ca3e953becc12ddea312031eee3f6ce1",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-percent-applications-82c80e8eb5",
-    "skillId": "act-percent-applications",
-    "prompt": "A $60 jacket is 25% off. With 10% sales tax added to the discounted price, what is the final cost?",
-    "answer": {
-      "type": "auto",
-      "value": "$49.50",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "$66"
-      },
-      {
-        "label": "B",
-        "text": "$35"
-      },
-      {
-        "label": "C",
-        "text": "$15"
-      },
-      {
-        "label": "D",
         "text": "$45"
       },
       {
+        "label": "C",
+        "text": "$5"
+      },
+      {
+        "label": "D",
+        "text": "$52.50"
+      },
+      {
         "label": "E",
-        "text": "$49.50"
+        "text": "$40"
       }
     ],
-    "correctOption": "E",
+    "correctOption": "A",
     "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
@@ -1148,43 +1104,43 @@
       "act-percent-applications"
     ],
     "source": "act-template-gen",
-    "contentHash": "82c80e8eb536eacfcdd20fbc699e3234eac37b70bd09d6de150f9256570e2a86",
+    "contentHash": "42a7fc21e2839c1d64f33adba2fc83a7a49fa221358f5a737e2580982731b683",
     "isActive": true
   },
   {
-    "problemId": "act-act-percent-applications-9c3a5d7476",
+    "problemId": "act-act-percent-applications-7364ebe44a",
     "skillId": "act-percent-applications",
-    "prompt": "A $120 jacket is 25% off. With 8% sales tax added to the discounted price, what is the final cost?",
+    "prompt": "A $60 desk lamp is 10% off. With 5% sales tax added to the discounted price, what is the final cost?",
     "answer": {
       "type": "auto",
-      "value": "$97.20",
+      "value": "$56.70",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "$129.60"
+        "text": "$6"
       },
       {
         "label": "B",
-        "text": "$97.20"
+        "text": "$63"
       },
       {
         "label": "C",
-        "text": "$90"
+        "text": "$54"
       },
       {
         "label": "D",
-        "text": "$95"
+        "text": "$56.70"
       },
       {
         "label": "E",
-        "text": "$30"
+        "text": "$50"
       }
     ],
-    "correctOption": "B",
-    "difficulty": 3,
+    "correctOption": "D",
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -1192,83 +1148,39 @@
       "act-percent-applications"
     ],
     "source": "act-template-gen",
-    "contentHash": "9c3a5d74767c9514df8e38ecda95104ee172d2d18d841f153812ee2bab13c153",
+    "contentHash": "7364ebe44a23b3354b5bb9888278c3c8e069059a8c418912dfda02a17a536784",
     "isActive": true
   },
   {
-    "problemId": "act-act-percent-applications-599e100e8b",
+    "problemId": "act-act-percent-applications-11b5cd6b33",
     "skillId": "act-percent-applications",
-    "prompt": "A $40 jacket is 25% off. With 8% sales tax added to the discounted price, what is the final cost?",
+    "prompt": "A $60 desk lamp is 10% off. With 8% sales tax added to the discounted price, what is the final cost?",
     "answer": {
       "type": "auto",
-      "value": "$32.40",
+      "value": "$58.32",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "$15"
+        "text": "$54"
       },
       {
         "label": "B",
-        "text": "$10"
+        "text": "$64.80"
       },
       {
         "label": "C",
-        "text": "$43.20"
+        "text": "$6"
       },
       {
         "label": "D",
-        "text": "$30"
+        "text": "$50"
       },
       {
         "label": "E",
-        "text": "$32.40"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-percent-applications"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "599e100e8b0cfe4fdf2c11803dc184fd281dde4b2cf8ae5794cfbe3fbea63709",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-percent-applications-bfdf0ff081",
-    "skillId": "act-percent-applications",
-    "prompt": "A $50 jacket is 20% off. With 10% sales tax added to the discounted price, what is the final cost?",
-    "answer": {
-      "type": "auto",
-      "value": "$44",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "$40"
-      },
-      {
-        "label": "B",
-        "text": "$55"
-      },
-      {
-        "label": "C",
-        "text": "$10"
-      },
-      {
-        "label": "D",
-        "text": "$30"
-      },
-      {
-        "label": "E",
-        "text": "$44"
+        "text": "$58.32"
       }
     ],
     "correctOption": "E",
@@ -1280,13 +1192,13 @@
       "act-percent-applications"
     ],
     "source": "act-template-gen",
-    "contentHash": "bfdf0ff081dabf066e325d1390a8d31ed7109c025a7f8c2d39eeb3db7a607eec",
+    "contentHash": "11b5cd6b338da349927c9619d4e40189c18d1282d1db3c3c36cd9e73a409f45f",
     "isActive": true
   },
   {
-    "problemId": "act-act-percent-applications-202b2575c4",
+    "problemId": "act-act-percent-applications-11e945ab31",
     "skillId": "act-percent-applications",
-    "prompt": "A $80 jacket is 20% off. With 5% sales tax added to the discounted price, what is the final cost?",
+    "prompt": "A $80 laptop is 20% off. With 5% sales tax added to the discounted price, what is the final cost?",
     "answer": {
       "type": "auto",
       "value": "$67.20",
@@ -1300,11 +1212,187 @@
       },
       {
         "label": "B",
-        "text": "$60"
+        "text": "$67.20"
       },
       {
         "label": "C",
+        "text": "$16"
+      },
+      {
+        "label": "D",
+        "text": "$60"
+      },
+      {
+        "label": "E",
         "text": "$64"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-percent-applications"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "11e945ab31aaa4a8a67c88932a34eaff5d79e89336432d3c1db37c77d2c4f3cd",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-percent-applications-1ac5f33dd0",
+    "skillId": "act-percent-applications",
+    "prompt": "A $60 laptop is 10% off. With 5% sales tax added to the discounted price, what is the final cost?",
+    "answer": {
+      "type": "auto",
+      "value": "$56.70",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$56.70"
+      },
+      {
+        "label": "B",
+        "text": "$63"
+      },
+      {
+        "label": "C",
+        "text": "$50"
+      },
+      {
+        "label": "D",
+        "text": "$6"
+      },
+      {
+        "label": "E",
+        "text": "$54"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-percent-applications"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "1ac5f33dd02acc67353e44443233ad6319b658c71c114691a85fadefde3b42ba",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-percent-applications-b944158e68",
+    "skillId": "act-percent-applications",
+    "prompt": "A $60 desk lamp is 25% off. With 8% sales tax added to the discounted price, what is the final cost?",
+    "answer": {
+      "type": "auto",
+      "value": "$48.60",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$35"
+      },
+      {
+        "label": "B",
+        "text": "$49.80"
+      },
+      {
+        "label": "C",
+        "text": "$45"
+      },
+      {
+        "label": "D",
+        "text": "$48.60"
+      },
+      {
+        "label": "E",
+        "text": "$64.80"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-percent-applications"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "b944158e6807e32df3b41e25b7f36ca1370b6c8b0791af6c98ff1875c3fb6d2a",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-percent-applications-64195c4440",
+    "skillId": "act-percent-applications",
+    "prompt": "A $40 bicycle is 20% off. With 10% sales tax added to the discounted price, what is the final cost?",
+    "answer": {
+      "type": "auto",
+      "value": "$35.20",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$32"
+      },
+      {
+        "label": "B",
+        "text": "$36"
+      },
+      {
+        "label": "C",
+        "text": "$44"
+      },
+      {
+        "label": "D",
+        "text": "$35.20"
+      },
+      {
+        "label": "E",
+        "text": "$20"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-percent-applications"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "64195c4440af404641f4a9ab0141e87c2ba8645b7ec6dae63bcd10ed85f6e9ba",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-percent-applications-ee49205942",
+    "skillId": "act-percent-applications",
+    "prompt": "A $80 backpack is 25% off. With 10% sales tax added to the discounted price, what is the final cost?",
+    "answer": {
+      "type": "auto",
+      "value": "$66",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$88"
+      },
+      {
+        "label": "B",
+        "text": "$55"
+      },
+      {
+        "label": "C",
+        "text": "$60"
       },
       {
         "label": "D",
@@ -1312,98 +1400,10 @@
       },
       {
         "label": "E",
-        "text": "$67.20"
+        "text": "$66"
       }
     ],
     "correctOption": "E",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-percent-applications"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "202b2575c4a6b747ea6e991bcc02b5031f32dd6461b8777f9c5dd0cf287596b6",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-percent-applications-2680623f86",
-    "skillId": "act-percent-applications",
-    "prompt": "A $40 jacket is 25% off. With 10% sales tax added to the discounted price, what is the final cost?",
-    "answer": {
-      "type": "auto",
-      "value": "$33",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "$44"
-      },
-      {
-        "label": "B",
-        "text": "$33"
-      },
-      {
-        "label": "C",
-        "text": "$15"
-      },
-      {
-        "label": "D",
-        "text": "$30"
-      },
-      {
-        "label": "E",
-        "text": "$34"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-percent-applications"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "2680623f86e444fcd2b28358d4b376fca1d2fac4f900b2c6ddb4e2af2c8533df",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-percent-applications-5e8ef1c2e8",
-    "skillId": "act-percent-applications",
-    "prompt": "A $40 jacket is 10% off. With 5% sales tax added to the discounted price, what is the final cost?",
-    "answer": {
-      "type": "auto",
-      "value": "$37.80",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "$42"
-      },
-      {
-        "label": "B",
-        "text": "$37.80"
-      },
-      {
-        "label": "C",
-        "text": "$30"
-      },
-      {
-        "label": "D",
-        "text": "$36"
-      },
-      {
-        "label": "E",
-        "text": "$38"
-      }
-    ],
-    "correctOption": "B",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -1412,39 +1412,39 @@
       "act-percent-applications"
     ],
     "source": "act-template-gen",
-    "contentHash": "5e8ef1c2e816a1247e113d414f1e44a777bda4ecddee91660bb164ece766a04c",
+    "contentHash": "ee492059422a5710a5b0da6cc55fb2b17e24b6842de3f01d96c1befdd9006053",
     "isActive": true
   },
   {
-    "problemId": "act-act-measurement-unit-conversion-6828ac9d72",
+    "problemId": "act-act-measurement-unit-conversion-b0cfeec1c0",
     "skillId": "act-measurement-unit-conversion",
-    "prompt": "How many ounces are in 5 pounds?",
+    "prompt": "How many seconds are in 6 hours?",
     "answer": {
       "type": "auto",
-      "value": "80",
+      "value": "21600",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "40"
+        "text": "21594"
       },
       {
         "label": "B",
-        "text": "21"
+        "text": "43200"
       },
       {
         "label": "C",
-        "text": "80"
+        "text": "21600"
       },
       {
         "label": "D",
-        "text": "75"
+        "text": "10800"
       },
       {
         "label": "E",
-        "text": "160"
+        "text": "3606"
       }
     ],
     "correctOption": "C",
@@ -1456,101 +1456,13 @@
       "act-measurement-unit-conversion"
     ],
     "source": "act-template-gen",
-    "contentHash": "6828ac9d72288372ac0e981f0eb44558533cace341d6ae0b28f76a31ef335490",
+    "contentHash": "b0cfeec1c065b6323971622c1708a778b4222cd6fed78a8705bf00cb744a209b",
     "isActive": true
   },
   {
-    "problemId": "act-act-measurement-unit-conversion-e2d0aae66d",
+    "problemId": "act-act-measurement-unit-conversion-0a9f3cea78",
     "skillId": "act-measurement-unit-conversion",
-    "prompt": "How many inches are in 2 feet?",
-    "answer": {
-      "type": "auto",
-      "value": "24",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "24"
-      },
-      {
-        "label": "B",
-        "text": "12"
-      },
-      {
-        "label": "C",
-        "text": "48"
-      },
-      {
-        "label": "D",
-        "text": "22"
-      },
-      {
-        "label": "E",
-        "text": "14"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-measurement-unit-conversion"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "e2d0aae66d74b3673d823ece66e20791f58a19e56687d9d277be5cc0aa7ac853",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-measurement-unit-conversion-a70340ed08",
-    "skillId": "act-measurement-unit-conversion",
-    "prompt": "How many inches are in 2 yards?",
-    "answer": {
-      "type": "auto",
-      "value": "72",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "72"
-      },
-      {
-        "label": "B",
-        "text": "38"
-      },
-      {
-        "label": "C",
-        "text": "144"
-      },
-      {
-        "label": "D",
-        "text": "70"
-      },
-      {
-        "label": "E",
-        "text": "36"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-measurement-unit-conversion"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "a70340ed084f8cb0a279b0227f80b8c8f281d96ba90025fcfaa4fcfab9c4678f",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-measurement-unit-conversion-1a47958926",
-    "skillId": "act-measurement-unit-conversion",
-    "prompt": "How many ounces are in 3 pounds?",
+    "prompt": "How many inches are in 4 feet?",
     "answer": {
       "type": "auto",
       "value": "48",
@@ -1560,71 +1472,27 @@
     "options": [
       {
         "label": "A",
-        "text": "96"
-      },
-      {
-        "label": "B",
-        "text": "48"
-      },
-      {
-        "label": "C",
-        "text": "45"
-      },
-      {
-        "label": "D",
         "text": "24"
       },
       {
-        "label": "E",
-        "text": "19"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-measurement-unit-conversion"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "1a4795892673c3e8d1744487ae4057b379ea4e17e34e4f3cbcd432d60c9c7b88",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-measurement-unit-conversion-e0cc892cc4",
-    "skillId": "act-measurement-unit-conversion",
-    "prompt": "How many seconds are in 5 hours?",
-    "answer": {
-      "type": "auto",
-      "value": "18000",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "36000"
-      },
-      {
         "label": "B",
-        "text": "3605"
+        "text": "16"
       },
       {
         "label": "C",
-        "text": "17995"
+        "text": "48"
       },
       {
         "label": "D",
-        "text": "18000"
+        "text": "96"
       },
       {
         "label": "E",
-        "text": "9000"
+        "text": "44"
       }
     ],
-    "correctOption": "D",
-    "difficulty": 3,
+    "correctOption": "C",
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -1632,7 +1500,7 @@
       "act-measurement-unit-conversion"
     ],
     "source": "act-template-gen",
-    "contentHash": "e0cc892cc40626653ca800b775c1e8f155ceaff9eef152e3a2d7cb3fc9726aeb",
+    "contentHash": "0a9f3cea7832234745bbf05767d4ad12ad05b13a8d10e0d2238865c53bb9872a",
     "isActive": true
   },
   {
@@ -1648,7 +1516,7 @@
     "options": [
       {
         "label": "A",
-        "text": "56"
+        "text": "224"
       },
       {
         "label": "B",
@@ -1656,19 +1524,19 @@
       },
       {
         "label": "C",
-        "text": "224"
-      },
-      {
-        "label": "D",
         "text": "112"
       },
       {
-        "label": "E",
+        "label": "D",
         "text": "23"
+      },
+      {
+        "label": "E",
+        "text": "56"
       }
     ],
-    "correctOption": "D",
-    "difficulty": 4,
+    "correctOption": "C",
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -1680,35 +1548,123 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-measurement-unit-conversion-2cc6ec7307",
+    "problemId": "act-act-measurement-unit-conversion-46ee909f33",
     "skillId": "act-measurement-unit-conversion",
-    "prompt": "How many ounces are in 4 pounds?",
+    "prompt": "How many inches are in 7 yards?",
     "answer": {
       "type": "auto",
-      "value": "64",
+      "value": "252",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "20"
+        "text": "504"
       },
       {
         "label": "B",
-        "text": "128"
+        "text": "252"
       },
       {
         "label": "C",
-        "text": "64"
+        "text": "245"
       },
       {
         "label": "D",
-        "text": "32"
+        "text": "126"
       },
       {
         "label": "E",
-        "text": "60"
+        "text": "43"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-measurement-unit-conversion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "46ee909f3368d351e1132d1ef2cced46d64f92a3eabf185d6e3cc30c5837e164",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-measurement-unit-conversion-45cfed9415",
+    "skillId": "act-measurement-unit-conversion",
+    "prompt": "How many inches are in 6 yards?",
+    "answer": {
+      "type": "auto",
+      "value": "216",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "42"
+      },
+      {
+        "label": "B",
+        "text": "108"
+      },
+      {
+        "label": "C",
+        "text": "210"
+      },
+      {
+        "label": "D",
+        "text": "432"
+      },
+      {
+        "label": "E",
+        "text": "216"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-measurement-unit-conversion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "45cfed9415d6c1d4619e89cbb2632f6d413b93e5df5dc6b81ec67cb65fd016bb",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-measurement-unit-conversion-41f6c64ec3",
+    "skillId": "act-measurement-unit-conversion",
+    "prompt": "How many seconds are in 3 hours?",
+    "answer": {
+      "type": "auto",
+      "value": "10800",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "3603"
+      },
+      {
+        "label": "B",
+        "text": "10797"
+      },
+      {
+        "label": "C",
+        "text": "10800"
+      },
+      {
+        "label": "D",
+        "text": "21600"
+      },
+      {
+        "label": "E",
+        "text": "360"
       }
     ],
     "correctOption": "C",
@@ -1720,42 +1676,86 @@
       "act-measurement-unit-conversion"
     ],
     "source": "act-template-gen",
-    "contentHash": "2cc6ec7307b34f13c74d2fd5a032c7a7e590905d99f4ef4bed9d6b6fe88a9887",
+    "contentHash": "41f6c64ec3bf3a445d7de7a91a4d6fadf05993906186b39a2c5efc908678e8ef",
     "isActive": true
   },
   {
-    "problemId": "act-act-measurement-unit-conversion-3da981fe2c",
+    "problemId": "act-act-measurement-unit-conversion-e0cc892cc4",
     "skillId": "act-measurement-unit-conversion",
-    "prompt": "How many ounces are in 2 pounds?",
+    "prompt": "How many seconds are in 5 hours?",
     "answer": {
       "type": "auto",
-      "value": "32",
+      "value": "18000",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "18"
+        "text": "17995"
       },
       {
         "label": "B",
-        "text": "30"
+        "text": "18000"
       },
       {
         "label": "C",
-        "text": "32"
+        "text": "36000"
       },
       {
         "label": "D",
-        "text": "64"
+        "text": "3605"
       },
       {
         "label": "E",
-        "text": "16"
+        "text": "600"
       }
     ],
-    "correctOption": "C",
+    "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-measurement-unit-conversion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "e0cc892cc40626653ca800b775c1e8f155ceaff9eef152e3a2d7cb3fc9726aeb",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-measurement-unit-conversion-8c505983a6",
+    "skillId": "act-measurement-unit-conversion",
+    "prompt": "How many inches are in 3 yards?",
+    "answer": {
+      "type": "auto",
+      "value": "108",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "108"
+      },
+      {
+        "label": "B",
+        "text": "105"
+      },
+      {
+        "label": "C",
+        "text": "39"
+      },
+      {
+        "label": "D",
+        "text": "216"
+      },
+      {
+        "label": "E",
+        "text": "45"
+      }
+    ],
+    "correctOption": "A",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -1764,42 +1764,42 @@
       "act-measurement-unit-conversion"
     ],
     "source": "act-template-gen",
-    "contentHash": "3da981fe2cc5ad7025cde8038af9d0658c379e6d50b77ed5f9b63b855406a561",
+    "contentHash": "8c505983a65aa8d7d79f688b9ab96d789caafbe10ff6273ca4a704c5ab61dc96",
     "isActive": true
   },
   {
-    "problemId": "act-act-angles-lines-triangles-6befe651f9",
+    "problemId": "act-act-angles-lines-triangles-d81641228c",
     "skillId": "act-angles-lines-triangles",
-    "prompt": "Two angles of a triangle measure 43° and 45°. What is the measure of the third angle?",
+    "prompt": "Two angles of a triangle measure 78° and 37°. What is the measure of the third angle?",
     "answer": {
       "type": "auto",
-      "value": "92°",
+      "value": "65°",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "137°"
+        "text": "143°"
       },
       {
         "label": "B",
-        "text": "88°"
-      },
-      {
-        "label": "C",
         "text": "90°"
       },
       {
+        "label": "C",
+        "text": "115°"
+      },
+      {
         "label": "D",
-        "text": "92°"
+        "text": "102°"
       },
       {
         "label": "E",
-        "text": "135°"
+        "text": "65°"
       }
     ],
-    "correctOption": "D",
+    "correctOption": "E",
     "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
@@ -1808,39 +1808,39 @@
       "act-angles-lines-triangles"
     ],
     "source": "act-template-gen",
-    "contentHash": "6befe651f90cc65ee92e1bc5cf651df039ee06c6b1a223bace5e16d6cbdc8797",
+    "contentHash": "d81641228cbb2367bf0c9cdca69bbd161cb9239894790ca064d486047490bfdb",
     "isActive": true
   },
   {
-    "problemId": "act-act-angles-lines-triangles-cc72dba960",
+    "problemId": "act-act-angles-lines-triangles-f0555d81e4",
     "skillId": "act-angles-lines-triangles",
-    "prompt": "Two angles of a triangle measure 58° and 50°. What is the measure of the third angle?",
+    "prompt": "Two angles of a triangle measure 38° and 79°. What is the measure of the third angle?",
     "answer": {
       "type": "auto",
-      "value": "72°",
+      "value": "63°",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "90°"
+        "text": "142°"
       },
       {
         "label": "B",
-        "text": "72°"
+        "text": "63°"
       },
       {
         "label": "C",
-        "text": "108°"
+        "text": "117°"
       },
       {
         "label": "D",
-        "text": "122°"
+        "text": "101°"
       },
       {
         "label": "E",
-        "text": "130°"
+        "text": "90°"
       }
     ],
     "correctOption": "B",
@@ -1852,163 +1852,31 @@
       "act-angles-lines-triangles"
     ],
     "source": "act-template-gen",
-    "contentHash": "cc72dba9603cb796effd2f70f8a473d2e707c1b6235f7beb16d75240ce3b05df",
+    "contentHash": "f0555d81e4c5f1b0f5cfa39a3af37e3b08cb226a9b29bf4fd39371e70d41027f",
     "isActive": true
   },
   {
-    "problemId": "act-act-angles-lines-triangles-4c249c9cfc",
+    "problemId": "act-act-angles-lines-triangles-c049f60b46",
     "skillId": "act-angles-lines-triangles",
-    "prompt": "Two angles of a triangle measure 39° and 40°. What is the measure of the third angle?",
+    "prompt": "Two angles of a triangle measure 67° and 65°. What is the measure of the third angle?",
     "answer": {
       "type": "auto",
-      "value": "101°",
+      "value": "48°",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "101°"
+        "text": "48°"
       },
       {
         "label": "B",
-        "text": "90°"
+        "text": "132°"
       },
       {
         "label": "C",
-        "text": "140°"
-      },
-      {
-        "label": "D",
-        "text": "79°"
-      },
-      {
-        "label": "E",
-        "text": "141°"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-angles-lines-triangles"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "4c249c9cfcd8ccbd4bfb1c0e35837b68d31f83a256888f842b7115c278bce2e0",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-angles-lines-triangles-6a0f0a9238",
-    "skillId": "act-angles-lines-triangles",
-    "prompt": "Two angles of a triangle measure 37° and 31°. What is the measure of the third angle?",
-    "answer": {
-      "type": "auto",
-      "value": "112°",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "90°"
-      },
-      {
-        "label": "B",
-        "text": "68°"
-      },
-      {
-        "label": "C",
-        "text": "112°"
-      },
-      {
-        "label": "D",
-        "text": "149°"
-      },
-      {
-        "label": "E",
-        "text": "143°"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-angles-lines-triangles"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "6a0f0a92388f8a3c2932bfca9bd1addfba1a6d84a269ba9a8506038d8998d480",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-angles-lines-triangles-541d725d47",
-    "skillId": "act-angles-lines-triangles",
-    "prompt": "Two angles of a triangle measure 79° and 76°. What is the measure of the third angle?",
-    "answer": {
-      "type": "auto",
-      "value": "25°",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "155°"
-      },
-      {
-        "label": "B",
-        "text": "101°"
-      },
-      {
-        "label": "C",
-        "text": "25°"
-      },
-      {
-        "label": "D",
-        "text": "90°"
-      },
-      {
-        "label": "E",
-        "text": "104°"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-angles-lines-triangles"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "541d725d47249152d9e9409cb6e5c6e8fbfdd50385cb9f65fc10d4b1084f4130",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-angles-lines-triangles-4b3bd712e1",
-    "skillId": "act-angles-lines-triangles",
-    "prompt": "Two angles of a triangle measure 65° and 77°. What is the measure of the third angle?",
-    "answer": {
-      "type": "auto",
-      "value": "38°",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "90°"
-      },
-      {
-        "label": "B",
-        "text": "38°"
-      },
-      {
-        "label": "C",
-        "text": "103°"
+        "text": "113°"
       },
       {
         "label": "D",
@@ -2016,98 +1884,230 @@
       },
       {
         "label": "E",
-        "text": "142°"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-angles-lines-triangles"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "4b3bd712e146a21bb9e1470287c237489d721015dc269e89469fb1eccf93fc8a",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-angles-lines-triangles-ab195559bb",
-    "skillId": "act-angles-lines-triangles",
-    "prompt": "Two angles of a triangle measure 79° and 60°. What is the measure of the third angle?",
-    "answer": {
-      "type": "auto",
-      "value": "41°",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "139°"
-      },
-      {
-        "label": "B",
-        "text": "101°"
-      },
-      {
-        "label": "C",
         "text": "90°"
-      },
-      {
-        "label": "D",
-        "text": "41°"
-      },
-      {
-        "label": "E",
-        "text": "120°"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-angles-lines-triangles"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "ab195559bb89e9ed5cc4907bf854b3a2bdded41e3f4a3028b9f7d942ab3735ba",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-angles-lines-triangles-0392524b57",
-    "skillId": "act-angles-lines-triangles",
-    "prompt": "Two angles of a triangle measure 31° and 76°. What is the measure of the third angle?",
-    "answer": {
-      "type": "auto",
-      "value": "73°",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "73°"
-      },
-      {
-        "label": "B",
-        "text": "90°"
-      },
-      {
-        "label": "C",
-        "text": "107°"
-      },
-      {
-        "label": "D",
-        "text": "104°"
-      },
-      {
-        "label": "E",
-        "text": "149°"
       }
     ],
     "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-angles-lines-triangles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "c049f60b463b804727547f79255a757c72459506bd3b1c7decc49b8383f5d46c",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-angles-lines-triangles-eee4e2ff7b",
+    "skillId": "act-angles-lines-triangles",
+    "prompt": "Two angles of a triangle measure 30° and 79°. What is the measure of the third angle?",
+    "answer": {
+      "type": "auto",
+      "value": "71°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "90°"
+      },
+      {
+        "label": "B",
+        "text": "150°"
+      },
+      {
+        "label": "C",
+        "text": "71°"
+      },
+      {
+        "label": "D",
+        "text": "101°"
+      },
+      {
+        "label": "E",
+        "text": "109°"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-angles-lines-triangles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "eee4e2ff7b5c673c23742956d814c9542cf0660cb0705d06e55334301b414330",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-angles-lines-triangles-1e8c1c1ead",
+    "skillId": "act-angles-lines-triangles",
+    "prompt": "Two angles of a triangle measure 63° and 31°. What is the measure of the third angle?",
+    "answer": {
+      "type": "auto",
+      "value": "86°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "86°"
+      },
+      {
+        "label": "B",
+        "text": "149°"
+      },
+      {
+        "label": "C",
+        "text": "94°"
+      },
+      {
+        "label": "D",
+        "text": "117°"
+      },
+      {
+        "label": "E",
+        "text": "90°"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-angles-lines-triangles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "1e8c1c1ead16dc38f5f55c7c2ad73d64627c7c3cd53cc6dc5b305700047fb498",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-angles-lines-triangles-276044cdf1",
+    "skillId": "act-angles-lines-triangles",
+    "prompt": "Two angles of a triangle measure 57° and 59°. What is the measure of the third angle?",
+    "answer": {
+      "type": "auto",
+      "value": "64°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "116°"
+      },
+      {
+        "label": "B",
+        "text": "90°"
+      },
+      {
+        "label": "C",
+        "text": "121°"
+      },
+      {
+        "label": "D",
+        "text": "123°"
+      },
+      {
+        "label": "E",
+        "text": "64°"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-angles-lines-triangles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "276044cdf1a40002c8cf83d9895c93c88aed0f5af3e5e567bcaafa347f974e63",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-angles-lines-triangles-d5f7aa21f4",
+    "skillId": "act-angles-lines-triangles",
+    "prompt": "Two angles of a triangle measure 68° and 34°. What is the measure of the third angle?",
+    "answer": {
+      "type": "auto",
+      "value": "78°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "146°"
+      },
+      {
+        "label": "B",
+        "text": "112°"
+      },
+      {
+        "label": "C",
+        "text": "78°"
+      },
+      {
+        "label": "D",
+        "text": "90°"
+      },
+      {
+        "label": "E",
+        "text": "102°"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-angles-lines-triangles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "d5f7aa21f4d105c894d74e76a70a10e15171c9717f119f9038e06fd8b20fc772",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-angles-lines-triangles-d1fb5e15c1",
+    "skillId": "act-angles-lines-triangles",
+    "prompt": "Two angles of a triangle measure 30° and 35°. What is the measure of the third angle?",
+    "answer": {
+      "type": "auto",
+      "value": "115°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "145°"
+      },
+      {
+        "label": "B",
+        "text": "65°"
+      },
+      {
+        "label": "C",
+        "text": "150°"
+      },
+      {
+        "label": "D",
+        "text": "90°"
+      },
+      {
+        "label": "E",
+        "text": "115°"
+      }
+    ],
+    "correctOption": "E",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -2116,7 +2116,97 @@
       "act-angles-lines-triangles"
     ],
     "source": "act-template-gen",
-    "contentHash": "0392524b57ee53978b567f17f3af576bdda58666060f2669e2dd784ca15fb5a8",
+    "contentHash": "d1fb5e15c149a1415c45fa8b2667056faa7e0fbbcc866bf4f7713c0477eae80c",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polygons-circles-5167a2fc11",
+    "skillId": "act-polygons-circles",
+    "prompt": "What is the measure of one interior angle of the regular 9-gon shown?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"100.0,17.0 137.3,30.6 157.1,64.9 150.2,104.0 119.8,129.5 80.2,129.5 49.8,104.0 42.9,64.9 62.7,30.6\" stroke-linejoin=\"round\"/></svg>",
+    "answer": {
+      "type": "auto",
+      "value": "140°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "40°"
+      },
+      {
+        "label": "B",
+        "text": "20°"
+      },
+      {
+        "label": "C",
+        "text": "1260°"
+      },
+      {
+        "label": "D",
+        "text": "140°"
+      },
+      {
+        "label": "E",
+        "text": "180°"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polygons-circles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "5167a2fc11904d6472e10059da24ffb68139257bc7afd6d9877d8e95328216cc",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polygons-circles-db43864a60",
+    "skillId": "act-polygons-circles",
+    "prompt": "What is the measure of one interior angle of the regular 10-gon shown?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"100.0,17.0 134.1,28.1 155.2,57.1 155.2,92.9 134.1,121.9 100.0,133.0 65.9,121.9 44.8,92.9 44.8,57.1 65.9,28.1\" stroke-linejoin=\"round\"/></svg>",
+    "answer": {
+      "type": "auto",
+      "value": "144°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "180°"
+      },
+      {
+        "label": "B",
+        "text": "18°"
+      },
+      {
+        "label": "C",
+        "text": "144°"
+      },
+      {
+        "label": "D",
+        "text": "36°"
+      },
+      {
+        "label": "E",
+        "text": "1440°"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polygons-circles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "db43864a60f9ee91815d5dc908104ff7e89aa3605ec2ba484a69b683c6e49b7e",
     "isActive": true
   },
   {
@@ -2132,27 +2222,27 @@
     "options": [
       {
         "label": "A",
-        "text": "12°"
-      },
-      {
-        "label": "B",
-        "text": "180°"
-      },
-      {
-        "label": "C",
         "text": "24°"
       },
       {
-        "label": "D",
+        "label": "B",
         "text": "2340°"
       },
       {
-        "label": "E",
+        "label": "C",
+        "text": "180°"
+      },
+      {
+        "label": "D",
         "text": "156°"
+      },
+      {
+        "label": "E",
+        "text": "12°"
       }
     ],
-    "correctOption": "E",
-    "difficulty": 2,
+    "correctOption": "D",
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -2176,113 +2266,23 @@
     "options": [
       {
         "label": "A",
+        "text": "180°"
+      },
+      {
+        "label": "B",
         "text": "3240°"
       },
       {
-        "label": "B",
-        "text": "180°"
-      },
-      {
         "label": "C",
-        "text": "9°"
-      },
-      {
-        "label": "D",
-        "text": "18°"
-      },
-      {
-        "label": "E",
         "text": "162°"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-polygons-circles"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "b68f36c479a3afa356ff30f1af51f3882475ced0c2e6c8e6905fb7380e887449",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-polygons-circles-f7031a29c3",
-    "skillId": "act-polygons-circles",
-    "prompt": "What is the measure of one interior angle of the regular 12-gon shown?",
-    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"100.0,17.0 129.0,24.8 150.2,46.0 158.0,75.0 150.2,104.0 129.0,125.2 100.0,133.0 71.0,125.2 49.8,104.0 42.0,75.0 49.8,46.0 71.0,24.8\" stroke-linejoin=\"round\"/></svg>",
-    "answer": {
-      "type": "auto",
-      "value": "150°",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "15°"
-      },
-      {
-        "label": "B",
-        "text": "150°"
-      },
-      {
-        "label": "C",
-        "text": "30°"
       },
       {
         "label": "D",
-        "text": "180°"
-      },
-      {
-        "label": "E",
-        "text": "1800°"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-polygons-circles"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "f7031a29c327cbae8a47feee82235b44d5476b0841eb5858e19ce6906dbcbd92",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-polygons-circles-db43864a60",
-    "skillId": "act-polygons-circles",
-    "prompt": "What is the measure of one interior angle of the regular 10-gon shown?",
-    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"100.0,17.0 134.1,28.1 155.2,57.1 155.2,92.9 134.1,121.9 100.0,133.0 65.9,121.9 44.8,92.9 44.8,57.1 65.9,28.1\" stroke-linejoin=\"round\"/></svg>",
-    "answer": {
-      "type": "auto",
-      "value": "144°",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "36°"
-      },
-      {
-        "label": "B",
         "text": "18°"
       },
       {
-        "label": "C",
-        "text": "144°"
-      },
-      {
-        "label": "D",
-        "text": "180°"
-      },
-      {
         "label": "E",
-        "text": "1440°"
+        "text": "9°"
       }
     ],
     "correctOption": "C",
@@ -2294,7 +2294,7 @@
       "act-polygons-circles"
     ],
     "source": "act-template-gen",
-    "contentHash": "db43864a60f9ee91815d5dc908104ff7e89aa3605ec2ba484a69b683c6e49b7e",
+    "contentHash": "b68f36c479a3afa356ff30f1af51f3882475ced0c2e6c8e6905fb7380e887449",
     "isActive": true
   },
   {
@@ -2311,15 +2311,15 @@
     "options": [
       {
         "label": "A",
-        "text": "72°"
+        "text": "108°"
       },
       {
         "label": "B",
-        "text": "36°"
+        "text": "72°"
       },
       {
         "label": "C",
-        "text": "108°"
+        "text": "540°"
       },
       {
         "label": "D",
@@ -2327,10 +2327,10 @@
       },
       {
         "label": "E",
-        "text": "540°"
+        "text": "36°"
       }
     ],
-    "correctOption": "C",
+    "correctOption": "A",
     "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
@@ -2340,95 +2340,6 @@
     ],
     "source": "act-template-gen",
     "contentHash": "7beecb7077129efd69b3a3471795d300dc179ce2cd7ccdebc86a6f64b322b19f",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-polygons-circles-5167a2fc11",
-    "skillId": "act-polygons-circles",
-    "prompt": "What is the measure of one interior angle of the regular 9-gon shown?",
-    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"100.0,17.0 137.3,30.6 157.1,64.9 150.2,104.0 119.8,129.5 80.2,129.5 49.8,104.0 42.9,64.9 62.7,30.6\" stroke-linejoin=\"round\"/></svg>",
-    "answer": {
-      "type": "auto",
-      "value": "140°",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "140°"
-      },
-      {
-        "label": "B",
-        "text": "20°"
-      },
-      {
-        "label": "C",
-        "text": "40°"
-      },
-      {
-        "label": "D",
-        "text": "180°"
-      },
-      {
-        "label": "E",
-        "text": "1260°"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-polygons-circles"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "5167a2fc11904d6472e10059da24ffb68139257bc7afd6d9877d8e95328216cc",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-polygons-circles-e9063bbaea",
-    "skillId": "act-polygons-circles",
-    "prompt": "What is the measure of one interior angle of the regular 36-gon shown?",
-    "answer": {
-      "type": "auto",
-      "value": "170°",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "170°"
-      },
-      {
-        "label": "B",
-        "text": "6120°"
-      },
-      {
-        "label": "C",
-        "text": "10°"
-      },
-      {
-        "label": "D",
-        "text": "180°"
-      },
-      {
-        "label": "E",
-        "text": "5°"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-polygons-circles"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "e9063bbaea131d620460fab1c162d76d67c50aece68476519e125613cccfbb86",
     "isActive": true
   },
   {
@@ -2445,15 +2356,15 @@
     "options": [
       {
         "label": "A",
-        "text": "30°"
-      },
-      {
-        "label": "B",
         "text": "720°"
       },
       {
-        "label": "C",
+        "label": "B",
         "text": "60°"
+      },
+      {
+        "label": "C",
+        "text": "180°"
       },
       {
         "label": "D",
@@ -2461,11 +2372,11 @@
       },
       {
         "label": "E",
-        "text": "180°"
+        "text": "30°"
       }
     ],
     "correctOption": "D",
-    "difficulty": 5,
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -2477,12 +2388,145 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-area-volume-surface-area-596879dc61",
-    "skillId": "act-area-volume-surface-area",
-    "prompt": "What is the area of a triangle with base 12 and height 5?",
+    "problemId": "act-act-polygons-circles-5851fb8b73",
+    "skillId": "act-polygons-circles",
+    "prompt": "What is the measure of one interior angle of the regular 8-gon shown?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"100.0,17.0 141.0,34.0 158.0,75.0 141.0,116.0 100.0,133.0 59.0,116.0 42.0,75.0 59.0,34.0\" stroke-linejoin=\"round\"/></svg>",
     "answer": {
       "type": "auto",
-      "value": "30",
+      "value": "135°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "135°"
+      },
+      {
+        "label": "B",
+        "text": "22.5°"
+      },
+      {
+        "label": "C",
+        "text": "180°"
+      },
+      {
+        "label": "D",
+        "text": "45°"
+      },
+      {
+        "label": "E",
+        "text": "1080°"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polygons-circles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "5851fb8b7376afbd65a1d3b3859424cefce4445c39f034a8d2e2c9f299c118b3",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polygons-circles-1b11ff8e8a",
+    "skillId": "act-polygons-circles",
+    "prompt": "What is the measure of one interior angle of the regular 18-gon shown?",
+    "answer": {
+      "type": "auto",
+      "value": "160°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "180°"
+      },
+      {
+        "label": "B",
+        "text": "10°"
+      },
+      {
+        "label": "C",
+        "text": "2880°"
+      },
+      {
+        "label": "D",
+        "text": "20°"
+      },
+      {
+        "label": "E",
+        "text": "160°"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polygons-circles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "1b11ff8e8ab46c2a650de720034211e941cf238a2aeec83396dcde04a040b8f5",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-volume-surface-area-c35421fc9c",
+    "skillId": "act-area-volume-surface-area",
+    "prompt": "What is the area of a triangle with base 9 and height 3?",
+    "answer": {
+      "type": "auto",
+      "value": "13.5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "13.5"
+      },
+      {
+        "label": "B",
+        "text": "27"
+      },
+      {
+        "label": "C",
+        "text": "9"
+      },
+      {
+        "label": "D",
+        "text": "6"
+      },
+      {
+        "label": "E",
+        "text": "12"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-volume-surface-area"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "c35421fc9c4e1bcaa532b59332cd960939b7ef52889c8b8049ff07dba853fb9b",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-volume-surface-area-f21e19ece8",
+    "skillId": "act-area-volume-surface-area",
+    "prompt": "What is the area of a triangle with base 10 and height 7?",
+    "answer": {
+      "type": "auto",
+      "value": "35",
       "equivalents": []
     },
     "answerType": "multiple-choice",
@@ -2493,19 +2537,19 @@
       },
       {
         "label": "B",
-        "text": "20"
+        "text": "23.333333333333332"
       },
       {
         "label": "C",
-        "text": "30"
+        "text": "35"
       },
       {
         "label": "D",
-        "text": "17"
+        "text": "70"
       },
       {
         "label": "E",
-        "text": "60"
+        "text": "17"
       }
     ],
     "correctOption": "C",
@@ -2517,86 +2561,42 @@
       "act-area-volume-surface-area"
     ],
     "source": "act-template-gen",
-    "contentHash": "596879dc612bbba654dc8580c8ce01063c98b489c47edb3f2f6551efa0bb27bb",
+    "contentHash": "f21e19ece869c826b1bd201d28356b8d0e633b30b7277d3fb548449d417c568b",
     "isActive": true
   },
   {
-    "problemId": "act-act-area-volume-surface-area-8523dc6def",
+    "problemId": "act-act-area-volume-surface-area-2d8a035fb0",
     "skillId": "act-area-volume-surface-area",
-    "prompt": "What is the area of a rectangle with length 7 and width 4?",
+    "prompt": "What is the area of a rectangle with length 4 and width 6?",
     "answer": {
       "type": "auto",
-      "value": "28",
+      "value": "24",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "28"
+        "text": "10"
       },
       {
         "label": "B",
-        "text": "11"
+        "text": "12"
       },
       {
         "label": "C",
-        "text": "56"
+        "text": "20"
       },
       {
         "label": "D",
-        "text": "14"
+        "text": "48"
       },
       {
         "label": "E",
-        "text": "22"
+        "text": "24"
       }
     ],
-    "correctOption": "A",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-area-volume-surface-area"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "8523dc6def7ec91fc6dd9bc3f87979df628059d0e36e1969bddf1b785dcde7a8",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-area-volume-surface-area-9ba9a538fc",
-    "skillId": "act-area-volume-surface-area",
-    "prompt": "What is the area of a triangle with base 6 and height 7?",
-    "answer": {
-      "type": "auto",
-      "value": "21",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "6.5"
-      },
-      {
-        "label": "B",
-        "text": "21"
-      },
-      {
-        "label": "C",
-        "text": "13"
-      },
-      {
-        "label": "D",
-        "text": "14"
-      },
-      {
-        "label": "E",
-        "text": "42"
-      }
-    ],
-    "correctOption": "B",
+    "correctOption": "E",
     "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
@@ -2605,13 +2605,145 @@
       "act-area-volume-surface-area"
     ],
     "source": "act-template-gen",
-    "contentHash": "9ba9a538fc929fd77e80a0cc3ca55fbafe45ccb655533f43ee758b74f170746b",
+    "contentHash": "2d8a035fb0a3dd8bb30a96d5488b5c14b33d022eb66c97a055bfd3520b29536f",
     "isActive": true
   },
   {
-    "problemId": "act-act-area-volume-surface-area-42491fd93a",
+    "problemId": "act-act-area-volume-surface-area-785ce6946e",
     "skillId": "act-area-volume-surface-area",
-    "prompt": "What is the volume of a box with dimensions 2 × 5 × 3?",
+    "prompt": "What is the area of a triangle with base 7 and height 7?",
+    "answer": {
+      "type": "auto",
+      "value": "24.5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "7"
+      },
+      {
+        "label": "B",
+        "text": "49"
+      },
+      {
+        "label": "C",
+        "text": "24.5"
+      },
+      {
+        "label": "D",
+        "text": "16.333333333333332"
+      },
+      {
+        "label": "E",
+        "text": "14"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-volume-surface-area"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "785ce6946e63ad0d4c8ee83570fedcce420394f8d280bbcaee3218fbcc38940b",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-volume-surface-area-4d81840caa",
+    "skillId": "act-area-volume-surface-area",
+    "prompt": "What is the volume of a box with dimensions 4 × 3 × 5?",
+    "answer": {
+      "type": "auto",
+      "value": "60",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "120"
+      },
+      {
+        "label": "B",
+        "text": "12"
+      },
+      {
+        "label": "C",
+        "text": "94"
+      },
+      {
+        "label": "D",
+        "text": "60"
+      },
+      {
+        "label": "E",
+        "text": "17"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-volume-surface-area"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "4d81840caab1e43d8c2a857fe946372a8d1d22d7a2ea340c3c24a882129aa881",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-volume-surface-area-cc7e6a3a00",
+    "skillId": "act-area-volume-surface-area",
+    "prompt": "What is the area of a triangle with base 10 and height 5?",
+    "answer": {
+      "type": "auto",
+      "value": "25",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "15"
+      },
+      {
+        "label": "B",
+        "text": "7.5"
+      },
+      {
+        "label": "C",
+        "text": "16.666666666666668"
+      },
+      {
+        "label": "D",
+        "text": "50"
+      },
+      {
+        "label": "E",
+        "text": "25"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-volume-surface-area"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "cc7e6a3a00cb40bffd2575d78aa63bfaeb30ddcb2434ea662a868ebda747fef6",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-volume-surface-area-6132a39084",
+    "skillId": "act-area-volume-surface-area",
+    "prompt": "What is the area of a triangle with base 10 and height 6?",
     "answer": {
       "type": "auto",
       "value": "30",
@@ -2625,7 +2757,7 @@
       },
       {
         "label": "B",
-        "text": "62"
+        "text": "8"
       },
       {
         "label": "C",
@@ -2633,15 +2765,15 @@
       },
       {
         "label": "D",
-        "text": "13"
+        "text": "20"
       },
       {
         "label": "E",
-        "text": "10"
+        "text": "16"
       }
     ],
     "correctOption": "C",
-    "difficulty": 3,
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -2649,57 +2781,13 @@
       "act-area-volume-surface-area"
     ],
     "source": "act-template-gen",
-    "contentHash": "42491fd93a24a2e5c05f144292f17a49cd4e9055955c282ee6aef780eb27b2b0",
+    "contentHash": "6132a39084f390b576190d3b42f919674ed0f7e58445de8e94638421f9f592e9",
     "isActive": true
   },
   {
-    "problemId": "act-act-area-volume-surface-area-c729f324b8",
+    "problemId": "act-act-area-volume-surface-area-fc44093ee3",
     "skillId": "act-area-volume-surface-area",
-    "prompt": "What is the area of a rectangle with length 8 and width 7?",
-    "answer": {
-      "type": "auto",
-      "value": "56",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "56"
-      },
-      {
-        "label": "B",
-        "text": "15"
-      },
-      {
-        "label": "C",
-        "text": "112"
-      },
-      {
-        "label": "D",
-        "text": "28"
-      },
-      {
-        "label": "E",
-        "text": "30"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-area-volume-surface-area"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "c729f324b8f64f2159391c8be421a6a534d9f99e2813668db317e90d37e9ebb5",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-area-volume-surface-area-2f0c15a25b",
-    "skillId": "act-area-volume-surface-area",
-    "prompt": "What is the volume of a box with dimensions 5 × 4 × 2?",
+    "prompt": "What is the volume of a box with dimensions 4 × 2 × 5?",
     "answer": {
       "type": "auto",
       "value": "40",
@@ -2709,114 +2797,26 @@
     "options": [
       {
         "label": "A",
-        "text": "40"
-      },
-      {
-        "label": "B",
         "text": "76"
       },
       {
-        "label": "C",
-        "text": "22"
-      },
-      {
-        "label": "D",
+        "label": "B",
         "text": "11"
       },
       {
-        "label": "E",
+        "label": "C",
+        "text": "40"
+      },
+      {
+        "label": "D",
         "text": "80"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-area-volume-surface-area"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "2f0c15a25b7daa86ed85696eddaccb2d72c4595eec94e9557799202d4510fb95",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-area-volume-surface-area-2dc96a9146",
-    "skillId": "act-area-volume-surface-area",
-    "prompt": "What is the area of a triangle with base 4 and height 7?",
-    "answer": {
-      "type": "auto",
-      "value": "14",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "14"
-      },
-      {
-        "label": "B",
-        "text": "28"
-      },
-      {
-        "label": "C",
-        "text": "11"
-      },
-      {
-        "label": "D",
-        "text": "9.333333333333334"
       },
       {
         "label": "E",
-        "text": "5.5"
+        "text": "13"
       }
     ],
-    "correctOption": "A",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-area-volume-surface-area"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "2dc96a91468306edf86d453588fb281aa52213ecce5766acb1090f9d4ea149c2",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-area-volume-surface-area-e50aedcef5",
-    "skillId": "act-area-volume-surface-area",
-    "prompt": "What is the volume of a box with dimensions 4 × 3 × 3?",
-    "answer": {
-      "type": "auto",
-      "value": "36",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "15"
-      },
-      {
-        "label": "B",
-        "text": "10"
-      },
-      {
-        "label": "C",
-        "text": "72"
-      },
-      {
-        "label": "D",
-        "text": "36"
-      },
-      {
-        "label": "E",
-        "text": "66"
-      }
-    ],
-    "correctOption": "D",
+    "correctOption": "C",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -2825,85 +2825,39 @@
       "act-area-volume-surface-area"
     ],
     "source": "act-template-gen",
-    "contentHash": "e50aedcef57623e61d480ace198f15afb31c317e7f44191c1d33e8a68d30c677",
+    "contentHash": "fc44093ee3e67d476acd276ae024ca3c9c3e6b6b71a643487daad7083b2e7890",
     "isActive": true
   },
   {
-    "problemId": "act-act-coordinate-geometry-89d8eac1f2",
+    "problemId": "act-act-coordinate-geometry-c8540cf8d7",
     "skillId": "act-coordinate-geometry",
-    "prompt": "What is the midpoint of the segment joining the two points shown, (-3, 5) and (0, 0)?",
-    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><line x1=\"20\" y1=\"75\" x2=\"180\" y2=\"75\" stroke=\"#bbb\" stroke-width=\"1\"/><line x1=\"100\" y1=\"15\" x2=\"100\" y2=\"140\" stroke=\"#bbb\" stroke-width=\"1\"/><circle cx=\"64\" cy=\"30\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"70\" y=\"24\" fill=\"#7c5cff\" stroke=\"none\">(-3, 5)</text><circle cx=\"100\" cy=\"75\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"106\" y=\"69\" fill=\"#7c5cff\" stroke=\"none\">(0, 0)</text></svg>",
+    "prompt": "What is the distance between (5, 0) and (10, 12)?",
     "answer": {
       "type": "auto",
-      "value": "(-1.5, 2.5)",
+      "value": "13",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "(-1.5, 2.5)"
+        "text": "17"
       },
       {
         "label": "B",
-        "text": "(3, -5)"
+        "text": "13"
       },
       {
         "label": "C",
-        "text": "(-0.5, 2.5)"
+        "text": "60"
       },
       {
         "label": "D",
-        "text": "(-3, 5)"
+        "text": "14"
       },
       {
         "label": "E",
-        "text": "(2.5, -1.5)"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-coordinate-geometry"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "89d8eac1f200c6a2810cd36e2198315b73583ae85dad7ac5a9c4fc3c6777fb8b",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-coordinate-geometry-9dc207e7dc",
-    "skillId": "act-coordinate-geometry",
-    "prompt": "What is the midpoint of the segment joining the two points shown, (-4, 0) and (2, 0)?",
-    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><line x1=\"20\" y1=\"75\" x2=\"180\" y2=\"75\" stroke=\"#bbb\" stroke-width=\"1\"/><line x1=\"100\" y1=\"15\" x2=\"100\" y2=\"140\" stroke=\"#bbb\" stroke-width=\"1\"/><circle cx=\"52\" cy=\"75\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"58\" y=\"69\" fill=\"#7c5cff\" stroke=\"none\">(-4, 0)</text><circle cx=\"124\" cy=\"75\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"130\" y=\"69\" fill=\"#7c5cff\" stroke=\"none\">(2, 0)</text></svg>",
-    "answer": {
-      "type": "auto",
-      "value": "(-1, 0)",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "(0, 0)"
-      },
-      {
-        "label": "B",
-        "text": "(-1, 0)"
-      },
-      {
-        "label": "C",
-        "text": "(6, 0)"
-      },
-      {
-        "label": "D",
-        "text": "(0, -1)"
-      },
-      {
-        "label": "E",
-        "text": "(-2, 0)"
+        "text": "8"
       }
     ],
     "correctOption": "B",
@@ -2915,58 +2869,13 @@
       "act-coordinate-geometry"
     ],
     "source": "act-template-gen",
-    "contentHash": "9dc207e7dc3c567816b1a3734e29567bc7123fffd6cd9d2341be1150943e48a4",
+    "contentHash": "c8540cf8d705098e15499df510aa7ca33cecd87d09ad4b1390349d7de606734b",
     "isActive": true
   },
   {
-    "problemId": "act-act-coordinate-geometry-8a610c691e",
+    "problemId": "act-act-coordinate-geometry-534f24514d",
     "skillId": "act-coordinate-geometry",
-    "prompt": "What is the midpoint of the segment joining the two points shown, (1, 1) and (2, -1)?",
-    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><line x1=\"20\" y1=\"75\" x2=\"180\" y2=\"75\" stroke=\"#bbb\" stroke-width=\"1\"/><line x1=\"100\" y1=\"15\" x2=\"100\" y2=\"140\" stroke=\"#bbb\" stroke-width=\"1\"/><circle cx=\"112\" cy=\"66\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"118\" y=\"60\" fill=\"#7c5cff\" stroke=\"none\">(1, 1)</text><circle cx=\"124\" cy=\"84\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"130\" y=\"78\" fill=\"#7c5cff\" stroke=\"none\">(2, -1)</text></svg>",
-    "answer": {
-      "type": "auto",
-      "value": "(1.5, 0)",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "(2.5, 0)"
-      },
-      {
-        "label": "B",
-        "text": "(1, -2)"
-      },
-      {
-        "label": "C",
-        "text": "(1.5, 0)"
-      },
-      {
-        "label": "D",
-        "text": "(3, 0)"
-      },
-      {
-        "label": "E",
-        "text": "(0, 1.5)"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-coordinate-geometry"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "8a610c691e9a19a8f491ef2ef9d4c8d228e559c21607e67224e858f2310ded32",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-coordinate-geometry-2367c7e31e",
-    "skillId": "act-coordinate-geometry",
-    "prompt": "What is the distance between (0, 0) and (8, 15)?",
+    "prompt": "What is the distance between (5, 1) and (13, 16)?",
     "answer": {
       "type": "auto",
       "value": "17",
@@ -2976,7 +2885,7 @@
     "options": [
       {
         "label": "A",
-        "text": "11"
+        "text": "120"
       },
       {
         "label": "B",
@@ -2988,7 +2897,7 @@
       },
       {
         "label": "D",
-        "text": "120"
+        "text": "11"
       },
       {
         "label": "E",
@@ -2996,7 +2905,7 @@
       }
     ],
     "correctOption": "B",
-    "difficulty": 3,
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -3004,57 +2913,13 @@
       "act-coordinate-geometry"
     ],
     "source": "act-template-gen",
-    "contentHash": "2367c7e31ee898f6dab5b20c2c3634b2c5b98a6c2da4f62d73a1492bfd880b4b",
+    "contentHash": "534f24514d2571ea2b36fe359085214d12c3eb588cf4a8b19f2ccd3601cca312",
     "isActive": true
   },
   {
-    "problemId": "act-act-coordinate-geometry-f6c2a6cc4a",
+    "problemId": "act-act-coordinate-geometry-65c9fbbf4f",
     "skillId": "act-coordinate-geometry",
-    "prompt": "What is the distance between (5, 2) and (8, 6)?",
-    "answer": {
-      "type": "auto",
-      "value": "5",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "7"
-      },
-      {
-        "label": "B",
-        "text": "5"
-      },
-      {
-        "label": "C",
-        "text": "12"
-      },
-      {
-        "label": "D",
-        "text": "3"
-      },
-      {
-        "label": "E",
-        "text": "6"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-coordinate-geometry"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "f6c2a6cc4a0ad808c7278e2c934bf27b3f36000879ab6198fd391c0fb48a9e30",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-coordinate-geometry-d5698c5e89",
-    "skillId": "act-coordinate-geometry",
-    "prompt": "What is the distance between (-3, 5) and (2, 17)?",
+    "prompt": "What is the distance between (-4, 0) and (1, 12)?",
     "answer": {
       "type": "auto",
       "value": "13",
@@ -3064,27 +2929,27 @@
     "options": [
       {
         "label": "A",
-        "text": "13"
+        "text": "8"
       },
       {
         "label": "B",
-        "text": "17"
-      },
-      {
-        "label": "C",
-        "text": "14"
-      },
-      {
-        "label": "D",
         "text": "60"
       },
       {
+        "label": "C",
+        "text": "17"
+      },
+      {
+        "label": "D",
+        "text": "13"
+      },
+      {
         "label": "E",
-        "text": "8"
+        "text": "14"
       }
     ],
-    "correctOption": "A",
-    "difficulty": 4,
+    "correctOption": "D",
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -3092,43 +2957,44 @@
       "act-coordinate-geometry"
     ],
     "source": "act-template-gen",
-    "contentHash": "d5698c5e8977763eb2f05afff2a1ccdac243775cc92a92df9ea1b8ab6ea65ac6",
+    "contentHash": "65c9fbbf4ff4e0737c19066d952c86f9305af8bc61b19e03986ae117f26c9c5b",
     "isActive": true
   },
   {
-    "problemId": "act-act-coordinate-geometry-e5cd812399",
+    "problemId": "act-act-coordinate-geometry-ecf81a001e",
     "skillId": "act-coordinate-geometry",
-    "prompt": "What is the distance between (-1, 5) and (4, 17)?",
+    "prompt": "What is the midpoint of the segment joining the two points shown, (-3, -1) and (2, -1)?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><line x1=\"20\" y1=\"75\" x2=\"180\" y2=\"75\" stroke=\"#bbb\" stroke-width=\"1\"/><line x1=\"100\" y1=\"15\" x2=\"100\" y2=\"140\" stroke=\"#bbb\" stroke-width=\"1\"/><circle cx=\"64\" cy=\"84\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"70\" y=\"78\" fill=\"#7c5cff\" stroke=\"none\">(-3, -1)</text><circle cx=\"124\" cy=\"84\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"130\" y=\"78\" fill=\"#7c5cff\" stroke=\"none\">(2, -1)</text></svg>",
     "answer": {
       "type": "auto",
-      "value": "13",
+      "value": "(-0.5, -1)",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "13"
+        "text": "(-1, -2)"
       },
       {
         "label": "B",
-        "text": "8"
+        "text": "(0.5, -1)"
       },
       {
         "label": "C",
-        "text": "60"
+        "text": "(-0.5, -1)"
       },
       {
         "label": "D",
-        "text": "17"
+        "text": "(5, 0)"
       },
       {
         "label": "E",
-        "text": "14"
+        "text": "(-1, -0.5)"
       }
     ],
-    "correctOption": "A",
-    "difficulty": 4,
+    "correctOption": "C",
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -3136,13 +3002,13 @@
       "act-coordinate-geometry"
     ],
     "source": "act-template-gen",
-    "contentHash": "e5cd812399e0a253d82dbdb108e3d090d9378e2871935c482db2e4444f4f7227",
+    "contentHash": "ecf81a001e474ca10bdd3ae49c912994570278a05a078fa3e3df53dcaf505a91",
     "isActive": true
   },
   {
-    "problemId": "act-act-coordinate-geometry-66ab6c2f43",
+    "problemId": "act-act-coordinate-geometry-584a79f472",
     "skillId": "act-coordinate-geometry",
-    "prompt": "What is the distance between (-3, -4) and (3, 4)?",
+    "prompt": "What is the distance between (-5, 1) and (1, 9)?",
     "answer": {
       "type": "auto",
       "value": "10",
@@ -3160,18 +3026,153 @@
       },
       {
         "label": "C",
-        "text": "10"
-      },
-      {
-        "label": "D",
         "text": "7"
       },
       {
-        "label": "E",
+        "label": "D",
         "text": "48"
+      },
+      {
+        "label": "E",
+        "text": "10"
       }
     ],
-    "correctOption": "C",
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-coordinate-geometry"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "584a79f4723fd52ad5c8adfde395bc9b35aab0d903efdc5eea6ddbbc1c6ac9d9",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-coordinate-geometry-df108a2588",
+    "skillId": "act-coordinate-geometry",
+    "prompt": "What is the midpoint of the segment joining the two points shown, (-2, 3) and (-1, 3)?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><line x1=\"20\" y1=\"75\" x2=\"180\" y2=\"75\" stroke=\"#bbb\" stroke-width=\"1\"/><line x1=\"100\" y1=\"15\" x2=\"100\" y2=\"140\" stroke=\"#bbb\" stroke-width=\"1\"/><circle cx=\"76\" cy=\"48\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"82\" y=\"42\" fill=\"#7c5cff\" stroke=\"none\">(-2, 3)</text><circle cx=\"88\" cy=\"48\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"94\" y=\"42\" fill=\"#7c5cff\" stroke=\"none\">(-1, 3)</text></svg>",
+    "answer": {
+      "type": "auto",
+      "value": "(-1.5, 3)",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "(-1.5, 3)"
+      },
+      {
+        "label": "B",
+        "text": "(1, 0)"
+      },
+      {
+        "label": "C",
+        "text": "(-3, 6)"
+      },
+      {
+        "label": "D",
+        "text": "(3, -1.5)"
+      },
+      {
+        "label": "E",
+        "text": "(-0.5, 3)"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-coordinate-geometry"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "df108a2588862111d308cd547c1e3346c56cbb4de9eceadf03dca1a70cb65c98",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-coordinate-geometry-8d69079c67",
+    "skillId": "act-coordinate-geometry",
+    "prompt": "What is the midpoint of the segment joining the two points shown, (2, 3) and (-1, -1)?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><line x1=\"20\" y1=\"75\" x2=\"180\" y2=\"75\" stroke=\"#bbb\" stroke-width=\"1\"/><line x1=\"100\" y1=\"15\" x2=\"100\" y2=\"140\" stroke=\"#bbb\" stroke-width=\"1\"/><circle cx=\"124\" cy=\"48\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"130\" y=\"42\" fill=\"#7c5cff\" stroke=\"none\">(2, 3)</text><circle cx=\"88\" cy=\"84\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"94\" y=\"78\" fill=\"#7c5cff\" stroke=\"none\">(-1, -1)</text></svg>",
+    "answer": {
+      "type": "auto",
+      "value": "(0.5, 1)",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "(1.5, 1)"
+      },
+      {
+        "label": "B",
+        "text": "(1, 0.5)"
+      },
+      {
+        "label": "C",
+        "text": "(1, 2)"
+      },
+      {
+        "label": "D",
+        "text": "(0.5, 1)"
+      },
+      {
+        "label": "E",
+        "text": "(-3, -4)"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-coordinate-geometry"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "8d69079c6793ce190859bd178b5c08edab3970dec451839e548f55db39441a75",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-coordinate-geometry-71e844b5f4",
+    "skillId": "act-coordinate-geometry",
+    "prompt": "What is the midpoint of the segment joining the two points shown, (4, 5) and (2, -3)?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><line x1=\"20\" y1=\"75\" x2=\"180\" y2=\"75\" stroke=\"#bbb\" stroke-width=\"1\"/><line x1=\"100\" y1=\"15\" x2=\"100\" y2=\"140\" stroke=\"#bbb\" stroke-width=\"1\"/><circle cx=\"148\" cy=\"30\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"154\" y=\"24\" fill=\"#7c5cff\" stroke=\"none\">(4, 5)</text><circle cx=\"124\" cy=\"102\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"130\" y=\"96\" fill=\"#7c5cff\" stroke=\"none\">(2, -3)</text></svg>",
+    "answer": {
+      "type": "auto",
+      "value": "(3, 1)",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "(6, 2)"
+      },
+      {
+        "label": "B",
+        "text": "(1, 3)"
+      },
+      {
+        "label": "C",
+        "text": "(4, 1)"
+      },
+      {
+        "label": "D",
+        "text": "(-2, -8)"
+      },
+      {
+        "label": "E",
+        "text": "(3, 1)"
+      }
+    ],
+    "correctOption": "E",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -3180,97 +3181,7 @@
       "act-coordinate-geometry"
     ],
     "source": "act-template-gen",
-    "contentHash": "66ab6c2f43415a201017784d2fb8bee261bb6f803b0d70cd47da5c9818278ffc",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-right-triangle-trig-54394e51d2",
-    "skillId": "act-right-triangle-trig",
-    "prompt": "In the right triangle shown, the legs have length 9 and 12. What is the length of the hypotenuse?",
-    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\">\n      <polygon points=\"30,120 170,120 30,30\" stroke-linejoin=\"round\"/>\n      <rect x=\"30\" y=\"108\" width=\"12\" height=\"12\" stroke-width=\"1.5\"/>\n      <text x=\"100\" y=\"138\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">9</text>\n      <text x=\"16\" y=\"78\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">12</text></svg>",
-    "answer": {
-      "type": "auto",
-      "value": "15",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "10"
-      },
-      {
-        "label": "B",
-        "text": "14"
-      },
-      {
-        "label": "C",
-        "text": "21"
-      },
-      {
-        "label": "D",
-        "text": "15"
-      },
-      {
-        "label": "E",
-        "text": "16"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-right-triangle-trig"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "54394e51d27e3f765b55a2aae3f19603ebf16bd4143c81e627e8bd61af21713c",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-right-triangle-trig-7fff992dd7",
-    "skillId": "act-right-triangle-trig",
-    "prompt": "In the right triangle shown, the legs have length 5 and 12. What is the length of the hypotenuse?",
-    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\">\n      <polygon points=\"30,120 170,120 30,30\" stroke-linejoin=\"round\"/>\n      <rect x=\"30\" y=\"108\" width=\"12\" height=\"12\" stroke-width=\"1.5\"/>\n      <text x=\"100\" y=\"138\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">5</text>\n      <text x=\"16\" y=\"78\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">12</text></svg>",
-    "answer": {
-      "type": "auto",
-      "value": "13",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "17"
-      },
-      {
-        "label": "B",
-        "text": "8"
-      },
-      {
-        "label": "C",
-        "text": "13"
-      },
-      {
-        "label": "D",
-        "text": "12"
-      },
-      {
-        "label": "E",
-        "text": "14"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-right-triangle-trig"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "7fff992dd736f447a26ec3f3d141f84866f7eaa4ee4b9f64f83f498dabb64d4c",
+    "contentHash": "71e844b5f429574f5696425c078ac2d863ecba7c8d929ccf6f2a4209eaf4c664",
     "isActive": true
   },
   {
@@ -3287,27 +3198,27 @@
     "options": [
       {
         "label": "A",
-        "text": "17"
-      },
-      {
-        "label": "B",
-        "text": "23"
-      },
-      {
-        "label": "C",
-        "text": "11"
-      },
-      {
-        "label": "D",
         "text": "18"
       },
       {
-        "label": "E",
+        "label": "B",
+        "text": "17"
+      },
+      {
+        "label": "C",
+        "text": "23"
+      },
+      {
+        "label": "D",
         "text": "16"
+      },
+      {
+        "label": "E",
+        "text": "11"
       }
     ],
-    "correctOption": "A",
-    "difficulty": 3,
+    "correctOption": "B",
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -3319,40 +3230,40 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-right-triangle-trig-d569434159",
+    "problemId": "act-act-right-triangle-trig-7fff992dd7",
     "skillId": "act-right-triangle-trig",
-    "prompt": "In the right triangle shown, the legs have length 6 and 8. What is the length of the hypotenuse?",
-    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\">\n      <polygon points=\"30,120 170,120 30,30\" stroke-linejoin=\"round\"/>\n      <rect x=\"30\" y=\"108\" width=\"12\" height=\"12\" stroke-width=\"1.5\"/>\n      <text x=\"100\" y=\"138\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">6</text>\n      <text x=\"16\" y=\"78\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">8</text></svg>",
+    "prompt": "In the right triangle shown, the legs have length 5 and 12. What is the length of the hypotenuse?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\">\n      <polygon points=\"30,120 170,120 30,30\" stroke-linejoin=\"round\"/>\n      <rect x=\"30\" y=\"108\" width=\"12\" height=\"12\" stroke-width=\"1.5\"/>\n      <text x=\"100\" y=\"138\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">5</text>\n      <text x=\"16\" y=\"78\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">12</text></svg>",
     "answer": {
       "type": "auto",
-      "value": "10",
+      "value": "13",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "11"
+        "text": "12"
       },
       {
         "label": "B",
-        "text": "14"
+        "text": "13"
       },
       {
         "label": "C",
-        "text": "10"
+        "text": "8"
       },
       {
         "label": "D",
-        "text": "7"
+        "text": "14"
       },
       {
         "label": "E",
-        "text": "9"
+        "text": "17"
       }
     ],
-    "correctOption": "C",
-    "difficulty": 3,
+    "correctOption": "B",
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -3360,7 +3271,7 @@
       "act-right-triangle-trig"
     ],
     "source": "act-template-gen",
-    "contentHash": "d56943415991ca0a0e0711a6de8bc811bc830a4d5f329be9023a9f0bf217e864",
+    "contentHash": "7fff992dd736f447a26ec3f3d141f84866f7eaa4ee4b9f64f83f498dabb64d4c",
     "isActive": true
   },
   {
@@ -3409,53 +3320,10 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-congruence-similarity-eaed7cf073",
-    "skillId": "act-congruence-similarity",
-    "prompt": "Two triangles are similar. A side of length 3 corresponds to a side of length 12. What length corresponds to a side of length 8?",
-    "answer": {
-      "type": "auto",
-      "value": "32",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "12"
-      },
-      {
-        "label": "B",
-        "text": "40"
-      },
-      {
-        "label": "C",
-        "text": "32"
-      },
-      {
-        "label": "D",
-        "text": "2"
-      },
-      {
-        "label": "E",
-        "text": "17"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-congruence-similarity"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "eaed7cf0736c76afb98528949b7cdff1721e724ac2586ff7c0d49c7ea94ae9b1",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-congruence-similarity-45c8405f7f",
-    "skillId": "act-congruence-similarity",
-    "prompt": "Two triangles are similar. A side of length 8 corresponds to a side of length 24. What length corresponds to a side of length 5?",
+    "problemId": "act-act-right-triangle-trig-54394e51d2",
+    "skillId": "act-right-triangle-trig",
+    "prompt": "In the right triangle shown, the legs have length 9 and 12. What is the length of the hypotenuse?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\">\n      <polygon points=\"30,120 170,120 30,30\" stroke-linejoin=\"round\"/>\n      <rect x=\"30\" y=\"108\" width=\"12\" height=\"12\" stroke-width=\"1.5\"/>\n      <text x=\"100\" y=\"138\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">9</text>\n      <text x=\"16\" y=\"78\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">12</text></svg>",
     "answer": {
       "type": "auto",
       "value": "15",
@@ -3465,15 +3333,15 @@
     "options": [
       {
         "label": "A",
-        "text": "2"
+        "text": "15"
       },
       {
         "label": "B",
-        "text": "8"
+        "text": "16"
       },
       {
         "label": "C",
-        "text": "20"
+        "text": "10"
       },
       {
         "label": "D",
@@ -3481,69 +3349,26 @@
       },
       {
         "label": "E",
-        "text": "15"
+        "text": "14"
       }
     ],
-    "correctOption": "E",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-congruence-similarity"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "45c8405f7f41c81e7b424ffb93b59ddccd32821e1f5b0c6ba3f1918ddc45691d",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-congruence-similarity-de538b28d6",
-    "skillId": "act-congruence-similarity",
-    "prompt": "Two triangles are similar. A side of length 6 corresponds to a side of length 12. What length corresponds to a side of length 9?",
-    "answer": {
-      "type": "auto",
-      "value": "18",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "15"
-      },
-      {
-        "label": "B",
-        "text": "27"
-      },
-      {
-        "label": "C",
-        "text": "11"
-      },
-      {
-        "label": "D",
-        "text": "18"
-      },
-      {
-        "label": "E",
-        "text": "5"
-      }
-    ],
-    "correctOption": "D",
+    "correctOption": "A",
     "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-congruence-similarity"
+      "act-right-triangle-trig"
     ],
     "source": "act-template-gen",
-    "contentHash": "de538b28d6717485c8eff07cf4a358304cb77245b487af9b1e9904910d87ab38",
+    "contentHash": "54394e51d27e3f765b55a2aae3f19603ebf16bd4143c81e627e8bd61af21713c",
     "isActive": true
   },
   {
-    "problemId": "act-act-congruence-similarity-cfcf2416c5",
-    "skillId": "act-congruence-similarity",
-    "prompt": "Two triangles are similar. A side of length 8 corresponds to a side of length 16. What length corresponds to a side of length 5?",
+    "problemId": "act-act-right-triangle-trig-d569434159",
+    "skillId": "act-right-triangle-trig",
+    "prompt": "In the right triangle shown, the legs have length 6 and 8. What is the length of the hypotenuse?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\">\n      <polygon points=\"30,120 170,120 30,30\" stroke-linejoin=\"round\"/>\n      <rect x=\"30\" y=\"108\" width=\"12\" height=\"12\" stroke-width=\"1.5\"/>\n      <text x=\"100\" y=\"138\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">6</text>\n      <text x=\"16\" y=\"78\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">8</text></svg>",
     "answer": {
       "type": "auto",
       "value": "10",
@@ -3553,11 +3378,11 @@
     "options": [
       {
         "label": "A",
-        "text": "15"
+        "text": "9"
       },
       {
         "label": "B",
-        "text": "10"
+        "text": "11"
       },
       {
         "label": "C",
@@ -3565,29 +3390,29 @@
       },
       {
         "label": "D",
-        "text": "3"
+        "text": "10"
       },
       {
         "label": "E",
-        "text": "13"
+        "text": "14"
       }
     ],
-    "correctOption": "B",
+    "correctOption": "D",
     "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-congruence-similarity"
+      "act-right-triangle-trig"
     ],
     "source": "act-template-gen",
-    "contentHash": "cfcf2416c5f57b90637dbd770e35a1dfbddc204b070c3d4a5558e19f5dba784d",
+    "contentHash": "d56943415991ca0a0e0711a6de8bc811bc830a4d5f329be9023a9f0bf217e864",
     "isActive": true
   },
   {
-    "problemId": "act-act-congruence-similarity-c2f0f3864d",
+    "problemId": "act-act-congruence-similarity-f6714cbd5d",
     "skillId": "act-congruence-similarity",
-    "prompt": "Two triangles are similar. A side of length 5 corresponds to a side of length 10. What length corresponds to a side of length 8?",
+    "prompt": "Two triangles are similar. A side of length 5 corresponds to a side of length 20. What length corresponds to a side of length 4?",
     "answer": {
       "type": "auto",
       "value": "16",
@@ -3597,115 +3422,27 @@
     "options": [
       {
         "label": "A",
-        "text": "4"
-      },
-      {
-        "label": "B",
         "text": "16"
       },
       {
-        "label": "C",
-        "text": "24"
-      },
-      {
-        "label": "D",
-        "text": "10"
-      },
-      {
-        "label": "E",
-        "text": "13"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-congruence-similarity"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "c2f0f3864d8da009bba52fe608cfc02dac69b939527c3d25ab2a2270888029a0",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-congruence-similarity-b285ef65b0",
-    "skillId": "act-congruence-similarity",
-    "prompt": "Two triangles are similar. A side of length 8 corresponds to a side of length 16. What length corresponds to a side of length 6?",
-    "answer": {
-      "type": "auto",
-      "value": "12",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "18"
-      },
-      {
         "label": "B",
-        "text": "12"
-      },
-      {
-        "label": "C",
-        "text": "14"
-      },
-      {
-        "label": "D",
-        "text": "3"
-      },
-      {
-        "label": "E",
-        "text": "8"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-congruence-similarity"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "b285ef65b0536cefe772a67c31b0beb9ccf269b8385f3cc8a9c3a658124888a4",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-congruence-similarity-188cbe4d01",
-    "skillId": "act-congruence-similarity",
-    "prompt": "Two triangles are similar. A side of length 8 corresponds to a side of length 32. What length corresponds to a side of length 5?",
-    "answer": {
-      "type": "auto",
-      "value": "20",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
         "text": "1"
       },
       {
-        "label": "B",
-        "text": "25"
-      },
-      {
         "label": "C",
-        "text": "9"
+        "text": "19"
       },
       {
         "label": "D",
+        "text": "8"
+      },
+      {
+        "label": "E",
         "text": "20"
-      },
-      {
-        "label": "E",
-        "text": "29"
       }
     ],
-    "correctOption": "D",
-    "difficulty": 4,
+    "correctOption": "A",
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -3713,155 +3450,23 @@
       "act-congruence-similarity"
     ],
     "source": "act-template-gen",
-    "contentHash": "188cbe4d01eff90275a6cb09855f28874fae3b0ae14fb6d9822224efca956010",
+    "contentHash": "f6714cbd5db6af501fe99ab1eeef68a4e53669f015bd48d0769d2f1f9e404cee",
     "isActive": true
   },
   {
-    "problemId": "act-act-congruence-similarity-fb89d9f19a",
+    "problemId": "act-act-congruence-similarity-f9595ceac0",
     "skillId": "act-congruence-similarity",
-    "prompt": "Two triangles are similar. A side of length 7 corresponds to a side of length 14. What length corresponds to a side of length 6?",
+    "prompt": "Two triangles are similar. A side of length 4 corresponds to a side of length 16. What length corresponds to a side of length 7?",
     "answer": {
       "type": "auto",
-      "value": "12",
+      "value": "28",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "13"
-      },
-      {
-        "label": "B",
-        "text": "18"
-      },
-      {
-        "label": "C",
-        "text": "3"
-      },
-      {
-        "label": "D",
-        "text": "8"
-      },
-      {
-        "label": "E",
-        "text": "12"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 5,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-congruence-similarity"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "fb89d9f19a944685c82a2487b36dd631be99f56d93f515a264ba047779ca2e48",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-linear-equations-c823d35b2a",
-    "skillId": "act-linear-equations",
-    "prompt": "If 3x - 6 = -2x - 21, then x = ?",
-    "answer": {
-      "type": "auto",
-      "value": "-3",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "-4"
-      },
-      {
-        "label": "B",
-        "text": "-2"
-      },
-      {
-        "label": "C",
-        "text": "-15"
-      },
-      {
-        "label": "D",
-        "text": "3"
-      },
-      {
-        "label": "E",
-        "text": "-3"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-linear-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "c823d35b2a65f958e7d35f465927dfd53e694364b4447e514ec627ba95926ab0",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-linear-equations-1845bb3f94",
-    "skillId": "act-linear-equations",
-    "prompt": "If 2x + 7 = -x + 31, then x = ?",
-    "answer": {
-      "type": "auto",
-      "value": "8",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "7"
-      },
-      {
-        "label": "B",
-        "text": "-8"
-      },
-      {
-        "label": "C",
-        "text": "24"
-      },
-      {
-        "label": "D",
-        "text": "9"
-      },
-      {
-        "label": "E",
-        "text": "8"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-linear-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "1845bb3f942ffd3364efbeebd5125b1e59e03a68e198afa5dea2213e9083abc9",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-linear-equations-03a18e6d12",
-    "skillId": "act-linear-equations",
-    "prompt": "If 2x - 7 = -4x + 11, then x = ?",
-    "answer": {
-      "type": "auto",
-      "value": "3",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "-3"
+        "text": "11"
       },
       {
         "label": "B",
@@ -3869,59 +3474,59 @@
       },
       {
         "label": "C",
-        "text": "18"
+        "text": "19"
       },
       {
         "label": "D",
-        "text": "3"
+        "text": "35"
       },
       {
         "label": "E",
-        "text": "4"
+        "text": "28"
       }
     ],
-    "correctOption": "D",
-    "difficulty": 3,
+    "correctOption": "E",
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-linear-equations"
+      "act-congruence-similarity"
     ],
     "source": "act-template-gen",
-    "contentHash": "03a18e6d12522ec42d0610d3eac80e8f8178507584223dcaf0fcd0e0354dc0e7",
+    "contentHash": "f9595ceac0733c82598d1115ecd96245843efae7e65ab145f74d6a8f20a1aa54",
     "isActive": true
   },
   {
-    "problemId": "act-act-linear-equations-042bb75324",
-    "skillId": "act-linear-equations",
-    "prompt": "If 5x + 8 = -x + 56, then x = ?",
+    "problemId": "act-act-congruence-similarity-eac1c13d57",
+    "skillId": "act-congruence-similarity",
+    "prompt": "Two triangles are similar. A side of length 5 corresponds to a side of length 20. What length corresponds to a side of length 3?",
     "answer": {
       "type": "auto",
-      "value": "8",
+      "value": "12",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "48"
+        "text": "18"
       },
       {
         "label": "B",
-        "text": "7"
+        "text": "15"
       },
       {
         "label": "C",
-        "text": "8"
+        "text": "12"
       },
       {
         "label": "D",
-        "text": "9"
+        "text": "1"
       },
       {
         "label": "E",
-        "text": "-8"
+        "text": "7"
       }
     ],
     "correctOption": "C",
@@ -3930,42 +3535,86 @@
     "tags": [
       "act",
       "act-math",
-      "act-linear-equations"
+      "act-congruence-similarity"
     ],
     "source": "act-template-gen",
-    "contentHash": "042bb753247418d0fbc123f6e1f364c5c544f5fb0f2aee7411cef9724a8f660c",
+    "contentHash": "eac1c13d57fd56744d20af22695491aa0519b281589cd939877b7c746e073ab5",
     "isActive": true
   },
   {
-    "problemId": "act-act-linear-equations-dc9ee19c85",
-    "skillId": "act-linear-equations",
-    "prompt": "If 5x - 4 = x - 24, then x = ?",
+    "problemId": "act-act-congruence-similarity-eb22153ae2",
+    "skillId": "act-congruence-similarity",
+    "prompt": "Two triangles are similar. A side of length 5 corresponds to a side of length 10. What length corresponds to a side of length 4?",
     "answer": {
       "type": "auto",
-      "value": "-5",
+      "value": "8",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "-6"
+        "text": "2"
       },
       {
         "label": "B",
-        "text": "-5"
+        "text": "12"
       },
       {
         "label": "C",
-        "text": "-4"
+        "text": "8"
       },
       {
         "label": "D",
-        "text": "-20"
+        "text": "9"
       },
       {
         "label": "E",
-        "text": "5"
+        "text": "6"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-congruence-similarity"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "eb22153ae2d1523ac5338b77dabe8dca2eab7e1eaca6b55c66674a93b9ac716a",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-congruence-similarity-21f006dee0",
+    "skillId": "act-congruence-similarity",
+    "prompt": "Two triangles are similar. A side of length 3 corresponds to a side of length 12. What length corresponds to a side of length 7?",
+    "answer": {
+      "type": "auto",
+      "value": "28",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "35"
+      },
+      {
+        "label": "B",
+        "text": "28"
+      },
+      {
+        "label": "C",
+        "text": "2"
+      },
+      {
+        "label": "D",
+        "text": "16"
+      },
+      {
+        "label": "E",
+        "text": "11"
       }
     ],
     "correctOption": "B",
@@ -3974,16 +3623,148 @@
     "tags": [
       "act",
       "act-math",
-      "act-linear-equations"
+      "act-congruence-similarity"
     ],
     "source": "act-template-gen",
-    "contentHash": "dc9ee19c8586117b2fbadce4eee352438544f2fe08c1ef0a94407621b738467b",
+    "contentHash": "21f006dee0d654bc33031cb8a53e17f3e77ea4aef9e44076fe32bbe191a3d05b",
     "isActive": true
   },
   {
-    "problemId": "act-act-linear-equations-cb6b4510fa",
+    "problemId": "act-act-congruence-similarity-ea6b609a86",
+    "skillId": "act-congruence-similarity",
+    "prompt": "Two triangles are similar. A side of length 3 corresponds to a side of length 6. What length corresponds to a side of length 6?",
+    "answer": {
+      "type": "auto",
+      "value": "12",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "3"
+      },
+      {
+        "label": "B",
+        "text": "18"
+      },
+      {
+        "label": "C",
+        "text": "8"
+      },
+      {
+        "label": "D",
+        "text": "9"
+      },
+      {
+        "label": "E",
+        "text": "12"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-congruence-similarity"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "ea6b609a86ae4fc040a5413105daaa291af72bd195b5d5063a5cf56187aeb69e",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-congruence-similarity-fb1f73249c",
+    "skillId": "act-congruence-similarity",
+    "prompt": "Two triangles are similar. A side of length 6 corresponds to a side of length 18. What length corresponds to a side of length 5?",
+    "answer": {
+      "type": "auto",
+      "value": "15",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "20"
+      },
+      {
+        "label": "B",
+        "text": "15"
+      },
+      {
+        "label": "C",
+        "text": "17"
+      },
+      {
+        "label": "D",
+        "text": "8"
+      },
+      {
+        "label": "E",
+        "text": "2"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-congruence-similarity"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "fb1f73249c889691f53d0af117407fe88c605748ef48754e278c17aee512d7d4",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-congruence-similarity-e405d98625",
+    "skillId": "act-congruence-similarity",
+    "prompt": "Two triangles are similar. A side of length 5 corresponds to a side of length 20. What length corresponds to a side of length 7?",
+    "answer": {
+      "type": "auto",
+      "value": "28",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "2"
+      },
+      {
+        "label": "B",
+        "text": "28"
+      },
+      {
+        "label": "C",
+        "text": "22"
+      },
+      {
+        "label": "D",
+        "text": "11"
+      },
+      {
+        "label": "E",
+        "text": "35"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-congruence-similarity"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "e405d986255c57c078363674d2ef3e004693cfcbdf7f42ba22ef6042c8af2541",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-equations-d7a4d89520",
     "skillId": "act-linear-equations",
-    "prompt": "If 5x + 0 = -x + 18, then x = ?",
+    "prompt": "If 6x - 6 = -x + 15, then x = ?",
     "answer": {
       "type": "auto",
       "value": "3",
@@ -3993,7 +3774,7 @@
     "options": [
       {
         "label": "A",
-        "text": "18"
+        "text": "-3"
       },
       {
         "label": "B",
@@ -4009,11 +3790,11 @@
       },
       {
         "label": "E",
-        "text": "-3"
+        "text": "21"
       }
     ],
     "correctOption": "B",
-    "difficulty": 4,
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -4021,16 +3802,60 @@
       "act-linear-equations"
     ],
     "source": "act-template-gen",
-    "contentHash": "cb6b4510fad3d65df5ccb81b79e26824529ae6387acda92350322866b6b40ba7",
+    "contentHash": "d7a4d89520649757208dd45e6f9c9d5839301d8081dd8b06c5d34fdf8633e932",
     "isActive": true
   },
   {
-    "problemId": "act-act-linear-equations-6d850644fb",
+    "problemId": "act-act-linear-equations-fdb58c2d47",
     "skillId": "act-linear-equations",
-    "prompt": "If 9x - 7 = 3x - 31, then x = ?",
+    "prompt": "If 5x - 6 = 2x + 3, then x = ?",
     "answer": {
       "type": "auto",
-      "value": "-4",
+      "value": "3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "9"
+      },
+      {
+        "label": "B",
+        "text": "4"
+      },
+      {
+        "label": "C",
+        "text": "2"
+      },
+      {
+        "label": "D",
+        "text": "-3"
+      },
+      {
+        "label": "E",
+        "text": "3"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "fdb58c2d47dd426d257f57f29d712b7bc847aa3d2d50e822ac5554af18dde773",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-equations-eb226c5b5c",
+    "skillId": "act-linear-equations",
+    "prompt": "If 7x + 9 = -x + 41, then x = ?",
+    "answer": {
+      "type": "auto",
+      "value": "4",
       "equivalents": []
     },
     "answerType": "multiple-choice",
@@ -4045,19 +3870,19 @@
       },
       {
         "label": "C",
-        "text": "-24"
+        "text": "32"
       },
       {
         "label": "D",
-        "text": "-3"
+        "text": "3"
       },
       {
         "label": "E",
-        "text": "-5"
+        "text": "5"
       }
     ],
-    "correctOption": "B",
-    "difficulty": 4,
+    "correctOption": "A",
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -4065,57 +3890,13 @@
       "act-linear-equations"
     ],
     "source": "act-template-gen",
-    "contentHash": "6d850644fb60d64a7ac5e9c91a0fb3f524fe2a82d38f4da5b477aae5083e930b",
+    "contentHash": "eb226c5b5c89766ee851784d988bb4ecc40895c05aec63919b61cdf806abb7ae",
     "isActive": true
   },
   {
-    "problemId": "act-act-linear-equations-5d853f9cf3",
+    "problemId": "act-act-linear-equations-bd4894a9ea",
     "skillId": "act-linear-equations",
-    "prompt": "If 4x + 3 = 2x - 9, then x = ?",
-    "answer": {
-      "type": "auto",
-      "value": "-6",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "-12"
-      },
-      {
-        "label": "B",
-        "text": "-6"
-      },
-      {
-        "label": "C",
-        "text": "-5"
-      },
-      {
-        "label": "D",
-        "text": "6"
-      },
-      {
-        "label": "E",
-        "text": "-7"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 5,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-linear-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "5d853f9cf32c3d5995f82b1f6b53598bbff8d160db7bc4a4bbbb4e7ff34138c0",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-systems-of-equations-e6b8c817a7",
-    "skillId": "act-systems-of-equations",
-    "prompt": "If 3x + 4y = 24 and 4x + 4y = 28, what is x + y?",
+    "prompt": "If 8x + 5 = 4x + 33, then x = ?",
     "answer": {
       "type": "auto",
       "value": "7",
@@ -4129,51 +3910,7 @@
       },
       {
         "label": "B",
-        "text": "1"
-      },
-      {
-        "label": "C",
-        "text": "4"
-      },
-      {
-        "label": "D",
-        "text": "12"
-      },
-      {
-        "label": "E",
-        "text": "3"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-systems-of-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "e6b8c817a75c86b739fe3f38661dca0297c4e1e2e604354f9578d09399517538",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-systems-of-equations-0d74e6b752",
-    "skillId": "act-systems-of-equations",
-    "prompt": "If 3x + y = 12 and 2x + 2y = 16, what is x + y?",
-    "answer": {
-      "type": "auto",
-      "value": "8",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "2"
-      },
-      {
-        "label": "B",
-        "text": "12"
+        "text": "-7"
       },
       {
         "label": "C",
@@ -4185,95 +3922,51 @@
       },
       {
         "label": "E",
-        "text": "-4"
+        "text": "28"
       }
     ],
-    "correctOption": "C",
-    "difficulty": 2,
+    "correctOption": "A",
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-systems-of-equations"
+      "act-linear-equations"
     ],
     "source": "act-template-gen",
-    "contentHash": "0d74e6b752980a118b71163ea05577ef9be18b0354d923a6e8a9fce139fc55be",
+    "contentHash": "bd4894a9eaf554eed3cb29bb3519ba4f24f882a2c6bea9f79be2cf9e8c86455c",
     "isActive": true
   },
   {
-    "problemId": "act-act-systems-of-equations-d53240f373",
-    "skillId": "act-systems-of-equations",
-    "prompt": "If 2x + 4y = -4 and 4x + 4y = 4, what is x + y?",
+    "problemId": "act-act-linear-equations-ba714f0aed",
+    "skillId": "act-linear-equations",
+    "prompt": "If 6x - 4 = -3x + 68, then x = ?",
     "answer": {
       "type": "auto",
-      "value": "1",
+      "value": "8",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "-12"
-      },
-      {
-        "label": "B",
-        "text": "1"
-      },
-      {
-        "label": "C",
         "text": "7"
       },
       {
-        "label": "D",
-        "text": "4"
-      },
-      {
-        "label": "E",
-        "text": "-3"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-systems-of-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "d53240f3738751d81a06f241f0a796d5827aff8d752c402cf03101683e1ce6bc",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-systems-of-equations-199c5075f9",
-    "skillId": "act-systems-of-equations",
-    "prompt": "If 4x + y = 11 and 3x + 2y = 2, what is x + y?",
-    "answer": {
-      "type": "auto",
-      "value": "-1",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "9"
-      },
-      {
         "label": "B",
-        "text": "-1"
+        "text": "8"
       },
       {
         "label": "C",
-        "text": "4"
+        "text": "9"
       },
       {
         "label": "D",
-        "text": "-5"
+        "text": "72"
       },
       {
         "label": "E",
-        "text": "-20"
+        "text": "-8"
       }
     ],
     "correctOption": "B",
@@ -4282,16 +3975,16 @@
     "tags": [
       "act",
       "act-math",
-      "act-systems-of-equations"
+      "act-linear-equations"
     ],
     "source": "act-template-gen",
-    "contentHash": "199c5075f93d34e139c53c7fa5837dcabd56248cd4ef62ca1e2fe3bce6e9019c",
+    "contentHash": "ba714f0aed0119ed7ac54536349a5b9daf08e8a6f37cb16fac47e6695e89e041",
     "isActive": true
   },
   {
-    "problemId": "act-act-systems-of-equations-6f2837dbd6",
-    "skillId": "act-systems-of-equations",
-    "prompt": "If 3x + 2y = 12 and 2x + 3y = 3, what is x + y?",
+    "problemId": "act-act-linear-equations-e507cbea8a",
+    "skillId": "act-linear-equations",
+    "prompt": "If 8x - 3 = -3x + 30, then x = ?",
     "answer": {
       "type": "auto",
       "value": "3",
@@ -4305,63 +3998,63 @@
       },
       {
         "label": "B",
-        "text": "-18"
+        "text": "-3"
       },
       {
         "label": "C",
-        "text": "6"
+        "text": "4"
       },
       {
         "label": "D",
-        "text": "9"
+        "text": "2"
       },
       {
         "label": "E",
-        "text": "-3"
+        "text": "33"
       }
     ],
     "correctOption": "A",
-    "difficulty": 3,
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-systems-of-equations"
+      "act-linear-equations"
     ],
     "source": "act-template-gen",
-    "contentHash": "6f2837dbd62560064818f1b00191db3d4506f2be8b6c34c3cb582ba6922fba44",
+    "contentHash": "e507cbea8a1ccb0219ceac6311ca8ce4efc6546afbd2dd0d88d6d8a6b39dcb2c",
     "isActive": true
   },
   {
-    "problemId": "act-act-systems-of-equations-ccd9aa5f45",
-    "skillId": "act-systems-of-equations",
-    "prompt": "If 3x + 3y = 24 and 3x + y = 14, what is x + y?",
+    "problemId": "act-act-linear-equations-0fc8937aee",
+    "skillId": "act-linear-equations",
+    "prompt": "If 6x + 6 = -3x + 33, then x = ?",
     "answer": {
       "type": "auto",
-      "value": "8",
+      "value": "3",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "-2"
+        "text": "4"
       },
       {
         "label": "B",
-        "text": "3"
+        "text": "-3"
       },
       {
         "label": "C",
-        "text": "15"
+        "text": "27"
       },
       {
         "label": "D",
-        "text": "5"
+        "text": "2"
       },
       {
         "label": "E",
-        "text": "8"
+        "text": "3"
       }
     ],
     "correctOption": "E",
@@ -4370,16 +4063,60 @@
     "tags": [
       "act",
       "act-math",
-      "act-systems-of-equations"
+      "act-linear-equations"
     ],
     "source": "act-template-gen",
-    "contentHash": "ccd9aa5f45da3f2f914fc6062c0148baa63e1f7cf6f0caca5780f4fe744b2886",
+    "contentHash": "0fc8937aeef3793d4bf92a6073c09ca21d735e7f709307aaa6afdbe8b53237f3",
     "isActive": true
   },
   {
-    "problemId": "act-act-systems-of-equations-252b489112",
+    "problemId": "act-act-linear-equations-2239f1acaf",
+    "skillId": "act-linear-equations",
+    "prompt": "If 10x + 4 = 3x - 10, then x = ?",
+    "answer": {
+      "type": "auto",
+      "value": "-2",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-14"
+      },
+      {
+        "label": "B",
+        "text": "2"
+      },
+      {
+        "label": "C",
+        "text": "-2"
+      },
+      {
+        "label": "D",
+        "text": "-3"
+      },
+      {
+        "label": "E",
+        "text": "-1"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "2239f1acafbcbca3eded7aed0e8d4329618054f6e314f5eb5b4a6ab4667067aa",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-systems-of-equations-56cf34e371",
     "skillId": "act-systems-of-equations",
-    "prompt": "If 3x + 2y = 2 and 4x + 3y = 4, what is x + y?",
+    "prompt": "If 2x + 3y = 0 and 3x + 4y = 2, what is x + y?",
     "answer": {
       "type": "auto",
       "value": "2",
@@ -4389,27 +4126,27 @@
     "options": [
       {
         "label": "A",
-        "text": "2"
+        "text": "-24"
       },
       {
         "label": "B",
-        "text": "-6"
+        "text": "10"
       },
       {
         "label": "C",
-        "text": "-2"
+        "text": "-4"
       },
       {
         "label": "D",
-        "text": "4"
+        "text": "6"
       },
       {
         "label": "E",
-        "text": "-8"
+        "text": "2"
       }
     ],
-    "correctOption": "A",
-    "difficulty": 4,
+    "correctOption": "E",
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -4417,7 +4154,7 @@
       "act-systems-of-equations"
     ],
     "source": "act-template-gen",
-    "contentHash": "252b489112ef1c69cace0a276bf5cd8c9038afd356e5c4158b27c069c1cdea36",
+    "contentHash": "56cf34e371c265aa93cb9f26b471a5acbaa478da861e65a573f5e36f9f6428fa",
     "isActive": true
   },
   {
@@ -4453,7 +4190,7 @@
       }
     ],
     "correctOption": "C",
-    "difficulty": 5,
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -4465,12 +4202,56 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-quadratic-equations-e4ce4fb629",
-    "skillId": "act-quadratic-equations",
-    "prompt": "Which of the following is a solution to x² + 8x + 15 = 0?",
+    "problemId": "act-act-systems-of-equations-4c90fcd47e",
+    "skillId": "act-systems-of-equations",
+    "prompt": "If x + 3y = 11 and 4x + y = 22, what is x + y?",
     "answer": {
       "type": "auto",
-      "value": "-3",
+      "value": "7",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "2"
+      },
+      {
+        "label": "B",
+        "text": "10"
+      },
+      {
+        "label": "C",
+        "text": "5"
+      },
+      {
+        "label": "D",
+        "text": "7"
+      },
+      {
+        "label": "E",
+        "text": "3"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-systems-of-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "4c90fcd47e08fb2af8ef1493a853d29e0dec5e405aa1d83f8d44cd49c2b03f25",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-systems-of-equations-ca8a657b47",
+    "skillId": "act-systems-of-equations",
+    "prompt": "If 3x + 3y = -24 and 2x + 4y = -26, what is x + y?",
+    "answer": {
+      "type": "auto",
+      "value": "-8",
       "equivalents": []
     },
     "answerType": "multiple-choice",
@@ -4481,81 +4262,37 @@
       },
       {
         "label": "B",
-        "text": "3"
-      },
-      {
-        "label": "C",
-        "text": "5"
-      },
-      {
-        "label": "D",
         "text": "-8"
       },
       {
-        "label": "E",
-        "text": "-3"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-quadratic-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "e4ce4fb6299de2369493613af28f1a69852536222c20fa39fa6db7ba43bef107",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-quadratic-equations-9144d958a9",
-    "skillId": "act-quadratic-equations",
-    "prompt": "Which of the following is a solution to x² + 1x - 20 = 0?",
-    "answer": {
-      "type": "auto",
-      "value": "4",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "-20"
-      },
-      {
-        "label": "B",
-        "text": "-1"
-      },
-      {
         "label": "C",
-        "text": "5"
+        "text": "2"
       },
       {
         "label": "D",
-        "text": "4"
+        "text": "-3"
       },
       {
         "label": "E",
-        "text": "-4"
+        "text": "-5"
       }
     ],
-    "correctOption": "D",
-    "difficulty": 2,
+    "correctOption": "B",
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-quadratic-equations"
+      "act-systems-of-equations"
     ],
     "source": "act-template-gen",
-    "contentHash": "9144d958a90c4914bc68d01c41ebe652f440f959e173621d0a9f2829036ee467",
+    "contentHash": "ca8a657b4739ff3008d82f22fd8705e13458ca3053c5d96950e9b26011ebd4a5",
     "isActive": true
   },
   {
-    "problemId": "act-act-quadratic-equations-234380b521",
-    "skillId": "act-quadratic-equations",
-    "prompt": "Which of the following is a solution to x² + 4x - 5 = 0?",
+    "problemId": "act-act-systems-of-equations-8e7b71b6c5",
+    "skillId": "act-systems-of-equations",
+    "prompt": "If 2x + y = 5 and 4x + 4y = 4, what is x + y?",
     "answer": {
       "type": "auto",
       "value": "1",
@@ -4565,11 +4302,99 @@
     "options": [
       {
         "label": "A",
-        "text": "1"
+        "text": "-12"
       },
       {
         "label": "B",
+        "text": "1"
+      },
+      {
+        "label": "C",
+        "text": "-3"
+      },
+      {
+        "label": "D",
+        "text": "4"
+      },
+      {
+        "label": "E",
+        "text": "7"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-systems-of-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "8e7b71b6c5cb330cf23d66705b641ca89b8aff0529e10deac774b7a444f0080c",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-systems-of-equations-5f6a1d8330",
+    "skillId": "act-systems-of-equations",
+    "prompt": "If 2x + 3y = 0 and x + 2y = -1, what is x + y?",
+    "answer": {
+      "type": "auto",
+      "value": "1",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
         "text": "5"
+      },
+      {
+        "label": "B",
+        "text": "-2"
+      },
+      {
+        "label": "C",
+        "text": "1"
+      },
+      {
+        "label": "D",
+        "text": "3"
+      },
+      {
+        "label": "E",
+        "text": "-6"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-systems-of-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "5f6a1d8330ae9fdbc6a62b03f5684674885f370c98fe1a3a6df44ac0a18b2e1a",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-systems-of-equations-68c0c7235e",
+    "skillId": "act-systems-of-equations",
+    "prompt": "If 2x + 2y = 2 and 2x + 3y = -2, what is x + y?",
+    "answer": {
+      "type": "auto",
+      "value": "1",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "9"
+      },
+      {
+        "label": "B",
+        "text": "-20"
       },
       {
         "label": "C",
@@ -4577,29 +4402,29 @@
       },
       {
         "label": "D",
-        "text": "-1"
+        "text": "5"
       },
       {
         "label": "E",
-        "text": "-5"
+        "text": "1"
       }
     ],
-    "correctOption": "A",
-    "difficulty": 3,
+    "correctOption": "E",
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-quadratic-equations"
+      "act-systems-of-equations"
     ],
     "source": "act-template-gen",
-    "contentHash": "234380b521211fc9d0f32da0d4786e45134b4590e2ff00e0fb724dfaeedbdcc7",
+    "contentHash": "68c0c7235e1d7b107f983e01712d6cd6f6decb292a3cdf0c96146490bb0d878e",
     "isActive": true
   },
   {
-    "problemId": "act-act-quadratic-equations-3ed6dfcbe5",
-    "skillId": "act-quadratic-equations",
-    "prompt": "Which of the following is a solution to x² + 10x + 24 = 0?",
+    "problemId": "act-act-systems-of-equations-e81b913639",
+    "skillId": "act-systems-of-equations",
+    "prompt": "If x + 3y = -10 and 2x + 2y = -8, what is x + y?",
     "answer": {
       "type": "auto",
       "value": "-4",
@@ -4609,71 +4434,71 @@
     "options": [
       {
         "label": "A",
+        "text": "-3"
+      },
+      {
+        "label": "B",
         "text": "-4"
       },
       {
-        "label": "B",
-        "text": "-10"
-      },
-      {
         "label": "C",
-        "text": "4"
+        "text": "-1"
       },
       {
         "label": "D",
-        "text": "6"
-      },
-      {
-        "label": "E",
-        "text": "24"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-quadratic-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "3ed6dfcbe55631c2fb5cb26cd197d5e84523dface616f20a3304fbed6c9db4c7",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-quadratic-equations-34250e0e10",
-    "skillId": "act-quadratic-equations",
-    "prompt": "Which of the following is a solution to x² + 8x + 12 = 0?",
-    "answer": {
-      "type": "auto",
-      "value": "-2",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "6"
-      },
-      {
-        "label": "B",
-        "text": "12"
-      },
-      {
-        "label": "C",
         "text": "2"
       },
       {
+        "label": "E",
+        "text": "3"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-systems-of-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "e81b9136393630c64eb4d8d1d12b6c54d4eab8f01185b9a42d15b57c0a9c4177",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-equations-d22793ff54",
+    "skillId": "act-quadratic-equations",
+    "prompt": "Which of the following is a solution to x² - 7x + 12 = 0?",
+    "answer": {
+      "type": "auto",
+      "value": "4",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "4"
+      },
+      {
+        "label": "B",
+        "text": "7"
+      },
+      {
+        "label": "C",
+        "text": "-4"
+      },
+      {
         "label": "D",
-        "text": "-2"
+        "text": "-3"
       },
       {
         "label": "E",
-        "text": "-8"
+        "text": "12"
       }
     ],
-    "correctOption": "D",
-    "difficulty": 3,
+    "correctOption": "A",
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -4681,35 +4506,35 @@
       "act-quadratic-equations"
     ],
     "source": "act-template-gen",
-    "contentHash": "34250e0e106f0577d82e6786ac4eeda5e63c3d8eb7dbe9470641cd99fab336b3",
+    "contentHash": "d22793ff54f47c55645c5c67c96fc780eeb63f5b8a8c07dce03348183a319936",
     "isActive": true
   },
   {
-    "problemId": "act-act-quadratic-equations-cc12b30c0c",
+    "problemId": "act-act-quadratic-equations-aec16618dd",
     "skillId": "act-quadratic-equations",
-    "prompt": "Which of the following is a solution to x² - 11x + 30 = 0?",
+    "prompt": "Which of the following is a solution to x² - 9x + 20 = 0?",
     "answer": {
       "type": "auto",
-      "value": "6",
+      "value": "5",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "11"
+        "text": "20"
       },
       {
         "label": "B",
-        "text": "6"
+        "text": "5"
       },
       {
         "label": "C",
-        "text": "30"
+        "text": "9"
       },
       {
         "label": "D",
-        "text": "-6"
+        "text": "-4"
       },
       {
         "label": "E",
@@ -4717,7 +4542,7 @@
       }
     ],
     "correctOption": "B",
-    "difficulty": 4,
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -4725,7 +4550,7 @@
       "act-quadratic-equations"
     ],
     "source": "act-template-gen",
-    "contentHash": "cc12b30c0cff1d2d7afdb77e48f20d9667aec5f1e4fdcadf34f1612bcfa9d820",
+    "contentHash": "aec16618dd9cc77c91fdb52de98d5fd1c38b8a8d74d632f75fc91e0ade3883df",
     "isActive": true
   },
   {
@@ -4741,27 +4566,27 @@
     "options": [
       {
         "label": "A",
-        "text": "-6"
-      },
-      {
-        "label": "B",
-        "text": "6"
-      },
-      {
-        "label": "C",
         "text": "9"
       },
       {
+        "label": "B",
+        "text": "-6"
+      },
+      {
+        "label": "C",
+        "text": "18"
+      },
+      {
         "label": "D",
-        "text": "-3"
+        "text": "6"
       },
       {
         "label": "E",
-        "text": "18"
+        "text": "-3"
       }
     ],
-    "correctOption": "B",
-    "difficulty": 4,
+    "correctOption": "D",
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -4773,38 +4598,214 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-quadratic-equations-0dbb9fc166",
+    "problemId": "act-act-quadratic-equations-f2a6d29739",
     "skillId": "act-quadratic-equations",
-    "prompt": "Which of the following is a solution to x² + 11x + 30 = 0?",
+    "prompt": "Which of the following is a solution to x² - 4x - 12 = 0?",
     "answer": {
       "type": "auto",
-      "value": "-5",
+      "value": "6",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "30"
+        "text": "-6"
       },
       {
         "label": "B",
-        "text": "-11"
-      },
-      {
-        "label": "C",
         "text": "6"
       },
       {
+        "label": "C",
+        "text": "2"
+      },
+      {
         "label": "D",
-        "text": "-5"
+        "text": "4"
       },
       {
         "label": "E",
-        "text": "5"
+        "text": "-12"
       }
     ],
-    "correctOption": "D",
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "f2a6d297397d630c03e54aa506b1dce8ca9fba8e7369c4cdafea180105fb96b9",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-equations-e4ce4fb629",
+    "skillId": "act-quadratic-equations",
+    "prompt": "Which of the following is a solution to x² + 8x + 15 = 0?",
+    "answer": {
+      "type": "auto",
+      "value": "-3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-8"
+      },
+      {
+        "label": "B",
+        "text": "-3"
+      },
+      {
+        "label": "C",
+        "text": "15"
+      },
+      {
+        "label": "D",
+        "text": "5"
+      },
+      {
+        "label": "E",
+        "text": "3"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "e4ce4fb6299de2369493613af28f1a69852536222c20fa39fa6db7ba43bef107",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-equations-9e53448a50",
+    "skillId": "act-quadratic-equations",
+    "prompt": "Which of the following is a solution to x² - 2x - 24 = 0?",
+    "answer": {
+      "type": "auto",
+      "value": "6",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-6"
+      },
+      {
+        "label": "B",
+        "text": "6"
+      },
+      {
+        "label": "C",
+        "text": "2"
+      },
+      {
+        "label": "D",
+        "text": "-24"
+      },
+      {
+        "label": "E",
+        "text": "4"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "9e53448a50a2938ebb46b458696e436c8818e90640262f7f8b733051f5f9fccb",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-equations-2a64810808",
+    "skillId": "act-quadratic-equations",
+    "prompt": "Which of the following is a solution to x² + 4x - 12 = 0?",
+    "answer": {
+      "type": "auto",
+      "value": "2",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-12"
+      },
+      {
+        "label": "B",
+        "text": "6"
+      },
+      {
+        "label": "C",
+        "text": "-2"
+      },
+      {
+        "label": "D",
+        "text": "-4"
+      },
+      {
+        "label": "E",
+        "text": "2"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "2a64810808234e25d531af1f6c2faa05b5cd55ae9354f92babac299570e9d717",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-equations-b41aa18819",
+    "skillId": "act-quadratic-equations",
+    "prompt": "Which of the following is a solution to x² + 5x - 6 = 0?",
+    "answer": {
+      "type": "auto",
+      "value": "1",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-5"
+      },
+      {
+        "label": "B",
+        "text": "-1"
+      },
+      {
+        "label": "C",
+        "text": "-6"
+      },
+      {
+        "label": "D",
+        "text": "6"
+      },
+      {
+        "label": "E",
+        "text": "1"
+      }
+    ],
+    "correctOption": "E",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -4813,7 +4814,139 @@
       "act-quadratic-equations"
     ],
     "source": "act-template-gen",
-    "contentHash": "0dbb9fc166c52a2a26360c55d7a56b766f8f3571046ea6aba07164e99bcaf9ea",
+    "contentHash": "b41aa188193b2efc5959d163f58a960fef4288395fd6287f0a8c17867820b9b0",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polynomial-expressions-c4a479504c",
+    "skillId": "act-polynomial-expressions",
+    "prompt": "Expand: (x - 6)(x - 5)",
+    "answer": {
+      "type": "auto",
+      "value": "x^2 - 11x + 30",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "x^2 - 11x - 30"
+      },
+      {
+        "label": "B",
+        "text": "x^2 - 11x + 30"
+      },
+      {
+        "label": "C",
+        "text": "x^2 + 11x + 30"
+      },
+      {
+        "label": "D",
+        "text": "x^2 + 11x - 30"
+      },
+      {
+        "label": "E",
+        "text": "x^2 + 30x - 11"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polynomial-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "c4a479504c7bd03ec58ec6d0577e3e88afd1ff5fc8bc2f0033ffb53719af6a84",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polynomial-expressions-099ea9924a",
+    "skillId": "act-polynomial-expressions",
+    "prompt": "Expand: (x - 5)(x + 1)",
+    "answer": {
+      "type": "auto",
+      "value": "x^2 - 4x - 5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "x^2 - 4x + 5"
+      },
+      {
+        "label": "B",
+        "text": "x^2 + 4x - 5"
+      },
+      {
+        "label": "C",
+        "text": "x^2 + 4x + 5"
+      },
+      {
+        "label": "D",
+        "text": "x^2 - 5x - 4"
+      },
+      {
+        "label": "E",
+        "text": "x^2 - 4x - 5"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polynomial-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "099ea9924a453b5ed7d3a92c9e875be2fcc878e4b84aaf80d17dddd12d126073",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polynomial-expressions-cbcce886de",
+    "skillId": "act-polynomial-expressions",
+    "prompt": "Expand: (x - 5)(x + 3)",
+    "answer": {
+      "type": "auto",
+      "value": "x^2 - 2x - 15",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "x^2 - 2x - 15"
+      },
+      {
+        "label": "B",
+        "text": "x^2 + 2x - 15"
+      },
+      {
+        "label": "C",
+        "text": "x^2 - 15x - 2"
+      },
+      {
+        "label": "D",
+        "text": "x^2 + 2x + 15"
+      },
+      {
+        "label": "E",
+        "text": "x^2 - 2x + 15"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polynomial-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "cbcce886de7fe5d30ba32a7b9f8666628c593003fb7c801054307c686ae1a56c",
     "isActive": true
   },
   {
@@ -4829,155 +4962,23 @@
     "options": [
       {
         "label": "A",
-        "text": "x^2 + 4"
+        "text": "x^2 + 4x - 3"
       },
       {
         "label": "B",
-        "text": "x^2 - 4"
+        "text": "x^2 - 4x - 3"
       },
       {
         "label": "C",
-        "text": "x^2 + 3x - 4"
-      },
-      {
-        "label": "D",
         "text": "x^2 - 4x + 3"
       },
       {
-        "label": "E",
-        "text": "x^2 - 4x - 3"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-polynomial-expressions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "c5e5a238f9c0b5e7cc84a890363cdf721cc809350e6aff963f0ccf9112ce1b33",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-polynomial-expressions-321446d37d",
-    "skillId": "act-polynomial-expressions",
-    "prompt": "Expand: (x + 2)(x - 6)",
-    "answer": {
-      "type": "auto",
-      "value": "x^2 - 4x - 12",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "x^2 - 12x - 4"
-      },
-      {
-        "label": "B",
-        "text": "x^2 - 4x + 12"
-      },
-      {
-        "label": "C",
-        "text": "x^2 - 4"
-      },
-      {
         "label": "D",
-        "text": "x^2 - 11"
+        "text": "x^2 + 4x + 3"
       },
       {
         "label": "E",
-        "text": "x^2 - 4x - 12"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-polynomial-expressions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "321446d37d8f560e5ee58a2147c7bacc08c279ce9523846e708d0a80eda1438f",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-polynomial-expressions-7737d9b6ad",
-    "skillId": "act-polynomial-expressions",
-    "prompt": "Expand: (x - 4)(x + 3)",
-    "answer": {
-      "type": "auto",
-      "value": "x^2 - 1x - 12",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "x^2 - 1x + 12"
-      },
-      {
-        "label": "B",
-        "text": "x^2 - 11"
-      },
-      {
-        "label": "C",
-        "text": "x^2 - 12x - 1"
-      },
-      {
-        "label": "D",
-        "text": "x^2 - 1x - 12"
-      },
-      {
-        "label": "E",
-        "text": "x^2 - 1"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-polynomial-expressions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "7737d9b6ad68428c42bd279d03cf2a676dfa300c25970b40de5b5e2ebe933bb8",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-polynomial-expressions-db1c7c22f1",
-    "skillId": "act-polynomial-expressions",
-    "prompt": "Expand: (x - 4)(x - 4)",
-    "answer": {
-      "type": "auto",
-      "value": "x^2 - 8x + 16",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "x^2 - 8"
-      },
-      {
-        "label": "B",
-        "text": "x^2 + 17"
-      },
-      {
-        "label": "C",
-        "text": "x^2 - 8x + 16"
-      },
-      {
-        "label": "D",
-        "text": "x^2 + 16x - 8"
-      },
-      {
-        "label": "E",
-        "text": "x^2 - 8x - 16"
+        "text": "x^2 + 3x - 4"
       }
     ],
     "correctOption": "C",
@@ -4989,42 +4990,42 @@
       "act-polynomial-expressions"
     ],
     "source": "act-template-gen",
-    "contentHash": "db1c7c22f1a0110762b14d4822bcd60774d8e816ab00e0179669eed6c1e5cb21",
+    "contentHash": "c5e5a238f9c0b5e7cc84a890363cdf721cc809350e6aff963f0ccf9112ce1b33",
     "isActive": true
   },
   {
-    "problemId": "act-act-polynomial-expressions-c76ba9dc0f",
+    "problemId": "act-act-polynomial-expressions-98a0e00eda",
     "skillId": "act-polynomial-expressions",
-    "prompt": "Expand: (x - 1)(x + 4)",
+    "prompt": "Expand: (x - 2)(x + 4)",
     "answer": {
       "type": "auto",
-      "value": "x^2 + 3x - 4",
+      "value": "x^2 + 2x - 8",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "x^2 + 3x - 4"
+        "text": "x^2 + 2x + 8"
       },
       {
         "label": "B",
-        "text": "x^2 + 3"
+        "text": "x^2 + 2x - 8"
       },
       {
         "label": "C",
-        "text": "x^2 - 3"
+        "text": "x^2 - 8x + 2"
       },
       {
         "label": "D",
-        "text": "x^2 + 3x + 4"
+        "text": "x^2 - 2x + 8"
       },
       {
         "label": "E",
-        "text": "x^2 - 4x + 3"
+        "text": "x^2 - 2x - 8"
       }
     ],
-    "correctOption": "A",
+    "correctOption": "B",
     "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
@@ -5033,42 +5034,42 @@
       "act-polynomial-expressions"
     ],
     "source": "act-template-gen",
-    "contentHash": "c76ba9dc0f7c6223fa698fa29110b09df2737752486713ec8296b70767314bf8",
+    "contentHash": "98a0e00eda44886d5c186c5c5ecbf11bf7755e9f3837eda1e682fdc776b6cecf",
     "isActive": true
   },
   {
-    "problemId": "act-act-polynomial-expressions-f04538c081",
+    "problemId": "act-act-polynomial-expressions-2f90f7315a",
     "skillId": "act-polynomial-expressions",
-    "prompt": "Expand: (x - 1)(x + 3)",
+    "prompt": "Expand: (x - 4)(x + 6)",
     "answer": {
       "type": "auto",
-      "value": "x^2 + 2x - 3",
+      "value": "x^2 + 2x - 24",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "x^2 + 2x - 3"
+        "text": "x^2 - 2x + 24"
       },
       {
         "label": "B",
-        "text": "x^2 - 3x + 2"
+        "text": "x^2 - 2x - 24"
       },
       {
         "label": "C",
-        "text": "x^2 + 2"
+        "text": "x^2 + 2x + 24"
       },
       {
         "label": "D",
-        "text": "x^2 - 2"
+        "text": "x^2 - 24x + 2"
       },
       {
         "label": "E",
-        "text": "x^2 + 2x + 3"
+        "text": "x^2 + 2x - 24"
       }
     ],
-    "correctOption": "A",
+    "correctOption": "E",
     "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
@@ -5077,42 +5078,42 @@
       "act-polynomial-expressions"
     ],
     "source": "act-template-gen",
-    "contentHash": "f04538c0816e28aa6876349f6d8e1a5bbfff31038564c2fd423bbaa037acd4ef",
+    "contentHash": "2f90f7315a7829a94450c81ac69a07665cf0aa2383b787a5e07c73ba24d5cb98",
     "isActive": true
   },
   {
-    "problemId": "act-act-polynomial-expressions-3cc5275086",
+    "problemId": "act-act-polynomial-expressions-4cfa8d6b5f",
     "skillId": "act-polynomial-expressions",
-    "prompt": "Expand: (x - 3)(x + 6)",
+    "prompt": "Expand: (x - 1)(x - 1)",
     "answer": {
       "type": "auto",
-      "value": "x^2 + 3x - 18",
+      "value": "x^2 - 2x + 1",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "x^2 + 3"
+        "text": "x^2 + 2x - 1"
       },
       {
         "label": "B",
-        "text": "x^2 + 3x - 18"
+        "text": "x^2 - 2x - 1"
       },
       {
         "label": "C",
-        "text": "x^2 + 3x + 18"
+        "text": "x^2 + x - 2"
       },
       {
         "label": "D",
-        "text": "x^2 - 17"
+        "text": "x^2 - 2x + 1"
       },
       {
         "label": "E",
-        "text": "x^2 - 18x + 3"
+        "text": "x^2 + 2x + 1"
       }
     ],
-    "correctOption": "B",
+    "correctOption": "D",
     "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
@@ -5121,42 +5122,42 @@
       "act-polynomial-expressions"
     ],
     "source": "act-template-gen",
-    "contentHash": "3cc527508616f6df9ccc75efc87fc30e91e68d05bd6a07bbeec6101808c1ee42",
+    "contentHash": "4cfa8d6b5fa40a155753649daeccc17345911078505fb624f7d877c6f918511c",
     "isActive": true
   },
   {
-    "problemId": "act-act-polynomial-expressions-91481e1c01",
+    "problemId": "act-act-polynomial-expressions-e462f3324f",
     "skillId": "act-polynomial-expressions",
-    "prompt": "Expand: (x - 4)(x - 2)",
+    "prompt": "Expand: (x - 3)(x - 4)",
     "answer": {
       "type": "auto",
-      "value": "x^2 - 6x + 8",
+      "value": "x^2 - 7x + 12",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "x^2 - 6x + 8"
+        "text": "x^2 - 7x - 12"
       },
       {
         "label": "B",
-        "text": "x^2 + 9"
+        "text": "x^2 + 12x - 7"
       },
       {
         "label": "C",
-        "text": "x^2 - 6x - 8"
+        "text": "x^2 + 7x + 12"
       },
       {
         "label": "D",
-        "text": "x^2 + 8x - 6"
+        "text": "x^2 + 7x - 12"
       },
       {
         "label": "E",
-        "text": "x^2 - 6"
+        "text": "x^2 - 7x + 12"
       }
     ],
-    "correctOption": "A",
+    "correctOption": "E",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -5165,39 +5166,39 @@
       "act-polynomial-expressions"
     ],
     "source": "act-template-gen",
-    "contentHash": "91481e1c012eb4966b2ccf210b25316c73a74610410feb17d7ecc41c9866d352",
+    "contentHash": "e462f3324fcac75ff6c9f9a984cea3aee070137bd840dd2188a7aadc5d4d8d0c",
     "isActive": true
   },
   {
-    "problemId": "act-act-radical-rational-expressions-dc4ef895c9",
+    "problemId": "act-act-radical-rational-expressions-8eb9d160c9",
     "skillId": "act-radical-rational-expressions",
-    "prompt": "Simplify: √63",
+    "prompt": "Simplify: √125",
     "answer": {
       "type": "auto",
-      "value": "3√7",
+      "value": "5√5",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "3√7"
+        "text": "5√5"
       },
       {
         "label": "B",
-        "text": "63"
+        "text": "5√10"
       },
       {
         "label": "C",
-        "text": "10√7"
+        "text": "125"
       },
       {
         "label": "D",
-        "text": "21√1"
+        "text": "25√1"
       },
       {
         "label": "E",
-        "text": "3√14"
+        "text": "10√5"
       }
     ],
     "correctOption": "A",
@@ -5209,7 +5210,183 @@
       "act-radical-rational-expressions"
     ],
     "source": "act-template-gen",
-    "contentHash": "dc4ef895c934f7012ea411359754f180121d4f6c3b197603ebbdc16f0431e5a8",
+    "contentHash": "8eb9d160c9074c0a1091db0a435ea5d0ee0f2e4a3525957fc03ce1036abfe968",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-radical-rational-expressions-8c792c7c79",
+    "skillId": "act-radical-rational-expressions",
+    "prompt": "Simplify: √112",
+    "answer": {
+      "type": "auto",
+      "value": "4√7",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "11√7"
+      },
+      {
+        "label": "B",
+        "text": "112"
+      },
+      {
+        "label": "C",
+        "text": "4√14"
+      },
+      {
+        "label": "D",
+        "text": "4√7"
+      },
+      {
+        "label": "E",
+        "text": "28√1"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-radical-rational-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "8c792c7c796a27fa385d45723fb379f880295dc03d9ae9dd6f9d2540b69fb564",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-radical-rational-expressions-59679bbf9d",
+    "skillId": "act-radical-rational-expressions",
+    "prompt": "Simplify: √45",
+    "answer": {
+      "type": "auto",
+      "value": "3√5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "3√10"
+      },
+      {
+        "label": "B",
+        "text": "8√5"
+      },
+      {
+        "label": "C",
+        "text": "3√5"
+      },
+      {
+        "label": "D",
+        "text": "15√1"
+      },
+      {
+        "label": "E",
+        "text": "45"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-radical-rational-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "59679bbf9d4b4b1a5f0d80d70391d110bde0c99a1740e98a3edf37fd8b551412",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-radical-rational-expressions-63cc21f580",
+    "skillId": "act-radical-rational-expressions",
+    "prompt": "Simplify: √75",
+    "answer": {
+      "type": "auto",
+      "value": "5√3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "15√1"
+      },
+      {
+        "label": "B",
+        "text": "75"
+      },
+      {
+        "label": "C",
+        "text": "8√3"
+      },
+      {
+        "label": "D",
+        "text": "5√6"
+      },
+      {
+        "label": "E",
+        "text": "5√3"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-radical-rational-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "63cc21f5805c334e62df23ae862b0d1b95233de588e3b6713c09b0c6f23257a9",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-radical-rational-expressions-281e03dcfa",
+    "skillId": "act-radical-rational-expressions",
+    "prompt": "Simplify: √18",
+    "answer": {
+      "type": "auto",
+      "value": "3√2",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "3√4"
+      },
+      {
+        "label": "B",
+        "text": "18"
+      },
+      {
+        "label": "C",
+        "text": "3√2"
+      },
+      {
+        "label": "D",
+        "text": "6√1"
+      },
+      {
+        "label": "E",
+        "text": "5√2"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-radical-rational-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "281e03dcfa2fb4a02dd89ad955b4bdf726c6e292396548637609c3f1e2de62ac",
     "isActive": true
   },
   {
@@ -5229,7 +5406,7 @@
       },
       {
         "label": "B",
-        "text": "8√1"
+        "text": "4√2"
       },
       {
         "label": "C",
@@ -5241,11 +5418,11 @@
       },
       {
         "label": "E",
-        "text": "4√2"
+        "text": "8√1"
       }
     ],
-    "correctOption": "E",
-    "difficulty": 2,
+    "correctOption": "B",
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -5254,226 +5431,6 @@
     ],
     "source": "act-template-gen",
     "contentHash": "dfde70e8123d295ef4efc090b89fff569c1f1c4c6099e42d8332e0cc538fcaa1",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-radical-rational-expressions-87927c8c7c",
-    "skillId": "act-radical-rational-expressions",
-    "prompt": "Simplify: √24",
-    "answer": {
-      "type": "auto",
-      "value": "2√6",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "24"
-      },
-      {
-        "label": "B",
-        "text": "8√6"
-      },
-      {
-        "label": "C",
-        "text": "2√6"
-      },
-      {
-        "label": "D",
-        "text": "2√12"
-      },
-      {
-        "label": "E",
-        "text": "12√1"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-radical-rational-expressions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "87927c8c7c975a367e3c302ab07f98b7d09be369ec56860b3dc45b2acc5d6777",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-radical-rational-expressions-bc45d35737",
-    "skillId": "act-radical-rational-expressions",
-    "prompt": "Simplify: √12",
-    "answer": {
-      "type": "auto",
-      "value": "2√3",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "5√3"
-      },
-      {
-        "label": "B",
-        "text": "2√3"
-      },
-      {
-        "label": "C",
-        "text": "2√6"
-      },
-      {
-        "label": "D",
-        "text": "6√1"
-      },
-      {
-        "label": "E",
-        "text": "12"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-radical-rational-expressions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "bc45d35737a4267130a69ba8fc315fde8f510f2e0ca2e327bf4e6501a0a8b41f",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-radical-rational-expressions-3b5367f4ab",
-    "skillId": "act-radical-rational-expressions",
-    "prompt": "Simplify: √48",
-    "answer": {
-      "type": "auto",
-      "value": "4√3",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "12√1"
-      },
-      {
-        "label": "B",
-        "text": "4√6"
-      },
-      {
-        "label": "C",
-        "text": "48"
-      },
-      {
-        "label": "D",
-        "text": "4√3"
-      },
-      {
-        "label": "E",
-        "text": "7√3"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-radical-rational-expressions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "3b5367f4ab67f79bee8495d64431f977467658f2df076e0d668acf5b040a7245",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-radical-rational-expressions-8eb9d160c9",
-    "skillId": "act-radical-rational-expressions",
-    "prompt": "Simplify: √125",
-    "answer": {
-      "type": "auto",
-      "value": "5√5",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "5√10"
-      },
-      {
-        "label": "B",
-        "text": "25√1"
-      },
-      {
-        "label": "C",
-        "text": "5√5"
-      },
-      {
-        "label": "D",
-        "text": "125"
-      },
-      {
-        "label": "E",
-        "text": "10√5"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-radical-rational-expressions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "8eb9d160c9074c0a1091db0a435ea5d0ee0f2e4a3525957fc03ce1036abfe968",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-radical-rational-expressions-94c1f4b75c",
-    "skillId": "act-radical-rational-expressions",
-    "prompt": "Simplify: √96",
-    "answer": {
-      "type": "auto",
-      "value": "4√6",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "4√12"
-      },
-      {
-        "label": "B",
-        "text": "4√6"
-      },
-      {
-        "label": "C",
-        "text": "24√1"
-      },
-      {
-        "label": "D",
-        "text": "10√6"
-      },
-      {
-        "label": "E",
-        "text": "96"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-radical-rational-expressions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "94c1f4b75ca657721c28e674a6802d12093698881a34bcbc6477db54ce9a7287",
     "isActive": true
   },
   {
@@ -5493,23 +5450,23 @@
       },
       {
         "label": "B",
-        "text": "7√2"
+        "text": "50"
       },
       {
         "label": "C",
-        "text": "5√2"
-      },
-      {
-        "label": "D",
         "text": "5√4"
       },
       {
+        "label": "D",
+        "text": "7√2"
+      },
+      {
         "label": "E",
-        "text": "50"
+        "text": "5√2"
       }
     ],
-    "correctOption": "C",
-    "difficulty": 5,
+    "correctOption": "E",
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -5521,214 +5478,170 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-function-notation-evaluation-2aa842d1f0",
-    "skillId": "act-function-notation-evaluation",
-    "prompt": "If f(x) = -2x² - 1, what is f(3)?",
+    "problemId": "act-act-radical-rational-expressions-ac1c0e81df",
+    "skillId": "act-radical-rational-expressions",
+    "prompt": "Simplify: √245",
     "answer": {
       "type": "auto",
-      "value": "-19",
+      "value": "7√5",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "-16"
+        "text": "12√5"
       },
       {
         "label": "B",
-        "text": "35"
+        "text": "35√1"
       },
       {
         "label": "C",
-        "text": "-17"
+        "text": "7√10"
       },
       {
         "label": "D",
-        "text": "-7"
+        "text": "7√5"
       },
       {
         "label": "E",
-        "text": "-19"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-function-notation-evaluation"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "2aa842d1f028f75f6837c17f9f9ca8912aeed4c24bc8c69d6bade5b72980145d",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-function-notation-evaluation-4f426cd1db",
-    "skillId": "act-function-notation-evaluation",
-    "prompt": "If f(x) = 3x² + 3, what is f(4)?",
-    "answer": {
-      "type": "auto",
-      "value": "51",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "15"
-      },
-      {
-        "label": "B",
-        "text": "57"
-      },
-      {
-        "label": "C",
-        "text": "51"
-      },
-      {
-        "label": "D",
-        "text": "147"
-      },
-      {
-        "label": "E",
-        "text": "45"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-function-notation-evaluation"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "4f426cd1dbbc12f944302dded7d07ef229a43764f3e1a152bd0ce6e97159d45a",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-function-notation-evaluation-aedc4ffe25",
-    "skillId": "act-function-notation-evaluation",
-    "prompt": "If f(x) = -2x² - 2, what is f(-4)?",
-    "answer": {
-      "type": "auto",
-      "value": "-34",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "-28"
-      },
-      {
-        "label": "B",
-        "text": "-30"
-      },
-      {
-        "label": "C",
-        "text": "6"
-      },
-      {
-        "label": "D",
-        "text": "-34"
-      },
-      {
-        "label": "E",
-        "text": "62"
+        "text": "245"
       }
     ],
     "correctOption": "D",
-    "difficulty": 3,
+    "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-function-notation-evaluation"
+      "act-radical-rational-expressions"
     ],
     "source": "act-template-gen",
-    "contentHash": "aedc4ffe2503e52474b8f85262099bd2a46a0276a3b117d996ca5cd3cdee5942",
+    "contentHash": "ac1c0e81df0db4577f4765a2d8b64da2fcf3041f0bb6f4de47a9d4281b7c49ef",
     "isActive": true
   },
   {
-    "problemId": "act-act-function-notation-evaluation-11f2babc51",
+    "problemId": "act-act-function-notation-evaluation-54b946284b",
     "skillId": "act-function-notation-evaluation",
-    "prompt": "If f(x) = -2x² + 6, what is f(-4)?",
+    "prompt": "If f(x) = -4x² + 5, what is f(-2)?",
     "answer": {
       "type": "auto",
-      "value": "-26",
+      "value": "-11",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "-44"
+        "text": "69"
       },
       {
         "label": "B",
-        "text": "-26"
+        "text": "-21"
       },
       {
         "label": "C",
-        "text": "70"
+        "text": "-36"
       },
       {
         "label": "D",
-        "text": "-38"
-      },
-      {
-        "label": "E",
-        "text": "14"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-function-notation-evaluation"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "11f2babc5132ba278a6c20a992eb1424a7c5679925e5f7860270f32c9111b981",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-function-notation-evaluation-9783314b62",
-    "skillId": "act-function-notation-evaluation",
-    "prompt": "If f(x) = -3x² - 1, what is f(-2)?",
-    "answer": {
-      "type": "auto",
-      "value": "-13",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "35"
-      },
-      {
-        "label": "B",
         "text": "-11"
       },
       {
-        "label": "C",
-        "text": "-9"
-      },
-      {
-        "label": "D",
-        "text": "-13"
-      },
-      {
         "label": "E",
-        "text": "5"
+        "text": "13"
       }
     ],
     "correctOption": "D",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-notation-evaluation"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "54b946284b25909de45b8857622156198539a5f7b483bf26bf7e05948d06bf8f",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-notation-evaluation-2f567b8505",
+    "skillId": "act-function-notation-evaluation",
+    "prompt": "If f(x) = -2x² - 1, what is f(-1)?",
+    "answer": {
+      "type": "auto",
+      "value": "-3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "1"
+      },
+      {
+        "label": "B",
+        "text": "-3"
+      },
+      {
+        "label": "C",
+        "text": "0"
+      },
+      {
+        "label": "D",
+        "text": "-1"
+      },
+      {
+        "label": "E",
+        "text": "3"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-notation-evaluation"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "2f567b8505e5ecb0a9356a3bae51d4c7e0a4ed7a372eb03c03f3711c1a62a0eb",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-notation-evaluation-ac47e21843",
+    "skillId": "act-function-notation-evaluation",
+    "prompt": "If f(x) = -4x² + 6, what is f(-2)?",
+    "answer": {
+      "type": "auto",
+      "value": "-10",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-40"
+      },
+      {
+        "label": "B",
+        "text": "14"
+      },
+      {
+        "label": "C",
+        "text": "-22"
+      },
+      {
+        "label": "D",
+        "text": "70"
+      },
+      {
+        "label": "E",
+        "text": "-10"
+      }
+    ],
+    "correctOption": "E",
     "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
@@ -5737,23 +5650,111 @@
       "act-function-notation-evaluation"
     ],
     "source": "act-template-gen",
-    "contentHash": "9783314b62289ce6ccbe9fe5ab2778f6cf59db4a01b44b2463e8678b2afd6d86",
+    "contentHash": "ac47e21843d51d2df4a23bf3b68ed2caa19db1c44ba32f1118b0785a17fca26e",
     "isActive": true
   },
   {
-    "problemId": "act-act-function-notation-evaluation-4389ba46f7",
+    "problemId": "act-act-function-notation-evaluation-2382c871ba",
     "skillId": "act-function-notation-evaluation",
-    "prompt": "If f(x) = 3x² + 2, what is f(-1)?",
+    "prompt": "If f(x) = 3x² - 1, what is f(4)?",
     "answer": {
       "type": "auto",
-      "value": "5",
+      "value": "47",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "5"
+        "text": "45"
+      },
+      {
+        "label": "B",
+        "text": "11"
+      },
+      {
+        "label": "C",
+        "text": "47"
+      },
+      {
+        "label": "D",
+        "text": "49"
+      },
+      {
+        "label": "E",
+        "text": "143"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-notation-evaluation"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "2382c871ba57d46fa93963bc57c115225dac9c28e96b9a7c53da351b3b08e278",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-notation-evaluation-409626c66a",
+    "skillId": "act-function-notation-evaluation",
+    "prompt": "If f(x) = 3x² + 6, what is f(-1)?",
+    "answer": {
+      "type": "auto",
+      "value": "9",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-3"
+      },
+      {
+        "label": "B",
+        "text": "15"
+      },
+      {
+        "label": "C",
+        "text": "3"
+      },
+      {
+        "label": "D",
+        "text": "21"
+      },
+      {
+        "label": "E",
+        "text": "9"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-notation-evaluation"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "409626c66a7d2eec5bb86696d99b05cc69e2d7b1938b8094505359e529e9f999",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-notation-evaluation-0757e74715",
+    "skillId": "act-function-notation-evaluation",
+    "prompt": "If f(x) = 5x² - 6, what is f(-1)?",
+    "answer": {
+      "type": "auto",
+      "value": "-1",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-11"
       },
       {
         "label": "B",
@@ -5761,103 +5762,103 @@
       },
       {
         "label": "C",
+        "text": "-25"
+      },
+      {
+        "label": "D",
+        "text": "19"
+      },
+      {
+        "label": "E",
         "text": "11"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-notation-evaluation"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "0757e74715bac21745e0667ce1677ff7fe22c485b1a27e74237766092e943e14",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-notation-evaluation-c6bf3aa45d",
+    "skillId": "act-function-notation-evaluation",
+    "prompt": "If f(x) = 3x² + 4, what is f(3)?",
+    "answer": {
+      "type": "auto",
+      "value": "31",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "13"
+      },
+      {
+        "label": "B",
+        "text": "23"
+      },
+      {
+        "label": "C",
+        "text": "85"
       },
       {
         "label": "D",
-        "text": "9"
+        "text": "31"
       },
       {
         "label": "E",
+        "text": "39"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-notation-evaluation"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "c6bf3aa45d09ba5b871e8dbc62696ca4bc6cb30274fb624ff33722286fbb72fe",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-notation-evaluation-511498f3e3",
+    "skillId": "act-function-notation-evaluation",
+    "prompt": "If f(x) = -3x² - 5, what is f(-2)?",
+    "answer": {
+      "type": "auto",
+      "value": "-17",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
         "text": "1"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-function-notation-evaluation"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "4389ba46f77c5e24c8cbe9bdfe390abf7bdb5ab99df44c146bfa2aded22da06a",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-function-notation-evaluation-96b4a131e5",
-    "skillId": "act-function-notation-evaluation",
-    "prompt": "If f(x) = 3x² - 1, what is f(-1)?",
-    "answer": {
-      "type": "auto",
-      "value": "2",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "4"
       },
       {
         "label": "B",
-        "text": "0"
+        "text": "-17"
       },
       {
         "label": "C",
-        "text": "2"
+        "text": "31"
       },
       {
         "label": "D",
-        "text": "-4"
+        "text": "3"
       },
       {
         "label": "E",
-        "text": "8"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-function-notation-evaluation"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "96b4a131e5f02607cabd59e788b9e1e34e1f7469ff5bef12368572f206cba5b5",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-function-notation-evaluation-94f40d87e7",
-    "skillId": "act-function-notation-evaluation",
-    "prompt": "If f(x) = -2x² + 2, what is f(-3)?",
-    "answer": {
-      "type": "auto",
-      "value": "-16",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "-22"
-      },
-      {
-        "label": "B",
-        "text": "-16"
-      },
-      {
-        "label": "C",
-        "text": "8"
-      },
-      {
-        "label": "D",
-        "text": "38"
-      },
-      {
-        "label": "E",
-        "text": "-20"
+        "text": "-7"
       }
     ],
     "correctOption": "B",
@@ -5869,42 +5870,42 @@
       "act-function-notation-evaluation"
     ],
     "source": "act-template-gen",
-    "contentHash": "94f40d87e7c06e6b4861044f8ba29776da7969130dd16139529825a09bcc4c7d",
+    "contentHash": "511498f3e3619e96b540a5adb92f6bd176396575c071a23b7d399f6900884fc5",
     "isActive": true
   },
   {
-    "problemId": "act-act-linear-functions-2c6f37db42",
+    "problemId": "act-act-linear-functions-3dd4f68c3f",
     "skillId": "act-linear-functions",
-    "prompt": "What is the slope of the line through (-3, -1) and (-1, -6)?",
+    "prompt": "What is the slope of the line through (-4, -3) and (3, 5)?",
     "answer": {
       "type": "auto",
-      "value": "-5/2",
+      "value": "8/7",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "2"
+        "text": "8"
       },
       {
         "label": "B",
-        "text": "2/-5"
+        "text": "8/7"
       },
       {
         "label": "C",
-        "text": "2.5"
+        "text": "7"
       },
       {
         "label": "D",
-        "text": "-5/2"
+        "text": "-1.1428571428571428"
       },
       {
         "label": "E",
-        "text": "-5"
+        "text": "7/8"
       }
     ],
-    "correctOption": "D",
+    "correctOption": "B",
     "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
@@ -5913,67 +5914,23 @@
       "act-linear-functions"
     ],
     "source": "act-template-gen",
-    "contentHash": "2c6f37db4245c9c665ebfedc4c82cd10ad7490fec70031d8a39df100cc4a801e",
+    "contentHash": "3dd4f68c3fb1500699221366a921c4766b5d126d6b3ff3a70769a5c95ddd2086",
     "isActive": true
   },
   {
-    "problemId": "act-act-linear-functions-34f1b45ca4",
+    "problemId": "act-act-linear-functions-046ec9f8c4",
     "skillId": "act-linear-functions",
-    "prompt": "What is the slope of the line through (-3, 4) and (0, 6)?",
+    "prompt": "What is the slope of the line through (-1, 2) and (5, -1)?",
     "answer": {
       "type": "auto",
-      "value": "2/3",
+      "value": "-1/2",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "2"
-      },
-      {
-        "label": "B",
-        "text": "-0.6666666666666666"
-      },
-      {
-        "label": "C",
-        "text": "3/2"
-      },
-      {
-        "label": "D",
-        "text": "3"
-      },
-      {
-        "label": "E",
-        "text": "2/3"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-linear-functions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "34f1b45ca4ab59a5bd048ad0567f10c0b6a34ae358359df4f56ebbb0f2c30028",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-linear-functions-44cc32d2ca",
-    "skillId": "act-linear-functions",
-    "prompt": "What is the slope of the line through (4, -4) and (-3, -6)?",
-    "answer": {
-      "type": "auto",
-      "value": "-2/-7",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "-2/-7"
+        "text": "6"
       },
       {
         "label": "B",
@@ -5981,19 +5938,19 @@
       },
       {
         "label": "C",
-        "text": "-7"
+        "text": "-3"
       },
       {
         "label": "D",
-        "text": "-0.2857142857142857"
+        "text": "0.5"
       },
       {
         "label": "E",
-        "text": "-7/-2"
+        "text": "-1/2"
       }
     ],
-    "correctOption": "A",
-    "difficulty": 3,
+    "correctOption": "E",
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -6001,39 +5958,39 @@
       "act-linear-functions"
     ],
     "source": "act-template-gen",
-    "contentHash": "44cc32d2cab44b708aa84c2b06c54d89ca5b44ba94d617c08b96d56c020be46b",
+    "contentHash": "046ec9f8c496f31181bfb4d7fdd842eaad986843d3eee30380721794bcde8fc7",
     "isActive": true
   },
   {
-    "problemId": "act-act-linear-functions-165366d07c",
+    "problemId": "act-act-linear-functions-d2d5439f75",
     "skillId": "act-linear-functions",
-    "prompt": "What is the slope of the line through (5, 6) and (1, -4)?",
+    "prompt": "What is the slope of the line through (5, -6) and (0, 5)?",
     "answer": {
       "type": "auto",
-      "value": "-5/-2",
+      "value": "11/-5",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "-2/-5"
+        "text": "-5/11"
       },
       {
         "label": "B",
-        "text": "-10"
+        "text": "2.2"
       },
       {
         "label": "C",
-        "text": "-2.5"
+        "text": "-5"
       },
       {
         "label": "D",
-        "text": "-4"
+        "text": "11"
       },
       {
         "label": "E",
-        "text": "-5/-2"
+        "text": "11/-5"
       }
     ],
     "correctOption": "E",
@@ -6045,39 +6002,39 @@
       "act-linear-functions"
     ],
     "source": "act-template-gen",
-    "contentHash": "165366d07cc02abcb73656d1231d8aea08158e51b116aee816a0e7f1b0928186",
+    "contentHash": "d2d5439f75d5420a212a863bbdcf239c97dd9d7f7bc38e96505592e8317da018",
     "isActive": true
   },
   {
-    "problemId": "act-act-linear-functions-d26d94a560",
+    "problemId": "act-act-linear-functions-44e9d1a7a0",
     "skillId": "act-linear-functions",
-    "prompt": "What is the slope of the line through (-3, 2) and (3, 4)?",
+    "prompt": "What is the slope of the line through (-3, 3) and (1, -5)?",
     "answer": {
       "type": "auto",
-      "value": "1/3",
+      "value": "-2",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "1/3"
+        "text": "-2"
       },
       {
         "label": "B",
-        "text": "3"
+        "text": "-8"
       },
       {
         "label": "C",
-        "text": "-0.3333333333333333"
+        "text": "4"
       },
       {
         "label": "D",
-        "text": "6"
+        "text": "2"
       },
       {
         "label": "E",
-        "text": "2"
+        "text": "1/-2"
       }
     ],
     "correctOption": "A",
@@ -6089,39 +6046,83 @@
       "act-linear-functions"
     ],
     "source": "act-template-gen",
-    "contentHash": "d26d94a560f0d718b3d8dd7e32963021da66ffa6e00f22c46ce3a75f1e18ad29",
+    "contentHash": "44e9d1a7a0be03fbea0dbd6dbaa2872f2936e57338ec3ae41646777cb9ac2530",
     "isActive": true
   },
   {
-    "problemId": "act-act-linear-functions-778281e087",
+    "problemId": "act-act-linear-functions-66f499e50b",
     "skillId": "act-linear-functions",
-    "prompt": "What is the slope of the line through (-4, 3) and (2, 6)?",
+    "prompt": "What is the slope of the line through (-3, 4) and (4, 2)?",
     "answer": {
       "type": "auto",
-      "value": "1/2",
+      "value": "-2/7",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "6"
+        "text": "-2"
       },
       {
         "label": "B",
-        "text": "-0.5"
+        "text": "-2/7"
       },
       {
         "label": "C",
-        "text": "3"
+        "text": "7/-2"
       },
       {
         "label": "D",
-        "text": "1/2"
+        "text": "7"
       },
       {
         "label": "E",
+        "text": "0.2857142857142857"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "66f499e50b695c45c4d90492d29df60e2a1a62c23f2edbed48af014300834a07",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-functions-7c5ffd5577",
+    "skillId": "act-linear-functions",
+    "prompt": "What is the slope of the line through (-3, -1) and (-1, 4)?",
+    "answer": {
+      "type": "auto",
+      "value": "5/2",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
         "text": "2"
+      },
+      {
+        "label": "B",
+        "text": "2/5"
+      },
+      {
+        "label": "C",
+        "text": "-2.5"
+      },
+      {
+        "label": "D",
+        "text": "5/2"
+      },
+      {
+        "label": "E",
+        "text": "5"
       }
     ],
     "correctOption": "D",
@@ -6133,42 +6134,42 @@
       "act-linear-functions"
     ],
     "source": "act-template-gen",
-    "contentHash": "778281e0872cfe67f1d801a51595f5756e9ee2b544c2fff29192b32bb45e4dc3",
+    "contentHash": "7c5ffd55775847e2b15a64d11dfe0b9ce11c506024ce1034423581ca8129f36e",
     "isActive": true
   },
   {
-    "problemId": "act-act-linear-functions-c1f77355c5",
+    "problemId": "act-act-linear-functions-57207cfcaf",
     "skillId": "act-linear-functions",
-    "prompt": "What is the slope of the line through (-2, 0) and (1, 4)?",
+    "prompt": "What is the slope of the line through (1, 2) and (-5, -2)?",
     "answer": {
       "type": "auto",
-      "value": "4/3",
+      "value": "-2/-3",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "4/3"
+        "text": "-4"
       },
       {
         "label": "B",
-        "text": "3/4"
+        "text": "-2/-3"
       },
       {
         "label": "C",
-        "text": "3"
+        "text": "-6"
       },
       {
         "label": "D",
-        "text": "-1.3333333333333333"
+        "text": "-0.6666666666666666"
       },
       {
         "label": "E",
-        "text": "4"
+        "text": "-3/-2"
       }
     ],
-    "correctOption": "A",
+    "correctOption": "B",
     "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
@@ -6177,31 +6178,31 @@
       "act-linear-functions"
     ],
     "source": "act-template-gen",
-    "contentHash": "c1f77355c5dbf524d0e85fafe7dc8b3e1a8f943392cae40ee40ce4b57d697d2c",
+    "contentHash": "57207cfcaf4fdca0d2c632e1f1ceb59f36136126c3e2b5a70fb587cd8e9c2c17",
     "isActive": true
   },
   {
-    "problemId": "act-act-linear-functions-c0b0a4403a",
+    "problemId": "act-act-linear-functions-6a6812fff1",
     "skillId": "act-linear-functions",
-    "prompt": "What is the slope of the line through (1, -6) and (5, -1)?",
+    "prompt": "What is the slope of the line through (-4, 3) and (1, 0)?",
     "answer": {
       "type": "auto",
-      "value": "5/4",
+      "value": "-3/5",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "4"
+        "text": "5/-3"
       },
       {
         "label": "B",
-        "text": "5/4"
+        "text": "0.6"
       },
       {
         "label": "C",
-        "text": "-1.25"
+        "text": "-3/5"
       },
       {
         "label": "D",
@@ -6209,10 +6210,10 @@
       },
       {
         "label": "E",
-        "text": "4/5"
+        "text": "-3"
       }
     ],
-    "correctOption": "B",
+    "correctOption": "C",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -6221,39 +6222,39 @@
       "act-linear-functions"
     ],
     "source": "act-template-gen",
-    "contentHash": "c0b0a4403a4bd5259f54ce2ee398e117efd8e1c0e8247f8972d57fe5e36e959e",
+    "contentHash": "6a6812fff1f360a78cf0d384c96a02980ee40b0cb7c8a8c3aa94d1250cc6e7f2",
     "isActive": true
   },
   {
-    "problemId": "act-act-quadratic-functions-41f74f98b2",
+    "problemId": "act-act-quadratic-functions-0a06ffdb92",
     "skillId": "act-quadratic-functions",
-    "prompt": "What is the vertex of the parabola y = 1(x + 2)² + 5?",
+    "prompt": "What is the vertex of the parabola y = 2(x + 4)² + 5?",
     "answer": {
       "type": "auto",
-      "value": "(-2, 5)",
+      "value": "(-4, 5)",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "(-2, -5)"
+        "text": "(4, -5)"
       },
       {
         "label": "B",
-        "text": "(2, 5)"
+        "text": "(-4, -5)"
       },
       {
         "label": "C",
-        "text": "(5, -2)"
+        "text": "(5, -4)"
       },
       {
         "label": "D",
-        "text": "(-2, 5)"
+        "text": "(-4, 5)"
       },
       {
         "label": "E",
-        "text": "(2, -5)"
+        "text": "(4, 5)"
       }
     ],
     "correctOption": "D",
@@ -6265,31 +6266,75 @@
       "act-quadratic-functions"
     ],
     "source": "act-template-gen",
-    "contentHash": "41f74f98b2e3516108b2dbf746126ba6c3c180c9817454b2be5db1f41894cac3",
+    "contentHash": "0a06ffdb927bddf87bc087c05a3d282cd4acef7a533e1c60c8e74f7042d6fd06",
     "isActive": true
   },
   {
-    "problemId": "act-act-quadratic-functions-35fc35f88f",
+    "problemId": "act-act-quadratic-functions-46a6a478e7",
     "skillId": "act-quadratic-functions",
-    "prompt": "What is the vertex of the parabola y = 1(x - 3)² - 2?",
+    "prompt": "What is the vertex of the parabola y = 1(x - 4)² + 5?",
     "answer": {
       "type": "auto",
-      "value": "(3, -2)",
+      "value": "(4, 5)",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "(3, 2)"
+        "text": "(-4, -5)"
       },
       {
         "label": "B",
-        "text": "(3, -2)"
+        "text": "(5, 4)"
       },
       {
         "label": "C",
-        "text": "(-3, 2)"
+        "text": "(4, -5)"
+      },
+      {
+        "label": "D",
+        "text": "(4, 5)"
+      },
+      {
+        "label": "E",
+        "text": "(-4, 5)"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "46a6a478e7b0563dae7ba0bf97c3874c4e1a4c1af0c60c22bb6fa5793bb24fc4",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-functions-460f58c8aa",
+    "skillId": "act-quadratic-functions",
+    "prompt": "What is the vertex of the parabola y = 2(x + 2)² - 3?",
+    "answer": {
+      "type": "auto",
+      "value": "(-2, -3)",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "(2, 3)"
+      },
+      {
+        "label": "B",
+        "text": "(-2, -3)"
+      },
+      {
+        "label": "C",
+        "text": "(-3, -2)"
       },
       {
         "label": "D",
@@ -6297,54 +6342,10 @@
       },
       {
         "label": "E",
-        "text": "(-3, -2)"
+        "text": "(2, -3)"
       }
     ],
     "correctOption": "B",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-quadratic-functions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "35fc35f88f8b6970288bb4ee028e6ba7256d047be005eeb88f1681c04576a14a",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-quadratic-functions-c744d428be",
-    "skillId": "act-quadratic-functions",
-    "prompt": "What is the vertex of the parabola y = 1(x + 2)² + 6?",
-    "answer": {
-      "type": "auto",
-      "value": "(-2, 6)",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "(2, -6)"
-      },
-      {
-        "label": "B",
-        "text": "(2, 6)"
-      },
-      {
-        "label": "C",
-        "text": "(-2, -6)"
-      },
-      {
-        "label": "D",
-        "text": "(-2, 6)"
-      },
-      {
-        "label": "E",
-        "text": "(6, -2)"
-      }
-    ],
-    "correctOption": "D",
     "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
@@ -6353,83 +6354,39 @@
       "act-quadratic-functions"
     ],
     "source": "act-template-gen",
-    "contentHash": "c744d428be4f4db2f273a35009f8ef1d61bbe39eab05f2cf0c6e78f577915726",
+    "contentHash": "460f58c8aa166f444ce900f21ba27fa0da0df8f150430c85b6bf1c655b43355c",
     "isActive": true
   },
   {
-    "problemId": "act-act-quadratic-functions-fbd665509e",
+    "problemId": "act-act-quadratic-functions-01b121854f",
     "skillId": "act-quadratic-functions",
-    "prompt": "What is the vertex of the parabola y = 2(x - 4)² - 6?",
+    "prompt": "What is the vertex of the parabola y = 1(x + 2)² + 4?",
     "answer": {
       "type": "auto",
-      "value": "(4, -6)",
+      "value": "(-2, 4)",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "(-4, 6)"
+        "text": "(-2, -4)"
       },
       {
         "label": "B",
-        "text": "(4, 6)"
+        "text": "(2, -4)"
       },
       {
         "label": "C",
-        "text": "(-4, -6)"
+        "text": "(4, -2)"
       },
       {
         "label": "D",
-        "text": "(4, -6)"
+        "text": "(2, 4)"
       },
       {
         "label": "E",
-        "text": "(-6, 4)"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-quadratic-functions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "fbd665509e56a65ce259cf9a0f2c794c82487f4cdbafb93f753ad90f010cbb47",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-quadratic-functions-06de2ba4f1",
-    "skillId": "act-quadratic-functions",
-    "prompt": "What is the vertex of the parabola y = 1(x + 3)² - 6?",
-    "answer": {
-      "type": "auto",
-      "value": "(-3, -6)",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "(-3, 6)"
-      },
-      {
-        "label": "B",
-        "text": "(3, -6)"
-      },
-      {
-        "label": "C",
-        "text": "(-6, -3)"
-      },
-      {
-        "label": "D",
-        "text": "(3, 6)"
-      },
-      {
-        "label": "E",
-        "text": "(-3, -6)"
+        "text": "(-2, 4)"
       }
     ],
     "correctOption": "E",
@@ -6441,7 +6398,7 @@
       "act-quadratic-functions"
     ],
     "source": "act-template-gen",
-    "contentHash": "06de2ba4f1cb97aa12985a47f2a62251b2f26622a13344e3a25259e1614b9c1e",
+    "contentHash": "01b121854ff6389776d39223715c6ca95781df8a4b7e8cfa378cf1de68307943",
     "isActive": true
   },
   {
@@ -6457,27 +6414,27 @@
     "options": [
       {
         "label": "A",
-        "text": "(-4, -3)"
-      },
-      {
-        "label": "B",
-        "text": "(-3, -4)"
-      },
-      {
-        "label": "C",
         "text": "(3, 4)"
       },
       {
-        "label": "D",
+        "label": "B",
         "text": "(-3, 4)"
       },
       {
-        "label": "E",
+        "label": "C",
         "text": "(3, -4)"
+      },
+      {
+        "label": "D",
+        "text": "(-4, -3)"
+      },
+      {
+        "label": "E",
+        "text": "(-3, -4)"
       }
     ],
-    "correctOption": "B",
-    "difficulty": 4,
+    "correctOption": "E",
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -6489,35 +6446,79 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-quadratic-functions-9c106efa00",
+    "problemId": "act-act-quadratic-functions-4cac7d519b",
     "skillId": "act-quadratic-functions",
-    "prompt": "What is the vertex of the parabola y = 2(x + 1)² - 3?",
+    "prompt": "What is the vertex of the parabola y = 1(x - 4)² + 6?",
     "answer": {
       "type": "auto",
-      "value": "(-1, -3)",
+      "value": "(4, 6)",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "(-1, -3)"
+        "text": "(4, -6)"
       },
       {
         "label": "B",
-        "text": "(-1, 3)"
+        "text": "(-4, -6)"
       },
       {
         "label": "C",
-        "text": "(1, -3)"
+        "text": "(4, 6)"
       },
       {
         "label": "D",
-        "text": "(1, 3)"
+        "text": "(-4, 6)"
       },
       {
         "label": "E",
-        "text": "(-3, -1)"
+        "text": "(6, 4)"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "4cac7d519b2e43e0566996ef84eefe41db5d71da4195cce01903bd23d0ac82b3",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-functions-53481e435e",
+    "skillId": "act-quadratic-functions",
+    "prompt": "What is the vertex of the parabola y = 2(x - 3)² + 5?",
+    "answer": {
+      "type": "auto",
+      "value": "(3, 5)",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "(3, 5)"
+      },
+      {
+        "label": "B",
+        "text": "(5, 3)"
+      },
+      {
+        "label": "C",
+        "text": "(3, -5)"
+      },
+      {
+        "label": "D",
+        "text": "(-3, -5)"
+      },
+      {
+        "label": "E",
+        "text": "(-3, 5)"
       }
     ],
     "correctOption": "A",
@@ -6529,42 +6530,42 @@
       "act-quadratic-functions"
     ],
     "source": "act-template-gen",
-    "contentHash": "9c106efa004500af0336c9d801a645f66ba1c38e3dee508419bc89f926abb6d4",
+    "contentHash": "53481e435e7551993c8662366112df2c240357ea0381d17c1711a0e0cf10c467",
     "isActive": true
   },
   {
-    "problemId": "act-act-quadratic-functions-818f30f47e",
+    "problemId": "act-act-quadratic-functions-aa3d8d5991",
     "skillId": "act-quadratic-functions",
-    "prompt": "What is the vertex of the parabola y = 3(x + 1)² - 6?",
+    "prompt": "What is the vertex of the parabola y = 2(x + 2)² - 5?",
     "answer": {
       "type": "auto",
-      "value": "(-1, -6)",
+      "value": "(-2, -5)",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "(-1, -6)"
+        "text": "(2, 5)"
       },
       {
         "label": "B",
-        "text": "(-1, 6)"
+        "text": "(-2, 5)"
       },
       {
         "label": "C",
-        "text": "(1, 6)"
+        "text": "(-5, -2)"
       },
       {
         "label": "D",
-        "text": "(-6, -1)"
+        "text": "(2, -5)"
       },
       {
         "label": "E",
-        "text": "(1, -6)"
+        "text": "(-2, -5)"
       }
     ],
-    "correctOption": "A",
+    "correctOption": "E",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -6573,7 +6574,7 @@
       "act-quadratic-functions"
     ],
     "source": "act-template-gen",
-    "contentHash": "818f30f47e489fa2d701f442533852c1597dfb3576a42e6c4dee04e8c97df7ba",
+    "contentHash": "aa3d8d5991161256778e77681ee05a9641ffe62b3b74cc1584e692c4048fe5b1",
     "isActive": true
   },
   {
@@ -6589,11 +6590,11 @@
     "options": [
       {
         "label": "A",
-        "text": "3125"
+        "text": "6"
       },
       {
         "label": "B",
-        "text": "6"
+        "text": "5"
       },
       {
         "label": "C",
@@ -6601,14 +6602,14 @@
       },
       {
         "label": "D",
-        "text": "5"
+        "text": "3125"
       },
       {
         "label": "E",
         "text": "25"
       }
     ],
-    "correctOption": "D",
+    "correctOption": "B",
     "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
@@ -6621,23 +6622,23 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-polynomial-exponential-log-3b910f180a",
+    "problemId": "act-act-polynomial-exponential-log-31fe16250a",
     "skillId": "act-polynomial-exponential-log",
-    "prompt": "What is log₍5₎(125)?",
+    "prompt": "What is log₍5₎(25)?",
     "answer": {
       "type": "auto",
-      "value": "3",
+      "value": "2",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "125"
+        "text": "5"
       },
       {
         "label": "B",
-        "text": "25"
+        "text": "2"
       },
       {
         "label": "C",
@@ -6645,14 +6646,14 @@
       },
       {
         "label": "D",
-        "text": "4"
+        "text": "10"
       },
       {
         "label": "E",
-        "text": "15"
+        "text": "25"
       }
     ],
-    "correctOption": "C",
+    "correctOption": "B",
     "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
@@ -6661,51 +6662,7 @@
       "act-polynomial-exponential-log"
     ],
     "source": "act-template-gen",
-    "contentHash": "3b910f180a8c3368e60d260702d752a2e00e645d03951421fb50a9dc0041fd52",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-polynomial-exponential-log-016b61dd6d",
-    "skillId": "act-polynomial-exponential-log",
-    "prompt": "What is log₍3₎(243)?",
-    "answer": {
-      "type": "auto",
-      "value": "5",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "81"
-      },
-      {
-        "label": "B",
-        "text": "6"
-      },
-      {
-        "label": "C",
-        "text": "15"
-      },
-      {
-        "label": "D",
-        "text": "243"
-      },
-      {
-        "label": "E",
-        "text": "5"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-polynomial-exponential-log"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "016b61dd6d9671b97b7419bf8318fd0e23f02d349ec9d969cef81cd98b15f706",
+    "contentHash": "31fe16250a926a8bc94fb1b3f859ba9e06f9382cf58bcdbaebb98a3bd18a8451",
     "isActive": true
   },
   {
@@ -6725,22 +6682,22 @@
       },
       {
         "label": "B",
-        "text": "3125"
+        "text": "15625"
       },
       {
         "label": "C",
-        "text": "6"
+        "text": "3125"
       },
       {
         "label": "D",
-        "text": "15625"
+        "text": "6"
       },
       {
         "label": "E",
         "text": "30"
       }
     ],
-    "correctOption": "C",
+    "correctOption": "D",
     "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
@@ -6753,9 +6710,97 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-polynomial-exponential-log-4acdea0ccb",
+    "problemId": "act-act-polynomial-exponential-log-3b910f180a",
     "skillId": "act-polynomial-exponential-log",
-    "prompt": "What is log₍3₎(81)?",
+    "prompt": "What is log₍5₎(125)?",
+    "answer": {
+      "type": "auto",
+      "value": "3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "25"
+      },
+      {
+        "label": "B",
+        "text": "125"
+      },
+      {
+        "label": "C",
+        "text": "4"
+      },
+      {
+        "label": "D",
+        "text": "3"
+      },
+      {
+        "label": "E",
+        "text": "15"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polynomial-exponential-log"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "3b910f180a8c3368e60d260702d752a2e00e645d03951421fb50a9dc0041fd52",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polynomial-exponential-log-49753e98e1",
+    "skillId": "act-polynomial-exponential-log",
+    "prompt": "What is log₍2₎(32)?",
+    "answer": {
+      "type": "auto",
+      "value": "5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "16"
+      },
+      {
+        "label": "B",
+        "text": "32"
+      },
+      {
+        "label": "C",
+        "text": "6"
+      },
+      {
+        "label": "D",
+        "text": "5"
+      },
+      {
+        "label": "E",
+        "text": "10"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polynomial-exponential-log"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "49753e98e193a14047a7c0dd63189c1009568e5c9c0a7ac0a3c4af70e1e76e7d",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polynomial-exponential-log-f0bbe30ff9",
+    "skillId": "act-polynomial-exponential-log",
+    "prompt": "What is log₍5₎(625)?",
     "answer": {
       "type": "auto",
       "value": "4",
@@ -6765,67 +6810,23 @@
     "options": [
       {
         "label": "A",
-        "text": "27"
+        "text": "125"
       },
       {
         "label": "B",
+        "text": "20"
+      },
+      {
+        "label": "C",
+        "text": "625"
+      },
+      {
+        "label": "D",
         "text": "4"
       },
       {
-        "label": "C",
-        "text": "5"
-      },
-      {
-        "label": "D",
-        "text": "81"
-      },
-      {
         "label": "E",
-        "text": "12"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-polynomial-exponential-log"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "4acdea0ccb84cfda8dd8d3cc05a06952a38c56150eefb18e1e7f7bec02373696",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-polynomial-exponential-log-31fe16250a",
-    "skillId": "act-polynomial-exponential-log",
-    "prompt": "What is log₍5₎(25)?",
-    "answer": {
-      "type": "auto",
-      "value": "2",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "3"
-      },
-      {
-        "label": "B",
         "text": "5"
-      },
-      {
-        "label": "C",
-        "text": "25"
-      },
-      {
-        "label": "D",
-        "text": "2"
-      },
-      {
-        "label": "E",
-        "text": "10"
       }
     ],
     "correctOption": "D",
@@ -6837,7 +6838,7 @@
       "act-polynomial-exponential-log"
     ],
     "source": "act-template-gen",
-    "contentHash": "31fe16250a926a8bc94fb1b3f859ba9e06f9382cf58bcdbaebb98a3bd18a8451",
+    "contentHash": "f0bbe30ff9e0e21e07a4a500defe788c8446aaaa43cf94f7e40f50dcec1d0354",
     "isActive": true
   },
   {
@@ -6853,7 +6854,7 @@
     "options": [
       {
         "label": "A",
-        "text": "243"
+        "text": "6"
       },
       {
         "label": "B",
@@ -6861,18 +6862,18 @@
       },
       {
         "label": "C",
-        "text": "18"
-      },
-      {
-        "label": "D",
         "text": "7"
       },
       {
+        "label": "D",
+        "text": "243"
+      },
+      {
         "label": "E",
-        "text": "6"
+        "text": "18"
       }
     ],
-    "correctOption": "E",
+    "correctOption": "A",
     "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
@@ -6885,12 +6886,12 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-polynomial-exponential-log-83cf5fdc4d",
+    "problemId": "act-act-polynomial-exponential-log-6edace870a",
     "skillId": "act-polynomial-exponential-log",
-    "prompt": "What is log₍2₎(256)?",
+    "prompt": "What is log₍3₎(2187)?",
     "answer": {
       "type": "auto",
-      "value": "8",
+      "value": "7",
       "equivalents": []
     },
     "answerType": "multiple-choice",
@@ -6901,22 +6902,22 @@
       },
       {
         "label": "B",
-        "text": "128"
+        "text": "2187"
       },
       {
         "label": "C",
-        "text": "256"
+        "text": "729"
       },
       {
         "label": "D",
-        "text": "16"
+        "text": "21"
       },
       {
         "label": "E",
-        "text": "9"
+        "text": "7"
       }
     ],
-    "correctOption": "A",
+    "correctOption": "E",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -6925,271 +6926,7 @@
       "act-polynomial-exponential-log"
     ],
     "source": "act-template-gen",
-    "contentHash": "83cf5fdc4d9febe190c692e07359c3de814b2e8ce136761d03bf5961493afec1",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-trig-functions-adcd7b2911",
-    "skillId": "act-trig-functions",
-    "prompt": "What is tan(30°)?",
-    "answer": {
-      "type": "auto",
-      "value": "√3/3",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "√2/2"
-      },
-      {
-        "label": "B",
-        "text": "√3/2"
-      },
-      {
-        "label": "C",
-        "text": "1/2"
-      },
-      {
-        "label": "D",
-        "text": "√3"
-      },
-      {
-        "label": "E",
-        "text": "√3/3"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-trig-functions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "adcd7b2911af744aec9371797981708e2058f7a68125f248f18241fa9b64656b",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-trig-functions-15e6b1dbed",
-    "skillId": "act-trig-functions",
-    "prompt": "What is tan(60°)?",
-    "answer": {
-      "type": "auto",
-      "value": "√3",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "√2/2"
-      },
-      {
-        "label": "B",
-        "text": "√3/2"
-      },
-      {
-        "label": "C",
-        "text": "√3"
-      },
-      {
-        "label": "D",
-        "text": "1"
-      },
-      {
-        "label": "E",
-        "text": "1/2"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-trig-functions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "15e6b1dbed27797708d26210d1b013a6efc39364c0c8216375656466147db1ca",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-trig-functions-8a998270b0",
-    "skillId": "act-trig-functions",
-    "prompt": "What is cos(45°)?",
-    "answer": {
-      "type": "auto",
-      "value": "√2/2",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "1"
-      },
-      {
-        "label": "B",
-        "text": "√3"
-      },
-      {
-        "label": "C",
-        "text": "√2/2"
-      },
-      {
-        "label": "D",
-        "text": "√3/2"
-      },
-      {
-        "label": "E",
-        "text": "1/2"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-trig-functions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "8a998270b0eebed240b38c07a9dca5ad517f975637e1e414afc732f9260a5be1",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-trig-functions-186797f58c",
-    "skillId": "act-trig-functions",
-    "prompt": "What is tan(45°)?",
-    "answer": {
-      "type": "auto",
-      "value": "1",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "1"
-      },
-      {
-        "label": "B",
-        "text": "√3/2"
-      },
-      {
-        "label": "C",
-        "text": "√2/2"
-      },
-      {
-        "label": "D",
-        "text": "√3"
-      },
-      {
-        "label": "E",
-        "text": "1/2"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-trig-functions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "186797f58caabf9593718504109738fe59e629bb6a325b9f85d333d9f732f838",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-trig-functions-874129888f",
-    "skillId": "act-trig-functions",
-    "prompt": "What is sin(45°)?",
-    "answer": {
-      "type": "auto",
-      "value": "√2/2",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "1/2"
-      },
-      {
-        "label": "B",
-        "text": "1"
-      },
-      {
-        "label": "C",
-        "text": "√2/2"
-      },
-      {
-        "label": "D",
-        "text": "√3/2"
-      },
-      {
-        "label": "E",
-        "text": "√3"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-trig-functions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "874129888fd008ee0ac20ca921cd40611e2843600230a8c0aca89f5caafe313f",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-trig-functions-a4d749b7f8",
-    "skillId": "act-trig-functions",
-    "prompt": "What is cos(60°)?",
-    "answer": {
-      "type": "auto",
-      "value": "1/2",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "√2/2"
-      },
-      {
-        "label": "B",
-        "text": "1"
-      },
-      {
-        "label": "C",
-        "text": "√3"
-      },
-      {
-        "label": "D",
-        "text": "1/2"
-      },
-      {
-        "label": "E",
-        "text": "√3/2"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-trig-functions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "a4d749b7f8778e28cadb1cc37de49152c930a0eb4bb3830723c8feac5d6bd5e2",
+    "contentHash": "6edace870a3797d208899f852dacb3b82dc091a0330e4583d56eece2cf9af897",
     "isActive": true
   },
   {
@@ -7213,19 +6950,19 @@
       },
       {
         "label": "C",
-        "text": "√3"
+        "text": "1/2"
       },
       {
         "label": "D",
-        "text": "√3/2"
+        "text": "√3"
       },
       {
         "label": "E",
-        "text": "1/2"
+        "text": "√3/2"
       }
     ],
-    "correctOption": "E",
-    "difficulty": 4,
+    "correctOption": "C",
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -7234,6 +6971,182 @@
     ],
     "source": "act-template-gen",
     "contentHash": "2da5063d6ef4b9451626bae425d96535ce3e9a08928806508b600c57bf8133e1",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-trig-functions-12c71b8208",
+    "skillId": "act-trig-functions",
+    "prompt": "What is cos(30°)?",
+    "answer": {
+      "type": "auto",
+      "value": "√3/2",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "√2/2"
+      },
+      {
+        "label": "B",
+        "text": "√3/2"
+      },
+      {
+        "label": "C",
+        "text": "√3"
+      },
+      {
+        "label": "D",
+        "text": "1/2"
+      },
+      {
+        "label": "E",
+        "text": "1"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-trig-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "12c71b8208ffe6c9ff98c1cb3c38c19a54847bc279acf23eaa2dabb7c2838efa",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-trig-functions-186797f58c",
+    "skillId": "act-trig-functions",
+    "prompt": "What is tan(45°)?",
+    "answer": {
+      "type": "auto",
+      "value": "1",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "√2/2"
+      },
+      {
+        "label": "B",
+        "text": "1"
+      },
+      {
+        "label": "C",
+        "text": "1/2"
+      },
+      {
+        "label": "D",
+        "text": "√3"
+      },
+      {
+        "label": "E",
+        "text": "√3/2"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-trig-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "186797f58caabf9593718504109738fe59e629bb6a325b9f85d333d9f732f838",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-trig-functions-a4d749b7f8",
+    "skillId": "act-trig-functions",
+    "prompt": "What is cos(60°)?",
+    "answer": {
+      "type": "auto",
+      "value": "1/2",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "√3"
+      },
+      {
+        "label": "B",
+        "text": "1"
+      },
+      {
+        "label": "C",
+        "text": "√3/2"
+      },
+      {
+        "label": "D",
+        "text": "1/2"
+      },
+      {
+        "label": "E",
+        "text": "√2/2"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-trig-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "a4d749b7f8778e28cadb1cc37de49152c930a0eb4bb3830723c8feac5d6bd5e2",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-trig-functions-874129888f",
+    "skillId": "act-trig-functions",
+    "prompt": "What is sin(45°)?",
+    "answer": {
+      "type": "auto",
+      "value": "√2/2",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "√3"
+      },
+      {
+        "label": "B",
+        "text": "1"
+      },
+      {
+        "label": "C",
+        "text": "√3/2"
+      },
+      {
+        "label": "D",
+        "text": "1/2"
+      },
+      {
+        "label": "E",
+        "text": "√2/2"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-trig-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "874129888fd008ee0ac20ca921cd40611e2843600230a8c0aca89f5caafe313f",
     "isActive": true
   },
   {
@@ -7249,7 +7162,7 @@
     "options": [
       {
         "label": "A",
-        "text": "1/2"
+        "text": "√3"
       },
       {
         "label": "B",
@@ -7261,15 +7174,15 @@
       },
       {
         "label": "D",
-        "text": "√3/2"
+        "text": "1/2"
       },
       {
         "label": "E",
-        "text": "√3"
+        "text": "√3/2"
       }
     ],
-    "correctOption": "D",
-    "difficulty": 5,
+    "correctOption": "E",
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -7281,12 +7194,408 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-function-transformations-1d58f5b4a0",
-    "skillId": "act-function-transformations",
-    "prompt": "If f(x) = -3x - 4 and g(x) = f(x − 4) + 2, what is g(-3)?",
+    "problemId": "act-act-trig-functions-15e6b1dbed",
+    "skillId": "act-trig-functions",
+    "prompt": "What is tan(60°)?",
     "answer": {
       "type": "auto",
-      "value": "19",
+      "value": "√3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "1"
+      },
+      {
+        "label": "B",
+        "text": "√3/2"
+      },
+      {
+        "label": "C",
+        "text": "√3"
+      },
+      {
+        "label": "D",
+        "text": "√2/2"
+      },
+      {
+        "label": "E",
+        "text": "1/2"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-trig-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "15e6b1dbed27797708d26210d1b013a6efc39364c0c8216375656466147db1ca",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-trig-functions-8a998270b0",
+    "skillId": "act-trig-functions",
+    "prompt": "What is cos(45°)?",
+    "answer": {
+      "type": "auto",
+      "value": "√2/2",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "1/2"
+      },
+      {
+        "label": "B",
+        "text": "√2/2"
+      },
+      {
+        "label": "C",
+        "text": "√3/2"
+      },
+      {
+        "label": "D",
+        "text": "1"
+      },
+      {
+        "label": "E",
+        "text": "√3"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-trig-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "8a998270b0eebed240b38c07a9dca5ad517f975637e1e414afc732f9260a5be1",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-transformations-67d16e7dad",
+    "skillId": "act-function-transformations",
+    "prompt": "If f(x) = 1x + 6 and g(x) = f(x − 2) + 6, what is g(2)?",
+    "answer": {
+      "type": "auto",
+      "value": "12",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "12"
+      },
+      {
+        "label": "B",
+        "text": "16"
+      },
+      {
+        "label": "C",
+        "text": "14"
+      },
+      {
+        "label": "D",
+        "text": "8"
+      },
+      {
+        "label": "E",
+        "text": "0"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-transformations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "67d16e7dad3f830db7b9878e273161f841e6ee0ef1e20f9d2f69282e6584512a",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-transformations-81f7f22095",
+    "skillId": "act-function-transformations",
+    "prompt": "If f(x) = 1x - 3 and g(x) = f(x − 4) + 1, what is g(1)?",
+    "answer": {
+      "type": "auto",
+      "value": "-5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "3"
+      },
+      {
+        "label": "B",
+        "text": "-7"
+      },
+      {
+        "label": "C",
+        "text": "-2"
+      },
+      {
+        "label": "D",
+        "text": "-5"
+      },
+      {
+        "label": "E",
+        "text": "-1"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-transformations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "81f7f22095c1fe75f7954acfa6c45a105bc6a68eead8fe1f167c096fe957493e",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-transformations-f98788c5af",
+    "skillId": "act-function-transformations",
+    "prompt": "If f(x) = -2x + 4 and g(x) = f(x − 1) + 5, what is g(-1)?",
+    "answer": {
+      "type": "auto",
+      "value": "13",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "13"
+      },
+      {
+        "label": "B",
+        "text": "6"
+      },
+      {
+        "label": "C",
+        "text": "9"
+      },
+      {
+        "label": "D",
+        "text": "3"
+      },
+      {
+        "label": "E",
+        "text": "11"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-transformations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "f98788c5af492555d0958a2fa8b712fc43b1539a2febe75efc607e8092589643",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-transformations-3677372ff3",
+    "skillId": "act-function-transformations",
+    "prompt": "If f(x) = 2x - 6 and g(x) = f(x − 2) + 6, what is g(-3)?",
+    "answer": {
+      "type": "auto",
+      "value": "-10",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-10"
+      },
+      {
+        "label": "B",
+        "text": "-2"
+      },
+      {
+        "label": "C",
+        "text": "-22"
+      },
+      {
+        "label": "D",
+        "text": "-6"
+      },
+      {
+        "label": "E",
+        "text": "-12"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-transformations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "3677372ff3dd77261e14667e0d69e170cb3afacc98fa877ee5aa3bbf381d105f",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-transformations-3fac91d69a",
+    "skillId": "act-function-transformations",
+    "prompt": "If f(x) = 4x - 4 and g(x) = f(x − 4) + 2, what is g(-1)?",
+    "answer": {
+      "type": "auto",
+      "value": "-22",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-26"
+      },
+      {
+        "label": "B",
+        "text": "-6"
+      },
+      {
+        "label": "C",
+        "text": "-8"
+      },
+      {
+        "label": "D",
+        "text": "10"
+      },
+      {
+        "label": "E",
+        "text": "-22"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-transformations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "3fac91d69a68718d3b515252ef5431193739111452e9f4353645398127edfb22",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-transformations-3b89f3a01a",
+    "skillId": "act-function-transformations",
+    "prompt": "If f(x) = -1x - 4 and g(x) = f(x − 4) + 3, what is g(2)?",
+    "answer": {
+      "type": "auto",
+      "value": "1",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-5"
+      },
+      {
+        "label": "B",
+        "text": "-6"
+      },
+      {
+        "label": "C",
+        "text": "-3"
+      },
+      {
+        "label": "D",
+        "text": "-7"
+      },
+      {
+        "label": "E",
+        "text": "1"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-transformations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "3b89f3a01a6bfe413c7c25397106f7e8cda4596d673a597383ef62d7b1e83848",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-transformations-cca90190d4",
+    "skillId": "act-function-transformations",
+    "prompt": "If f(x) = -1x + 3 and g(x) = f(x − 4) + 5, what is g(-1)?",
+    "answer": {
+      "type": "auto",
+      "value": "13",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "4"
+      },
+      {
+        "label": "B",
+        "text": "13"
+      },
+      {
+        "label": "C",
+        "text": "5"
+      },
+      {
+        "label": "D",
+        "text": "9"
+      },
+      {
+        "label": "E",
+        "text": "3"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-transformations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "cca90190d40f016d29623e00f76d726f2db9e2e6da715065b0f9b8f1d100d0c9",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-transformations-c56d8f1b6c",
+    "skillId": "act-function-transformations",
+    "prompt": "If f(x) = 1x - 2 and g(x) = f(x − 1) + 6, what is g(2)?",
+    "answer": {
+      "type": "auto",
+      "value": "5",
       "equivalents": []
     },
     "answerType": "multiple-choice",
@@ -7297,327 +7606,19 @@
       },
       {
         "label": "B",
+        "text": "6"
+      },
+      {
+        "label": "C",
         "text": "5"
       },
       {
-        "label": "C",
-        "text": "15"
-      },
-      {
         "label": "D",
-        "text": "-5"
+        "text": "-7"
       },
       {
         "label": "E",
-        "text": "19"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-function-transformations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "1d58f5b4a014164a18813435ae3405a6b869d2d847faffa54ac66906f280e814",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-function-transformations-fece4a2f20",
-    "skillId": "act-function-transformations",
-    "prompt": "If f(x) = 1x - 4 and g(x) = f(x − 2) + 1, what is g(-1)?",
-    "answer": {
-      "type": "auto",
-      "value": "-6",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "-8"
-      },
-      {
-        "label": "B",
-        "text": "-4"
-      },
-      {
-        "label": "C",
-        "text": "-2"
-      },
-      {
-        "label": "D",
-        "text": "-6"
-      },
-      {
-        "label": "E",
-        "text": "-5"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-function-transformations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "fece4a2f20aa6cfe8891b083a038d4c07f95b8a5270ab397163b765e9221d5e1",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-function-transformations-8f84a298f4",
-    "skillId": "act-function-transformations",
-    "prompt": "If f(x) = 2x + 1 and g(x) = f(x − 3) + 3, what is g(-1)?",
-    "answer": {
-      "type": "auto",
-      "value": "-4",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "8"
-      },
-      {
-        "label": "B",
-        "text": "-4"
-      },
-      {
-        "label": "C",
-        "text": "-10"
-      },
-      {
-        "label": "D",
-        "text": "2"
-      },
-      {
-        "label": "E",
-        "text": "-1"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-function-transformations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "8f84a298f473abbe396a8af19dbc7f5c28dc0f8128a38d1447431b7583276c99",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-function-transformations-24f1b209a0",
-    "skillId": "act-function-transformations",
-    "prompt": "If f(x) = 4x - 1 and g(x) = f(x − 2) + 1, what is g(-1)?",
-    "answer": {
-      "type": "auto",
-      "value": "-12",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "4"
-      },
-      {
-        "label": "B",
-        "text": "-4"
-      },
-      {
-        "label": "C",
-        "text": "-14"
-      },
-      {
-        "label": "D",
-        "text": "-12"
-      },
-      {
-        "label": "E",
-        "text": "-5"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-function-transformations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "24f1b209a058e99e464bf72304f783c35a9f5987bd155a54de585a58780ce888",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-function-transformations-87878ee342",
-    "skillId": "act-function-transformations",
-    "prompt": "If f(x) = 2x + 6 and g(x) = f(x − 3) + 5, what is g(-3)?",
-    "answer": {
-      "type": "auto",
-      "value": "-1",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "-11"
-      },
-      {
-        "label": "B",
         "text": "0"
-      },
-      {
-        "label": "C",
-        "text": "11"
-      },
-      {
-        "label": "D",
-        "text": "5"
-      },
-      {
-        "label": "E",
-        "text": "-1"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-function-transformations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "87878ee3420d34289b45bb5c7a6387e5df205f79be6aeab4a4a4dde2c580dc3d",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-function-transformations-784ee149b6",
-    "skillId": "act-function-transformations",
-    "prompt": "If f(x) = -1x - 1 and g(x) = f(x − 3) + 5, what is g(3)?",
-    "answer": {
-      "type": "auto",
-      "value": "4",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "-2"
-      },
-      {
-        "label": "B",
-        "text": "4"
-      },
-      {
-        "label": "C",
-        "text": "-6"
-      },
-      {
-        "label": "D",
-        "text": "1"
-      },
-      {
-        "label": "E",
-        "text": "-4"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-function-transformations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "784ee149b6fa287dfea80cfc6cb0874aca11269010cfea3002d4c1cc8963481c",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-function-transformations-088f501b84",
-    "skillId": "act-function-transformations",
-    "prompt": "If f(x) = -1x + 1 and g(x) = f(x − 3) + 4, what is g(4)?",
-    "answer": {
-      "type": "auto",
-      "value": "4",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "4"
-      },
-      {
-        "label": "B",
-        "text": "1"
-      },
-      {
-        "label": "C",
-        "text": "-3"
-      },
-      {
-        "label": "D",
-        "text": "-4"
-      },
-      {
-        "label": "E",
-        "text": "-2"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-function-transformations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "088f501b84a9a372022bcf6e0c64e1e9ff8c9649997f8d2aae08944f4fdae505",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-function-transformations-aa855a33b2",
-    "skillId": "act-function-transformations",
-    "prompt": "If f(x) = 3x - 1 and g(x) = f(x − 3) + 3, what is g(1)?",
-    "answer": {
-      "type": "auto",
-      "value": "-4",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "2"
-      },
-      {
-        "label": "B",
-        "text": "14"
-      },
-      {
-        "label": "C",
-        "text": "-4"
-      },
-      {
-        "label": "D",
-        "text": "-10"
-      },
-      {
-        "label": "E",
-        "text": "5"
       }
     ],
     "correctOption": "C",
@@ -7629,42 +7630,42 @@
       "act-function-transformations"
     ],
     "source": "act-template-gen",
-    "contentHash": "aa855a33b245d786392a9b5187bed11fcf39ce831cddc7385bde88747861eca3",
+    "contentHash": "c56d8f1b6cae1bdaf747d8b2585691bd22f6c620f7375b51baade1a0a3e61844",
     "isActive": true
   },
   {
-    "problemId": "act-act-center-spread-b23c0b8f31",
+    "problemId": "act-act-center-spread-25f283cbf1",
     "skillId": "act-center-spread",
-    "prompt": "What is the average (mean) of 10, 5, 12, 3, 15?",
+    "prompt": "What is the average (mean) of 23, 6, 16, 9, 11?",
     "answer": {
       "type": "auto",
-      "value": "9",
+      "value": "13",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "12"
+        "text": "17"
       },
       {
         "label": "B",
-        "text": "11"
+        "text": "16"
       },
       {
         "label": "C",
-        "text": "45"
+        "text": "11"
       },
       {
         "label": "D",
-        "text": "9"
+        "text": "65"
       },
       {
         "label": "E",
-        "text": "10"
+        "text": "13"
       }
     ],
-    "correctOption": "D",
+    "correctOption": "E",
     "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
@@ -7673,219 +7674,43 @@
       "act-center-spread"
     ],
     "source": "act-template-gen",
-    "contentHash": "b23c0b8f317a8193ef043b24e8cd39bf61f567f69651f2684935b135837d87ef",
+    "contentHash": "25f283cbf16a5932c1d84cc1f84bcba40a02d89a4ee37ca6916057b537eed65f",
     "isActive": true
   },
   {
-    "problemId": "act-act-center-spread-f23fdb88f2",
+    "problemId": "act-act-center-spread-480284d4a9",
     "skillId": "act-center-spread",
-    "prompt": "What is the average (mean) of 15, 5, 14, 8, 3?",
+    "prompt": "What is the average (mean) of 24, 11, 12, 12, 6?",
     "answer": {
       "type": "auto",
-      "value": "9",
+      "value": "13",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "9"
-      },
-      {
-        "label": "B",
-        "text": "12"
-      },
-      {
-        "label": "C",
-        "text": "11"
-      },
-      {
-        "label": "D",
-        "text": "45"
-      },
-      {
-        "label": "E",
-        "text": "8"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-center-spread"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "f23fdb88f2546468381c7c5dfebd528e7e501d069d0241661952bcd37d6652a0",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-center-spread-aec1f9f696",
-    "skillId": "act-center-spread",
-    "prompt": "What is the average (mean) of 19, 10, 10, 16, 15?",
-    "answer": {
-      "type": "auto",
-      "value": "14",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "15"
-      },
-      {
-        "label": "B",
-        "text": "14"
-      },
-      {
-        "label": "C",
-        "text": "70"
-      },
-      {
-        "label": "D",
-        "text": "18"
-      },
-      {
-        "label": "E",
-        "text": "9"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-center-spread"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "aec1f9f696af0225ecfba999b934a4ebdf7db804bfd8bdf1733d768459b155c1",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-center-spread-73b06a12a3",
-    "skillId": "act-center-spread",
-    "prompt": "What is the average (mean) of 10, 11, 2, 14, 8?",
-    "answer": {
-      "type": "auto",
-      "value": "9",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "9"
-      },
-      {
-        "label": "B",
-        "text": "45"
-      },
-      {
-        "label": "C",
-        "text": "10"
-      },
-      {
-        "label": "D",
-        "text": "11"
-      },
-      {
-        "label": "E",
-        "text": "12"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-center-spread"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "73b06a12a3032827e8525b6415661d05d4aff5e32a935bee35fe5a692468fbbe",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-center-spread-bc371c5df3",
-    "skillId": "act-center-spread",
-    "prompt": "What is the average (mean) of 13, 6, 17, 15, 19?",
-    "answer": {
-      "type": "auto",
-      "value": "14",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "70"
-      },
-      {
-        "label": "B",
         "text": "13"
       },
       {
+        "label": "B",
+        "text": "12"
+      },
+      {
         "label": "C",
-        "text": "14"
+        "text": "16"
       },
       {
         "label": "D",
-        "text": "15"
+        "text": "65"
       },
       {
         "label": "E",
         "text": "18"
       }
     ],
-    "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-center-spread"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "bc371c5df3da086bdbf7b9a2b9e96b8c54547fdbc64e16b95927767f71dbf985",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-center-spread-6c03f694ad",
-    "skillId": "act-center-spread",
-    "prompt": "What is the average (mean) of 20, 8, 7, 5, 5?",
-    "answer": {
-      "type": "auto",
-      "value": "9",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "9"
-      },
-      {
-        "label": "B",
-        "text": "11"
-      },
-      {
-        "label": "C",
-        "text": "7"
-      },
-      {
-        "label": "D",
-        "text": "45"
-      },
-      {
-        "label": "E",
-        "text": "15"
-      }
-    ],
     "correctOption": "A",
-    "difficulty": 4,
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -7893,57 +7718,13 @@
       "act-center-spread"
     ],
     "source": "act-template-gen",
-    "contentHash": "6c03f694ada319c72e8ea24e4c8c74a78bce2e38bfd6a091367d0c033dd300dc",
+    "contentHash": "480284d4a96f336e0ff8bf53b54a9b2b405c90bfa79217ea9f9a06661ebafb81",
     "isActive": true
   },
   {
-    "problemId": "act-act-center-spread-71d1f96546",
+    "problemId": "act-act-center-spread-2f3a152a08",
     "skillId": "act-center-spread",
-    "prompt": "What is the average (mean) of 9, 19, 12, 7, 8?",
-    "answer": {
-      "type": "auto",
-      "value": "11",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "12"
-      },
-      {
-        "label": "B",
-        "text": "11"
-      },
-      {
-        "label": "C",
-        "text": "9"
-      },
-      {
-        "label": "D",
-        "text": "14"
-      },
-      {
-        "label": "E",
-        "text": "55"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-center-spread"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "71d1f965463fdcc9641a384d1d2ce1d1a74069b4e1b37f971ad491d0a1920030",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-center-spread-a06a75418e",
-    "skillId": "act-center-spread",
-    "prompt": "What is the average (mean) of 9, 6, 6, 9, 20?",
+    "prompt": "What is the average (mean) of 7, 4, 12, 19, 8?",
     "answer": {
       "type": "auto",
       "value": "10",
@@ -7957,11 +7738,11 @@
       },
       {
         "label": "B",
-        "text": "13"
+        "text": "15"
       },
       {
         "label": "C",
-        "text": "9"
+        "text": "13"
       },
       {
         "label": "D",
@@ -7969,10 +7750,230 @@
       },
       {
         "label": "E",
-        "text": "14"
+        "text": "8"
       }
     ],
     "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-center-spread"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "2f3a152a0857e00ffacb4e296c90c54974b27d2a2de94dde221427e76ebd425c",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-center-spread-915b22d8ad",
+    "skillId": "act-center-spread",
+    "prompt": "What is the average (mean) of 15, 3, 5, 6, 6?",
+    "answer": {
+      "type": "auto",
+      "value": "7",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "12"
+      },
+      {
+        "label": "B",
+        "text": "7"
+      },
+      {
+        "label": "C",
+        "text": "35"
+      },
+      {
+        "label": "D",
+        "text": "9"
+      },
+      {
+        "label": "E",
+        "text": "6"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-center-spread"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "915b22d8ad78cd78511fc813ab3a058d839960343684a78b61e2f45d36eec978",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-center-spread-3ac28633b6",
+    "skillId": "act-center-spread",
+    "prompt": "What is the average (mean) of 11, 4, 11, 11, 13?",
+    "answer": {
+      "type": "auto",
+      "value": "10",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "11"
+      },
+      {
+        "label": "B",
+        "text": "9"
+      },
+      {
+        "label": "C",
+        "text": "13"
+      },
+      {
+        "label": "D",
+        "text": "10"
+      },
+      {
+        "label": "E",
+        "text": "50"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-center-spread"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "3ac28633b6e6301fcdeab5d128ec0c5e18774025d50f28ca8c58c9ddbc50f460",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-center-spread-c66cf44191",
+    "skillId": "act-center-spread",
+    "prompt": "What is the average (mean) of 17, 20, 3, 10, 10?",
+    "answer": {
+      "type": "auto",
+      "value": "12",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "10"
+      },
+      {
+        "label": "B",
+        "text": "60"
+      },
+      {
+        "label": "C",
+        "text": "17"
+      },
+      {
+        "label": "D",
+        "text": "15"
+      },
+      {
+        "label": "E",
+        "text": "12"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-center-spread"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "c66cf4419124868630b0faa824bb0b7e7c0c775b4f5f1b39cbb4d3e6c6bcf1d5",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-center-spread-fe197df8f1",
+    "skillId": "act-center-spread",
+    "prompt": "What is the average (mean) of 6, 14, 9, 13, 8?",
+    "answer": {
+      "type": "auto",
+      "value": "10",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "8"
+      },
+      {
+        "label": "B",
+        "text": "50"
+      },
+      {
+        "label": "C",
+        "text": "10"
+      },
+      {
+        "label": "D",
+        "text": "13"
+      },
+      {
+        "label": "E",
+        "text": "9"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-center-spread"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "fe197df8f1c12705630142c04c67faec8be959939b87ebf8da0e562aec8065b6",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-center-spread-988d6c8294",
+    "skillId": "act-center-spread",
+    "prompt": "What is the average (mean) of 7, 10, 2, 14, 7?",
+    "answer": {
+      "type": "auto",
+      "value": "8",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "12"
+      },
+      {
+        "label": "B",
+        "text": "7"
+      },
+      {
+        "label": "C",
+        "text": "40"
+      },
+      {
+        "label": "D",
+        "text": "10"
+      },
+      {
+        "label": "E",
+        "text": "8"
+      }
+    ],
+    "correctOption": "E",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -7981,13 +7982,57 @@
       "act-center-spread"
     ],
     "source": "act-template-gen",
-    "contentHash": "a06a75418e5d6a6e7922b11d447bc30ab1cb6588c0f7c28258f17f0857c3f0ff",
+    "contentHash": "988d6c8294c63f3e7c76a1d6c2dd69890c0b7bd732fe439e800de66e4484f9a9",
     "isActive": true
   },
   {
-    "problemId": "act-act-data-representations-11712ffa3f",
+    "problemId": "act-act-data-representations-e78d5b2a1e",
     "skillId": "act-data-representations",
-    "prompt": "A store's daily sales were Mon: 18, Tue: 18, Wed: 20, Thu: 19. What were the total sales?",
+    "prompt": "A store's daily sales were Mon: 23, Tue: 21, Wed: 26, Thu: 14. What were the total sales?",
+    "answer": {
+      "type": "auto",
+      "value": "84",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "70"
+      },
+      {
+        "label": "B",
+        "text": "12"
+      },
+      {
+        "label": "C",
+        "text": "84"
+      },
+      {
+        "label": "D",
+        "text": "26"
+      },
+      {
+        "label": "E",
+        "text": "21"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-data-representations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "e78d5b2a1e024c319253447759b0961e208f36ec0acfd7d6a033829db023fa73",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-data-representations-1281213f18",
+    "skillId": "act-data-representations",
+    "prompt": "A store's daily sales were Mon: 16, Tue: 24, Wed: 20, Thu: 15. What were the total sales?",
     "answer": {
       "type": "auto",
       "value": "75",
@@ -7997,7 +8042,7 @@
     "options": [
       {
         "label": "A",
-        "text": "20"
+        "text": "75"
       },
       {
         "label": "B",
@@ -8005,18 +8050,18 @@
       },
       {
         "label": "C",
-        "text": "2"
+        "text": "24"
       },
       {
         "label": "D",
-        "text": "57"
+        "text": "9"
       },
       {
         "label": "E",
-        "text": "75"
+        "text": "60"
       }
     ],
-    "correctOption": "E",
+    "correctOption": "A",
     "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
@@ -8025,83 +8070,39 @@
       "act-data-representations"
     ],
     "source": "act-template-gen",
-    "contentHash": "11712ffa3f3a0227722ad14d0bb54b027c5a8f7e365daf9fc2521e721fabf217",
+    "contentHash": "1281213f18d6aae3c095ce376dfdf9025689cd068bbdbbd537c8a83ad12fcb51",
     "isActive": true
   },
   {
-    "problemId": "act-act-data-representations-1dd0142fd9",
+    "problemId": "act-act-data-representations-17443a656b",
     "skillId": "act-data-representations",
-    "prompt": "A store's daily sales were Mon: 30, Tue: 7, Wed: 16, Thu: 16. What were the total sales?",
+    "prompt": "A store's daily sales were Mon: 26, Tue: 25, Wed: 12, Thu: 7. What were the total sales?",
     "answer": {
       "type": "auto",
-      "value": "69",
+      "value": "70",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "17"
+        "text": "63"
       },
       {
         "label": "B",
-        "text": "30"
+        "text": "70"
       },
       {
         "label": "C",
-        "text": "62"
+        "text": "19"
       },
       {
         "label": "D",
-        "text": "23"
+        "text": "18"
       },
       {
         "label": "E",
-        "text": "69"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-data-representations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "1dd0142fd988bcb87af6d5c4a15ffb6996ad7a65d4b27757cbd0df983ddc82a1",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-data-representations-cb7d5666fe",
-    "skillId": "act-data-representations",
-    "prompt": "A store's daily sales were Mon: 7, Tue: 22, Wed: 14, Thu: 21. What were the total sales?",
-    "answer": {
-      "type": "auto",
-      "value": "64",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "15"
-      },
-      {
-        "label": "B",
-        "text": "64"
-      },
-      {
-        "label": "C",
-        "text": "22"
-      },
-      {
-        "label": "D",
-        "text": "57"
-      },
-      {
-        "label": "E",
-        "text": "16"
+        "text": "26"
       }
     ],
     "correctOption": "B",
@@ -8113,207 +8114,31 @@
       "act-data-representations"
     ],
     "source": "act-template-gen",
-    "contentHash": "cb7d5666fee9c199c79d634b1f8bfd3ad3c64b9743ec1f2bd65523faacda1143",
+    "contentHash": "17443a656bc1e2b89e531997eb48d498380bcd838dddacd92bf013471f256665",
     "isActive": true
   },
   {
-    "problemId": "act-act-data-representations-9eede66e3b",
+    "problemId": "act-act-data-representations-4675c338dc",
     "skillId": "act-data-representations",
-    "prompt": "A store's daily sales were Mon: 9, Tue: 11, Wed: 16, Thu: 6. What were the total sales?",
+    "prompt": "A store's daily sales were Mon: 27, Tue: 5, Wed: 23, Thu: 23. What were the total sales?",
     "answer": {
       "type": "auto",
-      "value": "42",
+      "value": "78",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "16"
+        "text": "78"
       },
       {
         "label": "B",
-        "text": "36"
+        "text": "73"
       },
       {
         "label": "C",
-        "text": "42"
-      },
-      {
-        "label": "D",
-        "text": "11"
-      },
-      {
-        "label": "E",
-        "text": "10"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-data-representations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "9eede66e3b8738368263716b2af23490dca6c46efade525b8838447c785c3d24",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-data-representations-96f9d92f24",
-    "skillId": "act-data-representations",
-    "prompt": "A store's daily sales were Mon: 23, Tue: 19, Wed: 23, Thu: 21. What were the total sales?",
-    "answer": {
-      "type": "auto",
-      "value": "86",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "23"
-      },
-      {
-        "label": "B",
-        "text": "4"
-      },
-      {
-        "label": "C",
-        "text": "86"
-      },
-      {
-        "label": "D",
-        "text": "22"
-      },
-      {
-        "label": "E",
-        "text": "67"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-data-representations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "96f9d92f2480d0968c9ea5b70bd9c44eb97c6ccfe1b11233bd0d7da905e5d872",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-data-representations-85ca79611e",
-    "skillId": "act-data-representations",
-    "prompt": "A store's daily sales were Mon: 12, Tue: 8, Wed: 16, Thu: 24. What were the total sales?",
-    "answer": {
-      "type": "auto",
-      "value": "60",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "60"
-      },
-      {
-        "label": "B",
-        "text": "16"
-      },
-      {
-        "label": "C",
-        "text": "52"
-      },
-      {
-        "label": "D",
-        "text": "15"
-      },
-      {
-        "label": "E",
-        "text": "24"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-data-representations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "85ca79611eda4db2494283d20128129e966b28fa90cf323e0e8a19b5cb089b7f",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-data-representations-768fd1337b",
-    "skillId": "act-data-representations",
-    "prompt": "A store's daily sales were Mon: 25, Tue: 23, Wed: 26, Thu: 25. What were the total sales?",
-    "answer": {
-      "type": "auto",
-      "value": "99",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "26"
-      },
-      {
-        "label": "B",
-        "text": "3"
-      },
-      {
-        "label": "C",
-        "text": "76"
-      },
-      {
-        "label": "D",
-        "text": "99"
-      },
-      {
-        "label": "E",
-        "text": "25"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-data-representations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "768fd1337b3d9327086a89b693077ea0984c0e79512f55efc54adc2633673961",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-data-representations-102ea5e6ca",
-    "skillId": "act-data-representations",
-    "prompt": "A store's daily sales were Mon: 16, Tue: 6, Wed: 27, Thu: 5. What were the total sales?",
-    "answer": {
-      "type": "auto",
-      "value": "54",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "54"
-      },
-      {
-        "label": "B",
-        "text": "14"
-      },
-      {
-        "label": "C",
-        "text": "49"
+        "text": "20"
       },
       {
         "label": "D",
@@ -8325,6 +8150,182 @@
       }
     ],
     "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-data-representations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "4675c338dc959a7500947d193683ffed14c3de824b6f01e8513469bac0dbef84",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-data-representations-aeec37f31a",
+    "skillId": "act-data-representations",
+    "prompt": "A store's daily sales were Mon: 18, Tue: 11, Wed: 28, Thu: 30. What were the total sales?",
+    "answer": {
+      "type": "auto",
+      "value": "87",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "30"
+      },
+      {
+        "label": "B",
+        "text": "22"
+      },
+      {
+        "label": "C",
+        "text": "76"
+      },
+      {
+        "label": "D",
+        "text": "19"
+      },
+      {
+        "label": "E",
+        "text": "87"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-data-representations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "aeec37f31a73011b6ad10f00dec6bef07796b5320b162cea2031da0242b12dba",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-data-representations-f99492908f",
+    "skillId": "act-data-representations",
+    "prompt": "A store's daily sales were Mon: 19, Tue: 17, Wed: 12, Thu: 19. What were the total sales?",
+    "answer": {
+      "type": "auto",
+      "value": "67",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "55"
+      },
+      {
+        "label": "B",
+        "text": "7"
+      },
+      {
+        "label": "C",
+        "text": "19"
+      },
+      {
+        "label": "D",
+        "text": "17"
+      },
+      {
+        "label": "E",
+        "text": "67"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-data-representations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "f99492908f04e232a02632046d2646ff149e8be84eb82792ea042340e78352e2",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-data-representations-bf472485de",
+    "skillId": "act-data-representations",
+    "prompt": "A store's daily sales were Mon: 16, Tue: 5, Wed: 25, Thu: 8. What were the total sales?",
+    "answer": {
+      "type": "auto",
+      "value": "54",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "14"
+      },
+      {
+        "label": "B",
+        "text": "25"
+      },
+      {
+        "label": "C",
+        "text": "20"
+      },
+      {
+        "label": "D",
+        "text": "54"
+      },
+      {
+        "label": "E",
+        "text": "49"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-data-representations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "bf472485de5d148a3693503eefb8310a03bd747d494f14a48f52a748f553b9b6",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-data-representations-6b8ff0bebb",
+    "skillId": "act-data-representations",
+    "prompt": "A store's daily sales were Mon: 21, Tue: 11, Wed: 21, Thu: 18. What were the total sales?",
+    "answer": {
+      "type": "auto",
+      "value": "71",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "21"
+      },
+      {
+        "label": "B",
+        "text": "60"
+      },
+      {
+        "label": "C",
+        "text": "71"
+      },
+      {
+        "label": "D",
+        "text": "10"
+      },
+      {
+        "label": "E",
+        "text": "18"
+      }
+    ],
+    "correctOption": "C",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -8333,233 +8334,13 @@
       "act-data-representations"
     ],
     "source": "act-template-gen",
-    "contentHash": "102ea5e6caa1a06330e965faac6a3f6182498bfbfbc844992d51901265a7a6b2",
+    "contentHash": "6b8ff0bebb1cb15d11c769e994f64c5368c71a3ad1e4883a567aa4e784a92410",
     "isActive": true
   },
   {
-    "problemId": "act-act-two-way-tables-57e009105c",
+    "problemId": "act-act-two-way-tables-37476c5e6c",
     "skillId": "act-two-way-tables",
-    "prompt": "In a survey, 8 boys and 12 girls chose pizza; 10 boys and 7 girls chose tacos. How many boys were surveyed in total?",
-    "answer": {
-      "type": "auto",
-      "value": "8",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "18"
-      },
-      {
-        "label": "B",
-        "text": "20"
-      },
-      {
-        "label": "C",
-        "text": "8"
-      },
-      {
-        "label": "D",
-        "text": "19"
-      },
-      {
-        "label": "E",
-        "text": "37"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-two-way-tables"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "57e009105c46aa496bf78304874bcc0ce483bd9029f1f6194322efc4a7496467",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-two-way-tables-126a168f19",
-    "skillId": "act-two-way-tables",
-    "prompt": "In a survey, 6 boys and 14 girls chose pizza; 10 boys and 9 girls chose tacos. How many boys were surveyed in total?",
-    "answer": {
-      "type": "auto",
-      "value": "6",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "39"
-      },
-      {
-        "label": "B",
-        "text": "23"
-      },
-      {
-        "label": "C",
-        "text": "6"
-      },
-      {
-        "label": "D",
-        "text": "16"
-      },
-      {
-        "label": "E",
-        "text": "20"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-two-way-tables"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "126a168f19eca79b59071b0031ab44589c268f0d2094811ee610461cc19cfe1a",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-two-way-tables-18fddabd65",
-    "skillId": "act-two-way-tables",
-    "prompt": "In a survey, 13 boys and 11 girls chose pizza; 9 boys and 4 girls chose tacos. How many boys were surveyed in total?",
-    "answer": {
-      "type": "auto",
-      "value": "13",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "24"
-      },
-      {
-        "label": "B",
-        "text": "37"
-      },
-      {
-        "label": "C",
-        "text": "22"
-      },
-      {
-        "label": "D",
-        "text": "13"
-      },
-      {
-        "label": "E",
-        "text": "15"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-two-way-tables"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "18fddabd658ca0f4b5cfe8c66690868ae1ba68bd4d5bd0696cb38a45ae9698a9",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-two-way-tables-45e861aa36",
-    "skillId": "act-two-way-tables",
-    "prompt": "In a survey, 7 boys and 8 girls chose pizza; 11 boys and 6 girls chose tacos. How many boys were surveyed in total?",
-    "answer": {
-      "type": "auto",
-      "value": "7",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "32"
-      },
-      {
-        "label": "B",
-        "text": "15"
-      },
-      {
-        "label": "C",
-        "text": "7"
-      },
-      {
-        "label": "D",
-        "text": "18"
-      },
-      {
-        "label": "E",
-        "text": "14"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-two-way-tables"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "45e861aa36c402e4f08efec096f9b4b3689c772d98740e10ff78e25ab3ade866",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-two-way-tables-f7814ee7ed",
-    "skillId": "act-two-way-tables",
-    "prompt": "In a survey, 4 boys and 10 girls chose pizza; 9 boys and 8 girls chose tacos. How many boys were surveyed in total?",
-    "answer": {
-      "type": "auto",
-      "value": "4",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "31"
-      },
-      {
-        "label": "B",
-        "text": "18"
-      },
-      {
-        "label": "C",
-        "text": "4"
-      },
-      {
-        "label": "D",
-        "text": "13"
-      },
-      {
-        "label": "E",
-        "text": "14"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-two-way-tables"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "f7814ee7ed223433c2cdd6039ff16769ee7a232ad1d3e56f9abbfc52f9ef8421",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-two-way-tables-25f8addcc1",
-    "skillId": "act-two-way-tables",
-    "prompt": "In a survey, 9 boys and 15 girls chose pizza; 5 boys and 4 girls chose tacos. How many boys were surveyed in total?",
+    "prompt": "In a survey, 9 boys and 8 girls chose pizza; 7 boys and 11 girls chose tacos. How many boys were surveyed in total?",
     "answer": {
       "type": "auto",
       "value": "9",
@@ -8569,7 +8350,271 @@
     "options": [
       {
         "label": "A",
+        "text": "35"
+      },
+      {
+        "label": "B",
+        "text": "16"
+      },
+      {
+        "label": "C",
+        "text": "19"
+      },
+      {
+        "label": "D",
+        "text": "17"
+      },
+      {
+        "label": "E",
+        "text": "9"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-two-way-tables"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "37476c5e6c004cf3426a7a738f9110d084acee628de97d69b6b650fa0f8044f5",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-two-way-tables-d0b3d8421c",
+    "skillId": "act-two-way-tables",
+    "prompt": "In a survey, 6 boys and 15 girls chose pizza; 12 boys and 5 girls chose tacos. How many boys were surveyed in total?",
+    "answer": {
+      "type": "auto",
+      "value": "6",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "18"
+      },
+      {
+        "label": "B",
+        "text": "21"
+      },
+      {
+        "label": "C",
+        "text": "38"
+      },
+      {
+        "label": "D",
+        "text": "6"
+      },
+      {
+        "label": "E",
+        "text": "20"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-two-way-tables"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "d0b3d8421cef2a5eeb5d57b6c18bbaf67dfcd58ac93fe72e05154d4ba26c201c",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-two-way-tables-074c57f458",
+    "skillId": "act-two-way-tables",
+    "prompt": "In a survey, 10 boys and 8 girls chose pizza; 12 boys and 11 girls chose tacos. How many boys were surveyed in total?",
+    "answer": {
+      "type": "auto",
+      "value": "10",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "22"
+      },
+      {
+        "label": "B",
+        "text": "41"
+      },
+      {
+        "label": "C",
+        "text": "10"
+      },
+      {
+        "label": "D",
+        "text": "18"
+      },
+      {
+        "label": "E",
+        "text": "19"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-two-way-tables"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "074c57f458f997be67c018bde38907c6ddbcd835e58659ad9a8de8f4538b1b96",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-two-way-tables-4f4e4d8582",
+    "skillId": "act-two-way-tables",
+    "prompt": "In a survey, 10 boys and 12 girls chose pizza; 6 boys and 13 girls chose tacos. How many boys were surveyed in total?",
+    "answer": {
+      "type": "auto",
+      "value": "10",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "25"
+      },
+      {
+        "label": "B",
+        "text": "10"
+      },
+      {
+        "label": "C",
+        "text": "22"
+      },
+      {
+        "label": "D",
+        "text": "16"
+      },
+      {
+        "label": "E",
+        "text": "41"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-two-way-tables"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "4f4e4d8582c5537463e75e27551632c5c041549cd7d69150859c7afc1a91abbc",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-two-way-tables-a3157dedad",
+    "skillId": "act-two-way-tables",
+    "prompt": "In a survey, 14 boys and 5 girls chose pizza; 9 boys and 11 girls chose tacos. How many boys were surveyed in total?",
+    "answer": {
+      "type": "auto",
+      "value": "14",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "16"
+      },
+      {
+        "label": "B",
         "text": "14"
+      },
+      {
+        "label": "C",
+        "text": "23"
+      },
+      {
+        "label": "D",
+        "text": "39"
+      },
+      {
+        "label": "E",
+        "text": "19"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-two-way-tables"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "a3157dedad0f38bc7024653b0fd18be6f901c569d0f45adc5c8d18a325cce5fb",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-two-way-tables-8d51e7faef",
+    "skillId": "act-two-way-tables",
+    "prompt": "In a survey, 13 boys and 15 girls chose pizza; 13 boys and 8 girls chose tacos. How many boys were surveyed in total?",
+    "answer": {
+      "type": "auto",
+      "value": "13",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "28"
+      },
+      {
+        "label": "B",
+        "text": "13"
+      },
+      {
+        "label": "C",
+        "text": "49"
+      },
+      {
+        "label": "D",
+        "text": "23"
+      },
+      {
+        "label": "E",
+        "text": "26"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-two-way-tables"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "8d51e7faefe8189c7595af3c1056e13fb4a5c7b44a443e8953286e41213c61b2",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-two-way-tables-466fe7aa5b",
+    "skillId": "act-two-way-tables",
+    "prompt": "In a survey, 9 boys and 6 girls chose pizza; 15 boys and 14 girls chose tacos. How many boys were surveyed in total?",
+    "answer": {
+      "type": "auto",
+      "value": "9",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "20"
       },
       {
         "label": "B",
@@ -8577,11 +8622,11 @@
       },
       {
         "label": "C",
-        "text": "33"
+        "text": "44"
       },
       {
         "label": "D",
-        "text": "19"
+        "text": "15"
       },
       {
         "label": "E",
@@ -8597,71 +8642,27 @@
       "act-two-way-tables"
     ],
     "source": "act-template-gen",
-    "contentHash": "25f8addcc15c25a7e6fed3b1d5a7de758b8c1636a898903b2984ddb5080e2e71",
+    "contentHash": "466fe7aa5b718621cb8b54987b3e1aee8d6c914fd2af59691a0c1452c293be69",
     "isActive": true
   },
   {
-    "problemId": "act-act-two-way-tables-c3fd14232b",
+    "problemId": "act-act-two-way-tables-1c03aaace1",
     "skillId": "act-two-way-tables",
-    "prompt": "In a survey, 12 boys and 5 girls chose pizza; 11 boys and 5 girls chose tacos. How many boys were surveyed in total?",
+    "prompt": "In a survey, 15 boys and 13 girls chose pizza; 10 boys and 4 girls chose tacos. How many boys were surveyed in total?",
     "answer": {
       "type": "auto",
-      "value": "12",
+      "value": "15",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "23"
+        "text": "25"
       },
       {
         "label": "B",
-        "text": "12"
-      },
-      {
-        "label": "C",
-        "text": "33"
-      },
-      {
-        "label": "D",
-        "text": "10"
-      },
-      {
-        "label": "E",
-        "text": "17"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-two-way-tables"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "c3fd14232b04b911622dafcbc6eef8990ecd626eabbead438a6d5ffac29d6a2b",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-two-way-tables-c41f020a6e",
-    "skillId": "act-two-way-tables",
-    "prompt": "In a survey, 12 boys and 11 girls chose pizza; 12 boys and 7 girls chose tacos. How many boys were surveyed in total?",
-    "answer": {
-      "type": "auto",
-      "value": "12",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "12"
-      },
-      {
-        "label": "B",
-        "text": "18"
+        "text": "28"
       },
       {
         "label": "C",
@@ -8669,14 +8670,14 @@
       },
       {
         "label": "D",
-        "text": "24"
+        "text": "15"
       },
       {
         "label": "E",
-        "text": "23"
+        "text": "17"
       }
     ],
-    "correctOption": "A",
+    "correctOption": "D",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -8685,227 +8686,7 @@
       "act-two-way-tables"
     ],
     "source": "act-template-gen",
-    "contentHash": "c41f020a6ebcf467cdd3fb18340b166f356a31c10a0698feea5bd95ae6655c47",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-probability-080a1d414f",
-    "skillId": "act-probability",
-    "prompt": "A bag has 3 red, 5 green, and 6 blue marbles. What is the probability of drawing a red marble?",
-    "answer": {
-      "type": "auto",
-      "value": "3/14",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "3/5"
-      },
-      {
-        "label": "B",
-        "text": "5/14"
-      },
-      {
-        "label": "C",
-        "text": "3/14"
-      },
-      {
-        "label": "D",
-        "text": "3/11"
-      },
-      {
-        "label": "E",
-        "text": "14/3"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-probability"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "080a1d414fb482a6fdff4934bbbff20c8fa5cb2abae41631433664622d9e4523",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-probability-b31ae01916",
-    "skillId": "act-probability",
-    "prompt": "A bag has 2 red, 4 green, and 5 blue marbles. What is the probability of drawing a red marble?",
-    "answer": {
-      "type": "auto",
-      "value": "2/11",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "11/2"
-      },
-      {
-        "label": "B",
-        "text": "2/11"
-      },
-      {
-        "label": "C",
-        "text": "2/4"
-      },
-      {
-        "label": "D",
-        "text": "4/11"
-      },
-      {
-        "label": "E",
-        "text": "2/9"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-probability"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "b31ae0191652dc3f08da11ed8e877509fe9749880655e3267928a0a979bfd77c",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-probability-58430fd45d",
-    "skillId": "act-probability",
-    "prompt": "A bag has 5 red, 6 green, and 5 blue marbles. What is the probability of drawing a red marble?",
-    "answer": {
-      "type": "auto",
-      "value": "5/16",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "5/16"
-      },
-      {
-        "label": "B",
-        "text": "3/8"
-      },
-      {
-        "label": "C",
-        "text": "16/5"
-      },
-      {
-        "label": "D",
-        "text": "5/6"
-      },
-      {
-        "label": "E",
-        "text": "5/11"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-probability"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "58430fd45de5c6dde60a8c9574625270902ef24a423eb06bbe2cd8dc208c16b2",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-probability-b97c85ac31",
-    "skillId": "act-probability",
-    "prompt": "A bag has 3 red, 2 green, and 2 blue marbles. What is the probability of drawing a red marble?",
-    "answer": {
-      "type": "auto",
-      "value": "3/7",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "3/2"
-      },
-      {
-        "label": "B",
-        "text": "3/7"
-      },
-      {
-        "label": "C",
-        "text": "3/4"
-      },
-      {
-        "label": "D",
-        "text": "7/3"
-      },
-      {
-        "label": "E",
-        "text": "2/7"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-probability"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "b97c85ac3154452fdc9a80394681fcfb4e4cda8565f9e651da57dd450b53726c",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-probability-ec8c70f987",
-    "skillId": "act-probability",
-    "prompt": "A bag has 5 red, 2 green, and 2 blue marbles. What is the probability of drawing a red marble?",
-    "answer": {
-      "type": "auto",
-      "value": "5/9",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "5/4"
-      },
-      {
-        "label": "B",
-        "text": "5/2"
-      },
-      {
-        "label": "C",
-        "text": "9/5"
-      },
-      {
-        "label": "D",
-        "text": "5/9"
-      },
-      {
-        "label": "E",
-        "text": "2/9"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-probability"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "ec8c70f98786038e1f49ba6841eff3efaf3dc040a8e2c645b5fca8dedf1040e9",
+    "contentHash": "1c03aaace11d20e0687e778d636c0a48be1223db64e109440f614b35cc19d3bb",
     "isActive": true
   },
   {
@@ -8941,7 +8722,7 @@
       }
     ],
     "correctOption": "D",
-    "difficulty": 4,
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -8985,7 +8766,7 @@
       }
     ],
     "correctOption": "A",
-    "difficulty": 4,
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -9029,7 +8810,7 @@
       }
     ],
     "correctOption": "A",
-    "difficulty": 5,
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -9041,123 +8822,79 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-counting-techniques-34bea27ddc",
-    "skillId": "act-counting-techniques",
-    "prompt": "A meal has 4 appetizers, 4 entrées, and 2 desserts. How many different 3-course meals are possible?",
+    "problemId": "act-act-probability-29ffcfd52e",
+    "skillId": "act-probability",
+    "prompt": "A bag has 2 red, 5 green, and 2 blue marbles. What is the probability of drawing a red marble?",
     "answer": {
       "type": "auto",
-      "value": "32",
+      "value": "2/9",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "36"
+        "text": "2/7"
       },
       {
         "label": "B",
-        "text": "16"
+        "text": "5/9"
       },
       {
         "label": "C",
-        "text": "32"
+        "text": "2/9"
       },
       {
         "label": "D",
-        "text": "18"
+        "text": "2/5"
       },
       {
         "label": "E",
-        "text": "10"
+        "text": "9/2"
       }
     ],
     "correctOption": "C",
-    "difficulty": 2,
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-counting-techniques"
+      "act-probability"
     ],
     "source": "act-template-gen",
-    "contentHash": "34bea27ddc7a660c6e6fa54367eb86c1c4c15be500c8a8cd700f8a4ea0e0710f",
+    "contentHash": "29ffcfd52ebe19cdb6bd5b2bd7eb0317f708b2417d30da73f49a934ccf6cb42c",
     "isActive": true
   },
   {
-    "problemId": "act-act-counting-techniques-f30b48bed9",
-    "skillId": "act-counting-techniques",
-    "prompt": "A meal has 2 appetizers, 3 entrées, and 4 desserts. How many different 3-course meals are possible?",
+    "problemId": "act-act-probability-beaed2e736",
+    "skillId": "act-probability",
+    "prompt": "A bag has 5 red, 2 green, and 6 blue marbles. What is the probability of drawing a red marble?",
     "answer": {
       "type": "auto",
-      "value": "24",
+      "value": "5/13",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "26"
+        "text": "5/2"
       },
       {
         "label": "B",
-        "text": "10"
+        "text": "2/13"
       },
       {
         "label": "C",
-        "text": "24"
+        "text": "13/5"
       },
       {
         "label": "D",
-        "text": "12"
+        "text": "5/8"
       },
       {
         "label": "E",
-        "text": "9"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-counting-techniques"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "f30b48bed9f1ffacfc1afafaaea3f99068f4b4d9e624565cdeff25a3377b5536",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-counting-techniques-73368d60e1",
-    "skillId": "act-counting-techniques",
-    "prompt": "A meal has 4 appetizers, 2 entrées, and 3 desserts. How many different 3-course meals are possible?",
-    "answer": {
-      "type": "auto",
-      "value": "24",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "12"
-      },
-      {
-        "label": "B",
-        "text": "11"
-      },
-      {
-        "label": "C",
-        "text": "9"
-      },
-      {
-        "label": "D",
-        "text": "28"
-      },
-      {
-        "label": "E",
-        "text": "24"
+        "text": "5/13"
       }
     ],
     "correctOption": "E",
@@ -9166,98 +8903,142 @@
     "tags": [
       "act",
       "act-math",
-      "act-counting-techniques"
+      "act-probability"
     ],
     "source": "act-template-gen",
-    "contentHash": "73368d60e1fbaab72440f650f1aa9c07097f0f6af42f2fbe37843717b323fc8f",
+    "contentHash": "beaed2e736abd3305d5e412352387936fdd31256a01724ec47a0f0d6c27eb7fe",
     "isActive": true
   },
   {
-    "problemId": "act-act-counting-techniques-40c5516e4a",
-    "skillId": "act-counting-techniques",
-    "prompt": "A meal has 2 appetizers, 3 entrées, and 2 desserts. How many different 3-course meals are possible?",
+    "problemId": "act-act-probability-d0b0dfcbb8",
+    "skillId": "act-probability",
+    "prompt": "A bag has 4 red, 2 green, and 3 blue marbles. What is the probability of drawing a red marble?",
     "answer": {
       "type": "auto",
-      "value": "12",
+      "value": "4/9",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "6"
+        "text": "2/9"
       },
       {
         "label": "B",
-        "text": "8"
+        "text": "4/2"
       },
       {
         "label": "C",
-        "text": "7"
+        "text": "4/5"
       },
       {
         "label": "D",
-        "text": "14"
+        "text": "9/4"
       },
       {
         "label": "E",
-        "text": "12"
+        "text": "4/9"
       }
     ],
     "correctOption": "E",
-    "difficulty": 3,
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-counting-techniques"
+      "act-probability"
     ],
     "source": "act-template-gen",
-    "contentHash": "40c5516e4ad49db65fba65e6ccc29e2237627857cb1c734a7bf84f357e3f5f26",
+    "contentHash": "d0b0dfcbb8cd6b71a35befe64b1accd93fa0cb9c3e27b52cebf989a71150071e",
     "isActive": true
   },
   {
-    "problemId": "act-act-counting-techniques-1a0fd51d29",
-    "skillId": "act-counting-techniques",
-    "prompt": "A meal has 3 appetizers, 5 entrées, and 4 desserts. How many different 3-course meals are possible?",
+    "problemId": "act-act-probability-c9d99d23bb",
+    "skillId": "act-probability",
+    "prompt": "A bag has 2 red, 3 green, and 2 blue marbles. What is the probability of drawing a red marble?",
     "answer": {
       "type": "auto",
-      "value": "60",
+      "value": "2/7",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "60"
+        "text": "3/7"
       },
       {
         "label": "B",
-        "text": "19"
+        "text": "2/3"
       },
       {
         "label": "C",
-        "text": "30"
+        "text": "2/5"
       },
       {
         "label": "D",
-        "text": "12"
+        "text": "7/2"
       },
       {
         "label": "E",
-        "text": "63"
+        "text": "2/7"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-probability"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "c9d99d23bbc0787a0d90b95b3401a21600cd5b937c6b3e7874b670413a5fd6e0",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-probability-fdd9cdcc4e",
+    "skillId": "act-probability",
+    "prompt": "A bag has 4 red, 6 green, and 5 blue marbles. What is the probability of drawing a red marble?",
+    "answer": {
+      "type": "auto",
+      "value": "4/15",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "4/15"
+      },
+      {
+        "label": "B",
+        "text": "4/6"
+      },
+      {
+        "label": "C",
+        "text": "2/5"
+      },
+      {
+        "label": "D",
+        "text": "4/11"
+      },
+      {
+        "label": "E",
+        "text": "15/4"
       }
     ],
     "correctOption": "A",
-    "difficulty": 3,
+    "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-counting-techniques"
+      "act-probability"
     ],
     "source": "act-template-gen",
-    "contentHash": "1a0fd51d297d7d52322b0b3b136cd09dd4786c9267a41fad29367a1b0123c712",
+    "contentHash": "fdd9cdcc4ef8c9652790b805e3bb1ce728144f2aee0f28ee032446fedd79421e",
     "isActive": true
   },
   {
@@ -9293,7 +9074,7 @@
       }
     ],
     "correctOption": "C",
-    "difficulty": 4,
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -9337,7 +9118,7 @@
       }
     ],
     "correctOption": "A",
-    "difficulty": 4,
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -9381,7 +9162,7 @@
       }
     ],
     "correctOption": "D",
-    "difficulty": 5,
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -9393,171 +9174,259 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-real-complex-numbers-07f722d6e4",
-    "skillId": "act-real-complex-numbers",
-    "prompt": "(7 + 8i) + (-5 + 7i) = ?",
+    "problemId": "act-act-counting-techniques-9e225606a1",
+    "skillId": "act-counting-techniques",
+    "prompt": "A meal has 5 appetizers, 5 entrées, and 2 desserts. How many different 3-course meals are possible?",
     "answer": {
       "type": "auto",
-      "value": "2+15i",
+      "value": "50",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "2+15i"
+        "text": "50"
       },
       {
         "label": "B",
-        "text": "-35+56i"
+        "text": "12"
       },
       {
         "label": "C",
-        "text": "2+1i"
+        "text": "55"
       },
       {
         "label": "D",
-        "text": "15+2i"
+        "text": "27"
       },
       {
         "label": "E",
-        "text": "12+15i"
+        "text": "25"
       }
     ],
     "correctOption": "A",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-real-complex-numbers"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "07f722d6e42c6f95b501956dcedb661f1cdbb40ecce89c0195491714ed6ffbf7",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-real-complex-numbers-7337417079",
-    "skillId": "act-real-complex-numbers",
-    "prompt": "(8 + 5i) + (2 + 2i) = ?",
-    "answer": {
-      "type": "auto",
-      "value": "10+7i",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "16+10i"
-      },
-      {
-        "label": "B",
-        "text": "10+3i"
-      },
-      {
-        "label": "C",
-        "text": "6+7i"
-      },
-      {
-        "label": "D",
-        "text": "10+7i"
-      },
-      {
-        "label": "E",
-        "text": "7+10i"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-real-complex-numbers"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "7337417079b6ee38558c09dece854a467b21bd3d450ed05f5777cc4f204f97ac",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-real-complex-numbers-c2c609fe81",
-    "skillId": "act-real-complex-numbers",
-    "prompt": "(-6 - 4i) + (-6 + 8i) = ?",
-    "answer": {
-      "type": "auto",
-      "value": "-12+4i",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "0+4i"
-      },
-      {
-        "label": "B",
-        "text": "-12+4i"
-      },
-      {
-        "label": "C",
-        "text": "36-32i"
-      },
-      {
-        "label": "D",
-        "text": "4-12i"
-      },
-      {
-        "label": "E",
-        "text": "-12-12i"
-      }
-    ],
-    "correctOption": "B",
     "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-real-complex-numbers"
+      "act-counting-techniques"
     ],
     "source": "act-template-gen",
-    "contentHash": "c2c609fe817fb54ca7a780244887a20161b52a6ffe1ddab899305e4ac1f00a20",
+    "contentHash": "9e225606a1f51ff33f0d5529dc0285e23d1f6a4646b38f03c3591d1b57986dbf",
     "isActive": true
   },
   {
-    "problemId": "act-act-real-complex-numbers-5e94b71d6d",
-    "skillId": "act-real-complex-numbers",
-    "prompt": "(-3 + 7i) + (-3 + 3i) = ?",
+    "problemId": "act-act-counting-techniques-dca62d141a",
+    "skillId": "act-counting-techniques",
+    "prompt": "A meal has 4 appetizers, 5 entrées, and 3 desserts. How many different 3-course meals are possible?",
     "answer": {
       "type": "auto",
-      "value": "-6+10i",
+      "value": "60",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "9+21i"
+        "text": "60"
       },
       {
         "label": "B",
-        "text": "10-6i"
+        "text": "30"
       },
       {
         "label": "C",
-        "text": "-6+10i"
+        "text": "12"
       },
       {
         "label": "D",
-        "text": "-6+4i"
+        "text": "23"
       },
       {
         "label": "E",
-        "text": "0+10i"
+        "text": "64"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-counting-techniques"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "dca62d141a572d3801d56c4c0b9d38665758cac24bd3ffb78b91fc54cba84fcf",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-counting-techniques-a1500c2f4f",
+    "skillId": "act-counting-techniques",
+    "prompt": "A meal has 5 appetizers, 3 entrées, and 4 desserts. How many different 3-course meals are possible?",
+    "answer": {
+      "type": "auto",
+      "value": "60",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "60"
+      },
+      {
+        "label": "B",
+        "text": "19"
+      },
+      {
+        "label": "C",
+        "text": "65"
+      },
+      {
+        "label": "D",
+        "text": "30"
+      },
+      {
+        "label": "E",
+        "text": "12"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-counting-techniques"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "a1500c2f4f982f9b687dd8badbd050a997e25bf712e92629325e07e2dffc210d",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-counting-techniques-93ba14d05a",
+    "skillId": "act-counting-techniques",
+    "prompt": "A meal has 5 appetizers, 4 entrées, and 2 desserts. How many different 3-course meals are possible?",
+    "answer": {
+      "type": "auto",
+      "value": "40",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "40"
+      },
+      {
+        "label": "B",
+        "text": "22"
+      },
+      {
+        "label": "C",
+        "text": "45"
+      },
+      {
+        "label": "D",
+        "text": "11"
+      },
+      {
+        "label": "E",
+        "text": "20"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-counting-techniques"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "93ba14d05a5f242fad191696c2a0bcca1cc2c3e8716e6b514a7100dd17c9e1d1",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-counting-techniques-12eb7705aa",
+    "skillId": "act-counting-techniques",
+    "prompt": "A meal has 4 appetizers, 3 entrées, and 2 desserts. How many different 3-course meals are possible?",
+    "answer": {
+      "type": "auto",
+      "value": "24",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "28"
+      },
+      {
+        "label": "B",
+        "text": "12"
+      },
+      {
+        "label": "C",
+        "text": "24"
+      },
+      {
+        "label": "D",
+        "text": "9"
+      },
+      {
+        "label": "E",
+        "text": "14"
       }
     ],
     "correctOption": "C",
-    "difficulty": 3,
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-counting-techniques"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "12eb7705aa4d1d1e4dd8cd155081121998e7f910cab08c12bed2497275df5ac8",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-real-complex-numbers-f30d40c6da",
+    "skillId": "act-real-complex-numbers",
+    "prompt": "(-4 + 6i) + (-3 + 1i) = ?",
+    "answer": {
+      "type": "auto",
+      "value": "-7+7i",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-1+7i"
+      },
+      {
+        "label": "B",
+        "text": "12+6i"
+      },
+      {
+        "label": "C",
+        "text": "-7+7i"
+      },
+      {
+        "label": "D",
+        "text": "7-7i"
+      },
+      {
+        "label": "E",
+        "text": "-7+5i"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -9565,39 +9434,83 @@
       "act-real-complex-numbers"
     ],
     "source": "act-template-gen",
-    "contentHash": "5e94b71d6d8b4cf1af82845d76fdf0568a17a94a2ff4ac147db044061bf27a56",
+    "contentHash": "f30d40c6da55b1a3cc5c66c46343dceb33a7ede7a48c6ca98d64595694459820",
     "isActive": true
   },
   {
-    "problemId": "act-act-real-complex-numbers-c1c802fba5",
+    "problemId": "act-act-real-complex-numbers-357d486696",
     "skillId": "act-real-complex-numbers",
-    "prompt": "(1 - 1i) + (-2 - 1i) = ?",
+    "prompt": "(6 + 1i) + (-3 + 8i) = ?",
     "answer": {
       "type": "auto",
-      "value": "-1-2i",
+      "value": "3+9i",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "-2+1i"
+        "text": "3-7i"
       },
       {
         "label": "B",
-        "text": "-1+0i"
+        "text": "-18+8i"
       },
       {
         "label": "C",
-        "text": "-2-1i"
+        "text": "3+9i"
       },
       {
         "label": "D",
-        "text": "3-2i"
+        "text": "9+3i"
       },
       {
         "label": "E",
-        "text": "-1-2i"
+        "text": "9+9i"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-real-complex-numbers"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "357d4866961331ffc45866ad39069b4f18b24451872d89f6b083dfcdd0dae906",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-real-complex-numbers-c7b6546076",
+    "skillId": "act-real-complex-numbers",
+    "prompt": "(-3 + 7i) + (-4 - 4i) = ?",
+    "answer": {
+      "type": "auto",
+      "value": "-7+3i",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "1+3i"
+      },
+      {
+        "label": "B",
+        "text": "3-7i"
+      },
+      {
+        "label": "C",
+        "text": "-7+11i"
+      },
+      {
+        "label": "D",
+        "text": "12-28i"
+      },
+      {
+        "label": "E",
+        "text": "-7+3i"
       }
     ],
     "correctOption": "E",
@@ -9609,39 +9522,127 @@
       "act-real-complex-numbers"
     ],
     "source": "act-template-gen",
-    "contentHash": "c1c802fba56471965674cba8dca58fd478d7e7ca8da23e2be839cbb0bee2231f",
+    "contentHash": "c7b6546076f7d113f79bc85fadc482a5dc4044c5e528aae8d11eac62e42f3203",
     "isActive": true
   },
   {
-    "problemId": "act-act-real-complex-numbers-4f650878c4",
+    "problemId": "act-act-real-complex-numbers-f424f860ad",
     "skillId": "act-real-complex-numbers",
-    "prompt": "(2 + 2i) + (-3 + 6i) = ?",
+    "prompt": "(4 + 7i) + (1 + 7i) = ?",
     "answer": {
       "type": "auto",
-      "value": "-1+8i",
+      "value": "5+14i",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "5+8i"
+        "text": "5+14i"
       },
       {
         "label": "B",
-        "text": "-6+12i"
+        "text": "14+5i"
       },
       {
         "label": "C",
-        "text": "-1+8i"
+        "text": "5+0i"
       },
       {
         "label": "D",
-        "text": "-1-4i"
+        "text": "4+49i"
       },
       {
         "label": "E",
-        "text": "8-1i"
+        "text": "3+14i"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-real-complex-numbers"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "f424f860ad3164f31221127c96e84122cee4b90f6429534cb5d37b4326ae22ed",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-real-complex-numbers-e73e7c6120",
+    "skillId": "act-real-complex-numbers",
+    "prompt": "(3 + 6i) + (7 - 3i) = ?",
+    "answer": {
+      "type": "auto",
+      "value": "10+3i",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "21-18i"
+      },
+      {
+        "label": "B",
+        "text": "10+9i"
+      },
+      {
+        "label": "C",
+        "text": "-4+3i"
+      },
+      {
+        "label": "D",
+        "text": "10+3i"
+      },
+      {
+        "label": "E",
+        "text": "3+10i"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-real-complex-numbers"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "e73e7c61200dea41396518a912f491074d3a2d8c1c1f23aec5f79d4813e2894e",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-real-complex-numbers-df8162146d",
+    "skillId": "act-real-complex-numbers",
+    "prompt": "(2 - 5i) + (1 - 2i) = ?",
+    "answer": {
+      "type": "auto",
+      "value": "3-7i",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "1-7i"
+      },
+      {
+        "label": "B",
+        "text": "3-3i"
+      },
+      {
+        "label": "C",
+        "text": "3-7i"
+      },
+      {
+        "label": "D",
+        "text": "-7+3i"
+      },
+      {
+        "label": "E",
+        "text": "2+10i"
       }
     ],
     "correctOption": "C",
@@ -9653,42 +9654,42 @@
       "act-real-complex-numbers"
     ],
     "source": "act-template-gen",
-    "contentHash": "4f650878c49ce23f48bbdca22ad3acc112b89579274e788afe2a987fd74dee1a",
+    "contentHash": "df8162146d57cd32c017ea72c4a39291cfdefc5cb3115401932c7de4d0fcddce",
     "isActive": true
   },
   {
-    "problemId": "act-act-real-complex-numbers-3b2418be1d",
+    "problemId": "act-act-real-complex-numbers-53df24e9af",
     "skillId": "act-real-complex-numbers",
-    "prompt": "(4 + 8i) + (-6 + 6i) = ?",
+    "prompt": "(-5 - 6i) + (-3 - 5i) = ?",
     "answer": {
       "type": "auto",
-      "value": "-2+14i",
+      "value": "-8-11i",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "14-2i"
+        "text": "-11-8i"
       },
       {
         "label": "B",
-        "text": "-2+2i"
+        "text": "-8-11i"
       },
       {
         "label": "C",
-        "text": "-2+14i"
+        "text": "-2-11i"
       },
       {
         "label": "D",
-        "text": "10+14i"
+        "text": "-8-1i"
       },
       {
         "label": "E",
-        "text": "-24+48i"
+        "text": "15+30i"
       }
     ],
-    "correctOption": "C",
+    "correctOption": "B",
     "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
@@ -9697,39 +9698,39 @@
       "act-real-complex-numbers"
     ],
     "source": "act-template-gen",
-    "contentHash": "3b2418be1d8ba0aa284e9bb13ba5650f698e45f8d5db3f0eca63260c19cf4ba8",
+    "contentHash": "53df24e9af1813c7fb9b8cfe1f82ff422c0b2b60e4ccb0502cdc0b1fc9e76d7f",
     "isActive": true
   },
   {
-    "problemId": "act-act-real-complex-numbers-aefd19d5d8",
+    "problemId": "act-act-real-complex-numbers-7f1b4ec716",
     "skillId": "act-real-complex-numbers",
-    "prompt": "(-5 - 1i) + (5 - 5i) = ?",
+    "prompt": "(5 + 7i) + (3 - 5i) = ?",
     "answer": {
       "type": "auto",
-      "value": "0-6i",
+      "value": "8+2i",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "0-6i"
+        "text": "8+2i"
       },
       {
         "label": "B",
-        "text": "0+4i"
+        "text": "2+2i"
       },
       {
         "label": "C",
-        "text": "-25+5i"
+        "text": "2+8i"
       },
       {
         "label": "D",
-        "text": "-6+0i"
+        "text": "15-35i"
       },
       {
         "label": "E",
-        "text": "-10-6i"
+        "text": "8+12i"
       }
     ],
     "correctOption": "A",
@@ -9741,7 +9742,7 @@
       "act-real-complex-numbers"
     ],
     "source": "act-template-gen",
-    "contentHash": "aefd19d5d8b051846acc07dd8227c23003e22db73e068717edb82a0759047272",
+    "contentHash": "7f1b4ec7160318ccbb678b461d01bf52357b3ff659810ea4957e30b0c897c7d2",
     "isActive": true
   },
   {
@@ -9757,26 +9758,26 @@
     "options": [
       {
         "label": "A",
-        "text": "78125"
-      },
-      {
-        "label": "B",
-        "text": "244140625"
-      },
-      {
-        "label": "C",
         "text": "35"
       },
       {
+        "label": "B",
+        "text": "78125"
+      },
+      {
+        "label": "C",
+        "text": "244140625"
+      },
+      {
         "label": "D",
-        "text": "390625"
+        "text": "5"
       },
       {
         "label": "E",
-        "text": "5"
+        "text": "390625"
       }
     ],
-    "correctOption": "A",
+    "correctOption": "B",
     "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
@@ -9789,38 +9790,38 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-exponents-roots-956c2c0d5c",
+    "problemId": "act-act-exponents-roots-2a8677f3cc",
     "skillId": "act-exponents-roots",
-    "prompt": "The expression 2^4 · 2^2 is equal to:",
+    "prompt": "The expression 3^4 · 3^2 is equal to:",
     "answer": {
       "type": "auto",
-      "value": "64",
+      "value": "729",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "128"
+        "text": "9"
       },
       {
         "label": "B",
-        "text": "12"
+        "text": "729"
       },
       {
         "label": "C",
-        "text": "4"
+        "text": "18"
       },
       {
         "label": "D",
-        "text": "64"
+        "text": "2187"
       },
       {
         "label": "E",
-        "text": "256"
+        "text": "6561"
       }
     ],
-    "correctOption": "D",
+    "correctOption": "B",
     "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
@@ -9829,7 +9830,95 @@
       "act-exponents-roots"
     ],
     "source": "act-template-gen",
-    "contentHash": "956c2c0d5c0b5a3d8aee984f8a2f70d5b04c7d51585bfa0f5fbb410f54d43e89",
+    "contentHash": "2a8677f3cc6f8ca9a341f0c503a04f93fed7f93fc4ba8159b5931ca890ce3380",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-exponents-roots-6643fed0b6",
+    "skillId": "act-exponents-roots",
+    "prompt": "The expression 5^2 · 5^4 is equal to:",
+    "answer": {
+      "type": "auto",
+      "value": "15625",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "30"
+      },
+      {
+        "label": "B",
+        "text": "390625"
+      },
+      {
+        "label": "C",
+        "text": "15625"
+      },
+      {
+        "label": "D",
+        "text": "25"
+      },
+      {
+        "label": "E",
+        "text": "78125"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-exponents-roots"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "6643fed0b62fbf6a8ba7f04192959725b8e13b3610da167d726af534f0fdde4f",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-exponents-roots-ac46a25288",
+    "skillId": "act-exponents-roots",
+    "prompt": "The expression 3^5 · 3^2 is equal to:",
+    "answer": {
+      "type": "auto",
+      "value": "2187",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "27"
+      },
+      {
+        "label": "B",
+        "text": "21"
+      },
+      {
+        "label": "C",
+        "text": "2187"
+      },
+      {
+        "label": "D",
+        "text": "6561"
+      },
+      {
+        "label": "E",
+        "text": "59049"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-exponents-roots"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "ac46a252887133c6257de84297355e29fe2c00d9e581a3c6e838161f25ae359c",
     "isActive": true
   },
   {
@@ -9845,7 +9934,7 @@
     "options": [
       {
         "label": "A",
-        "text": "1953125"
+        "text": "15625"
       },
       {
         "label": "B",
@@ -9853,18 +9942,18 @@
       },
       {
         "label": "C",
-        "text": "30"
+        "text": "78125"
       },
       {
         "label": "D",
-        "text": "15625"
+        "text": "30"
       },
       {
         "label": "E",
-        "text": "78125"
+        "text": "1953125"
       }
     ],
-    "correctOption": "D",
+    "correctOption": "A",
     "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
@@ -9877,126 +9966,38 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-exponents-roots-1ef41456de",
+    "problemId": "act-act-exponents-roots-1e28d167cb",
     "skillId": "act-exponents-roots",
-    "prompt": "The expression 2^4 · 2^5 is equal to:",
+    "prompt": "The expression 2^3 · 2^5 is equal to:",
     "answer": {
       "type": "auto",
-      "value": "512",
+      "value": "256",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
+        "text": "32768"
+      },
+      {
+        "label": "B",
+        "text": "4"
+      },
+      {
+        "label": "C",
+        "text": "256"
+      },
+      {
+        "label": "D",
+        "text": "16"
+      },
+      {
+        "label": "E",
         "text": "512"
-      },
-      {
-        "label": "B",
-        "text": "18"
-      },
-      {
-        "label": "C",
-        "text": "1048576"
-      },
-      {
-        "label": "D",
-        "text": "2"
-      },
-      {
-        "label": "E",
-        "text": "1024"
       }
     ],
-    "correctOption": "A",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-exponents-roots"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "1ef41456de1d2dd5d8458ce4cf0b51661a3e56763b5d725a6c2db220af9b93c7",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-exponents-roots-ff41723e1b",
-    "skillId": "act-exponents-roots",
-    "prompt": "The expression 5^3 · 5^5 is equal to:",
-    "answer": {
-      "type": "auto",
-      "value": "390625",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "390625"
-      },
-      {
-        "label": "B",
-        "text": "25"
-      },
-      {
-        "label": "C",
-        "text": "30517578125"
-      },
-      {
-        "label": "D",
-        "text": "1953125"
-      },
-      {
-        "label": "E",
-        "text": "40"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-exponents-roots"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "ff41723e1b2a49899e178284c67c505f3f72fa9a3bd5e634a0723be847a5ef6b",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-exponents-roots-aecd1b3d9d",
-    "skillId": "act-exponents-roots",
-    "prompt": "The expression 5^5 · 5^5 is equal to:",
-    "answer": {
-      "type": "auto",
-      "value": "9765625",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "50"
-      },
-      {
-        "label": "B",
-        "text": "1"
-      },
-      {
-        "label": "C",
-        "text": "48828125"
-      },
-      {
-        "label": "D",
-        "text": "298023223876953150"
-      },
-      {
-        "label": "E",
-        "text": "9765625"
-      }
-    ],
-    "correctOption": "E",
+    "correctOption": "C",
     "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
@@ -10005,192 +10006,60 @@
       "act-exponents-roots"
     ],
     "source": "act-template-gen",
-    "contentHash": "aecd1b3d9d42b51e8b099a98ae99f83ee07f3238915a0f68e82d442ab4ee5b29",
+    "contentHash": "1e28d167cb59351b0979d4207d957cc1059b71ec47d5ee5be8c17f4b2f883bf3",
     "isActive": true
   },
   {
-    "problemId": "act-act-exponents-roots-ad88be80fc",
+    "problemId": "act-act-exponents-roots-65124a2990",
     "skillId": "act-exponents-roots",
-    "prompt": "The expression 2^5 · 2^5 is equal to:",
+    "prompt": "The expression 10^6 · 10^2 is equal to:",
     "answer": {
       "type": "auto",
-      "value": "1024",
+      "value": "100000000",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "20"
-      },
-      {
-        "label": "B",
-        "text": "33554432"
-      },
-      {
-        "label": "C",
-        "text": "1"
-      },
-      {
-        "label": "D",
-        "text": "2048"
-      },
-      {
-        "label": "E",
-        "text": "1024"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-exponents-roots"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "ad88be80fcdf783fc5d36105af255fbe6dfd3256fd1664080f34bd88aa67b390",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-exponents-roots-96fa05e065",
-    "skillId": "act-exponents-roots",
-    "prompt": "The expression 5^5 · 5^3 is equal to:",
-    "answer": {
-      "type": "auto",
-      "value": "390625",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "40"
-      },
-      {
-        "label": "B",
-        "text": "390625"
-      },
-      {
-        "label": "C",
-        "text": "25"
-      },
-      {
-        "label": "D",
-        "text": "30517578125"
-      },
-      {
-        "label": "E",
-        "text": "1953125"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 5,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-exponents-roots"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "96fa05e065c91a43972b91ed65889e2f9fa2ef6d24f70982446ac4af16565210",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-ratios-proportions-percents-238abe121e",
-    "skillId": "act-ratios-proportions-percents",
-    "prompt": "What is 20% of 100?",
-    "answer": {
-      "type": "auto",
-      "value": "20",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "10"
-      },
-      {
-        "label": "B",
-        "text": "2"
-      },
-      {
-        "label": "C",
-        "text": "40"
-      },
-      {
-        "label": "D",
         "text": "80"
       },
       {
-        "label": "E",
-        "text": "20"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-ratios-proportions-percents"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "238abe121ed22119f4c1a4adc61e137fc874b870050a50feda3771c9a0d67da5",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-ratios-proportions-percents-283d43137c",
-    "skillId": "act-ratios-proportions-percents",
-    "prompt": "What is 25% of 60?",
-    "answer": {
-      "type": "auto",
-      "value": "15",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "45"
-      },
-      {
         "label": "B",
-        "text": "15"
+        "text": "10000"
       },
       {
         "label": "C",
-        "text": "1.5"
+        "text": "1000000000000"
       },
       {
         "label": "D",
-        "text": "7.5"
+        "text": "1000000000"
       },
       {
         "label": "E",
-        "text": "30"
+        "text": "100000000"
       }
     ],
-    "correctOption": "B",
-    "difficulty": 2,
+    "correctOption": "E",
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-ratios-proportions-percents"
+      "act-exponents-roots"
     ],
     "source": "act-template-gen",
-    "contentHash": "283d43137c4b9332300da2580c2ee6ea56bf3824fbd74065164578be2f3311bb",
+    "contentHash": "65124a29902886d87ec40296757972b522a36b3911dddd4ca93ea513a4023ce0",
     "isActive": true
   },
   {
-    "problemId": "act-act-ratios-proportions-percents-ebd9d82c9a",
-    "skillId": "act-ratios-proportions-percents",
-    "prompt": "What is 20% of 40?",
+    "problemId": "act-act-exponents-roots-0ed6621a1c",
+    "skillId": "act-exponents-roots",
+    "prompt": "The expression 2^2 · 2^4 is equal to:",
     "answer": {
       "type": "auto",
-      "value": "8",
+      "value": "64",
       "equivalents": []
     },
     "answerType": "multiple-choice",
@@ -10201,99 +10070,55 @@
       },
       {
         "label": "B",
-        "text": "0.8"
+        "text": "12"
       },
       {
         "label": "C",
-        "text": "32"
-      },
-      {
-        "label": "D",
-        "text": "8"
-      },
-      {
-        "label": "E",
-        "text": "16"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-ratios-proportions-percents"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "ebd9d82c9a3a03327dedcafbb1500c0805b33e55b4b5b3562ea2103054d23c87",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-ratios-proportions-percents-12f38260a7",
-    "skillId": "act-ratios-proportions-percents",
-    "prompt": "What is 75% of 180?",
-    "answer": {
-      "type": "auto",
-      "value": "135",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "67.5"
-      },
-      {
-        "label": "B",
-        "text": "45"
-      },
-      {
-        "label": "C",
-        "text": "270"
-      },
-      {
-        "label": "D",
-        "text": "135"
-      },
-      {
-        "label": "E",
-        "text": "13.5"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-ratios-proportions-percents"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "12f38260a7b5f54909a962c100e19ecd9e40698a6de8d7c922261562a5b3e161",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-ratios-proportions-percents-9bd97b73bb",
-    "skillId": "act-ratios-proportions-percents",
-    "prompt": "What is 40% of 160?",
-    "answer": {
-      "type": "auto",
-      "value": "64",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
         "text": "128"
       },
       {
+        "label": "D",
+        "text": "256"
+      },
+      {
+        "label": "E",
+        "text": "64"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-exponents-roots"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "0ed6621a1c552caa6a29536d4a47c93b381b64f02f434e0716d0ab2c56e26811",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-ratios-proportions-percents-8478e77a09",
+    "skillId": "act-ratios-proportions-percents",
+    "prompt": "What is 60% of 160?",
+    "answer": {
+      "type": "auto",
+      "value": "96",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "9.6"
+      },
+      {
         "label": "B",
-        "text": "6.4"
+        "text": "96"
       },
       {
         "label": "C",
-        "text": "32"
+        "text": "48"
       },
       {
         "label": "D",
@@ -10301,7 +10126,447 @@
       },
       {
         "label": "E",
-        "text": "96"
+        "text": "192"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-ratios-proportions-percents"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "8478e77a09e0b90f1a4e88426029cf986a39aff220933c62ef8e4609a0ad5737",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-ratios-proportions-percents-93d2c997ef",
+    "skillId": "act-ratios-proportions-percents",
+    "prompt": "What is 75% of 80?",
+    "answer": {
+      "type": "auto",
+      "value": "60",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "6"
+      },
+      {
+        "label": "B",
+        "text": "120"
+      },
+      {
+        "label": "C",
+        "text": "60"
+      },
+      {
+        "label": "D",
+        "text": "20"
+      },
+      {
+        "label": "E",
+        "text": "30"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-ratios-proportions-percents"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "93d2c997ef0a7247c47a9687da8d02f1946ca35a5a2fc5e063f1b9917d62fb63",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-ratios-proportions-percents-47c362e254",
+    "skillId": "act-ratios-proportions-percents",
+    "prompt": "What is 60% of 40?",
+    "answer": {
+      "type": "auto",
+      "value": "24",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "16"
+      },
+      {
+        "label": "B",
+        "text": "2.4"
+      },
+      {
+        "label": "C",
+        "text": "24"
+      },
+      {
+        "label": "D",
+        "text": "48"
+      },
+      {
+        "label": "E",
+        "text": "12"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-ratios-proportions-percents"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "47c362e254f365620259c921a48dae11bccf4955bf61f8abf43c403b0162038e",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-ratios-proportions-percents-992a96bd75",
+    "skillId": "act-ratios-proportions-percents",
+    "prompt": "What is 25% of 40?",
+    "answer": {
+      "type": "auto",
+      "value": "10",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "5"
+      },
+      {
+        "label": "B",
+        "text": "10"
+      },
+      {
+        "label": "C",
+        "text": "20"
+      },
+      {
+        "label": "D",
+        "text": "1"
+      },
+      {
+        "label": "E",
+        "text": "30"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-ratios-proportions-percents"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "992a96bd7531a6cc63d9dcb7600a0f918e66723a8a8f757fc80078694b8b5aba",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-ratios-proportions-percents-4ee9634e6c",
+    "skillId": "act-ratios-proportions-percents",
+    "prompt": "What is 60% of 100?",
+    "answer": {
+      "type": "auto",
+      "value": "60",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "6"
+      },
+      {
+        "label": "B",
+        "text": "60"
+      },
+      {
+        "label": "C",
+        "text": "120"
+      },
+      {
+        "label": "D",
+        "text": "30"
+      },
+      {
+        "label": "E",
+        "text": "40"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-ratios-proportions-percents"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "4ee9634e6c08043842010fd610a8b9f525c217563f5cf0ac381ead93183ce233",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-ratios-proportions-percents-93102fe62f",
+    "skillId": "act-ratios-proportions-percents",
+    "prompt": "What is 25% of 120?",
+    "answer": {
+      "type": "auto",
+      "value": "30",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "3"
+      },
+      {
+        "label": "B",
+        "text": "90"
+      },
+      {
+        "label": "C",
+        "text": "30"
+      },
+      {
+        "label": "D",
+        "text": "60"
+      },
+      {
+        "label": "E",
+        "text": "15"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-ratios-proportions-percents"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "93102fe62f2f0b1f634a48b01677b0b510db6655a9d031727dad0e691f5b865c",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-ratios-proportions-percents-bd25abad52",
+    "skillId": "act-ratios-proportions-percents",
+    "prompt": "What is 40% of 40?",
+    "answer": {
+      "type": "auto",
+      "value": "16",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "16"
+      },
+      {
+        "label": "B",
+        "text": "8"
+      },
+      {
+        "label": "C",
+        "text": "32"
+      },
+      {
+        "label": "D",
+        "text": "24"
+      },
+      {
+        "label": "E",
+        "text": "1.6"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-ratios-proportions-percents"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "bd25abad52073c758d86ddc675d14691ed43428cc9b1a74a270f16d69c2eaf8a",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-ratios-proportions-percents-b109002742",
+    "skillId": "act-ratios-proportions-percents",
+    "prompt": "What is 25% of 140?",
+    "answer": {
+      "type": "auto",
+      "value": "35",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "3.5"
+      },
+      {
+        "label": "B",
+        "text": "105"
+      },
+      {
+        "label": "C",
+        "text": "35"
+      },
+      {
+        "label": "D",
+        "text": "17.5"
+      },
+      {
+        "label": "E",
+        "text": "70"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-ratios-proportions-percents"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "b109002742fe189e05d9f8b4d85921eb8a25a9214d856c01de2416fdf402922e",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-matrices-vectors-be59eace07",
+    "skillId": "act-matrices-vectors",
+    "prompt": "5 · [2, 1; 4, 3] = ? (scalar multiple of the 2×2 matrix)",
+    "answer": {
+      "type": "auto",
+      "value": "[10, 5; 20, 15]",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "[10, 1; 4, 15]"
+      },
+      {
+        "label": "B",
+        "text": "[2, 1; 4, 3]"
+      },
+      {
+        "label": "C",
+        "text": "[10, 5; 20, 15]"
+      },
+      {
+        "label": "D",
+        "text": "[7, 6; 9, 8]"
+      },
+      {
+        "label": "E",
+        "text": "[10, 5; 4, 3]"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-matrices-vectors"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "be59eace0762e6df848918175c04b9b17e989f206dbde2e9102358f8c2e8f8c0",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-matrices-vectors-d46422feaf",
+    "skillId": "act-matrices-vectors",
+    "prompt": "4 · [1, 4; 1, 4] = ? (scalar multiple of the 2×2 matrix)",
+    "answer": {
+      "type": "auto",
+      "value": "[4, 16; 4, 16]",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "[5, 8; 5, 8]"
+      },
+      {
+        "label": "B",
+        "text": "[4, 4; 1, 16]"
+      },
+      {
+        "label": "C",
+        "text": "[1, 4; 1, 4]"
+      },
+      {
+        "label": "D",
+        "text": "[4, 16; 4, 16]"
+      },
+      {
+        "label": "E",
+        "text": "[4, 16; 1, 4]"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-matrices-vectors"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "d46422feaf8044213a33b05be140686bb22ae7c7c07d6611b35153aea8e95415",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-matrices-vectors-5c246c80b3",
+    "skillId": "act-matrices-vectors",
+    "prompt": "6 · [2, 6; 6, 2] = ? (scalar multiple of the 2×2 matrix)",
+    "answer": {
+      "type": "auto",
+      "value": "[12, 36; 36, 12]",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "[8, 12; 12, 8]"
+      },
+      {
+        "label": "B",
+        "text": "[2, 6; 6, 2]"
+      },
+      {
+        "label": "C",
+        "text": "[12, 6; 6, 12]"
+      },
+      {
+        "label": "D",
+        "text": "[12, 36; 36, 12]"
+      },
+      {
+        "label": "E",
+        "text": "[12, 36; 6, 2]"
       }
     ],
     "correctOption": "D",
@@ -10310,265 +10575,89 @@
     "tags": [
       "act",
       "act-math",
-      "act-ratios-proportions-percents"
+      "act-matrices-vectors"
     ],
     "source": "act-template-gen",
-    "contentHash": "9bd97b73bb0b0c8086d7784e3c62d020265fe6794f52537240aa86b4905ea821",
+    "contentHash": "5c246c80b3891b0ffb333d988453b643dabc0194f9b21213c27b4411271b6b2e",
     "isActive": true
   },
   {
-    "problemId": "act-act-ratios-proportions-percents-f8f59099b6",
-    "skillId": "act-ratios-proportions-percents",
-    "prompt": "What is 10% of 120?",
+    "problemId": "act-act-matrices-vectors-98a5ea581a",
+    "skillId": "act-matrices-vectors",
+    "prompt": "4 · [3, 4; 1, 4] = ? (scalar multiple of the 2×2 matrix)",
     "answer": {
       "type": "auto",
-      "value": "12",
+      "value": "[12, 16; 4, 16]",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "1.2"
+        "text": "[12, 16; 1, 4]"
       },
       {
         "label": "B",
-        "text": "24"
+        "text": "[12, 4; 1, 16]"
       },
       {
         "label": "C",
-        "text": "6"
+        "text": "[3, 4; 1, 4]"
       },
       {
         "label": "D",
-        "text": "108"
+        "text": "[12, 16; 4, 16]"
       },
       {
         "label": "E",
-        "text": "12"
+        "text": "[7, 8; 5, 8]"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-matrices-vectors"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "98a5ea581abf0ed93cd7e15fa48d8f73c0cef3810df7b2ce17fa9abb00bcd652",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-matrices-vectors-208ce320a3",
+    "skillId": "act-matrices-vectors",
+    "prompt": "2 · [4, 2; 4, 5] = ? (scalar multiple of the 2×2 matrix)",
+    "answer": {
+      "type": "auto",
+      "value": "[8, 4; 8, 10]",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "[8, 2; 4, 10]"
+      },
+      {
+        "label": "B",
+        "text": "[8, 4; 4, 5]"
+      },
+      {
+        "label": "C",
+        "text": "[6, 4; 6, 7]"
+      },
+      {
+        "label": "D",
+        "text": "[4, 2; 4, 5]"
+      },
+      {
+        "label": "E",
+        "text": "[8, 4; 8, 10]"
       }
     ],
     "correctOption": "E",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-ratios-proportions-percents"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "f8f59099b62741b9376c294ecd70541fe06de68e065fdcb79bdf242607f58b9c",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-ratios-proportions-percents-8c4c5469ce",
-    "skillId": "act-ratios-proportions-percents",
-    "prompt": "What is 60% of 180?",
-    "answer": {
-      "type": "auto",
-      "value": "108",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "10.8"
-      },
-      {
-        "label": "B",
-        "text": "108"
-      },
-      {
-        "label": "C",
-        "text": "54"
-      },
-      {
-        "label": "D",
-        "text": "72"
-      },
-      {
-        "label": "E",
-        "text": "216"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-ratios-proportions-percents"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "8c4c5469cee9b4b2c114a0d2657c7225b04fd1d7033e647bc6051467edcceb1c",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-ratios-proportions-percents-6086307a62",
-    "skillId": "act-ratios-proportions-percents",
-    "prompt": "What is 75% of 100?",
-    "answer": {
-      "type": "auto",
-      "value": "75",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "7.5"
-      },
-      {
-        "label": "B",
-        "text": "150"
-      },
-      {
-        "label": "C",
-        "text": "75"
-      },
-      {
-        "label": "D",
-        "text": "25"
-      },
-      {
-        "label": "E",
-        "text": "37.5"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 5,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-ratios-proportions-percents"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "6086307a62f7bb8a1e39ce26a9818e140ca94e579c9048575ca54c0293981cec",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-matrices-vectors-2bfbb036ad",
-    "skillId": "act-matrices-vectors",
-    "prompt": "5 · [1, 3; 6, 2] = ? (scalar multiple of the 2×2 matrix)",
-    "answer": {
-      "type": "auto",
-      "value": "[5, 15; 30, 10]",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "[5, 3; 6, 10]"
-      },
-      {
-        "label": "B",
-        "text": "[1, 3; 6, 2]"
-      },
-      {
-        "label": "C",
-        "text": "[5, 15; 30, 10]"
-      },
-      {
-        "label": "D",
-        "text": "[5, 15; 6, 2]"
-      },
-      {
-        "label": "E",
-        "text": "[6, 8; 11, 7]"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-matrices-vectors"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "2bfbb036ad95e5846d1c948a7036a5ad32312ebe5f5006989d31f2148789bda4",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-matrices-vectors-7581f9867b",
-    "skillId": "act-matrices-vectors",
-    "prompt": "3 · [4, 2; 5, 3] = ? (scalar multiple of the 2×2 matrix)",
-    "answer": {
-      "type": "auto",
-      "value": "[12, 6; 15, 9]",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "[12, 6; 5, 3]"
-      },
-      {
-        "label": "B",
-        "text": "[12, 6; 15, 9]"
-      },
-      {
-        "label": "C",
-        "text": "[12, 2; 5, 9]"
-      },
-      {
-        "label": "D",
-        "text": "[4, 2; 5, 3]"
-      },
-      {
-        "label": "E",
-        "text": "[7, 5; 8, 6]"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-matrices-vectors"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "7581f9867b99c8137977f9c481ea1f6ae2711333c5b91915750fdb25daf8f589",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-matrices-vectors-5e5d114a81",
-    "skillId": "act-matrices-vectors",
-    "prompt": "3 · [3, 3; 6, 1] = ? (scalar multiple of the 2×2 matrix)",
-    "answer": {
-      "type": "auto",
-      "value": "[9, 9; 18, 3]",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "[9, 9; 6, 1]"
-      },
-      {
-        "label": "B",
-        "text": "[6, 6; 9, 4]"
-      },
-      {
-        "label": "C",
-        "text": "[9, 9; 18, 3]"
-      },
-      {
-        "label": "D",
-        "text": "[3, 3; 6, 1]"
-      },
-      {
-        "label": "E",
-        "text": "[9, 3; 6, 3]"
-      }
-    ],
-    "correctOption": "C",
     "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
@@ -10577,130 +10666,42 @@
       "act-matrices-vectors"
     ],
     "source": "act-template-gen",
-    "contentHash": "5e5d114a81cd93d8d6ee0cc4923bdc51fd27768c791d7d203e318dbe6aebfbdc",
+    "contentHash": "208ce320a323c144bb4311b70ef0ae20dbb870470ee1dff259a9078769ce6d85",
     "isActive": true
   },
   {
-    "problemId": "act-act-matrices-vectors-dcaa0aae95",
+    "problemId": "act-act-matrices-vectors-2830c4db86",
     "skillId": "act-matrices-vectors",
-    "prompt": "2 · [6, 3; 4, 6] = ? (scalar multiple of the 2×2 matrix)",
+    "prompt": "4 · [2, 4; 3, 1] = ? (scalar multiple of the 2×2 matrix)",
     "answer": {
       "type": "auto",
-      "value": "[12, 6; 8, 12]",
+      "value": "[8, 16; 12, 4]",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "[12, 6; 8, 12]"
+        "text": "[8, 4; 3, 4]"
       },
       {
         "label": "B",
-        "text": "[12, 6; 4, 6]"
+        "text": "[6, 8; 7, 5]"
       },
       {
         "label": "C",
-        "text": "[12, 3; 4, 12]"
+        "text": "[8, 16; 12, 4]"
       },
       {
         "label": "D",
-        "text": "[6, 3; 4, 6]"
+        "text": "[2, 4; 3, 1]"
       },
       {
         "label": "E",
-        "text": "[8, 5; 6, 8]"
+        "text": "[8, 16; 3, 1]"
       }
     ],
-    "correctOption": "A",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-matrices-vectors"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "dcaa0aae952c375f4b8dac2c6468bed060497f705b898230bf7213c5249c177e",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-matrices-vectors-bbb44e4fa8",
-    "skillId": "act-matrices-vectors",
-    "prompt": "3 · [6, 6; 2, 1] = ? (scalar multiple of the 2×2 matrix)",
-    "answer": {
-      "type": "auto",
-      "value": "[18, 18; 6, 3]",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "[18, 6; 2, 3]"
-      },
-      {
-        "label": "B",
-        "text": "[18, 18; 6, 3]"
-      },
-      {
-        "label": "C",
-        "text": "[18, 18; 2, 1]"
-      },
-      {
-        "label": "D",
-        "text": "[9, 9; 5, 4]"
-      },
-      {
-        "label": "E",
-        "text": "[6, 6; 2, 1]"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-matrices-vectors"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "bbb44e4fa8bb7fcb4168329db6a9a715962dde5529bae3a554dfd1ea94931a68",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-matrices-vectors-c750c09bb5",
-    "skillId": "act-matrices-vectors",
-    "prompt": "2 · [2, 5; 1, 4] = ? (scalar multiple of the 2×2 matrix)",
-    "answer": {
-      "type": "auto",
-      "value": "[4, 10; 2, 8]",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "[4, 7; 3, 6]"
-      },
-      {
-        "label": "B",
-        "text": "[4, 10; 1, 4]"
-      },
-      {
-        "label": "C",
-        "text": "[4, 5; 1, 8]"
-      },
-      {
-        "label": "D",
-        "text": "[2, 5; 1, 4]"
-      },
-      {
-        "label": "E",
-        "text": "[4, 10; 2, 8]"
-      }
-    ],
-    "correctOption": "E",
+    "correctOption": "C",
     "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
@@ -10709,42 +10710,42 @@
       "act-matrices-vectors"
     ],
     "source": "act-template-gen",
-    "contentHash": "c750c09bb5ed02a8a34f41e54c631f3fdaa3a9c6cc2c462026c64b056dee1fd4",
+    "contentHash": "2830c4db863e6f553c2f4d36af426cee499643d20a7832da59ac0df2d81ec038",
     "isActive": true
   },
   {
-    "problemId": "act-act-matrices-vectors-ee0c862c0b",
+    "problemId": "act-act-matrices-vectors-775f6c80f9",
     "skillId": "act-matrices-vectors",
-    "prompt": "6 · [1, 6; 2, 6] = ? (scalar multiple of the 2×2 matrix)",
+    "prompt": "5 · [1, 2; 6, 6] = ? (scalar multiple of the 2×2 matrix)",
     "answer": {
       "type": "auto",
-      "value": "[6, 36; 12, 36]",
+      "value": "[5, 10; 30, 30]",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "[6, 6; 2, 36]"
+        "text": "[6, 7; 11, 11]"
       },
       {
         "label": "B",
-        "text": "[6, 36; 12, 36]"
+        "text": "[1, 2; 6, 6]"
       },
       {
         "label": "C",
-        "text": "[1, 6; 2, 6]"
+        "text": "[5, 10; 30, 30]"
       },
       {
         "label": "D",
-        "text": "[7, 12; 8, 12]"
+        "text": "[5, 2; 6, 30]"
       },
       {
         "label": "E",
-        "text": "[6, 36; 2, 6]"
+        "text": "[5, 10; 6, 6]"
       }
     ],
-    "correctOption": "B",
+    "correctOption": "C",
     "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
@@ -10753,39 +10754,39 @@
       "act-matrices-vectors"
     ],
     "source": "act-template-gen",
-    "contentHash": "ee0c862c0baf50ceb874e0f530820222fe380ffaaa16ff323c2310aefe6436cc",
+    "contentHash": "775f6c80f95fc0ff95128bc969a4e6b2cd19b3d618450bdd3a99c743f05d9a40",
     "isActive": true
   },
   {
-    "problemId": "act-act-matrices-vectors-4c0d7b8b50",
+    "problemId": "act-act-matrices-vectors-c2ce4134d0",
     "skillId": "act-matrices-vectors",
-    "prompt": "2 · [2, 3; 3, 4] = ? (scalar multiple of the 2×2 matrix)",
+    "prompt": "2 · [5, 1; 3, 2] = ? (scalar multiple of the 2×2 matrix)",
     "answer": {
       "type": "auto",
-      "value": "[4, 6; 6, 8]",
+      "value": "[10, 2; 6, 4]",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "[4, 5; 5, 6]"
+        "text": "[10, 1; 3, 4]"
       },
       {
         "label": "B",
-        "text": "[4, 3; 3, 8]"
+        "text": "[7, 3; 5, 4]"
       },
       {
         "label": "C",
-        "text": "[4, 6; 3, 4]"
+        "text": "[5, 1; 3, 2]"
       },
       {
         "label": "D",
-        "text": "[2, 3; 3, 4]"
+        "text": "[10, 2; 3, 2]"
       },
       {
         "label": "E",
-        "text": "[4, 6; 6, 8]"
+        "text": "[10, 2; 6, 4]"
       }
     ],
     "correctOption": "E",
@@ -10797,7 +10798,7 @@
       "act-matrices-vectors"
     ],
     "source": "act-template-gen",
-    "contentHash": "4c0d7b8b50ebf5944f7d3255b1beb57566360c2b1babcfc12f9fc8dade0f94fd",
+    "contentHash": "c2ce4134d0f003101b10291a51075adc231c9c0ec83854b8d1fedc55d9ca0ed5",
     "isActive": true
   }
 ]


### PR DESCRIPTION
Follow-up to the ACT practice test (#1190, merged) from live QA — two real issues spotted while taking the test, plus a re-seed safety fix.

## Fixes

**1. Weak/weird distractors in polynomial expansion.** `act-polynomial-expressions` produced degenerate options like `x^2 + 3` and `x^2 - 17` (middle term dropped) that don't look like expansions. Now every distractor keeps the `x^2 + bx + c` form via a `trinomial()` formatter — real errors: sign flips on the middle/constant term, swapped middle & constant, arithmetic slips. Degenerate `sum = 0` cases are skipped.

**2. Repetition within a form.** Each skill had a single prompt template, so when a 60-item form drew the same skill 2–3 times (unavoidable — the essential-skills category alone needs 16 items from 5 skills) it read as the same question with new numbers. Added scenario variety to the high-frequency word-problem templates:
- rate/proportion → cyclist / delivery van / printer / assembly line
- fixed-fee context → gym / phone plan / pool club / tool service
- percent → 6 item types (jacket, laptop, shoes, backpack, desk lamp, bicycle)

**3. Clean re-seed.** `--fresh` (now the default for `npm run act:seed`) clears prior `source:'act-template-gen'` items before upserting, so regenerated prompts don't leave stale copies behind — and accidental double-seeds become a clean no-op.

## Verification
Regenerated bank: 245 items, **0 invalid**, fills **60/60**. Polynomial distractors and scenario variety hand-checked. Correctness-by-construction unchanged (every answer computed + validated).

## To apply after merge
`npm run act:seed` on the target DB (now defaults to `--fresh`, so it cleanly replaces the bank).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTm55BDVTnGaJm3DRVauGZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTm55BDVTnGaJm3DRVauGZ)_