### PR TITLE
feat(act): "Review with my tutor" + fix degenerate L-shape figure

### DIFF
--- a/public/js/act-test.js
+++ b/public/js/act-test.js
@@ -246,15 +246,46 @@
             <div class="actt-sub">${r.rawScore}/${r.totalItems} correct · ${r.accuracy}% · ${r.durationMinutes != null ? r.durationMinutes + ' min' : ''}</div>
           </div>
           <div style="max-width:520px;margin:0 auto">${cats}</div>
-          <div style="text-align:center;margin-top:22px;display:flex;gap:10px;justify-content:center">
+          <div style="text-align:center;margin-top:22px;display:flex;gap:10px;justify-content:center;flex-wrap:wrap">
+            <button class="actt-btn actt-next" id="actt-tutor">📤 Review with my tutor</button>
+            <button class="actt-btn actt-skip" id="actt-retake">Take another</button>
             <button class="actt-btn actt-skip" id="actt-done">Done</button>
-            <button class="actt-btn actt-next" id="actt-retake">Take another</button>
           </div>`;
         this.el('actt-done').addEventListener('click', () => this.close());
         this.el('actt-retake').addEventListener('click', () => { this.sessionId = null; this.open(); });
+        this.el('actt-tutor').addEventListener('click', () => this.sendToTutor(r));
       } catch (e) {
         this.el('actt-body').innerHTML = `<div class="actt-err">${e.message || 'Could not score the test.'}</div>`;
       }
+    }
+
+    // Compose a student-voiced results summary and hand it to the chat tutor so
+    // the conversation has context and remediation can start on the weak areas.
+    buildTutorMessage(r) {
+      const cats = Object.entries(r.byCategory || {})
+        .map(([k, v]) => ({ name: CATEGORY_LABELS[k] || k, correct: v.correct, total: v.total, pct: v.total ? v.correct / v.total : 1 }))
+        .sort((a, b) => a.pct - b.pct);
+      const weak = cats.filter(c => c.correct < c.total).slice(0, 2);
+      const head = `I just finished an ACT Math practice test — estimated score ${r.scaledScore != null ? r.scaledScore : '?'} (${r.rawScore}/${r.totalItems} correct).`;
+      if (!weak.length) {
+        return `${head} I got everything right — what should I work on to push my score even higher?`;
+      }
+      const list = weak.map(c => `${c.name} (${c.correct}/${c.total})`).join(' and ');
+      return `${head} My weakest areas were ${list}. Can we start reviewing those, one topic at a time?`;
+    }
+
+    sendToTutor(r) {
+      const msg = this.buildTutorMessage(r);
+      this.close();
+      const input = document.getElementById('user-input') || document.getElementById('chat-input');
+      const sendBtn = document.getElementById('send-button') || document.querySelector('.send-button');
+      if (!input || !sendBtn) { return; }
+      // #user-input is a contenteditable div; set text + fire input so the chat
+      // picks up the value, then trigger send (mirrors the app's own pattern).
+      if (input.isContentEditable) input.textContent = msg; else input.value = msg;
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      input.focus();
+      setTimeout(() => sendBtn.click(), 60);
     }
   }
 

--- a/scripts/generateActItems.js
+++ b/scripts/generateActItems.js
@@ -389,9 +389,12 @@ G['act-multi-step-rate-proportion'] = (d) => {
   };
 };
 G['act-area-perimeter-composite'] = (d) => {
-  const a = ri(3, 7), b = ri(3, 7), c = ri(2, 5); // L-shape: big rect a×b minus corner c×c
+  const a = ri(4, 8), b = ri(4, 8);
+  // Cut MUST be strictly smaller than both sides, or the remaining shape is a
+  // rectangle (or impossible) and contradicts the L-shape figure.
+  const c = ri(2, Math.min(a, b) - 1);
   const correct = a * b - c * c;
-  return { prompt: `In the figure shown, a square of side ${c} has been cut from the corner of a ${a}-by-${b} rectangle. What is the area of the remaining (shaded) region?`, correct, svg: SVG.lShape(a, b, c), distractors: [a * b, a * b + c * c, a * b - c, 2 * (a + b) - c], validate: () => a * b - c * c === correct && correct > 0 };
+  return { prompt: `In the figure shown, a square of side ${c} has been cut from the corner of a ${a}-by-${b} rectangle. What is the area of the remaining (shaded) region?`, correct, svg: SVG.lShape(a, b, c), distractors: [a * b, a * b + c * c, a * b - c, 2 * (a + b) - c, a * b - 2 * c], validate: () => c < a && c < b && a * b - c * c === correct && correct > 0 };
 };
 G['act-algebraic-reasoning-context'] = (d) => {
   // Set up total = fixed + per·m, then SOLVE for the number of months m.

--- a/seeds/act-math-items.generated.json
+++ b/seeds/act-math-items.generated.json
@@ -352,354 +352,354 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-area-perimeter-composite-15cf52b424",
+    "problemId": "act-act-area-perimeter-composite-41b3954dd3",
     "skillId": "act-area-perimeter-composite",
-    "prompt": "In the figure shown, a square of side 5 has been cut from the corner of a 5-by-7 rectangle. What is the area of the remaining (shaded) region?",
-    "svg": "<svg viewBox=\"0 0 120 124\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 30,20 30,80 90,80 90,104 30,104\" stroke-linejoin=\"round\"/></svg>",
+    "prompt": "In the figure shown, a square of side 4 has been cut from the corner of a 6-by-5 rectangle. What is the area of the remaining (shaded) region?",
+    "svg": "<svg viewBox=\"0 0 132 100\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 54,20 54,68 102,68 102,80 30,80\" stroke-linejoin=\"round\"/></svg>",
     "answer": {
       "type": "auto",
-      "value": "10",
+      "value": "14",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
+        "text": "26"
+      },
+      {
+        "label": "B",
+        "text": "46"
+      },
+      {
+        "label": "C",
         "text": "30"
       },
       {
-        "label": "B",
-        "text": "60"
-      },
-      {
-        "label": "C",
-        "text": "19"
-      },
-      {
         "label": "D",
-        "text": "35"
-      },
-      {
-        "label": "E",
-        "text": "10"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-area-perimeter-composite"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "15cf52b424382ab4ca9a939ca5c829995ab1debb393e1040a5695a383649be1f",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-area-perimeter-composite-1f6b36110f",
-    "skillId": "act-area-perimeter-composite",
-    "prompt": "In the figure shown, a square of side 3 has been cut from the corner of a 4-by-3 rectangle. What is the area of the remaining (shaded) region?",
-    "svg": "<svg viewBox=\"0 0 108 76\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 42,20 42,56 78,56 78,56 30,56\" stroke-linejoin=\"round\"/></svg>",
-    "answer": {
-      "type": "auto",
-      "value": "3",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "21"
-      },
-      {
-        "label": "B",
-        "text": "3"
-      },
-      {
-        "label": "C",
-        "text": "11"
-      },
-      {
-        "label": "D",
-        "text": "9"
-      },
-      {
-        "label": "E",
-        "text": "12"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-area-perimeter-composite"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "1f6b36110fe5376d8291ccfeb7422b44065a5b3280163cfffd8f903b80152ce6",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-area-perimeter-composite-05b1a8f284",
-    "skillId": "act-area-perimeter-composite",
-    "prompt": "In the figure shown, a square of side 3 has been cut from the corner of a 5-by-7 rectangle. What is the area of the remaining (shaded) region?",
-    "svg": "<svg viewBox=\"0 0 120 124\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 54,20 54,56 90,56 90,104 30,104\" stroke-linejoin=\"round\"/></svg>",
-    "answer": {
-      "type": "auto",
-      "value": "26",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "21"
-      },
-      {
-        "label": "B",
-        "text": "32"
-      },
-      {
-        "label": "C",
-        "text": "35"
-      },
-      {
-        "label": "D",
-        "text": "44"
-      },
-      {
-        "label": "E",
-        "text": "26"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-area-perimeter-composite"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "05b1a8f284863e9e334a2c8fd6977062c5fb741ecff7ab4c5b15f7c9f63beb32",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-area-perimeter-composite-c9bf870119",
-    "skillId": "act-area-perimeter-composite",
-    "prompt": "In the figure shown, a square of side 2 has been cut from the corner of a 5-by-5 rectangle. What is the area of the remaining (shaded) region?",
-    "svg": "<svg viewBox=\"0 0 120 100\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 66,20 66,44 90,44 90,80 30,80\" stroke-linejoin=\"round\"/></svg>",
-    "answer": {
-      "type": "auto",
-      "value": "21",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "23"
-      },
-      {
-        "label": "B",
-        "text": "25"
-      },
-      {
-        "label": "C",
-        "text": "21"
-      },
-      {
-        "label": "D",
-        "text": "29"
-      },
-      {
-        "label": "E",
         "text": "18"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-area-perimeter-composite"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "c9bf870119f926db47ecad6a1bab02468474e52bbc829f3fd5bb58eaeb0389de",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-area-perimeter-composite-6dbfb14bc8",
-    "skillId": "act-area-perimeter-composite",
-    "prompt": "In the figure shown, a square of side 4 has been cut from the corner of a 4-by-6 rectangle. What is the area of the remaining (shaded) region?",
-    "svg": "<svg viewBox=\"0 0 108 112\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 30,20 30,68 78,68 78,92 30,92\" stroke-linejoin=\"round\"/></svg>",
-    "answer": {
-      "type": "auto",
-      "value": "8",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "20"
-      },
-      {
-        "label": "B",
-        "text": "16"
-      },
-      {
-        "label": "C",
-        "text": "40"
-      },
-      {
-        "label": "D",
-        "text": "8"
-      },
-      {
-        "label": "E",
-        "text": "24"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-area-perimeter-composite"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "6dbfb14bc85e38ad0555043ef12d1565040dc89adc8e246be7426a56eaa79265",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-area-perimeter-composite-aba5bffee8",
-    "skillId": "act-area-perimeter-composite",
-    "prompt": "In the figure shown, a square of side 3 has been cut from the corner of a 7-by-6 rectangle. What is the area of the remaining (shaded) region?",
-    "svg": "<svg viewBox=\"0 0 144 112\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 78,20 78,56 114,56 114,92 30,92\" stroke-linejoin=\"round\"/></svg>",
-    "answer": {
-      "type": "auto",
-      "value": "33",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "39"
-      },
-      {
-        "label": "B",
-        "text": "42"
-      },
-      {
-        "label": "C",
-        "text": "33"
-      },
-      {
-        "label": "D",
-        "text": "51"
-      },
-      {
-        "label": "E",
-        "text": "23"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-area-perimeter-composite"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "aba5bffee87d8007c50eb69e3e7c96ab644373d33ae4e508f438c2b4eea5b6cd",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-area-perimeter-composite-978eac015c",
-    "skillId": "act-area-perimeter-composite",
-    "prompt": "In the figure shown, a square of side 5 has been cut from the corner of a 6-by-7 rectangle. What is the area of the remaining (shaded) region?",
-    "svg": "<svg viewBox=\"0 0 132 124\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 42,20 42,80 102,80 102,104 30,104\" stroke-linejoin=\"round\"/></svg>",
-    "answer": {
-      "type": "auto",
-      "value": "17",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "37"
-      },
-      {
-        "label": "B",
-        "text": "21"
-      },
-      {
-        "label": "C",
-        "text": "67"
-      },
-      {
-        "label": "D",
-        "text": "42"
-      },
-      {
-        "label": "E",
-        "text": "17"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-area-perimeter-composite"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "978eac015c1c0cad1f15fee8b91c84ce0e4936f5063486ca560ea0c1009d18b9",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-area-perimeter-composite-cea6e7feac",
-    "skillId": "act-area-perimeter-composite",
-    "prompt": "In the figure shown, a square of side 4 has been cut from the corner of a 4-by-5 rectangle. What is the area of the remaining (shaded) region?",
-    "svg": "<svg viewBox=\"0 0 108 100\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 30,20 30,68 78,68 78,80 30,80\" stroke-linejoin=\"round\"/></svg>",
-    "answer": {
-      "type": "auto",
-      "value": "4",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "36"
-      },
-      {
-        "label": "B",
-        "text": "16"
-      },
-      {
-        "label": "C",
-        "text": "4"
-      },
-      {
-        "label": "D",
-        "text": "20"
       },
       {
         "label": "E",
         "text": "14"
       }
     ],
+    "correctOption": "E",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-perimeter-composite"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "41b3954dd36e0d2973d42244c7bc4556cc3090f3ae5497ed22084b68cac62fd5",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-perimeter-composite-5c863ed303",
+    "skillId": "act-area-perimeter-composite",
+    "prompt": "In the figure shown, a square of side 2 has been cut from the corner of a 8-by-7 rectangle. What is the area of the remaining (shaded) region?",
+    "svg": "<svg viewBox=\"0 0 156 124\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 102,20 102,44 126,44 126,104 30,104\" stroke-linejoin=\"round\"/></svg>",
+    "answer": {
+      "type": "auto",
+      "value": "52",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "56"
+      },
+      {
+        "label": "B",
+        "text": "28"
+      },
+      {
+        "label": "C",
+        "text": "54"
+      },
+      {
+        "label": "D",
+        "text": "52"
+      },
+      {
+        "label": "E",
+        "text": "60"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-perimeter-composite"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "5c863ed303d7a065211e5c6b16737dade730f0a6c6d6e20de51478f4ac4b0836",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-perimeter-composite-c85e2fbbe6",
+    "skillId": "act-area-perimeter-composite",
+    "prompt": "In the figure shown, a square of side 2 has been cut from the corner of a 4-by-6 rectangle. What is the area of the remaining (shaded) region?",
+    "svg": "<svg viewBox=\"0 0 108 112\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 54,20 54,44 78,44 78,92 30,92\" stroke-linejoin=\"round\"/></svg>",
+    "answer": {
+      "type": "auto",
+      "value": "20",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "28"
+      },
+      {
+        "label": "B",
+        "text": "20"
+      },
+      {
+        "label": "C",
+        "text": "22"
+      },
+      {
+        "label": "D",
+        "text": "24"
+      },
+      {
+        "label": "E",
+        "text": "18"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-perimeter-composite"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "c85e2fbbe60b313c2635421d734f97f198f1cc7265d3845599e6d8b649b0f662",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-perimeter-composite-6f7bfd7667",
+    "skillId": "act-area-perimeter-composite",
+    "prompt": "In the figure shown, a square of side 3 has been cut from the corner of a 5-by-8 rectangle. What is the area of the remaining (shaded) region?",
+    "svg": "<svg viewBox=\"0 0 120 136\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 54,20 54,56 90,56 90,116 30,116\" stroke-linejoin=\"round\"/></svg>",
+    "answer": {
+      "type": "auto",
+      "value": "31",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "49"
+      },
+      {
+        "label": "B",
+        "text": "37"
+      },
+      {
+        "label": "C",
+        "text": "31"
+      },
+      {
+        "label": "D",
+        "text": "40"
+      },
+      {
+        "label": "E",
+        "text": "23"
+      }
+    ],
     "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-perimeter-composite"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "6f7bfd7667b171afe173f2b77f80932a3c5001f401ef00542f4be65c7305c550",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-perimeter-composite-d6bb9911c5",
+    "skillId": "act-area-perimeter-composite",
+    "prompt": "In the figure shown, a square of side 2 has been cut from the corner of a 6-by-6 rectangle. What is the area of the remaining (shaded) region?",
+    "svg": "<svg viewBox=\"0 0 132 112\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 78,20 78,44 102,44 102,92 30,92\" stroke-linejoin=\"round\"/></svg>",
+    "answer": {
+      "type": "auto",
+      "value": "32",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "22"
+      },
+      {
+        "label": "B",
+        "text": "34"
+      },
+      {
+        "label": "C",
+        "text": "36"
+      },
+      {
+        "label": "D",
+        "text": "40"
+      },
+      {
+        "label": "E",
+        "text": "32"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-perimeter-composite"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "d6bb9911c5f30d729ff72c03df1a82a976349834668f072da8a7ec79f4a58c16",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-perimeter-composite-460227bf19",
+    "skillId": "act-area-perimeter-composite",
+    "prompt": "In the figure shown, a square of side 3 has been cut from the corner of a 8-by-6 rectangle. What is the area of the remaining (shaded) region?",
+    "svg": "<svg viewBox=\"0 0 156 112\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 90,20 90,56 126,56 126,92 30,92\" stroke-linejoin=\"round\"/></svg>",
+    "answer": {
+      "type": "auto",
+      "value": "39",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "25"
+      },
+      {
+        "label": "B",
+        "text": "39"
+      },
+      {
+        "label": "C",
+        "text": "57"
+      },
+      {
+        "label": "D",
+        "text": "45"
+      },
+      {
+        "label": "E",
+        "text": "48"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-perimeter-composite"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "460227bf19201644b12f4f4c7a4102238a97c82d999f90382d672c5fb9ae7c96",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-perimeter-composite-316b1ffd46",
+    "skillId": "act-area-perimeter-composite",
+    "prompt": "In the figure shown, a square of side 4 has been cut from the corner of a 7-by-5 rectangle. What is the area of the remaining (shaded) region?",
+    "svg": "<svg viewBox=\"0 0 144 100\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 66,20 66,68 114,68 114,80 30,80\" stroke-linejoin=\"round\"/></svg>",
+    "answer": {
+      "type": "auto",
+      "value": "19",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "51"
+      },
+      {
+        "label": "B",
+        "text": "35"
+      },
+      {
+        "label": "C",
+        "text": "20"
+      },
+      {
+        "label": "D",
+        "text": "19"
+      },
+      {
+        "label": "E",
+        "text": "31"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-perimeter-composite"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "316b1ffd46b83a7c8535e01f38e7ba3ea6053526cd4bc4980e1eae36eeb6170b",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-perimeter-composite-55423845a8",
+    "skillId": "act-area-perimeter-composite",
+    "prompt": "In the figure shown, a square of side 4 has been cut from the corner of a 8-by-5 rectangle. What is the area of the remaining (shaded) region?",
+    "svg": "<svg viewBox=\"0 0 156 100\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"30,20 78,20 78,68 126,68 126,80 30,80\" stroke-linejoin=\"round\"/></svg>",
+    "answer": {
+      "type": "auto",
+      "value": "24",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "56"
+      },
+      {
+        "label": "B",
+        "text": "24"
+      },
+      {
+        "label": "C",
+        "text": "36"
+      },
+      {
+        "label": "D",
+        "text": "22"
+      },
+      {
+        "label": "E",
+        "text": "40"
+      }
+    ],
+    "correctOption": "B",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -708,42 +708,42 @@
       "act-area-perimeter-composite"
     ],
     "source": "act-template-gen",
-    "contentHash": "cea6e7feacf212bfa791adc677acbd6df3575a4936b1e630817a10ffa14d0df0",
+    "contentHash": "55423845a86458b909c3194fdc8b68a8cb296590707fd5dfbd7df3127989abe2",
     "isActive": true
   },
   {
-    "problemId": "act-act-algebraic-reasoning-context-fc2f277d50",
+    "problemId": "act-act-algebraic-reasoning-context-a7865e4425",
     "skillId": "act-algebraic-reasoning-context",
-    "prompt": "A pool club charges a $10 membership fee plus $8 per visit. After how many visits will the total paid reach $66?",
+    "prompt": "A tool service has a $25 flat fee plus $3 per day. After how many days will the total paid reach $43?",
     "answer": {
       "type": "auto",
-      "value": "7",
+      "value": "6",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "4"
-      },
-      {
-        "label": "B",
         "text": "7"
       },
       {
+        "label": "B",
+        "text": "5"
+      },
+      {
         "label": "C",
-        "text": "56"
+        "text": "2"
       },
       {
         "label": "D",
-        "text": "8"
+        "text": "14"
       },
       {
         "label": "E",
         "text": "6"
       }
     ],
-    "correctOption": "B",
+    "correctOption": "E",
     "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
@@ -752,13 +752,13 @@
       "act-algebraic-reasoning-context"
     ],
     "source": "act-template-gen",
-    "contentHash": "fc2f277d503399d49f7cdab4ce877aa832df5672b85baf64c190360220528ba2",
+    "contentHash": "a7865e4425b43e33d59d9538de40884d3a63d925431b0cd5649bcec656d93b6c",
     "isActive": true
   },
   {
-    "problemId": "act-act-algebraic-reasoning-context-8f148748cf",
+    "problemId": "act-act-algebraic-reasoning-context-889296a0b1",
     "skillId": "act-algebraic-reasoning-context",
-    "prompt": "A pool club charges a $30 membership fee plus $9 per visit. After how many visits will the total paid reach $111?",
+    "prompt": "A pool club charges a $25 membership fee plus $8 per visit. After how many visits will the total paid reach $97?",
     "answer": {
       "type": "auto",
       "value": "9",
@@ -768,11 +768,231 @@
     "options": [
       {
         "label": "A",
+        "text": "3"
+      },
+      {
+        "label": "B",
+        "text": "12"
+      },
+      {
+        "label": "C",
+        "text": "8"
+      },
+      {
+        "label": "D",
+        "text": "10"
+      },
+      {
+        "label": "E",
+        "text": "9"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-algebraic-reasoning-context"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "889296a0b1bb6c95dd28dccd23e44e8bf5c1184ee6a18e17cfd7675e5e66147e",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-algebraic-reasoning-context-01bdca0db7",
+    "skillId": "act-algebraic-reasoning-context",
+    "prompt": "A tool service has a $10 flat fee plus $9 per day. After how many days will the total paid reach $55?",
+    "answer": {
+      "type": "auto",
+      "value": "5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "4"
+      },
+      {
+        "label": "B",
+        "text": "6"
+      },
+      {
+        "label": "C",
+        "text": "3"
+      },
+      {
+        "label": "D",
+        "text": "45"
+      },
+      {
+        "label": "E",
+        "text": "5"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-algebraic-reasoning-context"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "01bdca0db7393de321aff61c2571e1d439d0ad30e1ea19327f01f5286470fe4e",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-algebraic-reasoning-context-a50ec094ae",
+    "skillId": "act-algebraic-reasoning-context",
+    "prompt": "A tool service has a $20 flat fee plus $5 per day. After how many days will the total paid reach $55?",
+    "answer": {
+      "type": "auto",
+      "value": "7",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "6"
+      },
+      {
+        "label": "B",
+        "text": "2"
+      },
+      {
+        "label": "C",
+        "text": "8"
+      },
+      {
+        "label": "D",
+        "text": "7"
+      },
+      {
+        "label": "E",
+        "text": "11"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-algebraic-reasoning-context"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "a50ec094aefcab09e3fa9e0e22ec1dd419018857f1b7321d287ba2b2a51be272",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-algebraic-reasoning-context-3eb64a9f96",
+    "skillId": "act-algebraic-reasoning-context",
+    "prompt": "A pool club charges a $30 membership fee plus $3 per visit. After how many visits will the total paid reach $51?",
+    "answer": {
+      "type": "auto",
+      "value": "7",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "6"
+      },
+      {
+        "label": "B",
+        "text": "2"
+      },
+      {
+        "label": "C",
+        "text": "7"
+      },
+      {
+        "label": "D",
+        "text": "8"
+      },
+      {
+        "label": "E",
+        "text": "17"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-algebraic-reasoning-context"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "3eb64a9f96fb4eafdf0e5d9dc3ac1f946535d89ef42c58a2544d237da9a32fc0",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-algebraic-reasoning-context-0a045a98af",
+    "skillId": "act-algebraic-reasoning-context",
+    "prompt": "A pool club charges a $40 membership fee plus $7 per visit. After how many visits will the total paid reach $82?",
+    "answer": {
+      "type": "auto",
+      "value": "6",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
         "text": "12"
       },
       {
         "label": "B",
-        "text": "8"
+        "text": "5"
+      },
+      {
+        "label": "C",
+        "text": "6"
+      },
+      {
+        "label": "D",
+        "text": "7"
+      },
+      {
+        "label": "E",
+        "text": "17"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-algebraic-reasoning-context"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "0a045a98afdea0f8516faa24bf942faaa2c18e939c88ac67ebd8ac7646bfb143",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-algebraic-reasoning-context-7f09cd4487",
+    "skillId": "act-algebraic-reasoning-context",
+    "prompt": "A phone plan has a $15 activation fee plus $3 each month. After how many months will the total paid reach $27?",
+    "answer": {
+      "type": "auto",
+      "value": "4",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "5"
+      },
+      {
+        "label": "B",
+        "text": "14"
       },
       {
         "label": "C",
@@ -784,11 +1004,11 @@
       },
       {
         "label": "E",
-        "text": "10"
+        "text": "4"
       }
     ],
-    "correctOption": "D",
-    "difficulty": 2,
+    "correctOption": "E",
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -796,16 +1016,412 @@
       "act-algebraic-reasoning-context"
     ],
     "source": "act-template-gen",
-    "contentHash": "8f148748cf1bd4be4cb0b03814d3ddf503334894ebc434aa5b24c3cded438176",
+    "contentHash": "7f09cd4487a0815feca651929ec0feafd5253a5cb4107901f57a5e530c5c3154",
     "isActive": true
   },
   {
-    "problemId": "act-act-algebraic-reasoning-context-17869de13b",
+    "problemId": "act-act-algebraic-reasoning-context-2b05e73ec8",
     "skillId": "act-algebraic-reasoning-context",
-    "prompt": "A phone plan has a $10 activation fee plus $8 each month. After how many months will the total paid reach $42?",
+    "prompt": "A phone plan has a $20 activation fee plus $7 each month. After how many months will the total paid reach $69?",
     "answer": {
       "type": "auto",
-      "value": "4",
+      "value": "7",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "6"
+      },
+      {
+        "label": "B",
+        "text": "7"
+      },
+      {
+        "label": "C",
+        "text": "8"
+      },
+      {
+        "label": "D",
+        "text": "13"
+      },
+      {
+        "label": "E",
+        "text": "10"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-algebraic-reasoning-context"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "2b05e73ec8194aff2fd9dfd372ecb05f6128350e533b470d5edad2ebde78287e",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-percent-applications-c0911cb364",
+    "skillId": "act-percent-applications",
+    "prompt": "A $40 laptop is 20% off. With 5% sales tax added to the discounted price, what is the final cost?",
+    "answer": {
+      "type": "auto",
+      "value": "$33.60",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$20"
+      },
+      {
+        "label": "B",
+        "text": "$33.60"
+      },
+      {
+        "label": "C",
+        "text": "$8"
+      },
+      {
+        "label": "D",
+        "text": "$32"
+      },
+      {
+        "label": "E",
+        "text": "$42"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-percent-applications"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "c0911cb364f1accd79e7a7de1afdbeb1b337e41e576e4c04fe1601b7fb40f41a",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-percent-applications-18aad66eca",
+    "skillId": "act-percent-applications",
+    "prompt": "A $40 desk lamp is 25% off. With 8% sales tax added to the discounted price, what is the final cost?",
+    "answer": {
+      "type": "auto",
+      "value": "$32.40",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$43.20"
+      },
+      {
+        "label": "B",
+        "text": "$32.40"
+      },
+      {
+        "label": "C",
+        "text": "$15"
+      },
+      {
+        "label": "D",
+        "text": "$30"
+      },
+      {
+        "label": "E",
+        "text": "$10"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-percent-applications"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "18aad66eca88b7e6d3ec5c094fb924c07675fe9fd12973a309df98a70acb35f8",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-percent-applications-2a85e57469",
+    "skillId": "act-percent-applications",
+    "prompt": "A $60 desk lamp is 20% off. With 5% sales tax added to the discounted price, what is the final cost?",
+    "answer": {
+      "type": "auto",
+      "value": "$50.40",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$12"
+      },
+      {
+        "label": "B",
+        "text": "$50.40"
+      },
+      {
+        "label": "C",
+        "text": "$63"
+      },
+      {
+        "label": "D",
+        "text": "$40"
+      },
+      {
+        "label": "E",
+        "text": "$48"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-percent-applications"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "2a85e57469e9f57ac59b0e3fd17a4c318562d83a1ed93a81f67178527c750e7f",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-percent-applications-3ffacee829",
+    "skillId": "act-percent-applications",
+    "prompt": "A $60 pair of shoes is 10% off. With 8% sales tax added to the discounted price, what is the final cost?",
+    "answer": {
+      "type": "auto",
+      "value": "$58.32",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$6"
+      },
+      {
+        "label": "B",
+        "text": "$58.32"
+      },
+      {
+        "label": "C",
+        "text": "$50"
+      },
+      {
+        "label": "D",
+        "text": "$54"
+      },
+      {
+        "label": "E",
+        "text": "$64.80"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-percent-applications"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "3ffacee829ca37532cc670cf25277cc7a70df318ab556a56ecbfe137a2f1292c",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-percent-applications-ee908bcb5c",
+    "skillId": "act-percent-applications",
+    "prompt": "A $50 desk lamp is 10% off. With 10% sales tax added to the discounted price, what is the final cost?",
+    "answer": {
+      "type": "auto",
+      "value": "$49.50",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$45"
+      },
+      {
+        "label": "B",
+        "text": "$49.50"
+      },
+      {
+        "label": "C",
+        "text": "$5"
+      },
+      {
+        "label": "D",
+        "text": "$40"
+      },
+      {
+        "label": "E",
+        "text": "$55"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-percent-applications"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "ee908bcb5c06a8df9728b1ec067b963d813f6da3349d0ddde9c9dc685ae8904f",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-percent-applications-c15bdabb96",
+    "skillId": "act-percent-applications",
+    "prompt": "A $50 backpack is 10% off. With 10% sales tax added to the discounted price, what is the final cost?",
+    "answer": {
+      "type": "auto",
+      "value": "$49.50",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$55"
+      },
+      {
+        "label": "B",
+        "text": "$40"
+      },
+      {
+        "label": "C",
+        "text": "$45"
+      },
+      {
+        "label": "D",
+        "text": "$50"
+      },
+      {
+        "label": "E",
+        "text": "$49.50"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-percent-applications"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "c15bdabb9632556c0cfec6cbed607c1918bf4157fb32355ecc286fef4ef0d957",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-percent-applications-bfdf0ff081",
+    "skillId": "act-percent-applications",
+    "prompt": "A $50 jacket is 20% off. With 10% sales tax added to the discounted price, what is the final cost?",
+    "answer": {
+      "type": "auto",
+      "value": "$44",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$44"
+      },
+      {
+        "label": "B",
+        "text": "$40"
+      },
+      {
+        "label": "C",
+        "text": "$55"
+      },
+      {
+        "label": "D",
+        "text": "$45"
+      },
+      {
+        "label": "E",
+        "text": "$30"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-percent-applications"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "bfdf0ff081dabf066e325d1390a8d31ed7109c025a7f8c2d39eeb3db7a607eec",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-percent-applications-74e5949da0",
+    "skillId": "act-percent-applications",
+    "prompt": "A $60 pair of shoes is 10% off. With 5% sales tax added to the discounted price, what is the final cost?",
+    "answer": {
+      "type": "auto",
+      "value": "$56.70",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "$54"
+      },
+      {
+        "label": "B",
+        "text": "$63"
+      },
+      {
+        "label": "C",
+        "text": "$56.70"
+      },
+      {
+        "label": "D",
+        "text": "$57"
+      },
+      {
+        "label": "E",
+        "text": "$50"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-percent-applications"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "74e5949da05aaae8948ee6950240692d1c2725983b59963fcdda13aaeecbba92",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-measurement-unit-conversion-2cc6ec7307",
+    "skillId": "act-measurement-unit-conversion",
+    "prompt": "How many ounces are in 4 pounds?",
+    "answer": {
+      "type": "auto",
+      "value": "64",
       "equivalents": []
     },
     "answerType": "multiple-choice",
@@ -816,187 +1432,11 @@
       },
       {
         "label": "B",
-        "text": "2"
+        "text": "60"
       },
       {
         "label": "C",
-        "text": "3"
-      },
-      {
-        "label": "D",
-        "text": "4"
-      },
-      {
-        "label": "E",
-        "text": "5"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-algebraic-reasoning-context"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "17869de13b7862361888ea86d34a3b4bebeef6291cf303312cf775fd337b7fdb",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-algebraic-reasoning-context-257d5c8bff",
-    "skillId": "act-algebraic-reasoning-context",
-    "prompt": "A pool club charges a $30 membership fee plus $8 per visit. After how many visits will the total paid reach $70?",
-    "answer": {
-      "type": "auto",
-      "value": "5",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "9"
-      },
-      {
-        "label": "B",
-        "text": "4"
-      },
-      {
-        "label": "C",
-        "text": "5"
-      },
-      {
-        "label": "D",
-        "text": "2"
-      },
-      {
-        "label": "E",
-        "text": "6"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-algebraic-reasoning-context"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "257d5c8bffc8e0ecaac9b835872e30cd50c82bc53d3b4a78ada8ce878d224d78",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-algebraic-reasoning-context-be02a502f1",
-    "skillId": "act-algebraic-reasoning-context",
-    "prompt": "A gym charges a $10 one-time sign-up fee plus $4 each month. After how many months will the total paid reach $30?",
-    "answer": {
-      "type": "auto",
-      "value": "5",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "6"
-      },
-      {
-        "label": "B",
-        "text": "4"
-      },
-      {
-        "label": "C",
-        "text": "5"
-      },
-      {
-        "label": "D",
-        "text": "2"
-      },
-      {
-        "label": "E",
-        "text": "8"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-algebraic-reasoning-context"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "be02a502f138702afb543c1cd901d29e39cfa69fdb4624b23d1d6c47dc180e49",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-algebraic-reasoning-context-815d75622a",
-    "skillId": "act-algebraic-reasoning-context",
-    "prompt": "A pool club charges a $10 membership fee plus $5 per visit. After how many visits will the total paid reach $45?",
-    "answer": {
-      "type": "auto",
-      "value": "7",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "7"
-      },
-      {
-        "label": "B",
-        "text": "9"
-      },
-      {
-        "label": "C",
-        "text": "11"
-      },
-      {
-        "label": "D",
-        "text": "6"
-      },
-      {
-        "label": "E",
-        "text": "8"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-algebraic-reasoning-context"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "815d75622a85272d5e12729a221157f18623308d42f453d2fbd8d4ab604cb868",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-algebraic-reasoning-context-0db596f0e4",
-    "skillId": "act-algebraic-reasoning-context",
-    "prompt": "A phone plan has a $20 activation fee plus $3 each month. After how many months will the total paid reach $41?",
-    "answer": {
-      "type": "auto",
-      "value": "7",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "7"
-      },
-      {
-        "label": "B",
-        "text": "6"
-      },
-      {
-        "label": "C",
-        "text": "14"
+        "text": "64"
       },
       {
         "label": "D",
@@ -1004,447 +1444,7 @@
       },
       {
         "label": "E",
-        "text": "8"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-algebraic-reasoning-context"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "0db596f0e4f4ae4144ae550584656ac17e5308b25fd971574bf85f2c714ca54c",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-algebraic-reasoning-context-a8a85c22b3",
-    "skillId": "act-algebraic-reasoning-context",
-    "prompt": "A pool club charges a $20 membership fee plus $3 per visit. After how many visits will the total paid reach $32?",
-    "answer": {
-      "type": "auto",
-      "value": "4",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "5"
-      },
-      {
-        "label": "B",
-        "text": "17"
-      },
-      {
-        "label": "C",
-        "text": "4"
-      },
-      {
-        "label": "D",
-        "text": "3"
-      },
-      {
-        "label": "E",
-        "text": "11"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 5,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-algebraic-reasoning-context"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "a8a85c22b3eef3a68c04feb6d00a67466034ca9d2b2f8e0f4c5c1dc0ad95c0f5",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-percent-applications-42a7fc21e2",
-    "skillId": "act-percent-applications",
-    "prompt": "A $50 bicycle is 10% off. With 5% sales tax added to the discounted price, what is the final cost?",
-    "answer": {
-      "type": "auto",
-      "value": "$47.25",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "$47.25"
-      },
-      {
-        "label": "B",
-        "text": "$45"
-      },
-      {
-        "label": "C",
-        "text": "$5"
-      },
-      {
-        "label": "D",
-        "text": "$52.50"
-      },
-      {
-        "label": "E",
-        "text": "$40"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-percent-applications"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "42a7fc21e2839c1d64f33adba2fc83a7a49fa221358f5a737e2580982731b683",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-percent-applications-7364ebe44a",
-    "skillId": "act-percent-applications",
-    "prompt": "A $60 desk lamp is 10% off. With 5% sales tax added to the discounted price, what is the final cost?",
-    "answer": {
-      "type": "auto",
-      "value": "$56.70",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "$6"
-      },
-      {
-        "label": "B",
-        "text": "$63"
-      },
-      {
-        "label": "C",
-        "text": "$54"
-      },
-      {
-        "label": "D",
-        "text": "$56.70"
-      },
-      {
-        "label": "E",
-        "text": "$50"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-percent-applications"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "7364ebe44a23b3354b5bb9888278c3c8e069059a8c418912dfda02a17a536784",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-percent-applications-11b5cd6b33",
-    "skillId": "act-percent-applications",
-    "prompt": "A $60 desk lamp is 10% off. With 8% sales tax added to the discounted price, what is the final cost?",
-    "answer": {
-      "type": "auto",
-      "value": "$58.32",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "$54"
-      },
-      {
-        "label": "B",
-        "text": "$64.80"
-      },
-      {
-        "label": "C",
-        "text": "$6"
-      },
-      {
-        "label": "D",
-        "text": "$50"
-      },
-      {
-        "label": "E",
-        "text": "$58.32"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-percent-applications"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "11b5cd6b338da349927c9619d4e40189c18d1282d1db3c3c36cd9e73a409f45f",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-percent-applications-11e945ab31",
-    "skillId": "act-percent-applications",
-    "prompt": "A $80 laptop is 20% off. With 5% sales tax added to the discounted price, what is the final cost?",
-    "answer": {
-      "type": "auto",
-      "value": "$67.20",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "$84"
-      },
-      {
-        "label": "B",
-        "text": "$67.20"
-      },
-      {
-        "label": "C",
-        "text": "$16"
-      },
-      {
-        "label": "D",
-        "text": "$60"
-      },
-      {
-        "label": "E",
-        "text": "$64"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-percent-applications"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "11e945ab31aaa4a8a67c88932a34eaff5d79e89336432d3c1db37c77d2c4f3cd",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-percent-applications-1ac5f33dd0",
-    "skillId": "act-percent-applications",
-    "prompt": "A $60 laptop is 10% off. With 5% sales tax added to the discounted price, what is the final cost?",
-    "answer": {
-      "type": "auto",
-      "value": "$56.70",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "$56.70"
-      },
-      {
-        "label": "B",
-        "text": "$63"
-      },
-      {
-        "label": "C",
-        "text": "$50"
-      },
-      {
-        "label": "D",
-        "text": "$6"
-      },
-      {
-        "label": "E",
-        "text": "$54"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-percent-applications"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "1ac5f33dd02acc67353e44443233ad6319b658c71c114691a85fadefde3b42ba",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-percent-applications-b944158e68",
-    "skillId": "act-percent-applications",
-    "prompt": "A $60 desk lamp is 25% off. With 8% sales tax added to the discounted price, what is the final cost?",
-    "answer": {
-      "type": "auto",
-      "value": "$48.60",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "$35"
-      },
-      {
-        "label": "B",
-        "text": "$49.80"
-      },
-      {
-        "label": "C",
-        "text": "$45"
-      },
-      {
-        "label": "D",
-        "text": "$48.60"
-      },
-      {
-        "label": "E",
-        "text": "$64.80"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-percent-applications"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "b944158e6807e32df3b41e25b7f36ca1370b6c8b0791af6c98ff1875c3fb6d2a",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-percent-applications-64195c4440",
-    "skillId": "act-percent-applications",
-    "prompt": "A $40 bicycle is 20% off. With 10% sales tax added to the discounted price, what is the final cost?",
-    "answer": {
-      "type": "auto",
-      "value": "$35.20",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "$32"
-      },
-      {
-        "label": "B",
-        "text": "$36"
-      },
-      {
-        "label": "C",
-        "text": "$44"
-      },
-      {
-        "label": "D",
-        "text": "$35.20"
-      },
-      {
-        "label": "E",
-        "text": "$20"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-percent-applications"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "64195c4440af404641f4a9ab0141e87c2ba8645b7ec6dae63bcd10ed85f6e9ba",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-percent-applications-ee49205942",
-    "skillId": "act-percent-applications",
-    "prompt": "A $80 backpack is 25% off. With 10% sales tax added to the discounted price, what is the final cost?",
-    "answer": {
-      "type": "auto",
-      "value": "$66",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "$88"
-      },
-      {
-        "label": "B",
-        "text": "$55"
-      },
-      {
-        "label": "C",
-        "text": "$60"
-      },
-      {
-        "label": "D",
-        "text": "$68"
-      },
-      {
-        "label": "E",
-        "text": "$66"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 5,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-percent-applications"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "ee492059422a5710a5b0da6cc55fb2b17e24b6842de3f01d96c1befdd9006053",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-measurement-unit-conversion-b0cfeec1c0",
-    "skillId": "act-measurement-unit-conversion",
-    "prompt": "How many seconds are in 6 hours?",
-    "answer": {
-      "type": "auto",
-      "value": "21600",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "21594"
-      },
-      {
-        "label": "B",
-        "text": "43200"
-      },
-      {
-        "label": "C",
-        "text": "21600"
-      },
-      {
-        "label": "D",
-        "text": "10800"
-      },
-      {
-        "label": "E",
-        "text": "3606"
+        "text": "128"
       }
     ],
     "correctOption": "C",
@@ -1456,183 +1456,7 @@
       "act-measurement-unit-conversion"
     ],
     "source": "act-template-gen",
-    "contentHash": "b0cfeec1c065b6323971622c1708a778b4222cd6fed78a8705bf00cb744a209b",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-measurement-unit-conversion-0a9f3cea78",
-    "skillId": "act-measurement-unit-conversion",
-    "prompt": "How many inches are in 4 feet?",
-    "answer": {
-      "type": "auto",
-      "value": "48",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "24"
-      },
-      {
-        "label": "B",
-        "text": "16"
-      },
-      {
-        "label": "C",
-        "text": "48"
-      },
-      {
-        "label": "D",
-        "text": "96"
-      },
-      {
-        "label": "E",
-        "text": "44"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-measurement-unit-conversion"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "0a9f3cea7832234745bbf05767d4ad12ad05b13a8d10e0d2238865c53bb9872a",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-measurement-unit-conversion-6079209f62",
-    "skillId": "act-measurement-unit-conversion",
-    "prompt": "How many ounces are in 7 pounds?",
-    "answer": {
-      "type": "auto",
-      "value": "112",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "224"
-      },
-      {
-        "label": "B",
-        "text": "105"
-      },
-      {
-        "label": "C",
-        "text": "112"
-      },
-      {
-        "label": "D",
-        "text": "23"
-      },
-      {
-        "label": "E",
-        "text": "56"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-measurement-unit-conversion"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "6079209f62eab69e54db81f3e5e3edf3b75e7ee36c7f9ae6960f17a3b046c4bb",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-measurement-unit-conversion-46ee909f33",
-    "skillId": "act-measurement-unit-conversion",
-    "prompt": "How many inches are in 7 yards?",
-    "answer": {
-      "type": "auto",
-      "value": "252",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "504"
-      },
-      {
-        "label": "B",
-        "text": "252"
-      },
-      {
-        "label": "C",
-        "text": "245"
-      },
-      {
-        "label": "D",
-        "text": "126"
-      },
-      {
-        "label": "E",
-        "text": "43"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-measurement-unit-conversion"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "46ee909f3368d351e1132d1ef2cced46d64f92a3eabf185d6e3cc30c5837e164",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-measurement-unit-conversion-45cfed9415",
-    "skillId": "act-measurement-unit-conversion",
-    "prompt": "How many inches are in 6 yards?",
-    "answer": {
-      "type": "auto",
-      "value": "216",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "42"
-      },
-      {
-        "label": "B",
-        "text": "108"
-      },
-      {
-        "label": "C",
-        "text": "210"
-      },
-      {
-        "label": "D",
-        "text": "432"
-      },
-      {
-        "label": "E",
-        "text": "216"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-measurement-unit-conversion"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "45cfed9415d6c1d4619e89cbb2632f6d413b93e5df5dc6b81ec67cb65fd016bb",
+    "contentHash": "2cc6ec7307b34f13c74d2fd5a032c7a7e590905d99f4ef4bed9d6b6fe88a9887",
     "isActive": true
   },
   {
@@ -1648,27 +1472,27 @@
     "options": [
       {
         "label": "A",
-        "text": "3603"
-      },
-      {
-        "label": "B",
-        "text": "10797"
-      },
-      {
-        "label": "C",
-        "text": "10800"
-      },
-      {
-        "label": "D",
         "text": "21600"
       },
       {
+        "label": "B",
+        "text": "10800"
+      },
+      {
+        "label": "C",
+        "text": "5400"
+      },
+      {
+        "label": "D",
+        "text": "10797"
+      },
+      {
         "label": "E",
-        "text": "360"
+        "text": "3603"
       }
     ],
-    "correctOption": "C",
-    "difficulty": 4,
+    "correctOption": "B",
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -1677,6 +1501,182 @@
     ],
     "source": "act-template-gen",
     "contentHash": "41f6c64ec3bf3a445d7de7a91a4d6fadf05993906186b39a2c5efc908678e8ef",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-measurement-unit-conversion-6828ac9d72",
+    "skillId": "act-measurement-unit-conversion",
+    "prompt": "How many ounces are in 5 pounds?",
+    "answer": {
+      "type": "auto",
+      "value": "80",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "40"
+      },
+      {
+        "label": "B",
+        "text": "21"
+      },
+      {
+        "label": "C",
+        "text": "80"
+      },
+      {
+        "label": "D",
+        "text": "75"
+      },
+      {
+        "label": "E",
+        "text": "160"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-measurement-unit-conversion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "6828ac9d72288372ac0e981f0eb44558533cace341d6ae0b28f76a31ef335490",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-measurement-unit-conversion-e2d0aae66d",
+    "skillId": "act-measurement-unit-conversion",
+    "prompt": "How many inches are in 2 feet?",
+    "answer": {
+      "type": "auto",
+      "value": "24",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "24"
+      },
+      {
+        "label": "B",
+        "text": "12"
+      },
+      {
+        "label": "C",
+        "text": "48"
+      },
+      {
+        "label": "D",
+        "text": "22"
+      },
+      {
+        "label": "E",
+        "text": "14"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-measurement-unit-conversion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "e2d0aae66d74b3673d823ece66e20791f58a19e56687d9d277be5cc0aa7ac853",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-measurement-unit-conversion-a70340ed08",
+    "skillId": "act-measurement-unit-conversion",
+    "prompt": "How many inches are in 2 yards?",
+    "answer": {
+      "type": "auto",
+      "value": "72",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "72"
+      },
+      {
+        "label": "B",
+        "text": "38"
+      },
+      {
+        "label": "C",
+        "text": "144"
+      },
+      {
+        "label": "D",
+        "text": "70"
+      },
+      {
+        "label": "E",
+        "text": "36"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-measurement-unit-conversion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "a70340ed084f8cb0a279b0227f80b8c8f281d96ba90025fcfaa4fcfab9c4678f",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-measurement-unit-conversion-1a47958926",
+    "skillId": "act-measurement-unit-conversion",
+    "prompt": "How many ounces are in 3 pounds?",
+    "answer": {
+      "type": "auto",
+      "value": "48",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "96"
+      },
+      {
+        "label": "B",
+        "text": "48"
+      },
+      {
+        "label": "C",
+        "text": "45"
+      },
+      {
+        "label": "D",
+        "text": "24"
+      },
+      {
+        "label": "E",
+        "text": "19"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-measurement-unit-conversion"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "1a4795892673c3e8d1744487ae4057b379ea4e17e34e4f3cbcd432d60c9c7b88",
     "isActive": true
   },
   {
@@ -1696,22 +1696,22 @@
       },
       {
         "label": "B",
-        "text": "18000"
+        "text": "600"
       },
       {
         "label": "C",
-        "text": "36000"
-      },
-      {
-        "label": "D",
         "text": "3605"
       },
       {
+        "label": "D",
+        "text": "18000"
+      },
+      {
         "label": "E",
-        "text": "600"
+        "text": "36000"
       }
     ],
-    "correctOption": "B",
+    "correctOption": "D",
     "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
@@ -1724,19 +1724,19 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-measurement-unit-conversion-8c505983a6",
+    "problemId": "act-act-measurement-unit-conversion-6079209f62",
     "skillId": "act-measurement-unit-conversion",
-    "prompt": "How many inches are in 3 yards?",
+    "prompt": "How many ounces are in 7 pounds?",
     "answer": {
       "type": "auto",
-      "value": "108",
+      "value": "112",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "108"
+        "text": "56"
       },
       {
         "label": "B",
@@ -1744,18 +1744,18 @@
       },
       {
         "label": "C",
-        "text": "39"
+        "text": "224"
       },
       {
         "label": "D",
-        "text": "216"
+        "text": "112"
       },
       {
         "label": "E",
-        "text": "45"
+        "text": "23"
       }
     ],
-    "correctOption": "A",
+    "correctOption": "D",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -1764,295 +1764,31 @@
       "act-measurement-unit-conversion"
     ],
     "source": "act-template-gen",
-    "contentHash": "8c505983a65aa8d7d79f688b9ab96d789caafbe10ff6273ca4a704c5ab61dc96",
+    "contentHash": "6079209f62eab69e54db81f3e5e3edf3b75e7ee36c7f9ae6960f17a3b046c4bb",
     "isActive": true
   },
   {
-    "problemId": "act-act-angles-lines-triangles-d81641228c",
+    "problemId": "act-act-angles-lines-triangles-661a5975e9",
     "skillId": "act-angles-lines-triangles",
-    "prompt": "Two angles of a triangle measure 78° and 37°. What is the measure of the third angle?",
+    "prompt": "Two angles of a triangle measure 68° and 46°. What is the measure of the third angle?",
     "answer": {
       "type": "auto",
-      "value": "65°",
+      "value": "66°",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "143°"
-      },
-      {
-        "label": "B",
-        "text": "90°"
-      },
-      {
-        "label": "C",
-        "text": "115°"
-      },
-      {
-        "label": "D",
-        "text": "102°"
-      },
-      {
-        "label": "E",
-        "text": "65°"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-angles-lines-triangles"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "d81641228cbb2367bf0c9cdca69bbd161cb9239894790ca064d486047490bfdb",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-angles-lines-triangles-f0555d81e4",
-    "skillId": "act-angles-lines-triangles",
-    "prompt": "Two angles of a triangle measure 38° and 79°. What is the measure of the third angle?",
-    "answer": {
-      "type": "auto",
-      "value": "63°",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "142°"
-      },
-      {
-        "label": "B",
-        "text": "63°"
-      },
-      {
-        "label": "C",
-        "text": "117°"
-      },
-      {
-        "label": "D",
-        "text": "101°"
-      },
-      {
-        "label": "E",
-        "text": "90°"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-angles-lines-triangles"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "f0555d81e4c5f1b0f5cfa39a3af37e3b08cb226a9b29bf4fd39371e70d41027f",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-angles-lines-triangles-c049f60b46",
-    "skillId": "act-angles-lines-triangles",
-    "prompt": "Two angles of a triangle measure 67° and 65°. What is the measure of the third angle?",
-    "answer": {
-      "type": "auto",
-      "value": "48°",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "48°"
-      },
-      {
-        "label": "B",
-        "text": "132°"
-      },
-      {
-        "label": "C",
-        "text": "113°"
-      },
-      {
-        "label": "D",
-        "text": "115°"
-      },
-      {
-        "label": "E",
-        "text": "90°"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-angles-lines-triangles"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "c049f60b463b804727547f79255a757c72459506bd3b1c7decc49b8383f5d46c",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-angles-lines-triangles-eee4e2ff7b",
-    "skillId": "act-angles-lines-triangles",
-    "prompt": "Two angles of a triangle measure 30° and 79°. What is the measure of the third angle?",
-    "answer": {
-      "type": "auto",
-      "value": "71°",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "90°"
-      },
-      {
-        "label": "B",
-        "text": "150°"
-      },
-      {
-        "label": "C",
-        "text": "71°"
-      },
-      {
-        "label": "D",
-        "text": "101°"
-      },
-      {
-        "label": "E",
-        "text": "109°"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-angles-lines-triangles"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "eee4e2ff7b5c673c23742956d814c9542cf0660cb0705d06e55334301b414330",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-angles-lines-triangles-1e8c1c1ead",
-    "skillId": "act-angles-lines-triangles",
-    "prompt": "Two angles of a triangle measure 63° and 31°. What is the measure of the third angle?",
-    "answer": {
-      "type": "auto",
-      "value": "86°",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "86°"
-      },
-      {
-        "label": "B",
-        "text": "149°"
-      },
-      {
-        "label": "C",
-        "text": "94°"
-      },
-      {
-        "label": "D",
-        "text": "117°"
-      },
-      {
-        "label": "E",
-        "text": "90°"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-angles-lines-triangles"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "1e8c1c1ead16dc38f5f55c7c2ad73d64627c7c3cd53cc6dc5b305700047fb498",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-angles-lines-triangles-276044cdf1",
-    "skillId": "act-angles-lines-triangles",
-    "prompt": "Two angles of a triangle measure 57° and 59°. What is the measure of the third angle?",
-    "answer": {
-      "type": "auto",
-      "value": "64°",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "116°"
-      },
-      {
-        "label": "B",
-        "text": "90°"
-      },
-      {
-        "label": "C",
-        "text": "121°"
-      },
-      {
-        "label": "D",
-        "text": "123°"
-      },
-      {
-        "label": "E",
-        "text": "64°"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-angles-lines-triangles"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "276044cdf1a40002c8cf83d9895c93c88aed0f5af3e5e567bcaafa347f974e63",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-angles-lines-triangles-d5f7aa21f4",
-    "skillId": "act-angles-lines-triangles",
-    "prompt": "Two angles of a triangle measure 68° and 34°. What is the measure of the third angle?",
-    "answer": {
-      "type": "auto",
-      "value": "78°",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "146°"
-      },
-      {
-        "label": "B",
         "text": "112°"
       },
       {
+        "label": "B",
+        "text": "114°"
+      },
+      {
         "label": "C",
-        "text": "78°"
+        "text": "66°"
       },
       {
         "label": "D",
@@ -2060,7 +1796,227 @@
       },
       {
         "label": "E",
-        "text": "102°"
+        "text": "134°"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-angles-lines-triangles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "661a5975e91b8f53b931e8c689f455135d2c8d844fc15447d042004667d1fea4",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-angles-lines-triangles-5fb13bda6e",
+    "skillId": "act-angles-lines-triangles",
+    "prompt": "Two angles of a triangle measure 63° and 33°. What is the measure of the third angle?",
+    "answer": {
+      "type": "auto",
+      "value": "84°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "117°"
+      },
+      {
+        "label": "B",
+        "text": "147°"
+      },
+      {
+        "label": "C",
+        "text": "84°"
+      },
+      {
+        "label": "D",
+        "text": "96°"
+      },
+      {
+        "label": "E",
+        "text": "90°"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-angles-lines-triangles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "5fb13bda6eced9c6668e0b660e8f8a89d6868cebdd74918b3aa8b5253da67f92",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-angles-lines-triangles-6befe651f9",
+    "skillId": "act-angles-lines-triangles",
+    "prompt": "Two angles of a triangle measure 43° and 45°. What is the measure of the third angle?",
+    "answer": {
+      "type": "auto",
+      "value": "92°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "137°"
+      },
+      {
+        "label": "B",
+        "text": "88°"
+      },
+      {
+        "label": "C",
+        "text": "90°"
+      },
+      {
+        "label": "D",
+        "text": "92°"
+      },
+      {
+        "label": "E",
+        "text": "135°"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-angles-lines-triangles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "6befe651f90cc65ee92e1bc5cf651df039ee06c6b1a223bace5e16d6cbdc8797",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-angles-lines-triangles-cc72dba960",
+    "skillId": "act-angles-lines-triangles",
+    "prompt": "Two angles of a triangle measure 58° and 50°. What is the measure of the third angle?",
+    "answer": {
+      "type": "auto",
+      "value": "72°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "90°"
+      },
+      {
+        "label": "B",
+        "text": "72°"
+      },
+      {
+        "label": "C",
+        "text": "108°"
+      },
+      {
+        "label": "D",
+        "text": "122°"
+      },
+      {
+        "label": "E",
+        "text": "130°"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-angles-lines-triangles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "cc72dba9603cb796effd2f70f8a473d2e707c1b6235f7beb16d75240ce3b05df",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-angles-lines-triangles-4c249c9cfc",
+    "skillId": "act-angles-lines-triangles",
+    "prompt": "Two angles of a triangle measure 39° and 40°. What is the measure of the third angle?",
+    "answer": {
+      "type": "auto",
+      "value": "101°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "101°"
+      },
+      {
+        "label": "B",
+        "text": "90°"
+      },
+      {
+        "label": "C",
+        "text": "140°"
+      },
+      {
+        "label": "D",
+        "text": "79°"
+      },
+      {
+        "label": "E",
+        "text": "141°"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-angles-lines-triangles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "4c249c9cfcd8ccbd4bfb1c0e35837b68d31f83a256888f842b7115c278bce2e0",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-angles-lines-triangles-6a0f0a9238",
+    "skillId": "act-angles-lines-triangles",
+    "prompt": "Two angles of a triangle measure 37° and 31°. What is the measure of the third angle?",
+    "answer": {
+      "type": "auto",
+      "value": "112°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "90°"
+      },
+      {
+        "label": "B",
+        "text": "68°"
+      },
+      {
+        "label": "C",
+        "text": "112°"
+      },
+      {
+        "label": "D",
+        "text": "149°"
+      },
+      {
+        "label": "E",
+        "text": "143°"
       }
     ],
     "correctOption": "C",
@@ -2072,31 +2028,31 @@
       "act-angles-lines-triangles"
     ],
     "source": "act-template-gen",
-    "contentHash": "d5f7aa21f4d105c894d74e76a70a10e15171c9717f119f9038e06fd8b20fc772",
+    "contentHash": "6a0f0a92388f8a3c2932bfca9bd1addfba1a6d84a269ba9a8506038d8998d480",
     "isActive": true
   },
   {
-    "problemId": "act-act-angles-lines-triangles-d1fb5e15c1",
+    "problemId": "act-act-angles-lines-triangles-541d725d47",
     "skillId": "act-angles-lines-triangles",
-    "prompt": "Two angles of a triangle measure 30° and 35°. What is the measure of the third angle?",
+    "prompt": "Two angles of a triangle measure 79° and 76°. What is the measure of the third angle?",
     "answer": {
       "type": "auto",
-      "value": "115°",
+      "value": "25°",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "145°"
+        "text": "155°"
       },
       {
         "label": "B",
-        "text": "65°"
+        "text": "101°"
       },
       {
         "label": "C",
-        "text": "150°"
+        "text": "25°"
       },
       {
         "label": "D",
@@ -2104,10 +2060,54 @@
       },
       {
         "label": "E",
-        "text": "115°"
+        "text": "104°"
       }
     ],
-    "correctOption": "E",
+    "correctOption": "C",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-angles-lines-triangles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "541d725d47249152d9e9409cb6e5c6e8fbfdd50385cb9f65fc10d4b1084f4130",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-angles-lines-triangles-4b3bd712e1",
+    "skillId": "act-angles-lines-triangles",
+    "prompt": "Two angles of a triangle measure 65° and 77°. What is the measure of the third angle?",
+    "answer": {
+      "type": "auto",
+      "value": "38°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "90°"
+      },
+      {
+        "label": "B",
+        "text": "38°"
+      },
+      {
+        "label": "C",
+        "text": "103°"
+      },
+      {
+        "label": "D",
+        "text": "115°"
+      },
+      {
+        "label": "E",
+        "text": "142°"
+      }
+    ],
+    "correctOption": "B",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -2116,7 +2116,318 @@
       "act-angles-lines-triangles"
     ],
     "source": "act-template-gen",
-    "contentHash": "d1fb5e15c149a1415c45fa8b2667056faa7e0fbbcc866bf4f7713c0477eae80c",
+    "contentHash": "4b3bd712e146a21bb9e1470287c237489d721015dc269e89469fb1eccf93fc8a",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polygons-circles-e9063bbaea",
+    "skillId": "act-polygons-circles",
+    "prompt": "What is the measure of one interior angle of the regular 36-gon shown?",
+    "answer": {
+      "type": "auto",
+      "value": "170°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "180°"
+      },
+      {
+        "label": "B",
+        "text": "6120°"
+      },
+      {
+        "label": "C",
+        "text": "170°"
+      },
+      {
+        "label": "D",
+        "text": "10°"
+      },
+      {
+        "label": "E",
+        "text": "5°"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polygons-circles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "e9063bbaea131d620460fab1c162d76d67c50aece68476519e125613cccfbb86",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polygons-circles-1b11ff8e8a",
+    "skillId": "act-polygons-circles",
+    "prompt": "What is the measure of one interior angle of the regular 18-gon shown?",
+    "answer": {
+      "type": "auto",
+      "value": "160°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "20°"
+      },
+      {
+        "label": "B",
+        "text": "2880°"
+      },
+      {
+        "label": "C",
+        "text": "180°"
+      },
+      {
+        "label": "D",
+        "text": "10°"
+      },
+      {
+        "label": "E",
+        "text": "160°"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polygons-circles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "1b11ff8e8ab46c2a650de720034211e941cf238a2aeec83396dcde04a040b8f5",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polygons-circles-b68f36c479",
+    "skillId": "act-polygons-circles",
+    "prompt": "What is the measure of one interior angle of the regular 20-gon shown?",
+    "answer": {
+      "type": "auto",
+      "value": "162°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "3240°"
+      },
+      {
+        "label": "B",
+        "text": "9°"
+      },
+      {
+        "label": "C",
+        "text": "162°"
+      },
+      {
+        "label": "D",
+        "text": "180°"
+      },
+      {
+        "label": "E",
+        "text": "18°"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polygons-circles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "b68f36c479a3afa356ff30f1af51f3882475ced0c2e6c8e6905fb7380e887449",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polygons-circles-68e6432c74",
+    "skillId": "act-polygons-circles",
+    "prompt": "What is the measure of one interior angle of the regular 24-gon shown?",
+    "answer": {
+      "type": "auto",
+      "value": "165°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "7.5°"
+      },
+      {
+        "label": "B",
+        "text": "180°"
+      },
+      {
+        "label": "C",
+        "text": "165°"
+      },
+      {
+        "label": "D",
+        "text": "15°"
+      },
+      {
+        "label": "E",
+        "text": "3960°"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polygons-circles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "68e6432c743ca7b87f760ef9aa22445da68875e9ee341bd158936a2daf0b4c72",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polygons-circles-7beecb7077",
+    "skillId": "act-polygons-circles",
+    "prompt": "What is the measure of one interior angle of the regular 5-gon shown?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"100.0,17.0 155.2,57.1 134.1,121.9 65.9,121.9 44.8,57.1\" stroke-linejoin=\"round\"/></svg>",
+    "answer": {
+      "type": "auto",
+      "value": "108°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "36°"
+      },
+      {
+        "label": "B",
+        "text": "72°"
+      },
+      {
+        "label": "C",
+        "text": "180°"
+      },
+      {
+        "label": "D",
+        "text": "540°"
+      },
+      {
+        "label": "E",
+        "text": "108°"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polygons-circles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "7beecb7077129efd69b3a3471795d300dc179ce2cd7ccdebc86a6f64b322b19f",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polygons-circles-5851fb8b73",
+    "skillId": "act-polygons-circles",
+    "prompt": "What is the measure of one interior angle of the regular 8-gon shown?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"100.0,17.0 141.0,34.0 158.0,75.0 141.0,116.0 100.0,133.0 59.0,116.0 42.0,75.0 59.0,34.0\" stroke-linejoin=\"round\"/></svg>",
+    "answer": {
+      "type": "auto",
+      "value": "135°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "45°"
+      },
+      {
+        "label": "B",
+        "text": "180°"
+      },
+      {
+        "label": "C",
+        "text": "1080°"
+      },
+      {
+        "label": "D",
+        "text": "135°"
+      },
+      {
+        "label": "E",
+        "text": "22.5°"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polygons-circles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "5851fb8b7376afbd65a1d3b3859424cefce4445c39f034a8d2e2c9f299c118b3",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polygons-circles-a438fc4cf0",
+    "skillId": "act-polygons-circles",
+    "prompt": "What is the measure of one interior angle of the regular 6-gon shown?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"100.0,17.0 150.2,46.0 150.2,104.0 100.0,133.0 49.8,104.0 49.8,46.0\" stroke-linejoin=\"round\"/></svg>",
+    "answer": {
+      "type": "auto",
+      "value": "120°",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "120°"
+      },
+      {
+        "label": "B",
+        "text": "60°"
+      },
+      {
+        "label": "C",
+        "text": "720°"
+      },
+      {
+        "label": "D",
+        "text": "30°"
+      },
+      {
+        "label": "E",
+        "text": "180°"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polygons-circles"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "a438fc4cf03173115b31662107f6bd8657e9ac360d2b4694ca48bc51e5d4cb3f",
     "isActive": true
   },
   {
@@ -2137,7 +2448,7 @@
       },
       {
         "label": "B",
-        "text": "20°"
+        "text": "180°"
       },
       {
         "label": "C",
@@ -2149,11 +2460,11 @@
       },
       {
         "label": "E",
-        "text": "180°"
+        "text": "20°"
       }
     ],
     "correctOption": "D",
-    "difficulty": 2,
+    "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -2165,394 +2476,38 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-polygons-circles-db43864a60",
-    "skillId": "act-polygons-circles",
-    "prompt": "What is the measure of one interior angle of the regular 10-gon shown?",
-    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"100.0,17.0 134.1,28.1 155.2,57.1 155.2,92.9 134.1,121.9 100.0,133.0 65.9,121.9 44.8,92.9 44.8,57.1 65.9,28.1\" stroke-linejoin=\"round\"/></svg>",
-    "answer": {
-      "type": "auto",
-      "value": "144°",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "180°"
-      },
-      {
-        "label": "B",
-        "text": "18°"
-      },
-      {
-        "label": "C",
-        "text": "144°"
-      },
-      {
-        "label": "D",
-        "text": "36°"
-      },
-      {
-        "label": "E",
-        "text": "1440°"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-polygons-circles"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "db43864a60f9ee91815d5dc908104ff7e89aa3605ec2ba484a69b683c6e49b7e",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-polygons-circles-d01292a4a9",
-    "skillId": "act-polygons-circles",
-    "prompt": "What is the measure of one interior angle of the regular 15-gon shown?",
-    "answer": {
-      "type": "auto",
-      "value": "156°",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "24°"
-      },
-      {
-        "label": "B",
-        "text": "2340°"
-      },
-      {
-        "label": "C",
-        "text": "180°"
-      },
-      {
-        "label": "D",
-        "text": "156°"
-      },
-      {
-        "label": "E",
-        "text": "12°"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-polygons-circles"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "d01292a4a9212f7f36f0f44cffe66ea27e58606438a122d3a8d34f52b3bdcf6d",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-polygons-circles-b68f36c479",
-    "skillId": "act-polygons-circles",
-    "prompt": "What is the measure of one interior angle of the regular 20-gon shown?",
-    "answer": {
-      "type": "auto",
-      "value": "162°",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "180°"
-      },
-      {
-        "label": "B",
-        "text": "3240°"
-      },
-      {
-        "label": "C",
-        "text": "162°"
-      },
-      {
-        "label": "D",
-        "text": "18°"
-      },
-      {
-        "label": "E",
-        "text": "9°"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-polygons-circles"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "b68f36c479a3afa356ff30f1af51f3882475ced0c2e6c8e6905fb7380e887449",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-polygons-circles-7beecb7077",
-    "skillId": "act-polygons-circles",
-    "prompt": "What is the measure of one interior angle of the regular 5-gon shown?",
-    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"100.0,17.0 155.2,57.1 134.1,121.9 65.9,121.9 44.8,57.1\" stroke-linejoin=\"round\"/></svg>",
-    "answer": {
-      "type": "auto",
-      "value": "108°",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "108°"
-      },
-      {
-        "label": "B",
-        "text": "72°"
-      },
-      {
-        "label": "C",
-        "text": "540°"
-      },
-      {
-        "label": "D",
-        "text": "180°"
-      },
-      {
-        "label": "E",
-        "text": "36°"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-polygons-circles"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "7beecb7077129efd69b3a3471795d300dc179ce2cd7ccdebc86a6f64b322b19f",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-polygons-circles-a438fc4cf0",
-    "skillId": "act-polygons-circles",
-    "prompt": "What is the measure of one interior angle of the regular 6-gon shown?",
-    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"100.0,17.0 150.2,46.0 150.2,104.0 100.0,133.0 49.8,104.0 49.8,46.0\" stroke-linejoin=\"round\"/></svg>",
-    "answer": {
-      "type": "auto",
-      "value": "120°",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "720°"
-      },
-      {
-        "label": "B",
-        "text": "60°"
-      },
-      {
-        "label": "C",
-        "text": "180°"
-      },
-      {
-        "label": "D",
-        "text": "120°"
-      },
-      {
-        "label": "E",
-        "text": "30°"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-polygons-circles"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "a438fc4cf03173115b31662107f6bd8657e9ac360d2b4694ca48bc51e5d4cb3f",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-polygons-circles-5851fb8b73",
-    "skillId": "act-polygons-circles",
-    "prompt": "What is the measure of one interior angle of the regular 8-gon shown?",
-    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><polygon points=\"100.0,17.0 141.0,34.0 158.0,75.0 141.0,116.0 100.0,133.0 59.0,116.0 42.0,75.0 59.0,34.0\" stroke-linejoin=\"round\"/></svg>",
-    "answer": {
-      "type": "auto",
-      "value": "135°",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "135°"
-      },
-      {
-        "label": "B",
-        "text": "22.5°"
-      },
-      {
-        "label": "C",
-        "text": "180°"
-      },
-      {
-        "label": "D",
-        "text": "45°"
-      },
-      {
-        "label": "E",
-        "text": "1080°"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-polygons-circles"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "5851fb8b7376afbd65a1d3b3859424cefce4445c39f034a8d2e2c9f299c118b3",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-polygons-circles-1b11ff8e8a",
-    "skillId": "act-polygons-circles",
-    "prompt": "What is the measure of one interior angle of the regular 18-gon shown?",
-    "answer": {
-      "type": "auto",
-      "value": "160°",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "180°"
-      },
-      {
-        "label": "B",
-        "text": "10°"
-      },
-      {
-        "label": "C",
-        "text": "2880°"
-      },
-      {
-        "label": "D",
-        "text": "20°"
-      },
-      {
-        "label": "E",
-        "text": "160°"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 5,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-polygons-circles"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "1b11ff8e8ab46c2a650de720034211e941cf238a2aeec83396dcde04a040b8f5",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-area-volume-surface-area-c35421fc9c",
+    "problemId": "act-act-area-volume-surface-area-7332746a78",
     "skillId": "act-area-volume-surface-area",
-    "prompt": "What is the area of a triangle with base 9 and height 3?",
+    "prompt": "What is the volume of a box with dimensions 2 × 3 × 3?",
     "answer": {
       "type": "auto",
-      "value": "13.5",
+      "value": "18",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "13.5"
-      },
-      {
-        "label": "B",
-        "text": "27"
-      },
-      {
-        "label": "C",
         "text": "9"
       },
       {
-        "label": "D",
-        "text": "6"
-      },
-      {
-        "label": "E",
-        "text": "12"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-area-volume-surface-area"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "c35421fc9c4e1bcaa532b59332cd960939b7ef52889c8b8049ff07dba853fb9b",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-area-volume-surface-area-f21e19ece8",
-    "skillId": "act-area-volume-surface-area",
-    "prompt": "What is the area of a triangle with base 10 and height 7?",
-    "answer": {
-      "type": "auto",
-      "value": "35",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "8.5"
-      },
-      {
         "label": "B",
-        "text": "23.333333333333332"
+        "text": "18"
       },
       {
         "label": "C",
-        "text": "35"
+        "text": "42"
       },
       {
         "label": "D",
-        "text": "70"
+        "text": "8"
       },
       {
         "label": "E",
-        "text": "17"
+        "text": "36"
       }
     ],
-    "correctOption": "C",
+    "correctOption": "B",
     "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
@@ -2561,27 +2516,115 @@
       "act-area-volume-surface-area"
     ],
     "source": "act-template-gen",
-    "contentHash": "f21e19ece869c826b1bd201d28356b8d0e633b30b7277d3fb548449d417c568b",
+    "contentHash": "7332746a785c642bc70dbd3ac0d1ba113c3837fb141200fdfddc7e7ec0028936",
     "isActive": true
   },
   {
-    "problemId": "act-act-area-volume-surface-area-2d8a035fb0",
+    "problemId": "act-act-area-volume-surface-area-90b4131d61",
     "skillId": "act-area-volume-surface-area",
-    "prompt": "What is the area of a rectangle with length 4 and width 6?",
+    "prompt": "What is the area of a triangle with base 5 and height 5?",
     "answer": {
       "type": "auto",
-      "value": "24",
+      "value": "12.5",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "10"
+        "text": "8.333333333333334"
       },
       {
         "label": "B",
-        "text": "12"
+        "text": "12.5"
+      },
+      {
+        "label": "C",
+        "text": "10"
+      },
+      {
+        "label": "D",
+        "text": "25"
+      },
+      {
+        "label": "E",
+        "text": "5"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-volume-surface-area"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "90b4131d61e60efe963d21b5d9384c42b5135039ab3b04badb0cb115af5f4251",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-volume-surface-area-9b3bc6d582",
+    "skillId": "act-area-volume-surface-area",
+    "prompt": "What is the volume of a box with dimensions 3 × 4 × 4?",
+    "answer": {
+      "type": "auto",
+      "value": "48",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "96"
+      },
+      {
+        "label": "B",
+        "text": "16"
+      },
+      {
+        "label": "C",
+        "text": "48"
+      },
+      {
+        "label": "D",
+        "text": "11"
+      },
+      {
+        "label": "E",
+        "text": "80"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-volume-surface-area"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "9b3bc6d582b0630cd692fc3e1c6df79160f3b6866f4c152f88913ef9741b60a8",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-volume-surface-area-94d13d2a0b",
+    "skillId": "act-area-volume-surface-area",
+    "prompt": "What is the area of a triangle with base 10 and height 10?",
+    "answer": {
+      "type": "auto",
+      "value": "50",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "33.333333333333336"
+      },
+      {
+        "label": "B",
+        "text": "100"
       },
       {
         "label": "C",
@@ -2589,11 +2632,55 @@
       },
       {
         "label": "D",
-        "text": "48"
+        "text": "50"
       },
       {
         "label": "E",
-        "text": "24"
+        "text": "10"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-area-volume-surface-area"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "94d13d2a0bb413a73059a44267d922adfdd5028c409c18b53b4cad9e383c4290",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-area-volume-surface-area-7b10aa3cfc",
+    "skillId": "act-area-volume-surface-area",
+    "prompt": "What is the area of a triangle with base 7 and height 5?",
+    "answer": {
+      "type": "auto",
+      "value": "17.5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "12"
+      },
+      {
+        "label": "B",
+        "text": "35"
+      },
+      {
+        "label": "C",
+        "text": "6"
+      },
+      {
+        "label": "D",
+        "text": "11.666666666666666"
+      },
+      {
+        "label": "E",
+        "text": "17.5"
       }
     ],
     "correctOption": "E",
@@ -2605,57 +2692,13 @@
       "act-area-volume-surface-area"
     ],
     "source": "act-template-gen",
-    "contentHash": "2d8a035fb0a3dd8bb30a96d5488b5c14b33d022eb66c97a055bfd3520b29536f",
+    "contentHash": "7b10aa3cfc64219d90e59f10ee8c77f360fd4d995ca5196c37d0414f9b6fd590",
     "isActive": true
   },
   {
-    "problemId": "act-act-area-volume-surface-area-785ce6946e",
+    "problemId": "act-act-area-volume-surface-area-63df05f2d9",
     "skillId": "act-area-volume-surface-area",
-    "prompt": "What is the area of a triangle with base 7 and height 7?",
-    "answer": {
-      "type": "auto",
-      "value": "24.5",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "7"
-      },
-      {
-        "label": "B",
-        "text": "49"
-      },
-      {
-        "label": "C",
-        "text": "24.5"
-      },
-      {
-        "label": "D",
-        "text": "16.333333333333332"
-      },
-      {
-        "label": "E",
-        "text": "14"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-area-volume-surface-area"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "785ce6946e63ad0d4c8ee83570fedcce420394f8d280bbcaee3218fbcc38940b",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-area-volume-surface-area-4d81840caa",
-    "skillId": "act-area-volume-surface-area",
-    "prompt": "What is the volume of a box with dimensions 4 × 3 × 5?",
+    "prompt": "What is the area of a rectangle with length 10 and width 6?",
     "answer": {
       "type": "auto",
       "value": "60",
@@ -2665,70 +2708,26 @@
     "options": [
       {
         "label": "A",
-        "text": "120"
-      },
-      {
-        "label": "B",
-        "text": "12"
-      },
-      {
-        "label": "C",
-        "text": "94"
-      },
-      {
-        "label": "D",
         "text": "60"
       },
       {
-        "label": "E",
-        "text": "17"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-area-volume-surface-area"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "4d81840caab1e43d8c2a857fe946372a8d1d22d7a2ea340c3c24a882129aa881",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-area-volume-surface-area-cc7e6a3a00",
-    "skillId": "act-area-volume-surface-area",
-    "prompt": "What is the area of a triangle with base 10 and height 5?",
-    "answer": {
-      "type": "auto",
-      "value": "25",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "15"
-      },
-      {
         "label": "B",
-        "text": "7.5"
+        "text": "120"
       },
       {
         "label": "C",
-        "text": "16.666666666666668"
+        "text": "32"
       },
       {
         "label": "D",
-        "text": "50"
+        "text": "30"
       },
       {
         "label": "E",
-        "text": "25"
+        "text": "16"
       }
     ],
-    "correctOption": "E",
+    "correctOption": "A",
     "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
@@ -2737,27 +2736,27 @@
       "act-area-volume-surface-area"
     ],
     "source": "act-template-gen",
-    "contentHash": "cc7e6a3a00cb40bffd2575d78aa63bfaeb30ddcb2434ea662a868ebda747fef6",
+    "contentHash": "63df05f2d914671d358d1dab15403fa019c6e39ab3a2721e7fa26d78eba9cf27",
     "isActive": true
   },
   {
-    "problemId": "act-act-area-volume-surface-area-6132a39084",
+    "problemId": "act-act-area-volume-surface-area-74ca31a2b2",
     "skillId": "act-area-volume-surface-area",
-    "prompt": "What is the area of a triangle with base 10 and height 6?",
+    "prompt": "What is the area of a triangle with base 10 and height 3?",
     "answer": {
       "type": "auto",
-      "value": "30",
+      "value": "15",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "60"
+        "text": "6.5"
       },
       {
         "label": "B",
-        "text": "8"
+        "text": "15"
       },
       {
         "label": "C",
@@ -2765,14 +2764,14 @@
       },
       {
         "label": "D",
-        "text": "20"
+        "text": "10"
       },
       {
         "label": "E",
-        "text": "16"
+        "text": "13"
       }
     ],
-    "correctOption": "C",
+    "correctOption": "B",
     "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
@@ -2781,13 +2780,13 @@
       "act-area-volume-surface-area"
     ],
     "source": "act-template-gen",
-    "contentHash": "6132a39084f390b576190d3b42f919674ed0f7e58445de8e94638421f9f592e9",
+    "contentHash": "74ca31a2b24122199c702047d5824ccd4f4a91f029c1d1ccf57776df4995de89",
     "isActive": true
   },
   {
-    "problemId": "act-act-area-volume-surface-area-fc44093ee3",
+    "problemId": "act-act-area-volume-surface-area-7cb51ead4c",
     "skillId": "act-area-volume-surface-area",
-    "prompt": "What is the volume of a box with dimensions 4 × 2 × 5?",
+    "prompt": "What is the volume of a box with dimensions 5 × 2 × 4?",
     "answer": {
       "type": "auto",
       "value": "40",
@@ -2797,26 +2796,26 @@
     "options": [
       {
         "label": "A",
-        "text": "76"
-      },
-      {
-        "label": "B",
-        "text": "11"
-      },
-      {
-        "label": "C",
         "text": "40"
       },
       {
+        "label": "B",
+        "text": "14"
+      },
+      {
+        "label": "C",
+        "text": "11"
+      },
+      {
         "label": "D",
-        "text": "80"
+        "text": "76"
       },
       {
         "label": "E",
-        "text": "13"
+        "text": "80"
       }
     ],
-    "correctOption": "C",
+    "correctOption": "A",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -2825,42 +2824,43 @@
       "act-area-volume-surface-area"
     ],
     "source": "act-template-gen",
-    "contentHash": "fc44093ee3e67d476acd276ae024ca3c9c3e6b6b71a643487daad7083b2e7890",
+    "contentHash": "7cb51ead4cf80d1ea45c2e1c4b2fa47d507dd0f9dc37f86d5f4762a656388ea8",
     "isActive": true
   },
   {
-    "problemId": "act-act-coordinate-geometry-c8540cf8d7",
+    "problemId": "act-act-coordinate-geometry-8a610c691e",
     "skillId": "act-coordinate-geometry",
-    "prompt": "What is the distance between (5, 0) and (10, 12)?",
+    "prompt": "What is the midpoint of the segment joining the two points shown, (1, 1) and (2, -1)?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><line x1=\"20\" y1=\"75\" x2=\"180\" y2=\"75\" stroke=\"#bbb\" stroke-width=\"1\"/><line x1=\"100\" y1=\"15\" x2=\"100\" y2=\"140\" stroke=\"#bbb\" stroke-width=\"1\"/><circle cx=\"112\" cy=\"66\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"118\" y=\"60\" fill=\"#7c5cff\" stroke=\"none\">(1, 1)</text><circle cx=\"124\" cy=\"84\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"130\" y=\"78\" fill=\"#7c5cff\" stroke=\"none\">(2, -1)</text></svg>",
     "answer": {
       "type": "auto",
-      "value": "13",
+      "value": "(1.5, 0)",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "17"
+        "text": "(2.5, 0)"
       },
       {
         "label": "B",
-        "text": "13"
+        "text": "(1, -2)"
       },
       {
         "label": "C",
-        "text": "60"
+        "text": "(1.5, 0)"
       },
       {
         "label": "D",
-        "text": "14"
+        "text": "(3, 0)"
       },
       {
         "label": "E",
-        "text": "8"
+        "text": "(0, 1.5)"
       }
     ],
-    "correctOption": "B",
+    "correctOption": "C",
     "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
@@ -2869,13 +2869,13 @@
       "act-coordinate-geometry"
     ],
     "source": "act-template-gen",
-    "contentHash": "c8540cf8d705098e15499df510aa7ca33cecd87d09ad4b1390349d7de606734b",
+    "contentHash": "8a610c691e9a19a8f491ef2ef9d4c8d228e559c21607e67224e858f2310ded32",
     "isActive": true
   },
   {
-    "problemId": "act-act-coordinate-geometry-534f24514d",
+    "problemId": "act-act-coordinate-geometry-2367c7e31e",
     "skillId": "act-coordinate-geometry",
-    "prompt": "What is the distance between (5, 1) and (13, 16)?",
+    "prompt": "What is the distance between (0, 0) and (8, 15)?",
     "answer": {
       "type": "auto",
       "value": "17",
@@ -2885,7 +2885,7 @@
     "options": [
       {
         "label": "A",
-        "text": "120"
+        "text": "11"
       },
       {
         "label": "B",
@@ -2897,7 +2897,7 @@
       },
       {
         "label": "D",
-        "text": "11"
+        "text": "120"
       },
       {
         "label": "E",
@@ -2913,13 +2913,57 @@
       "act-coordinate-geometry"
     ],
     "source": "act-template-gen",
-    "contentHash": "534f24514d2571ea2b36fe359085214d12c3eb588cf4a8b19f2ccd3601cca312",
+    "contentHash": "2367c7e31ee898f6dab5b20c2c3634b2c5b98a6c2da4f62d73a1492bfd880b4b",
     "isActive": true
   },
   {
-    "problemId": "act-act-coordinate-geometry-65c9fbbf4f",
+    "problemId": "act-act-coordinate-geometry-f6c2a6cc4a",
     "skillId": "act-coordinate-geometry",
-    "prompt": "What is the distance between (-4, 0) and (1, 12)?",
+    "prompt": "What is the distance between (5, 2) and (8, 6)?",
+    "answer": {
+      "type": "auto",
+      "value": "5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "7"
+      },
+      {
+        "label": "B",
+        "text": "5"
+      },
+      {
+        "label": "C",
+        "text": "12"
+      },
+      {
+        "label": "D",
+        "text": "3"
+      },
+      {
+        "label": "E",
+        "text": "6"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-coordinate-geometry"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "f6c2a6cc4a0ad808c7278e2c934bf27b3f36000879ab6198fd391c0fb48a9e30",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-coordinate-geometry-d5698c5e89",
+    "skillId": "act-coordinate-geometry",
+    "prompt": "What is the distance between (-3, 5) and (2, 17)?",
     "answer": {
       "type": "auto",
       "value": "13",
@@ -2929,26 +2973,26 @@
     "options": [
       {
         "label": "A",
-        "text": "8"
-      },
-      {
-        "label": "B",
-        "text": "60"
-      },
-      {
-        "label": "C",
-        "text": "17"
-      },
-      {
-        "label": "D",
         "text": "13"
       },
       {
-        "label": "E",
+        "label": "B",
+        "text": "17"
+      },
+      {
+        "label": "C",
         "text": "14"
+      },
+      {
+        "label": "D",
+        "text": "60"
+      },
+      {
+        "label": "E",
+        "text": "8"
       }
     ],
-    "correctOption": "D",
+    "correctOption": "A",
     "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
@@ -2957,43 +3001,42 @@
       "act-coordinate-geometry"
     ],
     "source": "act-template-gen",
-    "contentHash": "65c9fbbf4ff4e0737c19066d952c86f9305af8bc61b19e03986ae117f26c9c5b",
+    "contentHash": "d5698c5e8977763eb2f05afff2a1ccdac243775cc92a92df9ea1b8ab6ea65ac6",
     "isActive": true
   },
   {
-    "problemId": "act-act-coordinate-geometry-ecf81a001e",
+    "problemId": "act-act-coordinate-geometry-e5cd812399",
     "skillId": "act-coordinate-geometry",
-    "prompt": "What is the midpoint of the segment joining the two points shown, (-3, -1) and (2, -1)?",
-    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><line x1=\"20\" y1=\"75\" x2=\"180\" y2=\"75\" stroke=\"#bbb\" stroke-width=\"1\"/><line x1=\"100\" y1=\"15\" x2=\"100\" y2=\"140\" stroke=\"#bbb\" stroke-width=\"1\"/><circle cx=\"64\" cy=\"84\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"70\" y=\"78\" fill=\"#7c5cff\" stroke=\"none\">(-3, -1)</text><circle cx=\"124\" cy=\"84\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"130\" y=\"78\" fill=\"#7c5cff\" stroke=\"none\">(2, -1)</text></svg>",
+    "prompt": "What is the distance between (-1, 5) and (4, 17)?",
     "answer": {
       "type": "auto",
-      "value": "(-0.5, -1)",
+      "value": "13",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "(-1, -2)"
+        "text": "13"
       },
       {
         "label": "B",
-        "text": "(0.5, -1)"
+        "text": "8"
       },
       {
         "label": "C",
-        "text": "(-0.5, -1)"
+        "text": "60"
       },
       {
         "label": "D",
-        "text": "(5, 0)"
+        "text": "17"
       },
       {
         "label": "E",
-        "text": "(-1, -0.5)"
+        "text": "14"
       }
     ],
-    "correctOption": "C",
+    "correctOption": "A",
     "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
@@ -3002,13 +3045,13 @@
       "act-coordinate-geometry"
     ],
     "source": "act-template-gen",
-    "contentHash": "ecf81a001e474ca10bdd3ae49c912994570278a05a078fa3e3df53dcaf505a91",
+    "contentHash": "e5cd812399e0a253d82dbdb108e3d090d9378e2871935c482db2e4444f4f7227",
     "isActive": true
   },
   {
-    "problemId": "act-act-coordinate-geometry-584a79f472",
+    "problemId": "act-act-coordinate-geometry-66ab6c2f43",
     "skillId": "act-coordinate-geometry",
-    "prompt": "What is the distance between (-5, 1) and (1, 9)?",
+    "prompt": "What is the distance between (-3, -4) and (3, 4)?",
     "answer": {
       "type": "auto",
       "value": "10",
@@ -3026,63 +3069,18 @@
       },
       {
         "label": "C",
+        "text": "10"
+      },
+      {
+        "label": "D",
         "text": "7"
       },
       {
-        "label": "D",
+        "label": "E",
         "text": "48"
-      },
-      {
-        "label": "E",
-        "text": "10"
       }
     ],
-    "correctOption": "E",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-coordinate-geometry"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "584a79f4723fd52ad5c8adfde395bc9b35aab0d903efdc5eea6ddbbc1c6ac9d9",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-coordinate-geometry-df108a2588",
-    "skillId": "act-coordinate-geometry",
-    "prompt": "What is the midpoint of the segment joining the two points shown, (-2, 3) and (-1, 3)?",
-    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><line x1=\"20\" y1=\"75\" x2=\"180\" y2=\"75\" stroke=\"#bbb\" stroke-width=\"1\"/><line x1=\"100\" y1=\"15\" x2=\"100\" y2=\"140\" stroke=\"#bbb\" stroke-width=\"1\"/><circle cx=\"76\" cy=\"48\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"82\" y=\"42\" fill=\"#7c5cff\" stroke=\"none\">(-2, 3)</text><circle cx=\"88\" cy=\"48\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"94\" y=\"42\" fill=\"#7c5cff\" stroke=\"none\">(-1, 3)</text></svg>",
-    "answer": {
-      "type": "auto",
-      "value": "(-1.5, 3)",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "(-1.5, 3)"
-      },
-      {
-        "label": "B",
-        "text": "(1, 0)"
-      },
-      {
-        "label": "C",
-        "text": "(-3, 6)"
-      },
-      {
-        "label": "D",
-        "text": "(3, -1.5)"
-      },
-      {
-        "label": "E",
-        "text": "(-0.5, 3)"
-      }
-    ],
-    "correctOption": "A",
+    "correctOption": "C",
     "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
@@ -3091,88 +3089,87 @@
       "act-coordinate-geometry"
     ],
     "source": "act-template-gen",
-    "contentHash": "df108a2588862111d308cd547c1e3346c56cbb4de9eceadf03dca1a70cb65c98",
+    "contentHash": "66ab6c2f43415a201017784d2fb8bee261bb6f803b0d70cd47da5c9818278ffc",
     "isActive": true
   },
   {
-    "problemId": "act-act-coordinate-geometry-8d69079c67",
+    "problemId": "act-act-coordinate-geometry-8841e2e352",
     "skillId": "act-coordinate-geometry",
-    "prompt": "What is the midpoint of the segment joining the two points shown, (2, 3) and (-1, -1)?",
-    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><line x1=\"20\" y1=\"75\" x2=\"180\" y2=\"75\" stroke=\"#bbb\" stroke-width=\"1\"/><line x1=\"100\" y1=\"15\" x2=\"100\" y2=\"140\" stroke=\"#bbb\" stroke-width=\"1\"/><circle cx=\"124\" cy=\"48\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"130\" y=\"42\" fill=\"#7c5cff\" stroke=\"none\">(2, 3)</text><circle cx=\"88\" cy=\"84\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"94\" y=\"78\" fill=\"#7c5cff\" stroke=\"none\">(-1, -1)</text></svg>",
+    "prompt": "What is the midpoint of the segment joining the two points shown, (1, -3) and (-1, 2)?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><line x1=\"20\" y1=\"75\" x2=\"180\" y2=\"75\" stroke=\"#bbb\" stroke-width=\"1\"/><line x1=\"100\" y1=\"15\" x2=\"100\" y2=\"140\" stroke=\"#bbb\" stroke-width=\"1\"/><circle cx=\"112\" cy=\"102\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"118\" y=\"96\" fill=\"#7c5cff\" stroke=\"none\">(1, -3)</text><circle cx=\"88\" cy=\"57\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"94\" y=\"51\" fill=\"#7c5cff\" stroke=\"none\">(-1, 2)</text></svg>",
     "answer": {
       "type": "auto",
-      "value": "(0.5, 1)",
+      "value": "(0, -0.5)",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "(1.5, 1)"
+        "text": "(-0.5, 0)"
       },
       {
         "label": "B",
-        "text": "(1, 0.5)"
+        "text": "(0, -0.5)"
       },
       {
         "label": "C",
-        "text": "(1, 2)"
+        "text": "(0, -1)"
       },
       {
         "label": "D",
-        "text": "(0.5, 1)"
+        "text": "(1, -0.5)"
       },
       {
         "label": "E",
-        "text": "(-3, -4)"
+        "text": "(-2, 5)"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-coordinate-geometry"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "8841e2e352adb3ff97bb5aab67130ab5e8c01e6caf864d680ee0332d5512603d",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-coordinate-geometry-1bad85cd8f",
+    "skillId": "act-coordinate-geometry",
+    "prompt": "What is the distance between (-1, -5) and (4, 7)?",
+    "answer": {
+      "type": "auto",
+      "value": "13",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "8"
+      },
+      {
+        "label": "B",
+        "text": "14"
+      },
+      {
+        "label": "C",
+        "text": "17"
+      },
+      {
+        "label": "D",
+        "text": "13"
+      },
+      {
+        "label": "E",
+        "text": "60"
       }
     ],
     "correctOption": "D",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-coordinate-geometry"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "8d69079c6793ce190859bd178b5c08edab3970dec451839e548f55db39441a75",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-coordinate-geometry-71e844b5f4",
-    "skillId": "act-coordinate-geometry",
-    "prompt": "What is the midpoint of the segment joining the two points shown, (4, 5) and (2, -3)?",
-    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\"><line x1=\"20\" y1=\"75\" x2=\"180\" y2=\"75\" stroke=\"#bbb\" stroke-width=\"1\"/><line x1=\"100\" y1=\"15\" x2=\"100\" y2=\"140\" stroke=\"#bbb\" stroke-width=\"1\"/><circle cx=\"148\" cy=\"30\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"154\" y=\"24\" fill=\"#7c5cff\" stroke=\"none\">(4, 5)</text><circle cx=\"124\" cy=\"102\" r=\"3.5\" fill=\"#7c5cff\" stroke=\"none\"/><text x=\"130\" y=\"96\" fill=\"#7c5cff\" stroke=\"none\">(2, -3)</text></svg>",
-    "answer": {
-      "type": "auto",
-      "value": "(3, 1)",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "(6, 2)"
-      },
-      {
-        "label": "B",
-        "text": "(1, 3)"
-      },
-      {
-        "label": "C",
-        "text": "(4, 1)"
-      },
-      {
-        "label": "D",
-        "text": "(-2, -8)"
-      },
-      {
-        "label": "E",
-        "text": "(3, 1)"
-      }
-    ],
-    "correctOption": "E",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -3181,7 +3178,97 @@
       "act-coordinate-geometry"
     ],
     "source": "act-template-gen",
-    "contentHash": "71e844b5f429574f5696425c078ac2d863ecba7c8d929ccf6f2a4209eaf4c664",
+    "contentHash": "1bad85cd8ff5b8844cd5ac7471b49d1fafbb8b35e02f2c91fc22011ebb5f33db",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-right-triangle-trig-d569434159",
+    "skillId": "act-right-triangle-trig",
+    "prompt": "In the right triangle shown, the legs have length 6 and 8. What is the length of the hypotenuse?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\">\n      <polygon points=\"30,120 170,120 30,30\" stroke-linejoin=\"round\"/>\n      <rect x=\"30\" y=\"108\" width=\"12\" height=\"12\" stroke-width=\"1.5\"/>\n      <text x=\"100\" y=\"138\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">6</text>\n      <text x=\"16\" y=\"78\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">8</text></svg>",
+    "answer": {
+      "type": "auto",
+      "value": "10",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "11"
+      },
+      {
+        "label": "B",
+        "text": "10"
+      },
+      {
+        "label": "C",
+        "text": "7"
+      },
+      {
+        "label": "D",
+        "text": "14"
+      },
+      {
+        "label": "E",
+        "text": "9"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-right-triangle-trig"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "d56943415991ca0a0e0711a6de8bc811bc830a4d5f329be9023a9f0bf217e864",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-right-triangle-trig-54394e51d2",
+    "skillId": "act-right-triangle-trig",
+    "prompt": "In the right triangle shown, the legs have length 9 and 12. What is the length of the hypotenuse?",
+    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\">\n      <polygon points=\"30,120 170,120 30,30\" stroke-linejoin=\"round\"/>\n      <rect x=\"30\" y=\"108\" width=\"12\" height=\"12\" stroke-width=\"1.5\"/>\n      <text x=\"100\" y=\"138\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">9</text>\n      <text x=\"16\" y=\"78\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">12</text></svg>",
+    "answer": {
+      "type": "auto",
+      "value": "15",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "15"
+      },
+      {
+        "label": "B",
+        "text": "14"
+      },
+      {
+        "label": "C",
+        "text": "21"
+      },
+      {
+        "label": "D",
+        "text": "16"
+      },
+      {
+        "label": "E",
+        "text": "10"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-right-triangle-trig"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "54394e51d27e3f765b55a2aae3f19603ebf16bd4143c81e627e8bd61af21713c",
     "isActive": true
   },
   {
@@ -3198,7 +3285,7 @@
     "options": [
       {
         "label": "A",
-        "text": "18"
+        "text": "16"
       },
       {
         "label": "B",
@@ -3210,15 +3297,15 @@
       },
       {
         "label": "D",
-        "text": "16"
+        "text": "11"
       },
       {
         "label": "E",
-        "text": "11"
+        "text": "18"
       }
     ],
     "correctOption": "B",
-    "difficulty": 2,
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -3243,27 +3330,27 @@
     "options": [
       {
         "label": "A",
-        "text": "12"
+        "text": "14"
       },
       {
         "label": "B",
-        "text": "13"
-      },
-      {
-        "label": "C",
         "text": "8"
       },
       {
+        "label": "C",
+        "text": "13"
+      },
+      {
         "label": "D",
-        "text": "14"
+        "text": "12"
       },
       {
         "label": "E",
         "text": "17"
       }
     ],
-    "correctOption": "B",
-    "difficulty": 2,
+    "correctOption": "C",
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -3288,7 +3375,7 @@
     "options": [
       {
         "label": "A",
-        "text": "3"
+        "text": "7"
       },
       {
         "label": "B",
@@ -3296,18 +3383,18 @@
       },
       {
         "label": "C",
-        "text": "7"
+        "text": "3"
       },
       {
         "label": "D",
-        "text": "4"
+        "text": "5"
       },
       {
         "label": "E",
-        "text": "5"
+        "text": "4"
       }
     ],
-    "correctOption": "E",
+    "correctOption": "D",
     "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
@@ -3320,13 +3407,12 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-right-triangle-trig-54394e51d2",
-    "skillId": "act-right-triangle-trig",
-    "prompt": "In the right triangle shown, the legs have length 9 and 12. What is the length of the hypotenuse?",
-    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\">\n      <polygon points=\"30,120 170,120 30,30\" stroke-linejoin=\"round\"/>\n      <rect x=\"30\" y=\"108\" width=\"12\" height=\"12\" stroke-width=\"1.5\"/>\n      <text x=\"100\" y=\"138\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">9</text>\n      <text x=\"16\" y=\"78\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">12</text></svg>",
+    "problemId": "act-act-congruence-similarity-de538b28d6",
+    "skillId": "act-congruence-similarity",
+    "prompt": "Two triangles are similar. A side of length 6 corresponds to a side of length 12. What length corresponds to a side of length 9?",
     "answer": {
       "type": "auto",
-      "value": "15",
+      "value": "18",
       "equivalents": []
     },
     "answerType": "multiple-choice",
@@ -3337,38 +3423,37 @@
       },
       {
         "label": "B",
-        "text": "16"
+        "text": "27"
       },
       {
         "label": "C",
-        "text": "10"
+        "text": "11"
       },
       {
         "label": "D",
-        "text": "21"
+        "text": "18"
       },
       {
         "label": "E",
-        "text": "14"
+        "text": "5"
       }
     ],
-    "correctOption": "A",
-    "difficulty": 3,
+    "correctOption": "D",
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-right-triangle-trig"
+      "act-congruence-similarity"
     ],
     "source": "act-template-gen",
-    "contentHash": "54394e51d27e3f765b55a2aae3f19603ebf16bd4143c81e627e8bd61af21713c",
+    "contentHash": "de538b28d6717485c8eff07cf4a358304cb77245b487af9b1e9904910d87ab38",
     "isActive": true
   },
   {
-    "problemId": "act-act-right-triangle-trig-d569434159",
-    "skillId": "act-right-triangle-trig",
-    "prompt": "In the right triangle shown, the legs have length 6 and 8. What is the length of the hypotenuse?",
-    "svg": "<svg viewBox=\"0 0 200 150\" xmlns=\"http://www.w3.org/2000/svg\" width=\"100%\" style=\"max-width:220px\" stroke=\"#7c5cff\" fill=\"none\" stroke-width=\"2\" font-family=\"sans-serif\" font-size=\"13\">\n      <polygon points=\"30,120 170,120 30,30\" stroke-linejoin=\"round\"/>\n      <rect x=\"30\" y=\"108\" width=\"12\" height=\"12\" stroke-width=\"1.5\"/>\n      <text x=\"100\" y=\"138\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">6</text>\n      <text x=\"16\" y=\"78\" fill=\"#7c5cff\" stroke=\"none\" text-anchor=\"middle\">8</text></svg>",
+    "problemId": "act-act-congruence-similarity-cfcf2416c5",
+    "skillId": "act-congruence-similarity",
+    "prompt": "Two triangles are similar. A side of length 8 corresponds to a side of length 16. What length corresponds to a side of length 5?",
     "answer": {
       "type": "auto",
       "value": "10",
@@ -3378,11 +3463,11 @@
     "options": [
       {
         "label": "A",
-        "text": "9"
+        "text": "15"
       },
       {
         "label": "B",
-        "text": "11"
+        "text": "10"
       },
       {
         "label": "C",
@@ -3390,29 +3475,29 @@
       },
       {
         "label": "D",
-        "text": "10"
+        "text": "3"
       },
       {
         "label": "E",
-        "text": "14"
+        "text": "13"
       }
     ],
-    "correctOption": "D",
-    "difficulty": 3,
+    "correctOption": "B",
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-right-triangle-trig"
+      "act-congruence-similarity"
     ],
     "source": "act-template-gen",
-    "contentHash": "d56943415991ca0a0e0711a6de8bc811bc830a4d5f329be9023a9f0bf217e864",
+    "contentHash": "cfcf2416c5f57b90637dbd770e35a1dfbddc204b070c3d4a5558e19f5dba784d",
     "isActive": true
   },
   {
-    "problemId": "act-act-congruence-similarity-f6714cbd5d",
+    "problemId": "act-act-congruence-similarity-c2f0f3864d",
     "skillId": "act-congruence-similarity",
-    "prompt": "Two triangles are similar. A side of length 5 corresponds to a side of length 20. What length corresponds to a side of length 4?",
+    "prompt": "Two triangles are similar. A side of length 5 corresponds to a side of length 10. What length corresponds to a side of length 8?",
     "answer": {
       "type": "auto",
       "value": "16",
@@ -3422,27 +3507,27 @@
     "options": [
       {
         "label": "A",
+        "text": "4"
+      },
+      {
+        "label": "B",
         "text": "16"
       },
       {
-        "label": "B",
-        "text": "1"
-      },
-      {
         "label": "C",
-        "text": "19"
+        "text": "24"
       },
       {
         "label": "D",
-        "text": "8"
+        "text": "10"
       },
       {
         "label": "E",
-        "text": "20"
+        "text": "13"
       }
     ],
-    "correctOption": "A",
-    "difficulty": 2,
+    "correctOption": "B",
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -3450,57 +3535,13 @@
       "act-congruence-similarity"
     ],
     "source": "act-template-gen",
-    "contentHash": "f6714cbd5db6af501fe99ab1eeef68a4e53669f015bd48d0769d2f1f9e404cee",
+    "contentHash": "c2f0f3864d8da009bba52fe608cfc02dac69b939527c3d25ab2a2270888029a0",
     "isActive": true
   },
   {
-    "problemId": "act-act-congruence-similarity-f9595ceac0",
+    "problemId": "act-act-congruence-similarity-b285ef65b0",
     "skillId": "act-congruence-similarity",
-    "prompt": "Two triangles are similar. A side of length 4 corresponds to a side of length 16. What length corresponds to a side of length 7?",
-    "answer": {
-      "type": "auto",
-      "value": "28",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "11"
-      },
-      {
-        "label": "B",
-        "text": "2"
-      },
-      {
-        "label": "C",
-        "text": "19"
-      },
-      {
-        "label": "D",
-        "text": "35"
-      },
-      {
-        "label": "E",
-        "text": "28"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-congruence-similarity"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "f9595ceac0733c82598d1115ecd96245843efae7e65ab145f74d6a8f20a1aa54",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-congruence-similarity-eac1c13d57",
-    "skillId": "act-congruence-similarity",
-    "prompt": "Two triangles are similar. A side of length 5 corresponds to a side of length 20. What length corresponds to a side of length 3?",
+    "prompt": "Two triangles are similar. A side of length 8 corresponds to a side of length 16. What length corresponds to a side of length 6?",
     "answer": {
       "type": "auto",
       "value": "12",
@@ -3514,723 +3555,63 @@
       },
       {
         "label": "B",
-        "text": "15"
-      },
-      {
-        "label": "C",
         "text": "12"
       },
       {
+        "label": "C",
+        "text": "14"
+      },
+      {
         "label": "D",
+        "text": "3"
+      },
+      {
+        "label": "E",
+        "text": "8"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-congruence-similarity"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "b285ef65b0536cefe772a67c31b0beb9ccf269b8385f3cc8a9c3a658124888a4",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-congruence-similarity-188cbe4d01",
+    "skillId": "act-congruence-similarity",
+    "prompt": "Two triangles are similar. A side of length 8 corresponds to a side of length 32. What length corresponds to a side of length 5?",
+    "answer": {
+      "type": "auto",
+      "value": "20",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
         "text": "1"
       },
       {
-        "label": "E",
-        "text": "7"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-congruence-similarity"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "eac1c13d57fd56744d20af22695491aa0519b281589cd939877b7c746e073ab5",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-congruence-similarity-eb22153ae2",
-    "skillId": "act-congruence-similarity",
-    "prompt": "Two triangles are similar. A side of length 5 corresponds to a side of length 10. What length corresponds to a side of length 4?",
-    "answer": {
-      "type": "auto",
-      "value": "8",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "2"
-      },
-      {
         "label": "B",
-        "text": "12"
+        "text": "25"
       },
       {
         "label": "C",
-        "text": "8"
-      },
-      {
-        "label": "D",
         "text": "9"
       },
       {
-        "label": "E",
-        "text": "6"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-congruence-similarity"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "eb22153ae2d1523ac5338b77dabe8dca2eab7e1eaca6b55c66674a93b9ac716a",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-congruence-similarity-21f006dee0",
-    "skillId": "act-congruence-similarity",
-    "prompt": "Two triangles are similar. A side of length 3 corresponds to a side of length 12. What length corresponds to a side of length 7?",
-    "answer": {
-      "type": "auto",
-      "value": "28",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "35"
-      },
-      {
-        "label": "B",
-        "text": "28"
-      },
-      {
-        "label": "C",
-        "text": "2"
-      },
-      {
         "label": "D",
-        "text": "16"
-      },
-      {
-        "label": "E",
-        "text": "11"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-congruence-similarity"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "21f006dee0d654bc33031cb8a53e17f3e77ea4aef9e44076fe32bbe191a3d05b",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-congruence-similarity-ea6b609a86",
-    "skillId": "act-congruence-similarity",
-    "prompt": "Two triangles are similar. A side of length 3 corresponds to a side of length 6. What length corresponds to a side of length 6?",
-    "answer": {
-      "type": "auto",
-      "value": "12",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "3"
-      },
-      {
-        "label": "B",
-        "text": "18"
-      },
-      {
-        "label": "C",
-        "text": "8"
-      },
-      {
-        "label": "D",
-        "text": "9"
-      },
-      {
-        "label": "E",
-        "text": "12"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-congruence-similarity"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "ea6b609a86ae4fc040a5413105daaa291af72bd195b5d5063a5cf56187aeb69e",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-congruence-similarity-fb1f73249c",
-    "skillId": "act-congruence-similarity",
-    "prompt": "Two triangles are similar. A side of length 6 corresponds to a side of length 18. What length corresponds to a side of length 5?",
-    "answer": {
-      "type": "auto",
-      "value": "15",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
         "text": "20"
       },
       {
-        "label": "B",
-        "text": "15"
-      },
-      {
-        "label": "C",
-        "text": "17"
-      },
-      {
-        "label": "D",
-        "text": "8"
-      },
-      {
         "label": "E",
-        "text": "2"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-congruence-similarity"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "fb1f73249c889691f53d0af117407fe88c605748ef48754e278c17aee512d7d4",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-congruence-similarity-e405d98625",
-    "skillId": "act-congruence-similarity",
-    "prompt": "Two triangles are similar. A side of length 5 corresponds to a side of length 20. What length corresponds to a side of length 7?",
-    "answer": {
-      "type": "auto",
-      "value": "28",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "2"
-      },
-      {
-        "label": "B",
-        "text": "28"
-      },
-      {
-        "label": "C",
-        "text": "22"
-      },
-      {
-        "label": "D",
-        "text": "11"
-      },
-      {
-        "label": "E",
-        "text": "35"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 5,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-congruence-similarity"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "e405d986255c57c078363674d2ef3e004693cfcbdf7f42ba22ef6042c8af2541",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-linear-equations-d7a4d89520",
-    "skillId": "act-linear-equations",
-    "prompt": "If 6x - 6 = -x + 15, then x = ?",
-    "answer": {
-      "type": "auto",
-      "value": "3",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "-3"
-      },
-      {
-        "label": "B",
-        "text": "3"
-      },
-      {
-        "label": "C",
-        "text": "2"
-      },
-      {
-        "label": "D",
-        "text": "4"
-      },
-      {
-        "label": "E",
-        "text": "21"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-linear-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "d7a4d89520649757208dd45e6f9c9d5839301d8081dd8b06c5d34fdf8633e932",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-linear-equations-fdb58c2d47",
-    "skillId": "act-linear-equations",
-    "prompt": "If 5x - 6 = 2x + 3, then x = ?",
-    "answer": {
-      "type": "auto",
-      "value": "3",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "9"
-      },
-      {
-        "label": "B",
-        "text": "4"
-      },
-      {
-        "label": "C",
-        "text": "2"
-      },
-      {
-        "label": "D",
-        "text": "-3"
-      },
-      {
-        "label": "E",
-        "text": "3"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-linear-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "fdb58c2d47dd426d257f57f29d712b7bc847aa3d2d50e822ac5554af18dde773",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-linear-equations-eb226c5b5c",
-    "skillId": "act-linear-equations",
-    "prompt": "If 7x + 9 = -x + 41, then x = ?",
-    "answer": {
-      "type": "auto",
-      "value": "4",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "4"
-      },
-      {
-        "label": "B",
-        "text": "-4"
-      },
-      {
-        "label": "C",
-        "text": "32"
-      },
-      {
-        "label": "D",
-        "text": "3"
-      },
-      {
-        "label": "E",
-        "text": "5"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-linear-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "eb226c5b5c89766ee851784d988bb4ecc40895c05aec63919b61cdf806abb7ae",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-linear-equations-bd4894a9ea",
-    "skillId": "act-linear-equations",
-    "prompt": "If 8x + 5 = 4x + 33, then x = ?",
-    "answer": {
-      "type": "auto",
-      "value": "7",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "7"
-      },
-      {
-        "label": "B",
-        "text": "-7"
-      },
-      {
-        "label": "C",
-        "text": "8"
-      },
-      {
-        "label": "D",
-        "text": "6"
-      },
-      {
-        "label": "E",
-        "text": "28"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-linear-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "bd4894a9eaf554eed3cb29bb3519ba4f24f882a2c6bea9f79be2cf9e8c86455c",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-linear-equations-ba714f0aed",
-    "skillId": "act-linear-equations",
-    "prompt": "If 6x - 4 = -3x + 68, then x = ?",
-    "answer": {
-      "type": "auto",
-      "value": "8",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "7"
-      },
-      {
-        "label": "B",
-        "text": "8"
-      },
-      {
-        "label": "C",
-        "text": "9"
-      },
-      {
-        "label": "D",
-        "text": "72"
-      },
-      {
-        "label": "E",
-        "text": "-8"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-linear-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "ba714f0aed0119ed7ac54536349a5b9daf08e8a6f37cb16fac47e6695e89e041",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-linear-equations-e507cbea8a",
-    "skillId": "act-linear-equations",
-    "prompt": "If 8x - 3 = -3x + 30, then x = ?",
-    "answer": {
-      "type": "auto",
-      "value": "3",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "3"
-      },
-      {
-        "label": "B",
-        "text": "-3"
-      },
-      {
-        "label": "C",
-        "text": "4"
-      },
-      {
-        "label": "D",
-        "text": "2"
-      },
-      {
-        "label": "E",
-        "text": "33"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-linear-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "e507cbea8a1ccb0219ceac6311ca8ce4efc6546afbd2dd0d88d6d8a6b39dcb2c",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-linear-equations-0fc8937aee",
-    "skillId": "act-linear-equations",
-    "prompt": "If 6x + 6 = -3x + 33, then x = ?",
-    "answer": {
-      "type": "auto",
-      "value": "3",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "4"
-      },
-      {
-        "label": "B",
-        "text": "-3"
-      },
-      {
-        "label": "C",
-        "text": "27"
-      },
-      {
-        "label": "D",
-        "text": "2"
-      },
-      {
-        "label": "E",
-        "text": "3"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-linear-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "0fc8937aeef3793d4bf92a6073c09ca21d735e7f709307aaa6afdbe8b53237f3",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-linear-equations-2239f1acaf",
-    "skillId": "act-linear-equations",
-    "prompt": "If 10x + 4 = 3x - 10, then x = ?",
-    "answer": {
-      "type": "auto",
-      "value": "-2",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "-14"
-      },
-      {
-        "label": "B",
-        "text": "2"
-      },
-      {
-        "label": "C",
-        "text": "-2"
-      },
-      {
-        "label": "D",
-        "text": "-3"
-      },
-      {
-        "label": "E",
-        "text": "-1"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 5,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-linear-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "2239f1acafbcbca3eded7aed0e8d4329618054f6e314f5eb5b4a6ab4667067aa",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-systems-of-equations-56cf34e371",
-    "skillId": "act-systems-of-equations",
-    "prompt": "If 2x + 3y = 0 and 3x + 4y = 2, what is x + y?",
-    "answer": {
-      "type": "auto",
-      "value": "2",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "-24"
-      },
-      {
-        "label": "B",
-        "text": "10"
-      },
-      {
-        "label": "C",
-        "text": "-4"
-      },
-      {
-        "label": "D",
-        "text": "6"
-      },
-      {
-        "label": "E",
-        "text": "2"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-systems-of-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "56cf34e371c265aa93cb9f26b471a5acbaa478da861e65a573f5e36f9f6428fa",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-systems-of-equations-a3da93c892",
-    "skillId": "act-systems-of-equations",
-    "prompt": "If 4x + 4y = 12 and x + 3y = -1, what is x + y?",
-    "answer": {
-      "type": "auto",
-      "value": "3",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "7"
-      },
-      {
-        "label": "B",
-        "text": "-10"
-      },
-      {
-        "label": "C",
-        "text": "3"
-      },
-      {
-        "label": "D",
-        "text": "-2"
-      },
-      {
-        "label": "E",
-        "text": "5"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-systems-of-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "a3da93c8928ea100de08560ff39ab56f0b8acf2097101c0f0a10e971ac0207a9",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-systems-of-equations-4c90fcd47e",
-    "skillId": "act-systems-of-equations",
-    "prompt": "If x + 3y = 11 and 4x + y = 22, what is x + y?",
-    "answer": {
-      "type": "auto",
-      "value": "7",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "2"
-      },
-      {
-        "label": "B",
-        "text": "10"
-      },
-      {
-        "label": "C",
-        "text": "5"
-      },
-      {
-        "label": "D",
-        "text": "7"
-      },
-      {
-        "label": "E",
-        "text": "3"
+        "text": "29"
       }
     ],
     "correctOption": "D",
@@ -4239,19 +3620,63 @@
     "tags": [
       "act",
       "act-math",
-      "act-systems-of-equations"
+      "act-congruence-similarity"
     ],
     "source": "act-template-gen",
-    "contentHash": "4c90fcd47e08fb2af8ef1493a853d29e0dec5e405aa1d83f8d44cd49c2b03f25",
+    "contentHash": "188cbe4d01eff90275a6cb09855f28874fae3b0ae14fb6d9822224efca956010",
     "isActive": true
   },
   {
-    "problemId": "act-act-systems-of-equations-ca8a657b47",
-    "skillId": "act-systems-of-equations",
-    "prompt": "If 3x + 3y = -24 and 2x + 4y = -26, what is x + y?",
+    "problemId": "act-act-congruence-similarity-fb89d9f19a",
+    "skillId": "act-congruence-similarity",
+    "prompt": "Two triangles are similar. A side of length 7 corresponds to a side of length 14. What length corresponds to a side of length 6?",
     "answer": {
       "type": "auto",
-      "value": "-8",
+      "value": "12",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "13"
+      },
+      {
+        "label": "B",
+        "text": "18"
+      },
+      {
+        "label": "C",
+        "text": "3"
+      },
+      {
+        "label": "D",
+        "text": "8"
+      },
+      {
+        "label": "E",
+        "text": "12"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-congruence-similarity"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "fb89d9f19a944685c82a2487b36dd631be99f56d93f515a264ba047779ca2e48",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-congruence-similarity-1b466403c1",
+    "skillId": "act-congruence-similarity",
+    "prompt": "Two triangles are similar. A side of length 4 corresponds to a side of length 8. What length corresponds to a side of length 5?",
+    "answer": {
+      "type": "auto",
+      "value": "10",
       "equivalents": []
     },
     "answerType": "multiple-choice",
@@ -4262,99 +3687,11 @@
       },
       {
         "label": "B",
-        "text": "-8"
+        "text": "9"
       },
       {
         "label": "C",
-        "text": "2"
-      },
-      {
-        "label": "D",
-        "text": "-3"
-      },
-      {
-        "label": "E",
-        "text": "-5"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-systems-of-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "ca8a657b4739ff3008d82f22fd8705e13458ca3053c5d96950e9b26011ebd4a5",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-systems-of-equations-8e7b71b6c5",
-    "skillId": "act-systems-of-equations",
-    "prompt": "If 2x + y = 5 and 4x + 4y = 4, what is x + y?",
-    "answer": {
-      "type": "auto",
-      "value": "1",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "-12"
-      },
-      {
-        "label": "B",
-        "text": "1"
-      },
-      {
-        "label": "C",
-        "text": "-3"
-      },
-      {
-        "label": "D",
-        "text": "4"
-      },
-      {
-        "label": "E",
         "text": "7"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-systems-of-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "8e7b71b6c5cb330cf23d66705b641ca89b8aff0529e10deac774b7a444f0080c",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-systems-of-equations-5f6a1d8330",
-    "skillId": "act-systems-of-equations",
-    "prompt": "If 2x + 3y = 0 and x + 2y = -1, what is x + y?",
-    "answer": {
-      "type": "auto",
-      "value": "1",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "5"
-      },
-      {
-        "label": "B",
-        "text": "-2"
-      },
-      {
-        "label": "C",
-        "text": "1"
       },
       {
         "label": "D",
@@ -4362,28 +3699,28 @@
       },
       {
         "label": "E",
-        "text": "-6"
+        "text": "10"
       }
     ],
-    "correctOption": "C",
+    "correctOption": "E",
     "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-systems-of-equations"
+      "act-congruence-similarity"
     ],
     "source": "act-template-gen",
-    "contentHash": "5f6a1d8330ae9fdbc6a62b03f5684674885f370c98fe1a3a6df44ac0a18b2e1a",
+    "contentHash": "1b466403c1ca5988318fa799e5b013fbad95ae87da0c49a1b4a63341d6f20fba",
     "isActive": true
   },
   {
-    "problemId": "act-act-systems-of-equations-68c0c7235e",
-    "skillId": "act-systems-of-equations",
-    "prompt": "If 2x + 2y = 2 and 2x + 3y = -2, what is x + y?",
+    "problemId": "act-act-congruence-similarity-b11933d986",
+    "skillId": "act-congruence-similarity",
+    "prompt": "Two triangles are similar. A side of length 8 corresponds to a side of length 24. What length corresponds to a side of length 3?",
     "answer": {
       "type": "auto",
-      "value": "1",
+      "value": "9",
       "equivalents": []
     },
     "answerType": "multiple-choice",
@@ -4394,7 +3731,139 @@
       },
       {
         "label": "B",
-        "text": "-20"
+        "text": "1"
+      },
+      {
+        "label": "C",
+        "text": "12"
+      },
+      {
+        "label": "D",
+        "text": "6"
+      },
+      {
+        "label": "E",
+        "text": "19"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-congruence-similarity"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "b11933d986a4a7ea9363a71d7f3e24289c3efbce9d41d115c0200c918ddc28a3",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-equations-8c9a17f777",
+    "skillId": "act-linear-equations",
+    "prompt": "If 2x + 0 = -3x - 25, then x = ?",
+    "answer": {
+      "type": "auto",
+      "value": "-5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-25"
+      },
+      {
+        "label": "B",
+        "text": "-4"
+      },
+      {
+        "label": "C",
+        "text": "5"
+      },
+      {
+        "label": "D",
+        "text": "-6"
+      },
+      {
+        "label": "E",
+        "text": "-5"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "8c9a17f777ece919fb4c2356400171c2b7aeb81eaca207a3a4ae8f67b60d4b40",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-equations-0d4febd99e",
+    "skillId": "act-linear-equations",
+    "prompt": "If 5x + 8 = -x + 14, then x = ?",
+    "answer": {
+      "type": "auto",
+      "value": "1",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "6"
+      },
+      {
+        "label": "B",
+        "text": "0"
+      },
+      {
+        "label": "C",
+        "text": "1"
+      },
+      {
+        "label": "D",
+        "text": "2"
+      },
+      {
+        "label": "E",
+        "text": "-1"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "0d4febd99ecf97bf5d138bc5392889fb21be44baf4fe959ea382b5f47b075cc1",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-equations-dc9ee19c85",
+    "skillId": "act-linear-equations",
+    "prompt": "If 5x - 4 = x - 24, then x = ?",
+    "answer": {
+      "type": "auto",
+      "value": "-5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-6"
+      },
+      {
+        "label": "B",
+        "text": "-5"
       },
       {
         "label": "C",
@@ -4402,29 +3871,73 @@
       },
       {
         "label": "D",
-        "text": "5"
+        "text": "-20"
       },
       {
         "label": "E",
-        "text": "1"
+        "text": "5"
       }
     ],
-    "correctOption": "E",
-    "difficulty": 4,
+    "correctOption": "B",
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-systems-of-equations"
+      "act-linear-equations"
     ],
     "source": "act-template-gen",
-    "contentHash": "68c0c7235e1d7b107f983e01712d6cd6f6decb292a3cdf0c96146490bb0d878e",
+    "contentHash": "dc9ee19c8586117b2fbadce4eee352438544f2fe08c1ef0a94407621b738467b",
     "isActive": true
   },
   {
-    "problemId": "act-act-systems-of-equations-e81b913639",
-    "skillId": "act-systems-of-equations",
-    "prompt": "If x + 3y = -10 and 2x + 2y = -8, what is x + y?",
+    "problemId": "act-act-linear-equations-de1fcdcbdf",
+    "skillId": "act-linear-equations",
+    "prompt": "If 4x + 0 = -x + 15, then x = ?",
+    "answer": {
+      "type": "auto",
+      "value": "3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "15"
+      },
+      {
+        "label": "B",
+        "text": "3"
+      },
+      {
+        "label": "C",
+        "text": "2"
+      },
+      {
+        "label": "D",
+        "text": "4"
+      },
+      {
+        "label": "E",
+        "text": "-3"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "de1fcdcbdfe878d23e76568bb879ae3db8b21b86a8e779d27301c055a8e1c31a",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-equations-3a7208cb11",
+    "skillId": "act-linear-equations",
+    "prompt": "If 8x - 7 = 3x - 27, then x = ?",
     "answer": {
       "type": "auto",
       "value": "-4",
@@ -4434,7 +3947,7 @@
     "options": [
       {
         "label": "A",
-        "text": "-3"
+        "text": "4"
       },
       {
         "label": "B",
@@ -4442,7 +3955,315 @@
       },
       {
         "label": "C",
+        "text": "-20"
+      },
+      {
+        "label": "D",
+        "text": "-3"
+      },
+      {
+        "label": "E",
+        "text": "-5"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "3a7208cb119d16effcc07b1cd47e2210f63ec6cd40557666ab7fd666fb62edfb",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-equations-5d853f9cf3",
+    "skillId": "act-linear-equations",
+    "prompt": "If 4x + 3 = 2x - 9, then x = ?",
+    "answer": {
+      "type": "auto",
+      "value": "-6",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-12"
+      },
+      {
+        "label": "B",
+        "text": "-6"
+      },
+      {
+        "label": "C",
+        "text": "-5"
+      },
+      {
+        "label": "D",
+        "text": "6"
+      },
+      {
+        "label": "E",
+        "text": "-7"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "5d853f9cf32c3d5995f82b1f6b53598bbff8d160db7bc4a4bbbb4e7ff34138c0",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-equations-8af93b981d",
+    "skillId": "act-linear-equations",
+    "prompt": "If 7x + 8 = x + 38, then x = ?",
+    "answer": {
+      "type": "auto",
+      "value": "5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "5"
+      },
+      {
+        "label": "B",
+        "text": "-5"
+      },
+      {
+        "label": "C",
+        "text": "6"
+      },
+      {
+        "label": "D",
+        "text": "4"
+      },
+      {
+        "label": "E",
+        "text": "30"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "8af93b981db4d79498d5aa4b2783013544ff2aa2872dc16cddd870b488e5ac18",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-equations-de9c192182",
+    "skillId": "act-linear-equations",
+    "prompt": "If 9x + 8 = x + 56, then x = ?",
+    "answer": {
+      "type": "auto",
+      "value": "6",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-6"
+      },
+      {
+        "label": "B",
+        "text": "7"
+      },
+      {
+        "label": "C",
+        "text": "48"
+      },
+      {
+        "label": "D",
+        "text": "6"
+      },
+      {
+        "label": "E",
+        "text": "5"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "de9c192182e1f46d86628da95aae2ed741426554b3ae35b749a118d922dd93c6",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-systems-of-equations-696cd84a12",
+    "skillId": "act-systems-of-equations",
+    "prompt": "If 2x + 3y = 11 and 4x + y = -3, what is x + y?",
+    "answer": {
+      "type": "auto",
+      "value": "3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "3"
+      },
+      {
+        "label": "B",
+        "text": "-10"
+      },
+      {
+        "label": "C",
+        "text": "-2"
+      },
+      {
+        "label": "D",
+        "text": "5"
+      },
+      {
+        "label": "E",
+        "text": "-7"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-systems-of-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "696cd84a12de66e904c973598ddb1a7d9c159c49d9dddaf9cddd3cbdcafbea99",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-systems-of-equations-4e7599e47b",
+    "skillId": "act-systems-of-equations",
+    "prompt": "If 3x + 2y = 7 and 4x + 4y = 4, what is x + y?",
+    "answer": {
+      "type": "auto",
+      "value": "1",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-20"
+      },
+      {
+        "label": "B",
+        "text": "1"
+      },
+      {
+        "label": "C",
+        "text": "5"
+      },
+      {
+        "label": "D",
+        "text": "9"
+      },
+      {
+        "label": "E",
+        "text": "-4"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-systems-of-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "4e7599e47b660b0160e630ed12c82907f108503dab8899ef51f345714c466d0b",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-systems-of-equations-b917bd7d3f",
+    "skillId": "act-systems-of-equations",
+    "prompt": "If 2x + 3y = 3 and 3x + 2y = 7, what is x + y?",
+    "answer": {
+      "type": "auto",
+      "value": "2",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "2"
+      },
+      {
+        "label": "B",
         "text": "-1"
+      },
+      {
+        "label": "C",
+        "text": "4"
+      },
+      {
+        "label": "D",
+        "text": "3"
+      },
+      {
+        "label": "E",
+        "text": "-3"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-systems-of-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "b917bd7d3f75f03b40c824194fa894f54930efdf4ba0bff6612771ec8e94512a",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-systems-of-equations-a62b39f1fb",
+    "skillId": "act-systems-of-equations",
+    "prompt": "If 3x + 2y = 19 and 4x + 3y = 26, what is x + y?",
+    "answer": {
+      "type": "auto",
+      "value": "7",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "7"
+      },
+      {
+        "label": "B",
+        "text": "3"
+      },
+      {
+        "label": "C",
+        "text": "10"
       },
       {
         "label": "D",
@@ -4450,10 +4271,186 @@
       },
       {
         "label": "E",
+        "text": "5"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-systems-of-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "a62b39f1fbfecc7aeffce84ce7ea9c33c7bd4f33d3544a2fca21cb78b71984a5",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-systems-of-equations-c5bf50f626",
+    "skillId": "act-systems-of-equations",
+    "prompt": "If 3x + 2y = 12 and 4x + y = 21, what is x + y?",
+    "answer": {
+      "type": "auto",
+      "value": "3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-3"
+      },
+      {
+        "label": "B",
+        "text": "6"
+      },
+      {
+        "label": "C",
         "text": "3"
+      },
+      {
+        "label": "D",
+        "text": "-18"
+      },
+      {
+        "label": "E",
+        "text": "9"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-systems-of-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "c5bf50f626262ac26727d2836766e73b0414fe61d40408660f3aa3ef3cb50549",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-systems-of-equations-ac73a21cf2",
+    "skillId": "act-systems-of-equations",
+    "prompt": "If 4x + y = -10 and x + y = -1, what is x + y?",
+    "answer": {
+      "type": "auto",
+      "value": "-1",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-3"
+      },
+      {
+        "label": "B",
+        "text": "-1"
+      },
+      {
+        "label": "C",
+        "text": "-5"
+      },
+      {
+        "label": "D",
+        "text": "-6"
+      },
+      {
+        "label": "E",
+        "text": "2"
       }
     ],
     "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-systems-of-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "ac73a21cf23a37d654d0b58e52be4021d72e78a498a5603839628d14a13d9486",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-systems-of-equations-8f28065e26",
+    "skillId": "act-systems-of-equations",
+    "prompt": "If 2x + 4y = 4 and x + y = 3, what is x + y?",
+    "answer": {
+      "type": "auto",
+      "value": "3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "3"
+      },
+      {
+        "label": "B",
+        "text": "-4"
+      },
+      {
+        "label": "C",
+        "text": "5"
+      },
+      {
+        "label": "D",
+        "text": "4"
+      },
+      {
+        "label": "E",
+        "text": "-1"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-systems-of-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "8f28065e26f304a51ce9535db4d1ccf2d067931690af87ee02c209511b58adf1",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-systems-of-equations-7537610177",
+    "skillId": "act-systems-of-equations",
+    "prompt": "If 2x + y = 8 and 4x + y = 14, what is x + y?",
+    "answer": {
+      "type": "auto",
+      "value": "5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "2"
+      },
+      {
+        "label": "B",
+        "text": "6"
+      },
+      {
+        "label": "C",
+        "text": "3"
+      },
+      {
+        "label": "D",
+        "text": "5"
+      },
+      {
+        "label": "E",
+        "text": "1"
+      }
+    ],
+    "correctOption": "D",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -4462,13 +4459,233 @@
       "act-systems-of-equations"
     ],
     "source": "act-template-gen",
-    "contentHash": "e81b9136393630c64eb4d8d1d12b6c54d4eab8f01185b9a42d15b57c0a9c4177",
+    "contentHash": "7537610177e3764a2db048c35ae6ac5cc30bbceea440f3c2dc4a199abd17240d",
     "isActive": true
   },
   {
-    "problemId": "act-act-quadratic-equations-d22793ff54",
+    "problemId": "act-act-quadratic-equations-279ba12dff",
     "skillId": "act-quadratic-equations",
-    "prompt": "Which of the following is a solution to x² - 7x + 12 = 0?",
+    "prompt": "Which of the following is a solution to x² + 1x - 12 = 0?",
+    "answer": {
+      "type": "auto",
+      "value": "3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "3"
+      },
+      {
+        "label": "B",
+        "text": "4"
+      },
+      {
+        "label": "C",
+        "text": "-1"
+      },
+      {
+        "label": "D",
+        "text": "-12"
+      },
+      {
+        "label": "E",
+        "text": "-3"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "279ba12dffdf911d920d07b08f88e310fc45072c35f6ba7aefacddcb22392af7",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-equations-b9e3163355",
+    "skillId": "act-quadratic-equations",
+    "prompt": "Which of the following is a solution to x² - 8x + 12 = 0?",
+    "answer": {
+      "type": "auto",
+      "value": "6",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-6"
+      },
+      {
+        "label": "B",
+        "text": "12"
+      },
+      {
+        "label": "C",
+        "text": "-2"
+      },
+      {
+        "label": "D",
+        "text": "8"
+      },
+      {
+        "label": "E",
+        "text": "6"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "b9e31633556ed04e2bd3efcaa77d2c533aa3a47a6968b2dde8a13ce30fb539c6",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-equations-63403df8f1",
+    "skillId": "act-quadratic-equations",
+    "prompt": "Which of the following is a solution to x² + 1x - 6 = 0?",
+    "answer": {
+      "type": "auto",
+      "value": "2",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-2"
+      },
+      {
+        "label": "B",
+        "text": "-6"
+      },
+      {
+        "label": "C",
+        "text": "2"
+      },
+      {
+        "label": "D",
+        "text": "-1"
+      },
+      {
+        "label": "E",
+        "text": "3"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "63403df8f15b989133f1c7e98fdde407f3792d25163a54c013e1b28dc3f22f8c",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-equations-6b18949a24",
+    "skillId": "act-quadratic-equations",
+    "prompt": "Which of the following is a solution to x² - 7x + 10 = 0?",
+    "answer": {
+      "type": "auto",
+      "value": "5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-5"
+      },
+      {
+        "label": "B",
+        "text": "10"
+      },
+      {
+        "label": "C",
+        "text": "-2"
+      },
+      {
+        "label": "D",
+        "text": "7"
+      },
+      {
+        "label": "E",
+        "text": "5"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "6b18949a2470c14e1b30b8548f735063aa002782c11617f057d0f6f87cbc0899",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-equations-16f74564ac",
+    "skillId": "act-quadratic-equations",
+    "prompt": "Which of the following is a solution to x² + 2x - 3 = 0?",
+    "answer": {
+      "type": "auto",
+      "value": "1",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "1"
+      },
+      {
+        "label": "B",
+        "text": "3"
+      },
+      {
+        "label": "C",
+        "text": "-2"
+      },
+      {
+        "label": "D",
+        "text": "-3"
+      },
+      {
+        "label": "E",
+        "text": "-1"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-equations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "16f74564ac607941eb76c885fb2ef19ca21e451c4e681822504a0fd6c11a4409",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-equations-cd2c16805f",
+    "skillId": "act-quadratic-equations",
+    "prompt": "Which of the following is a solution to x² - 6x + 8 = 0?",
     "answer": {
       "type": "auto",
       "value": "4",
@@ -4482,7 +4699,7 @@
       },
       {
         "label": "B",
-        "text": "7"
+        "text": "8"
       },
       {
         "label": "C",
@@ -4490,234 +4707,14 @@
       },
       {
         "label": "D",
-        "text": "-3"
+        "text": "6"
       },
       {
         "label": "E",
-        "text": "12"
+        "text": "-2"
       }
     ],
     "correctOption": "A",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-quadratic-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "d22793ff54f47c55645c5c67c96fc780eeb63f5b8a8c07dce03348183a319936",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-quadratic-equations-aec16618dd",
-    "skillId": "act-quadratic-equations",
-    "prompt": "Which of the following is a solution to x² - 9x + 20 = 0?",
-    "answer": {
-      "type": "auto",
-      "value": "5",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "20"
-      },
-      {
-        "label": "B",
-        "text": "5"
-      },
-      {
-        "label": "C",
-        "text": "9"
-      },
-      {
-        "label": "D",
-        "text": "-4"
-      },
-      {
-        "label": "E",
-        "text": "-5"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-quadratic-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "aec16618dd9cc77c91fdb52de98d5fd1c38b8a8d74d632f75fc91e0ade3883df",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-quadratic-equations-e51a649025",
-    "skillId": "act-quadratic-equations",
-    "prompt": "Which of the following is a solution to x² - 9x + 18 = 0?",
-    "answer": {
-      "type": "auto",
-      "value": "6",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "9"
-      },
-      {
-        "label": "B",
-        "text": "-6"
-      },
-      {
-        "label": "C",
-        "text": "18"
-      },
-      {
-        "label": "D",
-        "text": "6"
-      },
-      {
-        "label": "E",
-        "text": "-3"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-quadratic-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "e51a64902548a3d96b83c40198a01d446557ede264c4146bba72ece920a6bda9",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-quadratic-equations-f2a6d29739",
-    "skillId": "act-quadratic-equations",
-    "prompt": "Which of the following is a solution to x² - 4x - 12 = 0?",
-    "answer": {
-      "type": "auto",
-      "value": "6",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "-6"
-      },
-      {
-        "label": "B",
-        "text": "6"
-      },
-      {
-        "label": "C",
-        "text": "2"
-      },
-      {
-        "label": "D",
-        "text": "4"
-      },
-      {
-        "label": "E",
-        "text": "-12"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-quadratic-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "f2a6d297397d630c03e54aa506b1dce8ca9fba8e7369c4cdafea180105fb96b9",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-quadratic-equations-e4ce4fb629",
-    "skillId": "act-quadratic-equations",
-    "prompt": "Which of the following is a solution to x² + 8x + 15 = 0?",
-    "answer": {
-      "type": "auto",
-      "value": "-3",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "-8"
-      },
-      {
-        "label": "B",
-        "text": "-3"
-      },
-      {
-        "label": "C",
-        "text": "15"
-      },
-      {
-        "label": "D",
-        "text": "5"
-      },
-      {
-        "label": "E",
-        "text": "3"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-quadratic-equations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "e4ce4fb6299de2369493613af28f1a69852536222c20fa39fa6db7ba43bef107",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-quadratic-equations-9e53448a50",
-    "skillId": "act-quadratic-equations",
-    "prompt": "Which of the following is a solution to x² - 2x - 24 = 0?",
-    "answer": {
-      "type": "auto",
-      "value": "6",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "-6"
-      },
-      {
-        "label": "B",
-        "text": "6"
-      },
-      {
-        "label": "C",
-        "text": "2"
-      },
-      {
-        "label": "D",
-        "text": "-24"
-      },
-      {
-        "label": "E",
-        "text": "4"
-      }
-    ],
-    "correctOption": "B",
     "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
@@ -4726,42 +4723,42 @@
       "act-quadratic-equations"
     ],
     "source": "act-template-gen",
-    "contentHash": "9e53448a50a2938ebb46b458696e436c8818e90640262f7f8b733051f5f9fccb",
+    "contentHash": "cd2c16805fe21b22bd9cad380a7d806dc3f1398158adb7b08a6538c5a7db0ef5",
     "isActive": true
   },
   {
-    "problemId": "act-act-quadratic-equations-2a64810808",
+    "problemId": "act-act-quadratic-equations-625758c62a",
     "skillId": "act-quadratic-equations",
-    "prompt": "Which of the following is a solution to x² + 4x - 12 = 0?",
+    "prompt": "Which of the following is a solution to x² + 6x + 8 = 0?",
     "answer": {
       "type": "auto",
-      "value": "2",
+      "value": "-2",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "-12"
-      },
-      {
-        "label": "B",
-        "text": "6"
-      },
-      {
-        "label": "C",
         "text": "-2"
       },
       {
+        "label": "B",
+        "text": "8"
+      },
+      {
+        "label": "C",
+        "text": "2"
+      },
+      {
         "label": "D",
-        "text": "-4"
+        "text": "4"
       },
       {
         "label": "E",
-        "text": "2"
+        "text": "-6"
       }
     ],
-    "correctOption": "E",
+    "correctOption": "A",
     "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
@@ -4770,42 +4767,42 @@
       "act-quadratic-equations"
     ],
     "source": "act-template-gen",
-    "contentHash": "2a64810808234e25d531af1f6c2faa05b5cd55ae9354f92babac299570e9d717",
+    "contentHash": "625758c62a7fe06e60691bed88eff0d1b544ea9b785720575d52fef8bf215f24",
     "isActive": true
   },
   {
-    "problemId": "act-act-quadratic-equations-b41aa18819",
+    "problemId": "act-act-quadratic-equations-df3bd84dee",
     "skillId": "act-quadratic-equations",
-    "prompt": "Which of the following is a solution to x² + 5x - 6 = 0?",
+    "prompt": "Which of the following is a solution to x² + 9x + 20 = 0?",
     "answer": {
       "type": "auto",
-      "value": "1",
+      "value": "-4",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "-5"
+        "text": "5"
       },
       {
         "label": "B",
-        "text": "-1"
+        "text": "20"
       },
       {
         "label": "C",
-        "text": "-6"
+        "text": "-4"
       },
       {
         "label": "D",
-        "text": "6"
+        "text": "-9"
       },
       {
         "label": "E",
-        "text": "1"
+        "text": "4"
       }
     ],
-    "correctOption": "E",
+    "correctOption": "C",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -4814,175 +4811,43 @@
       "act-quadratic-equations"
     ],
     "source": "act-template-gen",
-    "contentHash": "b41aa188193b2efc5959d163f58a960fef4288395fd6287f0a8c17867820b9b0",
+    "contentHash": "df3bd84dee7fa1380bdc7bb7cf3241f9f8b084872ef7b89b61814388aca48903",
     "isActive": true
   },
   {
-    "problemId": "act-act-polynomial-expressions-c4a479504c",
+    "problemId": "act-act-polynomial-expressions-92d9d17464",
     "skillId": "act-polynomial-expressions",
-    "prompt": "Expand: (x - 6)(x - 5)",
+    "prompt": "Expand: (x + 1)(x - 3)",
     "answer": {
       "type": "auto",
-      "value": "x^2 - 11x + 30",
+      "value": "x^2 - 2x - 3",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "x^2 - 11x - 30"
+        "text": "x^2 + 2x - 3"
       },
       {
         "label": "B",
-        "text": "x^2 - 11x + 30"
+        "text": "x^2 - 2x + 3"
       },
       {
         "label": "C",
-        "text": "x^2 + 11x + 30"
+        "text": "x^2 - 2x - 3"
       },
       {
         "label": "D",
-        "text": "x^2 + 11x - 30"
+        "text": "x^2 + 2x + 3"
       },
       {
         "label": "E",
-        "text": "x^2 + 30x - 11"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-polynomial-expressions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "c4a479504c7bd03ec58ec6d0577e3e88afd1ff5fc8bc2f0033ffb53719af6a84",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-polynomial-expressions-099ea9924a",
-    "skillId": "act-polynomial-expressions",
-    "prompt": "Expand: (x - 5)(x + 1)",
-    "answer": {
-      "type": "auto",
-      "value": "x^2 - 4x - 5",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "x^2 - 4x + 5"
-      },
-      {
-        "label": "B",
-        "text": "x^2 + 4x - 5"
-      },
-      {
-        "label": "C",
-        "text": "x^2 + 4x + 5"
-      },
-      {
-        "label": "D",
-        "text": "x^2 - 5x - 4"
-      },
-      {
-        "label": "E",
-        "text": "x^2 - 4x - 5"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-polynomial-expressions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "099ea9924a453b5ed7d3a92c9e875be2fcc878e4b84aaf80d17dddd12d126073",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-polynomial-expressions-cbcce886de",
-    "skillId": "act-polynomial-expressions",
-    "prompt": "Expand: (x - 5)(x + 3)",
-    "answer": {
-      "type": "auto",
-      "value": "x^2 - 2x - 15",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "x^2 - 2x - 15"
-      },
-      {
-        "label": "B",
-        "text": "x^2 + 2x - 15"
-      },
-      {
-        "label": "C",
-        "text": "x^2 - 15x - 2"
-      },
-      {
-        "label": "D",
-        "text": "x^2 + 2x + 15"
-      },
-      {
-        "label": "E",
-        "text": "x^2 - 2x + 15"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-polynomial-expressions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "cbcce886de7fe5d30ba32a7b9f8666628c593003fb7c801054307c686ae1a56c",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-polynomial-expressions-c5e5a238f9",
-    "skillId": "act-polynomial-expressions",
-    "prompt": "Expand: (x - 3)(x - 1)",
-    "answer": {
-      "type": "auto",
-      "value": "x^2 - 4x + 3",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "x^2 + 4x - 3"
-      },
-      {
-        "label": "B",
-        "text": "x^2 - 4x - 3"
-      },
-      {
-        "label": "C",
-        "text": "x^2 - 4x + 3"
-      },
-      {
-        "label": "D",
-        "text": "x^2 + 4x + 3"
-      },
-      {
-        "label": "E",
-        "text": "x^2 + 3x - 4"
+        "text": "x^2 - 3x - 2"
       }
     ],
     "correctOption": "C",
-    "difficulty": 3,
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -4990,7 +4855,7 @@
       "act-polynomial-expressions"
     ],
     "source": "act-template-gen",
-    "contentHash": "c5e5a238f9c0b5e7cc84a890363cdf721cc809350e6aff963f0ccf9112ce1b33",
+    "contentHash": "92d9d17464f78ce31a682c39738c80035c15cc1ffe7c8ece7dcd56152d3b00cf",
     "isActive": true
   },
   {
@@ -5010,7 +4875,7 @@
       },
       {
         "label": "B",
-        "text": "x^2 + 2x - 8"
+        "text": "x^2 - 2x + 8"
       },
       {
         "label": "C",
@@ -5018,15 +4883,15 @@
       },
       {
         "label": "D",
-        "text": "x^2 - 2x + 8"
+        "text": "x^2 + 2x - 8"
       },
       {
         "label": "E",
         "text": "x^2 - 2x - 8"
       }
     ],
-    "correctOption": "B",
-    "difficulty": 3,
+    "correctOption": "D",
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -5038,9 +4903,53 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-polynomial-expressions-2f90f7315a",
+    "problemId": "act-act-polynomial-expressions-c4a479504c",
     "skillId": "act-polynomial-expressions",
-    "prompt": "Expand: (x - 4)(x + 6)",
+    "prompt": "Expand: (x - 6)(x - 5)",
+    "answer": {
+      "type": "auto",
+      "value": "x^2 - 11x + 30",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "x^2 + 11x - 30"
+      },
+      {
+        "label": "B",
+        "text": "x^2 - 11x - 30"
+      },
+      {
+        "label": "C",
+        "text": "x^2 + 30x - 11"
+      },
+      {
+        "label": "D",
+        "text": "x^2 + 11x + 30"
+      },
+      {
+        "label": "E",
+        "text": "x^2 - 11x + 30"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polynomial-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "c4a479504c7bd03ec58ec6d0577e3e88afd1ff5fc8bc2f0033ffb53719af6a84",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polynomial-expressions-2ce8149c95",
+    "skillId": "act-polynomial-expressions",
+    "prompt": "Expand: (x + 6)(x - 4)",
     "answer": {
       "type": "auto",
       "value": "x^2 + 2x - 24",
@@ -5050,7 +4959,7 @@
     "options": [
       {
         "label": "A",
-        "text": "x^2 - 2x + 24"
+        "text": "x^2 + 2x - 24"
       },
       {
         "label": "B",
@@ -5066,10 +4975,98 @@
       },
       {
         "label": "E",
-        "text": "x^2 + 2x - 24"
+        "text": "x^2 - 2x + 24"
       }
     ],
-    "correctOption": "E",
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polynomial-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "2ce8149c9531249e049a6eb6bcecfcc74c33b9e6211c245d09dc1d05391c836d",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polynomial-expressions-6146153039",
+    "skillId": "act-polynomial-expressions",
+    "prompt": "Expand: (x + 4)(x + 2)",
+    "answer": {
+      "type": "auto",
+      "value": "x^2 + 6x + 8",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "x^2 + 6x + 8"
+      },
+      {
+        "label": "B",
+        "text": "x^2 + 8x + 6"
+      },
+      {
+        "label": "C",
+        "text": "x^2 - 6x - 8"
+      },
+      {
+        "label": "D",
+        "text": "x^2 + 6x - 8"
+      },
+      {
+        "label": "E",
+        "text": "x^2 - 6x + 8"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polynomial-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "61461530398e6e26af8587f7ce448b45378e9ec65c34f568b2bd7fa41e6c50cd",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polynomial-expressions-49377b97e9",
+    "skillId": "act-polynomial-expressions",
+    "prompt": "Expand: (x - 5)(x - 3)",
+    "answer": {
+      "type": "auto",
+      "value": "x^2 - 8x + 15",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "x^2 + 15x - 8"
+      },
+      {
+        "label": "B",
+        "text": "x^2 - 8x - 15"
+      },
+      {
+        "label": "C",
+        "text": "x^2 - 8x + 15"
+      },
+      {
+        "label": "D",
+        "text": "x^2 + 8x - 15"
+      },
+      {
+        "label": "E",
+        "text": "x^2 + 8x + 15"
+      }
+    ],
+    "correctOption": "C",
     "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
@@ -5078,39 +5075,39 @@
       "act-polynomial-expressions"
     ],
     "source": "act-template-gen",
-    "contentHash": "2f90f7315a7829a94450c81ac69a07665cf0aa2383b787a5e07c73ba24d5cb98",
+    "contentHash": "49377b97e986b3d5b7c75dca75a8f3a527837ba4debd86ff0139c5792d7f5574",
     "isActive": true
   },
   {
-    "problemId": "act-act-polynomial-expressions-4cfa8d6b5f",
+    "problemId": "act-act-polynomial-expressions-12e610795e",
     "skillId": "act-polynomial-expressions",
-    "prompt": "Expand: (x - 1)(x - 1)",
+    "prompt": "Expand: (x + 3)(x - 5)",
     "answer": {
       "type": "auto",
-      "value": "x^2 - 2x + 1",
+      "value": "x^2 - 2x - 15",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "x^2 + 2x - 1"
+        "text": "x^2 + 2x + 15"
       },
       {
         "label": "B",
-        "text": "x^2 - 2x - 1"
+        "text": "x^2 - 2x + 15"
       },
       {
         "label": "C",
-        "text": "x^2 + x - 2"
+        "text": "x^2 - 15x - 2"
       },
       {
         "label": "D",
-        "text": "x^2 - 2x + 1"
+        "text": "x^2 - 2x - 15"
       },
       {
         "label": "E",
-        "text": "x^2 + 2x + 1"
+        "text": "x^2 + 2x - 15"
       }
     ],
     "correctOption": "D",
@@ -5122,42 +5119,42 @@
       "act-polynomial-expressions"
     ],
     "source": "act-template-gen",
-    "contentHash": "4cfa8d6b5fa40a155753649daeccc17345911078505fb624f7d877c6f918511c",
+    "contentHash": "12e610795e5c02f569853944e740688e895bb55f5b2cfbb46c838199605487cd",
     "isActive": true
   },
   {
-    "problemId": "act-act-polynomial-expressions-e462f3324f",
+    "problemId": "act-act-polynomial-expressions-5c25fd653f",
     "skillId": "act-polynomial-expressions",
-    "prompt": "Expand: (x - 3)(x - 4)",
+    "prompt": "Expand: (x - 5)(x - 5)",
     "answer": {
       "type": "auto",
-      "value": "x^2 - 7x + 12",
+      "value": "x^2 - 10x + 25",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "x^2 - 7x - 12"
+        "text": "x^2 - 10x + 25"
       },
       {
         "label": "B",
-        "text": "x^2 + 12x - 7"
+        "text": "x^2 + 25x - 10"
       },
       {
         "label": "C",
-        "text": "x^2 + 7x + 12"
+        "text": "x^2 + 10x - 25"
       },
       {
         "label": "D",
-        "text": "x^2 + 7x - 12"
+        "text": "x^2 + 10x + 25"
       },
       {
         "label": "E",
-        "text": "x^2 - 7x + 12"
+        "text": "x^2 - 10x - 25"
       }
     ],
-    "correctOption": "E",
+    "correctOption": "A",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -5166,95 +5163,7 @@
       "act-polynomial-expressions"
     ],
     "source": "act-template-gen",
-    "contentHash": "e462f3324fcac75ff6c9f9a984cea3aee070137bd840dd2188a7aadc5d4d8d0c",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-radical-rational-expressions-8eb9d160c9",
-    "skillId": "act-radical-rational-expressions",
-    "prompt": "Simplify: √125",
-    "answer": {
-      "type": "auto",
-      "value": "5√5",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "5√5"
-      },
-      {
-        "label": "B",
-        "text": "5√10"
-      },
-      {
-        "label": "C",
-        "text": "125"
-      },
-      {
-        "label": "D",
-        "text": "25√1"
-      },
-      {
-        "label": "E",
-        "text": "10√5"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-radical-rational-expressions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "8eb9d160c9074c0a1091db0a435ea5d0ee0f2e4a3525957fc03ce1036abfe968",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-radical-rational-expressions-8c792c7c79",
-    "skillId": "act-radical-rational-expressions",
-    "prompt": "Simplify: √112",
-    "answer": {
-      "type": "auto",
-      "value": "4√7",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "11√7"
-      },
-      {
-        "label": "B",
-        "text": "112"
-      },
-      {
-        "label": "C",
-        "text": "4√14"
-      },
-      {
-        "label": "D",
-        "text": "4√7"
-      },
-      {
-        "label": "E",
-        "text": "28√1"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-radical-rational-expressions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "8c792c7c796a27fa385d45723fb379f880295dc03d9ae9dd6f9d2540b69fb564",
+    "contentHash": "5c25fd653fd9e8af73d6059a17525ac8fb6f3c88ad665706f6c78b3037ba63ce",
     "isActive": true
   },
   {
@@ -5270,15 +5179,15 @@
     "options": [
       {
         "label": "A",
-        "text": "3√10"
+        "text": "45"
       },
       {
         "label": "B",
-        "text": "8√5"
+        "text": "3√5"
       },
       {
         "label": "C",
-        "text": "3√5"
+        "text": "8√5"
       },
       {
         "label": "D",
@@ -5286,11 +5195,11 @@
       },
       {
         "label": "E",
-        "text": "45"
+        "text": "3√10"
       }
     ],
-    "correctOption": "C",
-    "difficulty": 3,
+    "correctOption": "B",
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -5299,138 +5208,6 @@
     ],
     "source": "act-template-gen",
     "contentHash": "59679bbf9d4b4b1a5f0d80d70391d110bde0c99a1740e98a3edf37fd8b551412",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-radical-rational-expressions-63cc21f580",
-    "skillId": "act-radical-rational-expressions",
-    "prompt": "Simplify: √75",
-    "answer": {
-      "type": "auto",
-      "value": "5√3",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "15√1"
-      },
-      {
-        "label": "B",
-        "text": "75"
-      },
-      {
-        "label": "C",
-        "text": "8√3"
-      },
-      {
-        "label": "D",
-        "text": "5√6"
-      },
-      {
-        "label": "E",
-        "text": "5√3"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-radical-rational-expressions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "63cc21f5805c334e62df23ae862b0d1b95233de588e3b6713c09b0c6f23257a9",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-radical-rational-expressions-281e03dcfa",
-    "skillId": "act-radical-rational-expressions",
-    "prompt": "Simplify: √18",
-    "answer": {
-      "type": "auto",
-      "value": "3√2",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "3√4"
-      },
-      {
-        "label": "B",
-        "text": "18"
-      },
-      {
-        "label": "C",
-        "text": "3√2"
-      },
-      {
-        "label": "D",
-        "text": "6√1"
-      },
-      {
-        "label": "E",
-        "text": "5√2"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-radical-rational-expressions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "281e03dcfa2fb4a02dd89ad955b4bdf726c6e292396548637609c3f1e2de62ac",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-radical-rational-expressions-dfde70e812",
-    "skillId": "act-radical-rational-expressions",
-    "prompt": "Simplify: √32",
-    "answer": {
-      "type": "auto",
-      "value": "4√2",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "4√4"
-      },
-      {
-        "label": "B",
-        "text": "4√2"
-      },
-      {
-        "label": "C",
-        "text": "6√2"
-      },
-      {
-        "label": "D",
-        "text": "32"
-      },
-      {
-        "label": "E",
-        "text": "8√1"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-radical-rational-expressions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "dfde70e8123d295ef4efc090b89fff569c1f1c4c6099e42d8332e0cc538fcaa1",
     "isActive": true
   },
   {
@@ -5446,11 +5223,11 @@
     "options": [
       {
         "label": "A",
-        "text": "10√1"
+        "text": "50"
       },
       {
         "label": "B",
-        "text": "50"
+        "text": "7√2"
       },
       {
         "label": "C",
@@ -5458,7 +5235,7 @@
       },
       {
         "label": "D",
-        "text": "7√2"
+        "text": "10√1"
       },
       {
         "label": "E",
@@ -5466,7 +5243,7 @@
       }
     ],
     "correctOption": "E",
-    "difficulty": 4,
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -5478,35 +5255,255 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-radical-rational-expressions-ac1c0e81df",
+    "problemId": "act-act-radical-rational-expressions-ce18ab0dae",
     "skillId": "act-radical-rational-expressions",
-    "prompt": "Simplify: √245",
+    "prompt": "Simplify: √54",
     "answer": {
       "type": "auto",
-      "value": "7√5",
+      "value": "3√6",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "12√5"
+        "text": "18√1"
       },
       {
         "label": "B",
-        "text": "35√1"
+        "text": "9√6"
       },
       {
         "label": "C",
-        "text": "7√10"
+        "text": "54"
       },
       {
         "label": "D",
-        "text": "7√5"
+        "text": "3√6"
       },
       {
         "label": "E",
-        "text": "245"
+        "text": "3√12"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-radical-rational-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "ce18ab0dae90c903895cf88b3fcb8ed3202bd6f8f69daf14dd7a1f51ef165ffc",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-radical-rational-expressions-3b5367f4ab",
+    "skillId": "act-radical-rational-expressions",
+    "prompt": "Simplify: √48",
+    "answer": {
+      "type": "auto",
+      "value": "4√3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "48"
+      },
+      {
+        "label": "B",
+        "text": "4√3"
+      },
+      {
+        "label": "C",
+        "text": "7√3"
+      },
+      {
+        "label": "D",
+        "text": "12√1"
+      },
+      {
+        "label": "E",
+        "text": "4√6"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-radical-rational-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "3b5367f4ab67f79bee8495d64431f977467658f2df076e0d668acf5b040a7245",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-radical-rational-expressions-dfde70e812",
+    "skillId": "act-radical-rational-expressions",
+    "prompt": "Simplify: √32",
+    "answer": {
+      "type": "auto",
+      "value": "4√2",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "6√2"
+      },
+      {
+        "label": "B",
+        "text": "4√4"
+      },
+      {
+        "label": "C",
+        "text": "4√2"
+      },
+      {
+        "label": "D",
+        "text": "32"
+      },
+      {
+        "label": "E",
+        "text": "8√1"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-radical-rational-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "dfde70e8123d295ef4efc090b89fff569c1f1c4c6099e42d8332e0cc538fcaa1",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-radical-rational-expressions-dbc95ea5e0",
+    "skillId": "act-radical-rational-expressions",
+    "prompt": "Simplify: √147",
+    "answer": {
+      "type": "auto",
+      "value": "7√3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "7√3"
+      },
+      {
+        "label": "B",
+        "text": "21√1"
+      },
+      {
+        "label": "C",
+        "text": "147"
+      },
+      {
+        "label": "D",
+        "text": "7√6"
+      },
+      {
+        "label": "E",
+        "text": "10√3"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-radical-rational-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "dbc95ea5e03abdf4b0a25dfdf9841f15f9884ff462bdc7dc8401bed48c0c8169",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-radical-rational-expressions-0d11ef6f50",
+    "skillId": "act-radical-rational-expressions",
+    "prompt": "Simplify: √72",
+    "answer": {
+      "type": "auto",
+      "value": "6√2",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "6√2"
+      },
+      {
+        "label": "B",
+        "text": "6√4"
+      },
+      {
+        "label": "C",
+        "text": "72"
+      },
+      {
+        "label": "D",
+        "text": "12√1"
+      },
+      {
+        "label": "E",
+        "text": "8√2"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-radical-rational-expressions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "0d11ef6f50a755e5d83138614b656636d6571914175f0866d9d1844f0ea26015",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-radical-rational-expressions-0e59fca760",
+    "skillId": "act-radical-rational-expressions",
+    "prompt": "Simplify: √180",
+    "answer": {
+      "type": "auto",
+      "value": "6√5",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "6√10"
+      },
+      {
+        "label": "B",
+        "text": "180"
+      },
+      {
+        "label": "C",
+        "text": "11√5"
+      },
+      {
+        "label": "D",
+        "text": "6√5"
+      },
+      {
+        "label": "E",
+        "text": "30√1"
       }
     ],
     "correctOption": "D",
@@ -5518,87 +5515,175 @@
       "act-radical-rational-expressions"
     ],
     "source": "act-template-gen",
-    "contentHash": "ac1c0e81df0db4577f4765a2d8b64da2fcf3041f0bb6f4de47a9d4281b7c49ef",
+    "contentHash": "0e59fca760f006b0dadbe0686280f353588cef4ead67511edfb0b8500fd6c388",
     "isActive": true
   },
   {
-    "problemId": "act-act-function-notation-evaluation-54b946284b",
+    "problemId": "act-act-function-notation-evaluation-1c245fdf07",
     "skillId": "act-function-notation-evaluation",
-    "prompt": "If f(x) = -4x² + 5, what is f(-2)?",
+    "prompt": "If f(x) = -2x² - 3, what is f(5)?",
     "answer": {
       "type": "auto",
-      "value": "-11",
+      "value": "-53",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "69"
+        "text": "-47"
       },
       {
         "label": "B",
-        "text": "-21"
+        "text": "97"
       },
       {
         "label": "C",
+        "text": "-44"
+      },
+      {
+        "label": "D",
+        "text": "-13"
+      },
+      {
+        "label": "E",
+        "text": "-53"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-notation-evaluation"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "1c245fdf07fbfd050ec4edd06a5d1884ab97cbde7e0abb4904b82d6ff61cee8b",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-notation-evaluation-2e8016ffeb",
+    "skillId": "act-function-notation-evaluation",
+    "prompt": "If f(x) = -4x² + 1, what is f(-4)?",
+    "answer": {
+      "type": "auto",
+      "value": "-63",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-68"
+      },
+      {
+        "label": "B",
+        "text": "17"
+      },
+      {
+        "label": "C",
+        "text": "-63"
+      },
+      {
+        "label": "D",
+        "text": "-65"
+      },
+      {
+        "label": "E",
+        "text": "257"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-notation-evaluation"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "2e8016ffeb143fa4c8b45b687750264cdca293dfd4063dc97c1a5d515f8f8211",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-notation-evaluation-b675853374",
+    "skillId": "act-function-notation-evaluation",
+    "prompt": "If f(x) = 3x² + 6, what is f(-4)?",
+    "answer": {
+      "type": "auto",
+      "value": "54",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "66"
+      },
+      {
+        "label": "B",
+        "text": "-6"
+      },
+      {
+        "label": "C",
+        "text": "54"
+      },
+      {
+        "label": "D",
+        "text": "42"
+      },
+      {
+        "label": "E",
+        "text": "150"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-notation-evaluation"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "b6758533745b73ca64b95200d0e4d30f527f0d98ed3faba05698393fc2990484",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-notation-evaluation-b1a1fd800a",
+    "skillId": "act-function-notation-evaluation",
+    "prompt": "If f(x) = -2x² - 4, what is f(-4)?",
+    "answer": {
+      "type": "auto",
+      "value": "-36",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
         "text": "-36"
       },
       {
-        "label": "D",
-        "text": "-11"
-      },
-      {
-        "label": "E",
-        "text": "13"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-function-notation-evaluation"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "54b946284b25909de45b8857622156198539a5f7b483bf26bf7e05948d06bf8f",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-function-notation-evaluation-2f567b8505",
-    "skillId": "act-function-notation-evaluation",
-    "prompt": "If f(x) = -2x² - 1, what is f(-1)?",
-    "answer": {
-      "type": "auto",
-      "value": "-3",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "1"
-      },
-      {
         "label": "B",
-        "text": "-3"
+        "text": "-28"
       },
       {
         "label": "C",
-        "text": "0"
+        "text": "-24"
       },
       {
         "label": "D",
-        "text": "-1"
+        "text": "60"
       },
       {
         "label": "E",
-        "text": "3"
+        "text": "4"
       }
     ],
-    "correctOption": "B",
-    "difficulty": 2,
+    "correctOption": "A",
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -5606,7 +5691,7 @@
       "act-function-notation-evaluation"
     ],
     "source": "act-template-gen",
-    "contentHash": "2f567b8505e5ecb0a9356a3bae51d4c7e0a4ed7a372eb03c03f3711c1a62a0eb",
+    "contentHash": "b1a1fd800a10fdd1d9e732a42fd6269aca1710348e80a32eb1188c8129e841de",
     "isActive": true
   },
   {
@@ -5686,7 +5771,7 @@
       }
     ],
     "correctOption": "C",
-    "difficulty": 3,
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -5730,7 +5815,7 @@
       }
     ],
     "correctOption": "E",
-    "difficulty": 3,
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -5774,7 +5859,7 @@
       }
     ],
     "correctOption": "B",
-    "difficulty": 4,
+    "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -5786,141 +5871,9 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-function-notation-evaluation-c6bf3aa45d",
-    "skillId": "act-function-notation-evaluation",
-    "prompt": "If f(x) = 3x² + 4, what is f(3)?",
-    "answer": {
-      "type": "auto",
-      "value": "31",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "13"
-      },
-      {
-        "label": "B",
-        "text": "23"
-      },
-      {
-        "label": "C",
-        "text": "85"
-      },
-      {
-        "label": "D",
-        "text": "31"
-      },
-      {
-        "label": "E",
-        "text": "39"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-function-notation-evaluation"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "c6bf3aa45d09ba5b871e8dbc62696ca4bc6cb30274fb624ff33722286fbb72fe",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-function-notation-evaluation-511498f3e3",
-    "skillId": "act-function-notation-evaluation",
-    "prompt": "If f(x) = -3x² - 5, what is f(-2)?",
-    "answer": {
-      "type": "auto",
-      "value": "-17",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "1"
-      },
-      {
-        "label": "B",
-        "text": "-17"
-      },
-      {
-        "label": "C",
-        "text": "31"
-      },
-      {
-        "label": "D",
-        "text": "3"
-      },
-      {
-        "label": "E",
-        "text": "-7"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 5,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-function-notation-evaluation"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "511498f3e3619e96b540a5adb92f6bd176396575c071a23b7d399f6900884fc5",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-linear-functions-3dd4f68c3f",
+    "problemId": "act-act-linear-functions-59fd0320a4",
     "skillId": "act-linear-functions",
-    "prompt": "What is the slope of the line through (-4, -3) and (3, 5)?",
-    "answer": {
-      "type": "auto",
-      "value": "8/7",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "8"
-      },
-      {
-        "label": "B",
-        "text": "8/7"
-      },
-      {
-        "label": "C",
-        "text": "7"
-      },
-      {
-        "label": "D",
-        "text": "-1.1428571428571428"
-      },
-      {
-        "label": "E",
-        "text": "7/8"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-linear-functions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "3dd4f68c3fb1500699221366a921c4766b5d126d6b3ff3a70769a5c95ddd2086",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-linear-functions-046ec9f8c4",
-    "skillId": "act-linear-functions",
-    "prompt": "What is the slope of the line through (-1, 2) and (5, -1)?",
+    "prompt": "What is the slope of the line through (2, 3) and (4, 2)?",
     "answer": {
       "type": "auto",
       "value": "-1/2",
@@ -5930,19 +5883,19 @@
     "options": [
       {
         "label": "A",
-        "text": "6"
+        "text": "2"
       },
       {
         "label": "B",
-        "text": "-2"
+        "text": "-1"
       },
       {
         "label": "C",
-        "text": "-3"
+        "text": "0.5"
       },
       {
         "label": "D",
-        "text": "0.5"
+        "text": "-2"
       },
       {
         "label": "E",
@@ -5958,39 +5911,83 @@
       "act-linear-functions"
     ],
     "source": "act-template-gen",
-    "contentHash": "046ec9f8c496f31181bfb4d7fdd842eaad986843d3eee30380721794bcde8fc7",
+    "contentHash": "59fd0320a42560a2c823f190a930a9517fda752922e10487f743ee97f56c7946",
     "isActive": true
   },
   {
-    "problemId": "act-act-linear-functions-d2d5439f75",
+    "problemId": "act-act-linear-functions-611952d245",
     "skillId": "act-linear-functions",
-    "prompt": "What is the slope of the line through (5, -6) and (0, 5)?",
+    "prompt": "What is the slope of the line through (5, -1) and (-5, -3)?",
     "answer": {
       "type": "auto",
-      "value": "11/-5",
+      "value": "-1/-5",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "-5/11"
+        "text": "5"
       },
       {
         "label": "B",
-        "text": "2.2"
+        "text": "-0.2"
       },
       {
         "label": "C",
-        "text": "-5"
+        "text": "-1/-5"
       },
       {
         "label": "D",
-        "text": "11"
+        "text": "-2"
       },
       {
         "label": "E",
-        "text": "11/-5"
+        "text": "-10"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-linear-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "611952d245500f36fdc9d8f0582c9606ad1825d1fe09a721e07f87dce50e63f9",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-linear-functions-31d6f61aae",
+    "skillId": "act-linear-functions",
+    "prompt": "What is the slope of the line through (-3, 5) and (0, 4)?",
+    "answer": {
+      "type": "auto",
+      "value": "-1/3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-3"
+      },
+      {
+        "label": "B",
+        "text": "3"
+      },
+      {
+        "label": "C",
+        "text": "-1"
+      },
+      {
+        "label": "D",
+        "text": "0.3333333333333333"
+      },
+      {
+        "label": "E",
+        "text": "-1/3"
       }
     ],
     "correctOption": "E",
@@ -6002,39 +5999,39 @@
       "act-linear-functions"
     ],
     "source": "act-template-gen",
-    "contentHash": "d2d5439f75d5420a212a863bbdcf239c97dd9d7f7bc38e96505592e8317da018",
+    "contentHash": "31d6f61aaed044d53624658ac0aa30d518da5cbf4efd073518a05c0a0aeec776",
     "isActive": true
   },
   {
-    "problemId": "act-act-linear-functions-44e9d1a7a0",
+    "problemId": "act-act-linear-functions-e41106c107",
     "skillId": "act-linear-functions",
-    "prompt": "What is the slope of the line through (-3, 3) and (1, -5)?",
+    "prompt": "What is the slope of the line through (4, -2) and (-1, 0)?",
     "answer": {
       "type": "auto",
-      "value": "-2",
+      "value": "2/-5",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "-2"
+        "text": "2/-5"
       },
       {
         "label": "B",
-        "text": "-8"
+        "text": "-5"
       },
       {
         "label": "C",
-        "text": "4"
+        "text": "0.4"
       },
       {
         "label": "D",
-        "text": "2"
+        "text": "-5/2"
       },
       {
         "label": "E",
-        "text": "1/-2"
+        "text": "2"
       }
     ],
     "correctOption": "A",
@@ -6046,42 +6043,42 @@
       "act-linear-functions"
     ],
     "source": "act-template-gen",
-    "contentHash": "44e9d1a7a0be03fbea0dbd6dbaa2872f2936e57338ec3ae41646777cb9ac2530",
+    "contentHash": "e41106c107963668741e5824e4e43672c0dd9ad077e6a2f751b4026e7907b278",
     "isActive": true
   },
   {
-    "problemId": "act-act-linear-functions-66f499e50b",
+    "problemId": "act-act-linear-functions-353cd8b1a5",
     "skillId": "act-linear-functions",
-    "prompt": "What is the slope of the line through (-3, 4) and (4, 2)?",
+    "prompt": "What is the slope of the line through (-1, -3) and (-5, 6)?",
     "answer": {
       "type": "auto",
-      "value": "-2/7",
+      "value": "9/-4",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "-2"
+        "text": "-4"
       },
       {
         "label": "B",
-        "text": "-2/7"
+        "text": "-4/9"
       },
       {
         "label": "C",
-        "text": "7/-2"
+        "text": "9"
       },
       {
         "label": "D",
-        "text": "7"
+        "text": "9/-4"
       },
       {
         "label": "E",
-        "text": "0.2857142857142857"
+        "text": "2.25"
       }
     ],
-    "correctOption": "B",
+    "correctOption": "D",
     "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
@@ -6090,39 +6087,39 @@
       "act-linear-functions"
     ],
     "source": "act-template-gen",
-    "contentHash": "66f499e50b695c45c4d90492d29df60e2a1a62c23f2edbed48af014300834a07",
+    "contentHash": "353cd8b1a5590ca7cd388841a169fe798aa0a9aeb16f610cf1c2c8b60c26e6ce",
     "isActive": true
   },
   {
-    "problemId": "act-act-linear-functions-7c5ffd5577",
+    "problemId": "act-act-linear-functions-1f618b29c3",
     "skillId": "act-linear-functions",
-    "prompt": "What is the slope of the line through (-3, -1) and (-1, 4)?",
+    "prompt": "What is the slope of the line through (1, 0) and (5, -6)?",
     "answer": {
       "type": "auto",
-      "value": "5/2",
+      "value": "-3/2",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "2"
+        "text": "4"
       },
       {
         "label": "B",
-        "text": "2/5"
+        "text": "-6"
       },
       {
         "label": "C",
-        "text": "-2.5"
+        "text": "2/-3"
       },
       {
         "label": "D",
-        "text": "5/2"
+        "text": "-3/2"
       },
       {
         "label": "E",
-        "text": "5"
+        "text": "1.5"
       }
     ],
     "correctOption": "D",
@@ -6134,27 +6131,27 @@
       "act-linear-functions"
     ],
     "source": "act-template-gen",
-    "contentHash": "7c5ffd55775847e2b15a64d11dfe0b9ce11c506024ce1034423581ca8129f36e",
+    "contentHash": "1f618b29c386dc6db281c530f1984994a812f6366a05d1e0e9f2050a2d82f7c5",
     "isActive": true
   },
   {
-    "problemId": "act-act-linear-functions-57207cfcaf",
+    "problemId": "act-act-linear-functions-344738fb0f",
     "skillId": "act-linear-functions",
-    "prompt": "What is the slope of the line through (1, 2) and (-5, -2)?",
+    "prompt": "What is the slope of the line through (3, 1) and (-3, 3)?",
     "answer": {
       "type": "auto",
-      "value": "-2/-3",
+      "value": "1/-3",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "-4"
+        "text": "2"
       },
       {
         "label": "B",
-        "text": "-2/-3"
+        "text": "-3"
       },
       {
         "label": "C",
@@ -6162,14 +6159,14 @@
       },
       {
         "label": "D",
-        "text": "-0.6666666666666666"
+        "text": "0.3333333333333333"
       },
       {
         "label": "E",
-        "text": "-3/-2"
+        "text": "1/-3"
       }
     ],
-    "correctOption": "B",
+    "correctOption": "E",
     "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
@@ -6178,42 +6175,42 @@
       "act-linear-functions"
     ],
     "source": "act-template-gen",
-    "contentHash": "57207cfcaf4fdca0d2c632e1f1ceb59f36136126c3e2b5a70fb587cd8e9c2c17",
+    "contentHash": "344738fb0f94634fbf6a266a0e260a17a1d711961335da804a6528da744f08a2",
     "isActive": true
   },
   {
-    "problemId": "act-act-linear-functions-6a6812fff1",
+    "problemId": "act-act-linear-functions-39786bd0f2",
     "skillId": "act-linear-functions",
-    "prompt": "What is the slope of the line through (-4, 3) and (1, 0)?",
+    "prompt": "What is the slope of the line through (2, 1) and (0, 0)?",
     "answer": {
       "type": "auto",
-      "value": "-3/5",
+      "value": "-1/-2",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "5/-3"
+        "text": "-1/-2"
       },
       {
         "label": "B",
-        "text": "0.6"
+        "text": "-2"
       },
       {
         "label": "C",
-        "text": "-3/5"
+        "text": "-1"
       },
       {
         "label": "D",
-        "text": "5"
+        "text": "-0.5"
       },
       {
         "label": "E",
-        "text": "-3"
+        "text": "2"
       }
     ],
-    "correctOption": "C",
+    "correctOption": "A",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -6222,13 +6219,189 @@
       "act-linear-functions"
     ],
     "source": "act-template-gen",
-    "contentHash": "6a6812fff1f360a78cf0d384c96a02980ee40b0cb7c8a8c3aa94d1250cc6e7f2",
+    "contentHash": "39786bd0f2cc5bf97d851501b373d0b6b46e1a9a66ec81bc94137b13e7ba0ec9",
     "isActive": true
   },
   {
-    "problemId": "act-act-quadratic-functions-0a06ffdb92",
+    "problemId": "act-act-quadratic-functions-dbea447dd8",
     "skillId": "act-quadratic-functions",
-    "prompt": "What is the vertex of the parabola y = 2(x + 4)² + 5?",
+    "prompt": "What is the vertex of the parabola y = 2(x - 3)² + 6?",
+    "answer": {
+      "type": "auto",
+      "value": "(3, 6)",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "(6, 3)"
+      },
+      {
+        "label": "B",
+        "text": "(3, -6)"
+      },
+      {
+        "label": "C",
+        "text": "(-3, -6)"
+      },
+      {
+        "label": "D",
+        "text": "(3, 6)"
+      },
+      {
+        "label": "E",
+        "text": "(-3, 6)"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "dbea447dd8ae839ade0aa5e89004f625de14a9392b577b87c37803b0947d2dd1",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-functions-a8f434b47b",
+    "skillId": "act-quadratic-functions",
+    "prompt": "What is the vertex of the parabola y = 2(x - 3)² + 1?",
+    "answer": {
+      "type": "auto",
+      "value": "(3, 1)",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "(1, 3)"
+      },
+      {
+        "label": "B",
+        "text": "(-3, 1)"
+      },
+      {
+        "label": "C",
+        "text": "(-3, -1)"
+      },
+      {
+        "label": "D",
+        "text": "(3, -1)"
+      },
+      {
+        "label": "E",
+        "text": "(3, 1)"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "a8f434b47be901a354144f8e1beffbde0e14a1f897967b2ddeeaf422e71a514a",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-functions-fd6f8a73f2",
+    "skillId": "act-quadratic-functions",
+    "prompt": "What is the vertex of the parabola y = 1(x + 1)² + 2?",
+    "answer": {
+      "type": "auto",
+      "value": "(-1, 2)",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "(1, -2)"
+      },
+      {
+        "label": "B",
+        "text": "(-1, -2)"
+      },
+      {
+        "label": "C",
+        "text": "(1, 2)"
+      },
+      {
+        "label": "D",
+        "text": "(2, -1)"
+      },
+      {
+        "label": "E",
+        "text": "(-1, 2)"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "fd6f8a73f22a7da072a04f1a62342c13f105c0fcc31e126cdd6c778c9605a8c9",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-functions-030afc0653",
+    "skillId": "act-quadratic-functions",
+    "prompt": "What is the vertex of the parabola y = 2(x - 1)² + 5?",
+    "answer": {
+      "type": "auto",
+      "value": "(1, 5)",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "(-1, -5)"
+      },
+      {
+        "label": "B",
+        "text": "(5, 1)"
+      },
+      {
+        "label": "C",
+        "text": "(1, -5)"
+      },
+      {
+        "label": "D",
+        "text": "(-1, 5)"
+      },
+      {
+        "label": "E",
+        "text": "(1, 5)"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-quadratic-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "030afc06531d6eb2351af8ef4c55f1467a4f466534a8ec5c5e50db2f66197316",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-quadratic-functions-e054295091",
+    "skillId": "act-quadratic-functions",
+    "prompt": "What is the vertex of the parabola y = 1(x + 4)² + 5?",
     "answer": {
       "type": "auto",
       "value": "(-4, 5)",
@@ -6258,7 +6431,7 @@
       }
     ],
     "correctOption": "D",
-    "difficulty": 2,
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -6266,7 +6439,7 @@
       "act-quadratic-functions"
     ],
     "source": "act-template-gen",
-    "contentHash": "0a06ffdb927bddf87bc087c05a3d282cd4acef7a533e1c60c8e74f7042d6fd06",
+    "contentHash": "e05429509115b8998977b9d601cdef17e768fbe70446aaf5275c6dea5a68f952",
     "isActive": true
   },
   {
@@ -6302,7 +6475,7 @@
       }
     ],
     "correctOption": "D",
-    "difficulty": 2,
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -6346,7 +6519,7 @@
       }
     ],
     "correctOption": "B",
-    "difficulty": 3,
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -6390,7 +6563,7 @@
       }
     ],
     "correctOption": "E",
-    "difficulty": 3,
+    "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -6402,179 +6575,91 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-quadratic-functions-c55b6cac28",
-    "skillId": "act-quadratic-functions",
-    "prompt": "What is the vertex of the parabola y = 3(x + 3)² - 4?",
+    "problemId": "act-act-polynomial-exponential-log-31fe16250a",
+    "skillId": "act-polynomial-exponential-log",
+    "prompt": "What is log₍5₎(25)?",
     "answer": {
       "type": "auto",
-      "value": "(-3, -4)",
+      "value": "2",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "(3, 4)"
+        "text": "5"
       },
       {
         "label": "B",
-        "text": "(-3, 4)"
+        "text": "10"
       },
       {
         "label": "C",
-        "text": "(3, -4)"
+        "text": "3"
       },
       {
         "label": "D",
-        "text": "(-4, -3)"
+        "text": "2"
       },
       {
         "label": "E",
-        "text": "(-3, -4)"
+        "text": "25"
       }
     ],
-    "correctOption": "E",
-    "difficulty": 3,
+    "correctOption": "D",
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-quadratic-functions"
+      "act-polynomial-exponential-log"
     ],
     "source": "act-template-gen",
-    "contentHash": "c55b6cac286cf1c51b161bd728f642b2bf07e7ebfd90f007b2518a93a8e90696",
+    "contentHash": "31fe16250a926a8bc94fb1b3f859ba9e06f9382cf58bcdbaebb98a3bd18a8451",
     "isActive": true
   },
   {
-    "problemId": "act-act-quadratic-functions-4cac7d519b",
-    "skillId": "act-quadratic-functions",
-    "prompt": "What is the vertex of the parabola y = 1(x - 4)² + 6?",
+    "problemId": "act-act-polynomial-exponential-log-016b61dd6d",
+    "skillId": "act-polynomial-exponential-log",
+    "prompt": "What is log₍3₎(243)?",
     "answer": {
       "type": "auto",
-      "value": "(4, 6)",
+      "value": "5",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "(4, -6)"
+        "text": "5"
       },
       {
         "label": "B",
-        "text": "(-4, -6)"
+        "text": "6"
       },
       {
         "label": "C",
-        "text": "(4, 6)"
+        "text": "15"
       },
       {
         "label": "D",
-        "text": "(-4, 6)"
+        "text": "243"
       },
       {
         "label": "E",
-        "text": "(6, 4)"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-quadratic-functions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "4cac7d519b2e43e0566996ef84eefe41db5d71da4195cce01903bd23d0ac82b3",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-quadratic-functions-53481e435e",
-    "skillId": "act-quadratic-functions",
-    "prompt": "What is the vertex of the parabola y = 2(x - 3)² + 5?",
-    "answer": {
-      "type": "auto",
-      "value": "(3, 5)",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "(3, 5)"
-      },
-      {
-        "label": "B",
-        "text": "(5, 3)"
-      },
-      {
-        "label": "C",
-        "text": "(3, -5)"
-      },
-      {
-        "label": "D",
-        "text": "(-3, -5)"
-      },
-      {
-        "label": "E",
-        "text": "(-3, 5)"
+        "text": "81"
       }
     ],
     "correctOption": "A",
-    "difficulty": 4,
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-quadratic-functions"
+      "act-polynomial-exponential-log"
     ],
     "source": "act-template-gen",
-    "contentHash": "53481e435e7551993c8662366112df2c240357ea0381d17c1711a0e0cf10c467",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-quadratic-functions-aa3d8d5991",
-    "skillId": "act-quadratic-functions",
-    "prompt": "What is the vertex of the parabola y = 2(x + 2)² - 5?",
-    "answer": {
-      "type": "auto",
-      "value": "(-2, -5)",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "(2, 5)"
-      },
-      {
-        "label": "B",
-        "text": "(-2, 5)"
-      },
-      {
-        "label": "C",
-        "text": "(-5, -2)"
-      },
-      {
-        "label": "D",
-        "text": "(2, -5)"
-      },
-      {
-        "label": "E",
-        "text": "(-2, -5)"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 5,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-quadratic-functions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "aa3d8d5991161256778e77681ee05a9641ffe62b3b74cc1584e692c4048fe5b1",
+    "contentHash": "016b61dd6d9671b97b7419bf8318fd0e23f02d349ec9d969cef81cd98b15f706",
     "isActive": true
   },
   {
@@ -6610,7 +6695,7 @@
       }
     ],
     "correctOption": "B",
-    "difficulty": 2,
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -6619,50 +6704,6 @@
     ],
     "source": "act-template-gen",
     "contentHash": "81ef195d8103a0cfbd2d7e288d7b3cf55b952ad24745262e850b018e7c8b2798",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-polynomial-exponential-log-31fe16250a",
-    "skillId": "act-polynomial-exponential-log",
-    "prompt": "What is log₍5₎(25)?",
-    "answer": {
-      "type": "auto",
-      "value": "2",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "5"
-      },
-      {
-        "label": "B",
-        "text": "2"
-      },
-      {
-        "label": "C",
-        "text": "3"
-      },
-      {
-        "label": "D",
-        "text": "10"
-      },
-      {
-        "label": "E",
-        "text": "25"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-polynomial-exponential-log"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "31fe16250a926a8bc94fb1b3f859ba9e06f9382cf58bcdbaebb98a3bd18a8451",
     "isActive": true
   },
   {
@@ -6766,27 +6807,27 @@
     "options": [
       {
         "label": "A",
-        "text": "16"
-      },
-      {
-        "label": "B",
-        "text": "32"
-      },
-      {
-        "label": "C",
         "text": "6"
       },
       {
+        "label": "B",
+        "text": "16"
+      },
+      {
+        "label": "C",
+        "text": "10"
+      },
+      {
         "label": "D",
-        "text": "5"
+        "text": "32"
       },
       {
         "label": "E",
-        "text": "10"
+        "text": "5"
       }
     ],
-    "correctOption": "D",
-    "difficulty": 3,
+    "correctOption": "E",
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -6798,97 +6839,9 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-polynomial-exponential-log-f0bbe30ff9",
+    "problemId": "act-act-polynomial-exponential-log-8be29e0e9c",
     "skillId": "act-polynomial-exponential-log",
-    "prompt": "What is log₍5₎(625)?",
-    "answer": {
-      "type": "auto",
-      "value": "4",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "125"
-      },
-      {
-        "label": "B",
-        "text": "20"
-      },
-      {
-        "label": "C",
-        "text": "625"
-      },
-      {
-        "label": "D",
-        "text": "4"
-      },
-      {
-        "label": "E",
-        "text": "5"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-polynomial-exponential-log"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "f0bbe30ff9e0e21e07a4a500defe788c8446aaaa43cf94f7e40f50dcec1d0354",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-polynomial-exponential-log-73789f00f0",
-    "skillId": "act-polynomial-exponential-log",
-    "prompt": "What is log₍3₎(729)?",
-    "answer": {
-      "type": "auto",
-      "value": "6",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "6"
-      },
-      {
-        "label": "B",
-        "text": "729"
-      },
-      {
-        "label": "C",
-        "text": "7"
-      },
-      {
-        "label": "D",
-        "text": "243"
-      },
-      {
-        "label": "E",
-        "text": "18"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-polynomial-exponential-log"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "73789f00f0ddc1a6abd94bf02f6f313342718920f3e5a7618a8f50cd5c5b47cb",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-polynomial-exponential-log-6edace870a",
-    "skillId": "act-polynomial-exponential-log",
-    "prompt": "What is log₍3₎(2187)?",
+    "prompt": "What is log₍2₎(128)?",
     "answer": {
       "type": "auto",
       "value": "7",
@@ -6898,19 +6851,19 @@
     "options": [
       {
         "label": "A",
-        "text": "8"
+        "text": "64"
       },
       {
         "label": "B",
-        "text": "2187"
+        "text": "8"
       },
       {
         "label": "C",
-        "text": "729"
+        "text": "14"
       },
       {
         "label": "D",
-        "text": "21"
+        "text": "128"
       },
       {
         "label": "E",
@@ -6918,6 +6871,50 @@
       }
     ],
     "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-polynomial-exponential-log"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "8be29e0e9c34add54e1779006617a2f05f0dd48ef6b430cbfdafbe14fc29af8a",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-polynomial-exponential-log-83cf5fdc4d",
+    "skillId": "act-polynomial-exponential-log",
+    "prompt": "What is log₍2₎(256)?",
+    "answer": {
+      "type": "auto",
+      "value": "8",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "16"
+      },
+      {
+        "label": "B",
+        "text": "128"
+      },
+      {
+        "label": "C",
+        "text": "8"
+      },
+      {
+        "label": "D",
+        "text": "256"
+      },
+      {
+        "label": "E",
+        "text": "9"
+      }
+    ],
+    "correctOption": "C",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -6926,183 +6923,7 @@
       "act-polynomial-exponential-log"
     ],
     "source": "act-template-gen",
-    "contentHash": "6edace870a3797d208899f852dacb3b82dc091a0330e4583d56eece2cf9af897",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-trig-functions-2da5063d6e",
-    "skillId": "act-trig-functions",
-    "prompt": "What is sin(30°)?",
-    "answer": {
-      "type": "auto",
-      "value": "1/2",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "1"
-      },
-      {
-        "label": "B",
-        "text": "√2/2"
-      },
-      {
-        "label": "C",
-        "text": "1/2"
-      },
-      {
-        "label": "D",
-        "text": "√3"
-      },
-      {
-        "label": "E",
-        "text": "√3/2"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-trig-functions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "2da5063d6ef4b9451626bae425d96535ce3e9a08928806508b600c57bf8133e1",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-trig-functions-12c71b8208",
-    "skillId": "act-trig-functions",
-    "prompt": "What is cos(30°)?",
-    "answer": {
-      "type": "auto",
-      "value": "√3/2",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "√2/2"
-      },
-      {
-        "label": "B",
-        "text": "√3/2"
-      },
-      {
-        "label": "C",
-        "text": "√3"
-      },
-      {
-        "label": "D",
-        "text": "1/2"
-      },
-      {
-        "label": "E",
-        "text": "1"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-trig-functions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "12c71b8208ffe6c9ff98c1cb3c38c19a54847bc279acf23eaa2dabb7c2838efa",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-trig-functions-186797f58c",
-    "skillId": "act-trig-functions",
-    "prompt": "What is tan(45°)?",
-    "answer": {
-      "type": "auto",
-      "value": "1",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "√2/2"
-      },
-      {
-        "label": "B",
-        "text": "1"
-      },
-      {
-        "label": "C",
-        "text": "1/2"
-      },
-      {
-        "label": "D",
-        "text": "√3"
-      },
-      {
-        "label": "E",
-        "text": "√3/2"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-trig-functions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "186797f58caabf9593718504109738fe59e629bb6a325b9f85d333d9f732f838",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-trig-functions-a4d749b7f8",
-    "skillId": "act-trig-functions",
-    "prompt": "What is cos(60°)?",
-    "answer": {
-      "type": "auto",
-      "value": "1/2",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "√3"
-      },
-      {
-        "label": "B",
-        "text": "1"
-      },
-      {
-        "label": "C",
-        "text": "√3/2"
-      },
-      {
-        "label": "D",
-        "text": "1/2"
-      },
-      {
-        "label": "E",
-        "text": "√2/2"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-trig-functions"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "a4d749b7f8778e28cadb1cc37de49152c930a0eb4bb3830723c8feac5d6bd5e2",
+    "contentHash": "83cf5fdc4d9febe190c692e07359c3de814b2e8ce136761d03bf5961493afec1",
     "isActive": true
   },
   {
@@ -7118,7 +6939,7 @@
     "options": [
       {
         "label": "A",
-        "text": "√3"
+        "text": "√2/2"
       },
       {
         "label": "B",
@@ -7130,15 +6951,15 @@
       },
       {
         "label": "D",
-        "text": "1/2"
+        "text": "√3"
       },
       {
         "label": "E",
-        "text": "√2/2"
+        "text": "1/2"
       }
     ],
-    "correctOption": "E",
-    "difficulty": 3,
+    "correctOption": "A",
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -7150,39 +6971,39 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-trig-functions-4832211b7a",
+    "problemId": "act-act-trig-functions-a4d749b7f8",
     "skillId": "act-trig-functions",
-    "prompt": "What is sin(60°)?",
+    "prompt": "What is cos(60°)?",
     "answer": {
       "type": "auto",
-      "value": "√3/2",
+      "value": "1/2",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "√3"
-      },
-      {
-        "label": "B",
-        "text": "1"
-      },
-      {
-        "label": "C",
-        "text": "√2/2"
-      },
-      {
-        "label": "D",
         "text": "1/2"
       },
       {
-        "label": "E",
+        "label": "B",
         "text": "√3/2"
+      },
+      {
+        "label": "C",
+        "text": "1"
+      },
+      {
+        "label": "D",
+        "text": "√2/2"
+      },
+      {
+        "label": "E",
+        "text": "√3"
       }
     ],
-    "correctOption": "E",
-    "difficulty": 4,
+    "correctOption": "A",
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -7190,7 +7011,51 @@
       "act-trig-functions"
     ],
     "source": "act-template-gen",
-    "contentHash": "4832211b7ad3359409eec5552bb7fbb23a0231da40daa5bd2ee692ae14b7b7fe",
+    "contentHash": "a4d749b7f8778e28cadb1cc37de49152c930a0eb4bb3830723c8feac5d6bd5e2",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-trig-functions-2da5063d6e",
+    "skillId": "act-trig-functions",
+    "prompt": "What is sin(30°)?",
+    "answer": {
+      "type": "auto",
+      "value": "1/2",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "1/2"
+      },
+      {
+        "label": "B",
+        "text": "√3"
+      },
+      {
+        "label": "C",
+        "text": "√3/2"
+      },
+      {
+        "label": "D",
+        "text": "1"
+      },
+      {
+        "label": "E",
+        "text": "√2/2"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-trig-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "2da5063d6ef4b9451626bae425d96535ce3e9a08928806508b600c57bf8133e1",
     "isActive": true
   },
   {
@@ -7206,7 +7071,7 @@
     "options": [
       {
         "label": "A",
-        "text": "1"
+        "text": "1/2"
       },
       {
         "label": "B",
@@ -7214,19 +7079,19 @@
       },
       {
         "label": "C",
-        "text": "√3"
+        "text": "1"
       },
       {
         "label": "D",
-        "text": "√2/2"
+        "text": "√3"
       },
       {
         "label": "E",
-        "text": "1/2"
+        "text": "√2/2"
       }
     ],
-    "correctOption": "C",
-    "difficulty": 4,
+    "correctOption": "D",
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -7258,11 +7123,11 @@
       },
       {
         "label": "C",
-        "text": "√3/2"
+        "text": "1"
       },
       {
         "label": "D",
-        "text": "1"
+        "text": "√3/2"
       },
       {
         "label": "E",
@@ -7270,7 +7135,7 @@
       }
     ],
     "correctOption": "B",
-    "difficulty": 5,
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -7282,229 +7147,53 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-function-transformations-67d16e7dad",
-    "skillId": "act-function-transformations",
-    "prompt": "If f(x) = 1x + 6 and g(x) = f(x − 2) + 6, what is g(2)?",
+    "problemId": "act-act-trig-functions-adcd7b2911",
+    "skillId": "act-trig-functions",
+    "prompt": "What is tan(30°)?",
     "answer": {
       "type": "auto",
-      "value": "12",
+      "value": "√3/3",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "12"
+        "text": "√3/2"
       },
       {
         "label": "B",
-        "text": "16"
+        "text": "1/2"
       },
       {
         "label": "C",
-        "text": "14"
+        "text": "√2/2"
       },
       {
         "label": "D",
-        "text": "8"
+        "text": "√3"
       },
       {
         "label": "E",
-        "text": "0"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-function-transformations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "67d16e7dad3f830db7b9878e273161f841e6ee0ef1e20f9d2f69282e6584512a",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-function-transformations-81f7f22095",
-    "skillId": "act-function-transformations",
-    "prompt": "If f(x) = 1x - 3 and g(x) = f(x − 4) + 1, what is g(1)?",
-    "answer": {
-      "type": "auto",
-      "value": "-5",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "3"
-      },
-      {
-        "label": "B",
-        "text": "-7"
-      },
-      {
-        "label": "C",
-        "text": "-2"
-      },
-      {
-        "label": "D",
-        "text": "-5"
-      },
-      {
-        "label": "E",
-        "text": "-1"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-function-transformations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "81f7f22095c1fe75f7954acfa6c45a105bc6a68eead8fe1f167c096fe957493e",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-function-transformations-f98788c5af",
-    "skillId": "act-function-transformations",
-    "prompt": "If f(x) = -2x + 4 and g(x) = f(x − 1) + 5, what is g(-1)?",
-    "answer": {
-      "type": "auto",
-      "value": "13",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "13"
-      },
-      {
-        "label": "B",
-        "text": "6"
-      },
-      {
-        "label": "C",
-        "text": "9"
-      },
-      {
-        "label": "D",
-        "text": "3"
-      },
-      {
-        "label": "E",
-        "text": "11"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-function-transformations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "f98788c5af492555d0958a2fa8b712fc43b1539a2febe75efc607e8092589643",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-function-transformations-3677372ff3",
-    "skillId": "act-function-transformations",
-    "prompt": "If f(x) = 2x - 6 and g(x) = f(x − 2) + 6, what is g(-3)?",
-    "answer": {
-      "type": "auto",
-      "value": "-10",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "-10"
-      },
-      {
-        "label": "B",
-        "text": "-2"
-      },
-      {
-        "label": "C",
-        "text": "-22"
-      },
-      {
-        "label": "D",
-        "text": "-6"
-      },
-      {
-        "label": "E",
-        "text": "-12"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-function-transformations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "3677372ff3dd77261e14667e0d69e170cb3afacc98fa877ee5aa3bbf381d105f",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-function-transformations-3fac91d69a",
-    "skillId": "act-function-transformations",
-    "prompt": "If f(x) = 4x - 4 and g(x) = f(x − 4) + 2, what is g(-1)?",
-    "answer": {
-      "type": "auto",
-      "value": "-22",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "-26"
-      },
-      {
-        "label": "B",
-        "text": "-6"
-      },
-      {
-        "label": "C",
-        "text": "-8"
-      },
-      {
-        "label": "D",
-        "text": "10"
-      },
-      {
-        "label": "E",
-        "text": "-22"
+        "text": "√3/3"
       }
     ],
     "correctOption": "E",
-    "difficulty": 3,
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-function-transformations"
+      "act-trig-functions"
     ],
     "source": "act-template-gen",
-    "contentHash": "3fac91d69a68718d3b515252ef5431193739111452e9f4353645398127edfb22",
+    "contentHash": "adcd7b2911af744aec9371797981708e2058f7a68125f248f18241fa9b64656b",
     "isActive": true
   },
   {
-    "problemId": "act-act-function-transformations-3b89f3a01a",
-    "skillId": "act-function-transformations",
-    "prompt": "If f(x) = -1x - 4 and g(x) = f(x − 4) + 3, what is g(2)?",
+    "problemId": "act-act-trig-functions-186797f58c",
+    "skillId": "act-trig-functions",
+    "prompt": "What is tan(45°)?",
     "answer": {
       "type": "auto",
       "value": "1",
@@ -7514,199 +7203,155 @@
     "options": [
       {
         "label": "A",
-        "text": "-5"
+        "text": "√2/2"
       },
       {
         "label": "B",
-        "text": "-6"
+        "text": "√3"
       },
       {
         "label": "C",
-        "text": "-3"
-      },
-      {
-        "label": "D",
-        "text": "-7"
-      },
-      {
-        "label": "E",
         "text": "1"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-function-transformations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "3b89f3a01a6bfe413c7c25397106f7e8cda4596d673a597383ef62d7b1e83848",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-function-transformations-cca90190d4",
-    "skillId": "act-function-transformations",
-    "prompt": "If f(x) = -1x + 3 and g(x) = f(x − 4) + 5, what is g(-1)?",
-    "answer": {
-      "type": "auto",
-      "value": "13",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "4"
-      },
-      {
-        "label": "B",
-        "text": "13"
-      },
-      {
-        "label": "C",
-        "text": "5"
       },
       {
         "label": "D",
-        "text": "9"
+        "text": "1/2"
       },
       {
         "label": "E",
-        "text": "3"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-function-transformations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "cca90190d40f016d29623e00f76d726f2db9e2e6da715065b0f9b8f1d100d0c9",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-function-transformations-c56d8f1b6c",
-    "skillId": "act-function-transformations",
-    "prompt": "If f(x) = 1x - 2 and g(x) = f(x − 1) + 6, what is g(2)?",
-    "answer": {
-      "type": "auto",
-      "value": "5",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "7"
-      },
-      {
-        "label": "B",
-        "text": "6"
-      },
-      {
-        "label": "C",
-        "text": "5"
-      },
-      {
-        "label": "D",
-        "text": "-7"
-      },
-      {
-        "label": "E",
-        "text": "0"
+        "text": "√3/2"
       }
     ],
     "correctOption": "C",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-trig-functions"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "186797f58caabf9593718504109738fe59e629bb6a325b9f85d333d9f732f838",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-trig-functions-4832211b7a",
+    "skillId": "act-trig-functions",
+    "prompt": "What is sin(60°)?",
+    "answer": {
+      "type": "auto",
+      "value": "√3/2",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "1"
+      },
+      {
+        "label": "B",
+        "text": "√3"
+      },
+      {
+        "label": "C",
+        "text": "1/2"
+      },
+      {
+        "label": "D",
+        "text": "√2/2"
+      },
+      {
+        "label": "E",
+        "text": "√3/2"
+      }
+    ],
+    "correctOption": "E",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-function-transformations"
+      "act-trig-functions"
     ],
     "source": "act-template-gen",
-    "contentHash": "c56d8f1b6cae1bdaf747d8b2585691bd22f6c620f7375b51baade1a0a3e61844",
+    "contentHash": "4832211b7ad3359409eec5552bb7fbb23a0231da40daa5bd2ee692ae14b7b7fe",
     "isActive": true
   },
   {
-    "problemId": "act-act-center-spread-25f283cbf1",
-    "skillId": "act-center-spread",
-    "prompt": "What is the average (mean) of 23, 6, 16, 9, 11?",
+    "problemId": "act-act-function-transformations-5f459a2f01",
+    "skillId": "act-function-transformations",
+    "prompt": "If f(x) = 4x + 3 and g(x) = f(x − 4) + 1, what is g(-3)?",
     "answer": {
       "type": "auto",
-      "value": "13",
+      "value": "-24",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "17"
+        "text": "8"
       },
       {
         "label": "B",
-        "text": "16"
+        "text": "-24"
       },
       {
         "label": "C",
-        "text": "11"
+        "text": "-9"
       },
       {
         "label": "D",
-        "text": "65"
+        "text": "-26"
       },
       {
         "label": "E",
-        "text": "13"
+        "text": "-8"
       }
     ],
-    "correctOption": "E",
+    "correctOption": "B",
     "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-center-spread"
+      "act-function-transformations"
     ],
     "source": "act-template-gen",
-    "contentHash": "25f283cbf16a5932c1d84cc1f84bcba40a02d89a4ee37ca6916057b537eed65f",
+    "contentHash": "5f459a2f01cb5d0a628e3f05d91a5d9ecd9103d1a6c1e75008732f3ec4e52495",
     "isActive": true
   },
   {
-    "problemId": "act-act-center-spread-480284d4a9",
-    "skillId": "act-center-spread",
-    "prompt": "What is the average (mean) of 24, 11, 12, 12, 6?",
+    "problemId": "act-act-function-transformations-ea35b66cc5",
+    "skillId": "act-function-transformations",
+    "prompt": "If f(x) = 4x - 3 and g(x) = f(x − 4) + 2, what is g(-1)?",
     "answer": {
       "type": "auto",
-      "value": "13",
+      "value": "-21",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "13"
+        "text": "-21"
       },
       {
         "label": "B",
-        "text": "12"
+        "text": "-5"
       },
       {
         "label": "C",
-        "text": "16"
+        "text": "-25"
       },
       {
         "label": "D",
-        "text": "65"
+        "text": "-7"
       },
       {
         "label": "E",
-        "text": "18"
+        "text": "11"
       }
     ],
     "correctOption": "A",
@@ -7715,26 +7360,70 @@
     "tags": [
       "act",
       "act-math",
-      "act-center-spread"
+      "act-function-transformations"
     ],
     "source": "act-template-gen",
-    "contentHash": "480284d4a96f336e0ff8bf53b54a9b2b405c90bfa79217ea9f9a06661ebafb81",
+    "contentHash": "ea35b66cc54665b3fc7bcba7f56485d0e1e3e78616c0ca4c8b85b0148af044ed",
     "isActive": true
   },
   {
-    "problemId": "act-act-center-spread-2f3a152a08",
-    "skillId": "act-center-spread",
-    "prompt": "What is the average (mean) of 7, 4, 12, 19, 8?",
+    "problemId": "act-act-function-transformations-f4938be252",
+    "skillId": "act-function-transformations",
+    "prompt": "If f(x) = 4x - 1 and g(x) = f(x − 3) + 2, what is g(-1)?",
     "answer": {
       "type": "auto",
-      "value": "10",
+      "value": "-15",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "50"
+        "text": "-15"
+      },
+      {
+        "label": "B",
+        "text": "-19"
+      },
+      {
+        "label": "C",
+        "text": "-3"
+      },
+      {
+        "label": "D",
+        "text": "-5"
+      },
+      {
+        "label": "E",
+        "text": "9"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-transformations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "f4938be252c796e49865d60013637d4cf5b5a0dd5c94a0110b455f73477b9129",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-transformations-5aac69e1c5",
+    "skillId": "act-function-transformations",
+    "prompt": "If f(x) = 4x + 2 and g(x) = f(x − 3) + 5, what is g(2)?",
+    "answer": {
+      "type": "auto",
+      "value": "3",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-7"
       },
       {
         "label": "B",
@@ -7742,7 +7431,7 @@
       },
       {
         "label": "C",
-        "text": "13"
+        "text": "3"
       },
       {
         "label": "D",
@@ -7750,113 +7439,201 @@
       },
       {
         "label": "E",
-        "text": "8"
+        "text": "27"
       }
     ],
-    "correctOption": "D",
+    "correctOption": "C",
     "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-center-spread"
+      "act-function-transformations"
     ],
     "source": "act-template-gen",
-    "contentHash": "2f3a152a0857e00ffacb4e296c90c54974b27d2a2de94dde221427e76ebd425c",
+    "contentHash": "5aac69e1c588af09aecd9659a45bf974da5ead060218e79b8f221d7f2d09b804",
     "isActive": true
   },
   {
-    "problemId": "act-act-center-spread-915b22d8ad",
-    "skillId": "act-center-spread",
-    "prompt": "What is the average (mean) of 15, 3, 5, 6, 6?",
+    "problemId": "act-act-function-transformations-afef1258f9",
+    "skillId": "act-function-transformations",
+    "prompt": "If f(x) = -2x + 1 and g(x) = f(x − 2) + 1, what is g(2)?",
     "answer": {
       "type": "auto",
-      "value": "7",
+      "value": "2",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "12"
+        "text": "-3"
       },
       {
         "label": "B",
-        "text": "7"
+        "text": "0"
       },
       {
         "label": "C",
-        "text": "35"
+        "text": "2"
       },
       {
         "label": "D",
-        "text": "9"
+        "text": "-2"
+      },
+      {
+        "label": "E",
+        "text": "-6"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-transformations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "afef1258f92b657d3ec52f575411dd1a8c068f401381c0f79f61b30063e81fac",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-function-transformations-2d155b2421",
+    "skillId": "act-function-transformations",
+    "prompt": "If f(x) = -3x + 3 and g(x) = f(x − 2) + 2, what is g(-1)?",
+    "answer": {
+      "type": "auto",
+      "value": "14",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "14"
+      },
+      {
+        "label": "B",
+        "text": "2"
+      },
+      {
+        "label": "C",
+        "text": "8"
+      },
+      {
+        "label": "D",
+        "text": "10"
       },
       {
         "label": "E",
         "text": "6"
       }
     ],
-    "correctOption": "B",
-    "difficulty": 3,
+    "correctOption": "A",
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-center-spread"
+      "act-function-transformations"
     ],
     "source": "act-template-gen",
-    "contentHash": "915b22d8ad78cd78511fc813ab3a058d839960343684a78b61e2f45d36eec978",
+    "contentHash": "2d155b2421013303e80bad777a726627fa92f34f0307d71759474bdbf87296ad",
     "isActive": true
   },
   {
-    "problemId": "act-act-center-spread-3ac28633b6",
-    "skillId": "act-center-spread",
-    "prompt": "What is the average (mean) of 11, 4, 11, 11, 13?",
+    "problemId": "act-act-function-transformations-ee7e2d0bb6",
+    "skillId": "act-function-transformations",
+    "prompt": "If f(x) = -3x - 2 and g(x) = f(x − 4) + 1, what is g(4)?",
     "answer": {
       "type": "auto",
-      "value": "10",
+      "value": "-1",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "11"
+        "text": "-1"
       },
       {
         "label": "B",
-        "text": "9"
+        "text": "-13"
       },
       {
         "label": "C",
-        "text": "13"
+        "text": "-3"
       },
       {
         "label": "D",
-        "text": "10"
+        "text": "-14"
       },
       {
         "label": "E",
-        "text": "50"
+        "text": "-25"
       }
     ],
-    "correctOption": "D",
-    "difficulty": 3,
+    "correctOption": "A",
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-center-spread"
+      "act-function-transformations"
     ],
     "source": "act-template-gen",
-    "contentHash": "3ac28633b6e6301fcdeab5d128ec0c5e18774025d50f28ca8c58c9ddbc50f460",
+    "contentHash": "ee7e2d0bb679650ba7b97d080014107c7397b7d8fda24a6783fae3fff976ca5b",
     "isActive": true
   },
   {
-    "problemId": "act-act-center-spread-c66cf44191",
+    "problemId": "act-act-function-transformations-95b2320097",
+    "skillId": "act-function-transformations",
+    "prompt": "If f(x) = 1x - 4 and g(x) = f(x − 4) + 2, what is g(-1)?",
+    "answer": {
+      "type": "auto",
+      "value": "-7",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-11"
+      },
+      {
+        "label": "B",
+        "text": "-3"
+      },
+      {
+        "label": "C",
+        "text": "-5"
+      },
+      {
+        "label": "D",
+        "text": "1"
+      },
+      {
+        "label": "E",
+        "text": "-7"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-function-transformations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "95b2320097d298615751e3b2ac87cf5a64af97d6de13e6f4984f523522f7410f",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-center-spread-eee2cc6378",
     "skillId": "act-center-spread",
-    "prompt": "What is the average (mean) of 17, 20, 3, 10, 10?",
+    "prompt": "What is the average (mean) of 10, 6, 20, 10, 14?",
     "answer": {
       "type": "auto",
       "value": "12",
@@ -7866,19 +7643,19 @@
     "options": [
       {
         "label": "A",
-        "text": "10"
+        "text": "15"
       },
       {
         "label": "B",
-        "text": "60"
+        "text": "14"
       },
       {
         "label": "C",
-        "text": "17"
+        "text": "10"
       },
       {
         "label": "D",
-        "text": "15"
+        "text": "60"
       },
       {
         "label": "E",
@@ -7886,6 +7663,226 @@
       }
     ],
     "correctOption": "E",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-center-spread"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "eee2cc6378c1841b6263e9261dcf4ffc8b0330470d4d6fa586c24d8695099028",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-center-spread-3de39f4ed4",
+    "skillId": "act-center-spread",
+    "prompt": "What is the average (mean) of 12, 16, 19, 16, 7?",
+    "answer": {
+      "type": "auto",
+      "value": "14",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "12"
+      },
+      {
+        "label": "B",
+        "text": "14"
+      },
+      {
+        "label": "C",
+        "text": "70"
+      },
+      {
+        "label": "D",
+        "text": "16"
+      },
+      {
+        "label": "E",
+        "text": "18"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-center-spread"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "3de39f4ed4d451d8eddb11f674760a59427e4b194d0623ef7e6c6bd4bc6538da",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-center-spread-aec1f9f696",
+    "skillId": "act-center-spread",
+    "prompt": "What is the average (mean) of 19, 10, 10, 16, 15?",
+    "answer": {
+      "type": "auto",
+      "value": "14",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "15"
+      },
+      {
+        "label": "B",
+        "text": "14"
+      },
+      {
+        "label": "C",
+        "text": "70"
+      },
+      {
+        "label": "D",
+        "text": "18"
+      },
+      {
+        "label": "E",
+        "text": "9"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-center-spread"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "aec1f9f696af0225ecfba999b934a4ebdf7db804bfd8bdf1733d768459b155c1",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-center-spread-73b06a12a3",
+    "skillId": "act-center-spread",
+    "prompt": "What is the average (mean) of 10, 11, 2, 14, 8?",
+    "answer": {
+      "type": "auto",
+      "value": "9",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "9"
+      },
+      {
+        "label": "B",
+        "text": "45"
+      },
+      {
+        "label": "C",
+        "text": "10"
+      },
+      {
+        "label": "D",
+        "text": "11"
+      },
+      {
+        "label": "E",
+        "text": "12"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-center-spread"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "73b06a12a3032827e8525b6415661d05d4aff5e32a935bee35fe5a692468fbbe",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-center-spread-bc371c5df3",
+    "skillId": "act-center-spread",
+    "prompt": "What is the average (mean) of 13, 6, 17, 15, 19?",
+    "answer": {
+      "type": "auto",
+      "value": "14",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "70"
+      },
+      {
+        "label": "B",
+        "text": "13"
+      },
+      {
+        "label": "C",
+        "text": "14"
+      },
+      {
+        "label": "D",
+        "text": "15"
+      },
+      {
+        "label": "E",
+        "text": "18"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-center-spread"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "bc371c5df3da086bdbf7b9a2b9e96b8c54547fdbc64e16b95927767f71dbf985",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-center-spread-6c03f694ad",
+    "skillId": "act-center-spread",
+    "prompt": "What is the average (mean) of 20, 8, 7, 5, 5?",
+    "answer": {
+      "type": "auto",
+      "value": "9",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "9"
+      },
+      {
+        "label": "B",
+        "text": "11"
+      },
+      {
+        "label": "C",
+        "text": "7"
+      },
+      {
+        "label": "D",
+        "text": "45"
+      },
+      {
+        "label": "E",
+        "text": "15"
+      }
+    ],
+    "correctOption": "A",
     "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
@@ -7894,13 +7891,57 @@
       "act-center-spread"
     ],
     "source": "act-template-gen",
-    "contentHash": "c66cf4419124868630b0faa824bb0b7e7c0c775b4f5f1b39cbb4d3e6c6bcf1d5",
+    "contentHash": "6c03f694ada319c72e8ea24e4c8c74a78bce2e38bfd6a091367d0c033dd300dc",
     "isActive": true
   },
   {
-    "problemId": "act-act-center-spread-fe197df8f1",
+    "problemId": "act-act-center-spread-71d1f96546",
     "skillId": "act-center-spread",
-    "prompt": "What is the average (mean) of 6, 14, 9, 13, 8?",
+    "prompt": "What is the average (mean) of 9, 19, 12, 7, 8?",
+    "answer": {
+      "type": "auto",
+      "value": "11",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "12"
+      },
+      {
+        "label": "B",
+        "text": "11"
+      },
+      {
+        "label": "C",
+        "text": "9"
+      },
+      {
+        "label": "D",
+        "text": "14"
+      },
+      {
+        "label": "E",
+        "text": "55"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-center-spread"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "71d1f965463fdcc9641a384d1d2ce1d1a74069b4e1b37f971ad491d0a1920030",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-center-spread-a06a75418e",
+    "skillId": "act-center-spread",
+    "prompt": "What is the average (mean) of 9, 6, 6, 9, 20?",
     "answer": {
       "type": "auto",
       "value": "10",
@@ -7910,59 +7951,15 @@
     "options": [
       {
         "label": "A",
-        "text": "8"
-      },
-      {
-        "label": "B",
         "text": "50"
       },
       {
-        "label": "C",
-        "text": "10"
-      },
-      {
-        "label": "D",
+        "label": "B",
         "text": "13"
       },
       {
-        "label": "E",
-        "text": "9"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-center-spread"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "fe197df8f1c12705630142c04c67faec8be959939b87ebf8da0e562aec8065b6",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-center-spread-988d6c8294",
-    "skillId": "act-center-spread",
-    "prompt": "What is the average (mean) of 7, 10, 2, 14, 7?",
-    "answer": {
-      "type": "auto",
-      "value": "8",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "12"
-      },
-      {
-        "label": "B",
-        "text": "7"
-      },
-      {
         "label": "C",
-        "text": "40"
+        "text": "9"
       },
       {
         "label": "D",
@@ -7970,10 +7967,10 @@
       },
       {
         "label": "E",
-        "text": "8"
+        "text": "14"
       }
     ],
-    "correctOption": "E",
+    "correctOption": "D",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -7982,57 +7979,13 @@
       "act-center-spread"
     ],
     "source": "act-template-gen",
-    "contentHash": "988d6c8294c63f3e7c76a1d6c2dd69890c0b7bd732fe439e800de66e4484f9a9",
+    "contentHash": "a06a75418e5d6a6e7922b11d447bc30ab1cb6588c0f7c28258f17f0857c3f0ff",
     "isActive": true
   },
   {
-    "problemId": "act-act-data-representations-e78d5b2a1e",
+    "problemId": "act-act-data-representations-11712ffa3f",
     "skillId": "act-data-representations",
-    "prompt": "A store's daily sales were Mon: 23, Tue: 21, Wed: 26, Thu: 14. What were the total sales?",
-    "answer": {
-      "type": "auto",
-      "value": "84",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "70"
-      },
-      {
-        "label": "B",
-        "text": "12"
-      },
-      {
-        "label": "C",
-        "text": "84"
-      },
-      {
-        "label": "D",
-        "text": "26"
-      },
-      {
-        "label": "E",
-        "text": "21"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-data-representations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "e78d5b2a1e024c319253447759b0961e208f36ec0acfd7d6a033829db023fa73",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-data-representations-1281213f18",
-    "skillId": "act-data-representations",
-    "prompt": "A store's daily sales were Mon: 16, Tue: 24, Wed: 20, Thu: 15. What were the total sales?",
+    "prompt": "A store's daily sales were Mon: 18, Tue: 18, Wed: 20, Thu: 19. What were the total sales?",
     "answer": {
       "type": "auto",
       "value": "75",
@@ -8042,7 +7995,7 @@
     "options": [
       {
         "label": "A",
-        "text": "75"
+        "text": "20"
       },
       {
         "label": "B",
@@ -8050,18 +8003,18 @@
       },
       {
         "label": "C",
-        "text": "24"
+        "text": "2"
       },
       {
         "label": "D",
-        "text": "9"
+        "text": "57"
       },
       {
         "label": "E",
-        "text": "60"
+        "text": "75"
       }
     ],
-    "correctOption": "A",
+    "correctOption": "E",
     "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
@@ -8070,39 +8023,83 @@
       "act-data-representations"
     ],
     "source": "act-template-gen",
-    "contentHash": "1281213f18d6aae3c095ce376dfdf9025689cd068bbdbbd537c8a83ad12fcb51",
+    "contentHash": "11712ffa3f3a0227722ad14d0bb54b027c5a8f7e365daf9fc2521e721fabf217",
     "isActive": true
   },
   {
-    "problemId": "act-act-data-representations-17443a656b",
+    "problemId": "act-act-data-representations-1dd0142fd9",
     "skillId": "act-data-representations",
-    "prompt": "A store's daily sales were Mon: 26, Tue: 25, Wed: 12, Thu: 7. What were the total sales?",
+    "prompt": "A store's daily sales were Mon: 30, Tue: 7, Wed: 16, Thu: 16. What were the total sales?",
     "answer": {
       "type": "auto",
-      "value": "70",
+      "value": "69",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "63"
+        "text": "17"
       },
       {
         "label": "B",
-        "text": "70"
+        "text": "30"
       },
       {
         "label": "C",
-        "text": "19"
+        "text": "62"
       },
       {
         "label": "D",
-        "text": "18"
+        "text": "23"
       },
       {
         "label": "E",
-        "text": "26"
+        "text": "69"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-data-representations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "1dd0142fd988bcb87af6d5c4a15ffb6996ad7a65d4b27757cbd0df983ddc82a1",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-data-representations-cb7d5666fe",
+    "skillId": "act-data-representations",
+    "prompt": "A store's daily sales were Mon: 7, Tue: 22, Wed: 14, Thu: 21. What were the total sales?",
+    "answer": {
+      "type": "auto",
+      "value": "64",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "15"
+      },
+      {
+        "label": "B",
+        "text": "64"
+      },
+      {
+        "label": "C",
+        "text": "22"
+      },
+      {
+        "label": "D",
+        "text": "57"
+      },
+      {
+        "label": "E",
+        "text": "16"
       }
     ],
     "correctOption": "B",
@@ -8114,31 +8111,207 @@
       "act-data-representations"
     ],
     "source": "act-template-gen",
-    "contentHash": "17443a656bc1e2b89e531997eb48d498380bcd838dddacd92bf013471f256665",
+    "contentHash": "cb7d5666fee9c199c79d634b1f8bfd3ad3c64b9743ec1f2bd65523faacda1143",
     "isActive": true
   },
   {
-    "problemId": "act-act-data-representations-4675c338dc",
+    "problemId": "act-act-data-representations-9eede66e3b",
     "skillId": "act-data-representations",
-    "prompt": "A store's daily sales were Mon: 27, Tue: 5, Wed: 23, Thu: 23. What were the total sales?",
+    "prompt": "A store's daily sales were Mon: 9, Tue: 11, Wed: 16, Thu: 6. What were the total sales?",
     "answer": {
       "type": "auto",
-      "value": "78",
+      "value": "42",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "78"
+        "text": "16"
       },
       {
         "label": "B",
-        "text": "73"
+        "text": "36"
       },
       {
         "label": "C",
-        "text": "20"
+        "text": "42"
+      },
+      {
+        "label": "D",
+        "text": "11"
+      },
+      {
+        "label": "E",
+        "text": "10"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-data-representations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "9eede66e3b8738368263716b2af23490dca6c46efade525b8838447c785c3d24",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-data-representations-96f9d92f24",
+    "skillId": "act-data-representations",
+    "prompt": "A store's daily sales were Mon: 23, Tue: 19, Wed: 23, Thu: 21. What were the total sales?",
+    "answer": {
+      "type": "auto",
+      "value": "86",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "23"
+      },
+      {
+        "label": "B",
+        "text": "4"
+      },
+      {
+        "label": "C",
+        "text": "86"
+      },
+      {
+        "label": "D",
+        "text": "22"
+      },
+      {
+        "label": "E",
+        "text": "67"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-data-representations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "96f9d92f2480d0968c9ea5b70bd9c44eb97c6ccfe1b11233bd0d7da905e5d872",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-data-representations-85ca79611e",
+    "skillId": "act-data-representations",
+    "prompt": "A store's daily sales were Mon: 12, Tue: 8, Wed: 16, Thu: 24. What were the total sales?",
+    "answer": {
+      "type": "auto",
+      "value": "60",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "60"
+      },
+      {
+        "label": "B",
+        "text": "16"
+      },
+      {
+        "label": "C",
+        "text": "52"
+      },
+      {
+        "label": "D",
+        "text": "15"
+      },
+      {
+        "label": "E",
+        "text": "24"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-data-representations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "85ca79611eda4db2494283d20128129e966b28fa90cf323e0e8a19b5cb089b7f",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-data-representations-768fd1337b",
+    "skillId": "act-data-representations",
+    "prompt": "A store's daily sales were Mon: 25, Tue: 23, Wed: 26, Thu: 25. What were the total sales?",
+    "answer": {
+      "type": "auto",
+      "value": "99",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "26"
+      },
+      {
+        "label": "B",
+        "text": "3"
+      },
+      {
+        "label": "C",
+        "text": "76"
+      },
+      {
+        "label": "D",
+        "text": "99"
+      },
+      {
+        "label": "E",
+        "text": "25"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-data-representations"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "768fd1337b3d9327086a89b693077ea0984c0e79512f55efc54adc2633673961",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-data-representations-102ea5e6ca",
+    "skillId": "act-data-representations",
+    "prompt": "A store's daily sales were Mon: 16, Tue: 6, Wed: 27, Thu: 5. What were the total sales?",
+    "answer": {
+      "type": "auto",
+      "value": "54",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "54"
+      },
+      {
+        "label": "B",
+        "text": "14"
+      },
+      {
+        "label": "C",
+        "text": "49"
       },
       {
         "label": "D",
@@ -8150,182 +8323,6 @@
       }
     ],
     "correctOption": "A",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-data-representations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "4675c338dc959a7500947d193683ffed14c3de824b6f01e8513469bac0dbef84",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-data-representations-aeec37f31a",
-    "skillId": "act-data-representations",
-    "prompt": "A store's daily sales were Mon: 18, Tue: 11, Wed: 28, Thu: 30. What were the total sales?",
-    "answer": {
-      "type": "auto",
-      "value": "87",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "30"
-      },
-      {
-        "label": "B",
-        "text": "22"
-      },
-      {
-        "label": "C",
-        "text": "76"
-      },
-      {
-        "label": "D",
-        "text": "19"
-      },
-      {
-        "label": "E",
-        "text": "87"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-data-representations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "aeec37f31a73011b6ad10f00dec6bef07796b5320b162cea2031da0242b12dba",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-data-representations-f99492908f",
-    "skillId": "act-data-representations",
-    "prompt": "A store's daily sales were Mon: 19, Tue: 17, Wed: 12, Thu: 19. What were the total sales?",
-    "answer": {
-      "type": "auto",
-      "value": "67",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "55"
-      },
-      {
-        "label": "B",
-        "text": "7"
-      },
-      {
-        "label": "C",
-        "text": "19"
-      },
-      {
-        "label": "D",
-        "text": "17"
-      },
-      {
-        "label": "E",
-        "text": "67"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-data-representations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "f99492908f04e232a02632046d2646ff149e8be84eb82792ea042340e78352e2",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-data-representations-bf472485de",
-    "skillId": "act-data-representations",
-    "prompt": "A store's daily sales were Mon: 16, Tue: 5, Wed: 25, Thu: 8. What were the total sales?",
-    "answer": {
-      "type": "auto",
-      "value": "54",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "14"
-      },
-      {
-        "label": "B",
-        "text": "25"
-      },
-      {
-        "label": "C",
-        "text": "20"
-      },
-      {
-        "label": "D",
-        "text": "54"
-      },
-      {
-        "label": "E",
-        "text": "49"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-data-representations"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "bf472485de5d148a3693503eefb8310a03bd747d494f14a48f52a748f553b9b6",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-data-representations-6b8ff0bebb",
-    "skillId": "act-data-representations",
-    "prompt": "A store's daily sales were Mon: 21, Tue: 11, Wed: 21, Thu: 18. What were the total sales?",
-    "answer": {
-      "type": "auto",
-      "value": "71",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "21"
-      },
-      {
-        "label": "B",
-        "text": "60"
-      },
-      {
-        "label": "C",
-        "text": "71"
-      },
-      {
-        "label": "D",
-        "text": "10"
-      },
-      {
-        "label": "E",
-        "text": "18"
-      }
-    ],
-    "correctOption": "C",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -8334,42 +8331,42 @@
       "act-data-representations"
     ],
     "source": "act-template-gen",
-    "contentHash": "6b8ff0bebb1cb15d11c769e994f64c5368c71a3ad1e4883a567aa4e784a92410",
+    "contentHash": "102ea5e6caa1a06330e965faac6a3f6182498bfbfbc844992d51901265a7a6b2",
     "isActive": true
   },
   {
-    "problemId": "act-act-two-way-tables-37476c5e6c",
+    "problemId": "act-act-two-way-tables-57e009105c",
     "skillId": "act-two-way-tables",
-    "prompt": "In a survey, 9 boys and 8 girls chose pizza; 7 boys and 11 girls chose tacos. How many boys were surveyed in total?",
+    "prompt": "In a survey, 8 boys and 12 girls chose pizza; 10 boys and 7 girls chose tacos. How many boys were surveyed in total?",
     "answer": {
       "type": "auto",
-      "value": "9",
+      "value": "8",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "35"
+        "text": "18"
       },
       {
         "label": "B",
-        "text": "16"
+        "text": "20"
       },
       {
         "label": "C",
-        "text": "19"
+        "text": "8"
       },
       {
         "label": "D",
-        "text": "17"
+        "text": "19"
       },
       {
         "label": "E",
-        "text": "9"
+        "text": "37"
       }
     ],
-    "correctOption": "E",
+    "correctOption": "C",
     "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
@@ -8378,13 +8375,13 @@
       "act-two-way-tables"
     ],
     "source": "act-template-gen",
-    "contentHash": "37476c5e6c004cf3426a7a738f9110d084acee628de97d69b6b650fa0f8044f5",
+    "contentHash": "57e009105c46aa496bf78304874bcc0ce483bd9029f1f6194322efc4a7496467",
     "isActive": true
   },
   {
-    "problemId": "act-act-two-way-tables-d0b3d8421c",
+    "problemId": "act-act-two-way-tables-126a168f19",
     "skillId": "act-two-way-tables",
-    "prompt": "In a survey, 6 boys and 15 girls chose pizza; 12 boys and 5 girls chose tacos. How many boys were surveyed in total?",
+    "prompt": "In a survey, 6 boys and 14 girls chose pizza; 10 boys and 9 girls chose tacos. How many boys were surveyed in total?",
     "answer": {
       "type": "auto",
       "value": "6",
@@ -8394,26 +8391,26 @@
     "options": [
       {
         "label": "A",
-        "text": "18"
+        "text": "39"
       },
       {
         "label": "B",
-        "text": "21"
+        "text": "23"
       },
       {
         "label": "C",
-        "text": "38"
+        "text": "6"
       },
       {
         "label": "D",
-        "text": "6"
+        "text": "16"
       },
       {
         "label": "E",
         "text": "20"
       }
     ],
-    "correctOption": "D",
+    "correctOption": "C",
     "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
@@ -8422,31 +8419,75 @@
       "act-two-way-tables"
     ],
     "source": "act-template-gen",
-    "contentHash": "d0b3d8421cef2a5eeb5d57b6c18bbaf67dfcd58ac93fe72e05154d4ba26c201c",
+    "contentHash": "126a168f19eca79b59071b0031ab44589c268f0d2094811ee610461cc19cfe1a",
     "isActive": true
   },
   {
-    "problemId": "act-act-two-way-tables-074c57f458",
+    "problemId": "act-act-two-way-tables-18fddabd65",
     "skillId": "act-two-way-tables",
-    "prompt": "In a survey, 10 boys and 8 girls chose pizza; 12 boys and 11 girls chose tacos. How many boys were surveyed in total?",
+    "prompt": "In a survey, 13 boys and 11 girls chose pizza; 9 boys and 4 girls chose tacos. How many boys were surveyed in total?",
     "answer": {
       "type": "auto",
-      "value": "10",
+      "value": "13",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "22"
+        "text": "24"
       },
       {
         "label": "B",
-        "text": "41"
+        "text": "37"
       },
       {
         "label": "C",
-        "text": "10"
+        "text": "22"
+      },
+      {
+        "label": "D",
+        "text": "13"
+      },
+      {
+        "label": "E",
+        "text": "15"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-two-way-tables"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "18fddabd658ca0f4b5cfe8c66690868ae1ba68bd4d5bd0696cb38a45ae9698a9",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-two-way-tables-45e861aa36",
+    "skillId": "act-two-way-tables",
+    "prompt": "In a survey, 7 boys and 8 girls chose pizza; 11 boys and 6 girls chose tacos. How many boys were surveyed in total?",
+    "answer": {
+      "type": "auto",
+      "value": "7",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "32"
+      },
+      {
+        "label": "B",
+        "text": "15"
+      },
+      {
+        "label": "C",
+        "text": "7"
       },
       {
         "label": "D",
@@ -8454,7 +8495,7 @@
       },
       {
         "label": "E",
-        "text": "19"
+        "text": "14"
       }
     ],
     "correctOption": "C",
@@ -8466,131 +8507,43 @@
       "act-two-way-tables"
     ],
     "source": "act-template-gen",
-    "contentHash": "074c57f458f997be67c018bde38907c6ddbcd835e58659ad9a8de8f4538b1b96",
+    "contentHash": "45e861aa36c402e4f08efec096f9b4b3689c772d98740e10ff78e25ab3ade866",
     "isActive": true
   },
   {
-    "problemId": "act-act-two-way-tables-4f4e4d8582",
+    "problemId": "act-act-two-way-tables-f7814ee7ed",
     "skillId": "act-two-way-tables",
-    "prompt": "In a survey, 10 boys and 12 girls chose pizza; 6 boys and 13 girls chose tacos. How many boys were surveyed in total?",
+    "prompt": "In a survey, 4 boys and 10 girls chose pizza; 9 boys and 8 girls chose tacos. How many boys were surveyed in total?",
     "answer": {
       "type": "auto",
-      "value": "10",
+      "value": "4",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "25"
+        "text": "31"
       },
       {
         "label": "B",
-        "text": "10"
+        "text": "18"
       },
       {
         "label": "C",
-        "text": "22"
+        "text": "4"
       },
       {
         "label": "D",
-        "text": "16"
-      },
-      {
-        "label": "E",
-        "text": "41"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-two-way-tables"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "4f4e4d8582c5537463e75e27551632c5c041549cd7d69150859c7afc1a91abbc",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-two-way-tables-a3157dedad",
-    "skillId": "act-two-way-tables",
-    "prompt": "In a survey, 14 boys and 5 girls chose pizza; 9 boys and 11 girls chose tacos. How many boys were surveyed in total?",
-    "answer": {
-      "type": "auto",
-      "value": "14",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "16"
-      },
-      {
-        "label": "B",
-        "text": "14"
-      },
-      {
-        "label": "C",
-        "text": "23"
-      },
-      {
-        "label": "D",
-        "text": "39"
-      },
-      {
-        "label": "E",
-        "text": "19"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-two-way-tables"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "a3157dedad0f38bc7024653b0fd18be6f901c569d0f45adc5c8d18a325cce5fb",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-two-way-tables-8d51e7faef",
-    "skillId": "act-two-way-tables",
-    "prompt": "In a survey, 13 boys and 15 girls chose pizza; 13 boys and 8 girls chose tacos. How many boys were surveyed in total?",
-    "answer": {
-      "type": "auto",
-      "value": "13",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "28"
-      },
-      {
-        "label": "B",
         "text": "13"
       },
       {
-        "label": "C",
-        "text": "49"
-      },
-      {
-        "label": "D",
-        "text": "23"
-      },
-      {
         "label": "E",
-        "text": "26"
+        "text": "14"
       }
     ],
-    "correctOption": "B",
-    "difficulty": 4,
+    "correctOption": "C",
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -8598,13 +8551,13 @@
       "act-two-way-tables"
     ],
     "source": "act-template-gen",
-    "contentHash": "8d51e7faefe8189c7595af3c1056e13fb4a5c7b44a443e8953286e41213c61b2",
+    "contentHash": "f7814ee7ed223433c2cdd6039ff16769ee7a232ad1d3e56f9abbfc52f9ef8421",
     "isActive": true
   },
   {
-    "problemId": "act-act-two-way-tables-466fe7aa5b",
+    "problemId": "act-act-two-way-tables-25f8addcc1",
     "skillId": "act-two-way-tables",
-    "prompt": "In a survey, 9 boys and 6 girls chose pizza; 15 boys and 14 girls chose tacos. How many boys were surveyed in total?",
+    "prompt": "In a survey, 9 boys and 15 girls chose pizza; 5 boys and 4 girls chose tacos. How many boys were surveyed in total?",
     "answer": {
       "type": "auto",
       "value": "9",
@@ -8614,7 +8567,7 @@
     "options": [
       {
         "label": "A",
-        "text": "20"
+        "text": "14"
       },
       {
         "label": "B",
@@ -8622,11 +8575,11 @@
       },
       {
         "label": "C",
-        "text": "44"
+        "text": "33"
       },
       {
         "label": "D",
-        "text": "15"
+        "text": "19"
       },
       {
         "label": "E",
@@ -8642,27 +8595,71 @@
       "act-two-way-tables"
     ],
     "source": "act-template-gen",
-    "contentHash": "466fe7aa5b718621cb8b54987b3e1aee8d6c914fd2af59691a0c1452c293be69",
+    "contentHash": "25f8addcc15c25a7e6fed3b1d5a7de758b8c1636a898903b2984ddb5080e2e71",
     "isActive": true
   },
   {
-    "problemId": "act-act-two-way-tables-1c03aaace1",
+    "problemId": "act-act-two-way-tables-c3fd14232b",
     "skillId": "act-two-way-tables",
-    "prompt": "In a survey, 15 boys and 13 girls chose pizza; 10 boys and 4 girls chose tacos. How many boys were surveyed in total?",
+    "prompt": "In a survey, 12 boys and 5 girls chose pizza; 11 boys and 5 girls chose tacos. How many boys were surveyed in total?",
     "answer": {
       "type": "auto",
-      "value": "15",
+      "value": "12",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "25"
+        "text": "23"
       },
       {
         "label": "B",
-        "text": "28"
+        "text": "12"
+      },
+      {
+        "label": "C",
+        "text": "33"
+      },
+      {
+        "label": "D",
+        "text": "10"
+      },
+      {
+        "label": "E",
+        "text": "17"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-two-way-tables"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "c3fd14232b04b911622dafcbc6eef8990ecd626eabbead438a6d5ffac29d6a2b",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-two-way-tables-c41f020a6e",
+    "skillId": "act-two-way-tables",
+    "prompt": "In a survey, 12 boys and 11 girls chose pizza; 12 boys and 7 girls chose tacos. How many boys were surveyed in total?",
+    "answer": {
+      "type": "auto",
+      "value": "12",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "12"
+      },
+      {
+        "label": "B",
+        "text": "18"
       },
       {
         "label": "C",
@@ -8670,14 +8667,14 @@
       },
       {
         "label": "D",
-        "text": "15"
+        "text": "24"
       },
       {
         "label": "E",
-        "text": "17"
+        "text": "23"
       }
     ],
-    "correctOption": "D",
+    "correctOption": "A",
     "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
@@ -8686,7 +8683,227 @@
       "act-two-way-tables"
     ],
     "source": "act-template-gen",
-    "contentHash": "1c03aaace11d20e0687e778d636c0a48be1223db64e109440f614b35cc19d3bb",
+    "contentHash": "c41f020a6ebcf467cdd3fb18340b166f356a31c10a0698feea5bd95ae6655c47",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-probability-080a1d414f",
+    "skillId": "act-probability",
+    "prompt": "A bag has 3 red, 5 green, and 6 blue marbles. What is the probability of drawing a red marble?",
+    "answer": {
+      "type": "auto",
+      "value": "3/14",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "3/5"
+      },
+      {
+        "label": "B",
+        "text": "5/14"
+      },
+      {
+        "label": "C",
+        "text": "3/14"
+      },
+      {
+        "label": "D",
+        "text": "3/11"
+      },
+      {
+        "label": "E",
+        "text": "14/3"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-probability"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "080a1d414fb482a6fdff4934bbbff20c8fa5cb2abae41631433664622d9e4523",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-probability-b31ae01916",
+    "skillId": "act-probability",
+    "prompt": "A bag has 2 red, 4 green, and 5 blue marbles. What is the probability of drawing a red marble?",
+    "answer": {
+      "type": "auto",
+      "value": "2/11",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "11/2"
+      },
+      {
+        "label": "B",
+        "text": "2/11"
+      },
+      {
+        "label": "C",
+        "text": "2/4"
+      },
+      {
+        "label": "D",
+        "text": "4/11"
+      },
+      {
+        "label": "E",
+        "text": "2/9"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-probability"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "b31ae0191652dc3f08da11ed8e877509fe9749880655e3267928a0a979bfd77c",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-probability-58430fd45d",
+    "skillId": "act-probability",
+    "prompt": "A bag has 5 red, 6 green, and 5 blue marbles. What is the probability of drawing a red marble?",
+    "answer": {
+      "type": "auto",
+      "value": "5/16",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "5/16"
+      },
+      {
+        "label": "B",
+        "text": "3/8"
+      },
+      {
+        "label": "C",
+        "text": "16/5"
+      },
+      {
+        "label": "D",
+        "text": "5/6"
+      },
+      {
+        "label": "E",
+        "text": "5/11"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-probability"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "58430fd45de5c6dde60a8c9574625270902ef24a423eb06bbe2cd8dc208c16b2",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-probability-b97c85ac31",
+    "skillId": "act-probability",
+    "prompt": "A bag has 3 red, 2 green, and 2 blue marbles. What is the probability of drawing a red marble?",
+    "answer": {
+      "type": "auto",
+      "value": "3/7",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "3/2"
+      },
+      {
+        "label": "B",
+        "text": "3/7"
+      },
+      {
+        "label": "C",
+        "text": "3/4"
+      },
+      {
+        "label": "D",
+        "text": "7/3"
+      },
+      {
+        "label": "E",
+        "text": "2/7"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-probability"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "b97c85ac3154452fdc9a80394681fcfb4e4cda8565f9e651da57dd450b53726c",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-probability-ec8c70f987",
+    "skillId": "act-probability",
+    "prompt": "A bag has 5 red, 2 green, and 2 blue marbles. What is the probability of drawing a red marble?",
+    "answer": {
+      "type": "auto",
+      "value": "5/9",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "5/4"
+      },
+      {
+        "label": "B",
+        "text": "5/2"
+      },
+      {
+        "label": "C",
+        "text": "9/5"
+      },
+      {
+        "label": "D",
+        "text": "5/9"
+      },
+      {
+        "label": "E",
+        "text": "2/9"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-probability"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "ec8c70f98786038e1f49ba6841eff3efaf3dc040a8e2c645b5fca8dedf1040e9",
     "isActive": true
   },
   {
@@ -8722,7 +8939,7 @@
       }
     ],
     "correctOption": "D",
-    "difficulty": 2,
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -8766,7 +8983,7 @@
       }
     ],
     "correctOption": "A",
-    "difficulty": 2,
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -8810,7 +9027,7 @@
       }
     ],
     "correctOption": "A",
-    "difficulty": 3,
+    "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -8822,79 +9039,123 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-probability-29ffcfd52e",
-    "skillId": "act-probability",
-    "prompt": "A bag has 2 red, 5 green, and 2 blue marbles. What is the probability of drawing a red marble?",
+    "problemId": "act-act-counting-techniques-34bea27ddc",
+    "skillId": "act-counting-techniques",
+    "prompt": "A meal has 4 appetizers, 4 entrées, and 2 desserts. How many different 3-course meals are possible?",
     "answer": {
       "type": "auto",
-      "value": "2/9",
+      "value": "32",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "2/7"
+        "text": "36"
       },
       {
         "label": "B",
-        "text": "5/9"
+        "text": "16"
       },
       {
         "label": "C",
-        "text": "2/9"
+        "text": "32"
       },
       {
         "label": "D",
-        "text": "2/5"
+        "text": "18"
       },
       {
         "label": "E",
-        "text": "9/2"
+        "text": "10"
       }
     ],
     "correctOption": "C",
-    "difficulty": 3,
+    "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-probability"
+      "act-counting-techniques"
     ],
     "source": "act-template-gen",
-    "contentHash": "29ffcfd52ebe19cdb6bd5b2bd7eb0317f708b2417d30da73f49a934ccf6cb42c",
+    "contentHash": "34bea27ddc7a660c6e6fa54367eb86c1c4c15be500c8a8cd700f8a4ea0e0710f",
     "isActive": true
   },
   {
-    "problemId": "act-act-probability-beaed2e736",
-    "skillId": "act-probability",
-    "prompt": "A bag has 5 red, 2 green, and 6 blue marbles. What is the probability of drawing a red marble?",
+    "problemId": "act-act-counting-techniques-f30b48bed9",
+    "skillId": "act-counting-techniques",
+    "prompt": "A meal has 2 appetizers, 3 entrées, and 4 desserts. How many different 3-course meals are possible?",
     "answer": {
       "type": "auto",
-      "value": "5/13",
+      "value": "24",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "5/2"
+        "text": "26"
       },
       {
         "label": "B",
-        "text": "2/13"
+        "text": "10"
       },
       {
         "label": "C",
-        "text": "13/5"
+        "text": "24"
       },
       {
         "label": "D",
-        "text": "5/8"
+        "text": "12"
       },
       {
         "label": "E",
-        "text": "5/13"
+        "text": "9"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-counting-techniques"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "f30b48bed9f1ffacfc1afafaaea3f99068f4b4d9e624565cdeff25a3377b5536",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-counting-techniques-73368d60e1",
+    "skillId": "act-counting-techniques",
+    "prompt": "A meal has 4 appetizers, 2 entrées, and 3 desserts. How many different 3-course meals are possible?",
+    "answer": {
+      "type": "auto",
+      "value": "24",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "12"
+      },
+      {
+        "label": "B",
+        "text": "11"
+      },
+      {
+        "label": "C",
+        "text": "9"
+      },
+      {
+        "label": "D",
+        "text": "28"
+      },
+      {
+        "label": "E",
+        "text": "24"
       }
     ],
     "correctOption": "E",
@@ -8903,142 +9164,98 @@
     "tags": [
       "act",
       "act-math",
-      "act-probability"
+      "act-counting-techniques"
     ],
     "source": "act-template-gen",
-    "contentHash": "beaed2e736abd3305d5e412352387936fdd31256a01724ec47a0f0d6c27eb7fe",
+    "contentHash": "73368d60e1fbaab72440f650f1aa9c07097f0f6af42f2fbe37843717b323fc8f",
     "isActive": true
   },
   {
-    "problemId": "act-act-probability-d0b0dfcbb8",
-    "skillId": "act-probability",
-    "prompt": "A bag has 4 red, 2 green, and 3 blue marbles. What is the probability of drawing a red marble?",
+    "problemId": "act-act-counting-techniques-40c5516e4a",
+    "skillId": "act-counting-techniques",
+    "prompt": "A meal has 2 appetizers, 3 entrées, and 2 desserts. How many different 3-course meals are possible?",
     "answer": {
       "type": "auto",
-      "value": "4/9",
+      "value": "12",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "2/9"
+        "text": "6"
       },
       {
         "label": "B",
-        "text": "4/2"
+        "text": "8"
       },
       {
         "label": "C",
-        "text": "4/5"
+        "text": "7"
       },
       {
         "label": "D",
-        "text": "9/4"
+        "text": "14"
       },
       {
         "label": "E",
-        "text": "4/9"
+        "text": "12"
       }
     ],
     "correctOption": "E",
-    "difficulty": 4,
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-probability"
+      "act-counting-techniques"
     ],
     "source": "act-template-gen",
-    "contentHash": "d0b0dfcbb8cd6b71a35befe64b1accd93fa0cb9c3e27b52cebf989a71150071e",
+    "contentHash": "40c5516e4ad49db65fba65e6ccc29e2237627857cb1c734a7bf84f357e3f5f26",
     "isActive": true
   },
   {
-    "problemId": "act-act-probability-c9d99d23bb",
-    "skillId": "act-probability",
-    "prompt": "A bag has 2 red, 3 green, and 2 blue marbles. What is the probability of drawing a red marble?",
+    "problemId": "act-act-counting-techniques-1a0fd51d29",
+    "skillId": "act-counting-techniques",
+    "prompt": "A meal has 3 appetizers, 5 entrées, and 4 desserts. How many different 3-course meals are possible?",
     "answer": {
       "type": "auto",
-      "value": "2/7",
+      "value": "60",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "3/7"
+        "text": "60"
       },
       {
         "label": "B",
-        "text": "2/3"
+        "text": "19"
       },
       {
         "label": "C",
-        "text": "2/5"
+        "text": "30"
       },
       {
         "label": "D",
-        "text": "7/2"
+        "text": "12"
       },
       {
         "label": "E",
-        "text": "2/7"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-probability"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "c9d99d23bbc0787a0d90b95b3401a21600cd5b937c6b3e7874b670413a5fd6e0",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-probability-fdd9cdcc4e",
-    "skillId": "act-probability",
-    "prompt": "A bag has 4 red, 6 green, and 5 blue marbles. What is the probability of drawing a red marble?",
-    "answer": {
-      "type": "auto",
-      "value": "4/15",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "4/15"
-      },
-      {
-        "label": "B",
-        "text": "4/6"
-      },
-      {
-        "label": "C",
-        "text": "2/5"
-      },
-      {
-        "label": "D",
-        "text": "4/11"
-      },
-      {
-        "label": "E",
-        "text": "15/4"
+        "text": "63"
       }
     ],
     "correctOption": "A",
-    "difficulty": 5,
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
       "act-math",
-      "act-probability"
+      "act-counting-techniques"
     ],
     "source": "act-template-gen",
-    "contentHash": "fdd9cdcc4ef8c9652790b805e3bb1ce728144f2aee0f28ee032446fedd79421e",
+    "contentHash": "1a0fd51d297d7d52322b0b3b136cd09dd4786c9267a41fad29367a1b0123c712",
     "isActive": true
   },
   {
@@ -9074,7 +9291,7 @@
       }
     ],
     "correctOption": "C",
-    "difficulty": 2,
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -9118,7 +9335,7 @@
       }
     ],
     "correctOption": "A",
-    "difficulty": 2,
+    "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -9162,7 +9379,7 @@
       }
     ],
     "correctOption": "D",
-    "difficulty": 3,
+    "difficulty": 5,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -9174,258 +9391,38 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-counting-techniques-9e225606a1",
-    "skillId": "act-counting-techniques",
-    "prompt": "A meal has 5 appetizers, 5 entrées, and 2 desserts. How many different 3-course meals are possible?",
-    "answer": {
-      "type": "auto",
-      "value": "50",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "50"
-      },
-      {
-        "label": "B",
-        "text": "12"
-      },
-      {
-        "label": "C",
-        "text": "55"
-      },
-      {
-        "label": "D",
-        "text": "27"
-      },
-      {
-        "label": "E",
-        "text": "25"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-counting-techniques"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "9e225606a1f51ff33f0d5529dc0285e23d1f6a4646b38f03c3591d1b57986dbf",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-counting-techniques-dca62d141a",
-    "skillId": "act-counting-techniques",
-    "prompt": "A meal has 4 appetizers, 5 entrées, and 3 desserts. How many different 3-course meals are possible?",
-    "answer": {
-      "type": "auto",
-      "value": "60",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "60"
-      },
-      {
-        "label": "B",
-        "text": "30"
-      },
-      {
-        "label": "C",
-        "text": "12"
-      },
-      {
-        "label": "D",
-        "text": "23"
-      },
-      {
-        "label": "E",
-        "text": "64"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-counting-techniques"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "dca62d141a572d3801d56c4c0b9d38665758cac24bd3ffb78b91fc54cba84fcf",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-counting-techniques-a1500c2f4f",
-    "skillId": "act-counting-techniques",
-    "prompt": "A meal has 5 appetizers, 3 entrées, and 4 desserts. How many different 3-course meals are possible?",
-    "answer": {
-      "type": "auto",
-      "value": "60",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "60"
-      },
-      {
-        "label": "B",
-        "text": "19"
-      },
-      {
-        "label": "C",
-        "text": "65"
-      },
-      {
-        "label": "D",
-        "text": "30"
-      },
-      {
-        "label": "E",
-        "text": "12"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-counting-techniques"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "a1500c2f4f982f9b687dd8badbd050a997e25bf712e92629325e07e2dffc210d",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-counting-techniques-93ba14d05a",
-    "skillId": "act-counting-techniques",
-    "prompt": "A meal has 5 appetizers, 4 entrées, and 2 desserts. How many different 3-course meals are possible?",
-    "answer": {
-      "type": "auto",
-      "value": "40",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "40"
-      },
-      {
-        "label": "B",
-        "text": "22"
-      },
-      {
-        "label": "C",
-        "text": "45"
-      },
-      {
-        "label": "D",
-        "text": "11"
-      },
-      {
-        "label": "E",
-        "text": "20"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-counting-techniques"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "93ba14d05a5f242fad191696c2a0bcca1cc2c3e8716e6b514a7100dd17c9e1d1",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-counting-techniques-12eb7705aa",
-    "skillId": "act-counting-techniques",
-    "prompt": "A meal has 4 appetizers, 3 entrées, and 2 desserts. How many different 3-course meals are possible?",
-    "answer": {
-      "type": "auto",
-      "value": "24",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "28"
-      },
-      {
-        "label": "B",
-        "text": "12"
-      },
-      {
-        "label": "C",
-        "text": "24"
-      },
-      {
-        "label": "D",
-        "text": "9"
-      },
-      {
-        "label": "E",
-        "text": "14"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 5,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-counting-techniques"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "12eb7705aa4d1d1e4dd8cd155081121998e7f910cab08c12bed2497275df5ac8",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-real-complex-numbers-f30d40c6da",
+    "problemId": "act-act-real-complex-numbers-07f722d6e4",
     "skillId": "act-real-complex-numbers",
-    "prompt": "(-4 + 6i) + (-3 + 1i) = ?",
+    "prompt": "(7 + 8i) + (-5 + 7i) = ?",
     "answer": {
       "type": "auto",
-      "value": "-7+7i",
+      "value": "2+15i",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "-1+7i"
+        "text": "2+15i"
       },
       {
         "label": "B",
-        "text": "12+6i"
+        "text": "-35+56i"
       },
       {
         "label": "C",
-        "text": "-7+7i"
+        "text": "2+1i"
       },
       {
         "label": "D",
-        "text": "7-7i"
+        "text": "15+2i"
       },
       {
         "label": "E",
-        "text": "-7+5i"
+        "text": "12+15i"
       }
     ],
-    "correctOption": "C",
+    "correctOption": "A",
     "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
@@ -9434,42 +9431,42 @@
       "act-real-complex-numbers"
     ],
     "source": "act-template-gen",
-    "contentHash": "f30d40c6da55b1a3cc5c66c46343dceb33a7ede7a48c6ca98d64595694459820",
+    "contentHash": "07f722d6e42c6f95b501956dcedb661f1cdbb40ecce89c0195491714ed6ffbf7",
     "isActive": true
   },
   {
-    "problemId": "act-act-real-complex-numbers-357d486696",
+    "problemId": "act-act-real-complex-numbers-7337417079",
     "skillId": "act-real-complex-numbers",
-    "prompt": "(6 + 1i) + (-3 + 8i) = ?",
+    "prompt": "(8 + 5i) + (2 + 2i) = ?",
     "answer": {
       "type": "auto",
-      "value": "3+9i",
+      "value": "10+7i",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "3-7i"
+        "text": "16+10i"
       },
       {
         "label": "B",
-        "text": "-18+8i"
+        "text": "10+3i"
       },
       {
         "label": "C",
-        "text": "3+9i"
+        "text": "6+7i"
       },
       {
         "label": "D",
-        "text": "9+3i"
+        "text": "10+7i"
       },
       {
         "label": "E",
-        "text": "9+9i"
+        "text": "7+10i"
       }
     ],
-    "correctOption": "C",
+    "correctOption": "D",
     "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
@@ -9478,39 +9475,127 @@
       "act-real-complex-numbers"
     ],
     "source": "act-template-gen",
-    "contentHash": "357d4866961331ffc45866ad39069b4f18b24451872d89f6b083dfcdd0dae906",
+    "contentHash": "7337417079b6ee38558c09dece854a467b21bd3d450ed05f5777cc4f204f97ac",
     "isActive": true
   },
   {
-    "problemId": "act-act-real-complex-numbers-c7b6546076",
+    "problemId": "act-act-real-complex-numbers-c2c609fe81",
     "skillId": "act-real-complex-numbers",
-    "prompt": "(-3 + 7i) + (-4 - 4i) = ?",
+    "prompt": "(-6 - 4i) + (-6 + 8i) = ?",
     "answer": {
       "type": "auto",
-      "value": "-7+3i",
+      "value": "-12+4i",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "1+3i"
+        "text": "0+4i"
       },
       {
         "label": "B",
-        "text": "3-7i"
+        "text": "-12+4i"
       },
       {
         "label": "C",
-        "text": "-7+11i"
+        "text": "36-32i"
       },
       {
         "label": "D",
-        "text": "12-28i"
+        "text": "4-12i"
       },
       {
         "label": "E",
-        "text": "-7+3i"
+        "text": "-12-12i"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-real-complex-numbers"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "c2c609fe817fb54ca7a780244887a20161b52a6ffe1ddab899305e4ac1f00a20",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-real-complex-numbers-5e94b71d6d",
+    "skillId": "act-real-complex-numbers",
+    "prompt": "(-3 + 7i) + (-3 + 3i) = ?",
+    "answer": {
+      "type": "auto",
+      "value": "-6+10i",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "9+21i"
+      },
+      {
+        "label": "B",
+        "text": "10-6i"
+      },
+      {
+        "label": "C",
+        "text": "-6+10i"
+      },
+      {
+        "label": "D",
+        "text": "-6+4i"
+      },
+      {
+        "label": "E",
+        "text": "0+10i"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-real-complex-numbers"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "5e94b71d6d8b4cf1af82845d76fdf0568a17a94a2ff4ac147db044061bf27a56",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-real-complex-numbers-c1c802fba5",
+    "skillId": "act-real-complex-numbers",
+    "prompt": "(1 - 1i) + (-2 - 1i) = ?",
+    "answer": {
+      "type": "auto",
+      "value": "-1-2i",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "-2+1i"
+      },
+      {
+        "label": "B",
+        "text": "-1+0i"
+      },
+      {
+        "label": "C",
+        "text": "-2-1i"
+      },
+      {
+        "label": "D",
+        "text": "3-2i"
+      },
+      {
+        "label": "E",
+        "text": "-1-2i"
       }
     ],
     "correctOption": "E",
@@ -9522,127 +9607,39 @@
       "act-real-complex-numbers"
     ],
     "source": "act-template-gen",
-    "contentHash": "c7b6546076f7d113f79bc85fadc482a5dc4044c5e528aae8d11eac62e42f3203",
+    "contentHash": "c1c802fba56471965674cba8dca58fd478d7e7ca8da23e2be839cbb0bee2231f",
     "isActive": true
   },
   {
-    "problemId": "act-act-real-complex-numbers-f424f860ad",
+    "problemId": "act-act-real-complex-numbers-4f650878c4",
     "skillId": "act-real-complex-numbers",
-    "prompt": "(4 + 7i) + (1 + 7i) = ?",
+    "prompt": "(2 + 2i) + (-3 + 6i) = ?",
     "answer": {
       "type": "auto",
-      "value": "5+14i",
+      "value": "-1+8i",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "5+14i"
+        "text": "5+8i"
       },
       {
         "label": "B",
-        "text": "14+5i"
+        "text": "-6+12i"
       },
       {
         "label": "C",
-        "text": "5+0i"
+        "text": "-1+8i"
       },
       {
         "label": "D",
-        "text": "4+49i"
+        "text": "-1-4i"
       },
       {
         "label": "E",
-        "text": "3+14i"
-      }
-    ],
-    "correctOption": "A",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-real-complex-numbers"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "f424f860ad3164f31221127c96e84122cee4b90f6429534cb5d37b4326ae22ed",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-real-complex-numbers-e73e7c6120",
-    "skillId": "act-real-complex-numbers",
-    "prompt": "(3 + 6i) + (7 - 3i) = ?",
-    "answer": {
-      "type": "auto",
-      "value": "10+3i",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "21-18i"
-      },
-      {
-        "label": "B",
-        "text": "10+9i"
-      },
-      {
-        "label": "C",
-        "text": "-4+3i"
-      },
-      {
-        "label": "D",
-        "text": "10+3i"
-      },
-      {
-        "label": "E",
-        "text": "3+10i"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-real-complex-numbers"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "e73e7c61200dea41396518a912f491074d3a2d8c1c1f23aec5f79d4813e2894e",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-real-complex-numbers-df8162146d",
-    "skillId": "act-real-complex-numbers",
-    "prompt": "(2 - 5i) + (1 - 2i) = ?",
-    "answer": {
-      "type": "auto",
-      "value": "3-7i",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "1-7i"
-      },
-      {
-        "label": "B",
-        "text": "3-3i"
-      },
-      {
-        "label": "C",
-        "text": "3-7i"
-      },
-      {
-        "label": "D",
-        "text": "-7+3i"
-      },
-      {
-        "label": "E",
-        "text": "2+10i"
+        "text": "8-1i"
       }
     ],
     "correctOption": "C",
@@ -9654,42 +9651,42 @@
       "act-real-complex-numbers"
     ],
     "source": "act-template-gen",
-    "contentHash": "df8162146d57cd32c017ea72c4a39291cfdefc5cb3115401932c7de4d0fcddce",
+    "contentHash": "4f650878c49ce23f48bbdca22ad3acc112b89579274e788afe2a987fd74dee1a",
     "isActive": true
   },
   {
-    "problemId": "act-act-real-complex-numbers-53df24e9af",
+    "problemId": "act-act-real-complex-numbers-3b2418be1d",
     "skillId": "act-real-complex-numbers",
-    "prompt": "(-5 - 6i) + (-3 - 5i) = ?",
+    "prompt": "(4 + 8i) + (-6 + 6i) = ?",
     "answer": {
       "type": "auto",
-      "value": "-8-11i",
+      "value": "-2+14i",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "-11-8i"
+        "text": "14-2i"
       },
       {
         "label": "B",
-        "text": "-8-11i"
+        "text": "-2+2i"
       },
       {
         "label": "C",
-        "text": "-2-11i"
+        "text": "-2+14i"
       },
       {
         "label": "D",
-        "text": "-8-1i"
+        "text": "10+14i"
       },
       {
         "label": "E",
-        "text": "15+30i"
+        "text": "-24+48i"
       }
     ],
-    "correctOption": "B",
+    "correctOption": "C",
     "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
@@ -9698,39 +9695,39 @@
       "act-real-complex-numbers"
     ],
     "source": "act-template-gen",
-    "contentHash": "53df24e9af1813c7fb9b8cfe1f82ff422c0b2b60e4ccb0502cdc0b1fc9e76d7f",
+    "contentHash": "3b2418be1d8ba0aa284e9bb13ba5650f698e45f8d5db3f0eca63260c19cf4ba8",
     "isActive": true
   },
   {
-    "problemId": "act-act-real-complex-numbers-7f1b4ec716",
+    "problemId": "act-act-real-complex-numbers-aefd19d5d8",
     "skillId": "act-real-complex-numbers",
-    "prompt": "(5 + 7i) + (3 - 5i) = ?",
+    "prompt": "(-5 - 1i) + (5 - 5i) = ?",
     "answer": {
       "type": "auto",
-      "value": "8+2i",
+      "value": "0-6i",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "8+2i"
+        "text": "0-6i"
       },
       {
         "label": "B",
-        "text": "2+2i"
+        "text": "0+4i"
       },
       {
         "label": "C",
-        "text": "2+8i"
+        "text": "-25+5i"
       },
       {
         "label": "D",
-        "text": "15-35i"
+        "text": "-6+0i"
       },
       {
         "label": "E",
-        "text": "8+12i"
+        "text": "-10-6i"
       }
     ],
     "correctOption": "A",
@@ -9742,7 +9739,7 @@
       "act-real-complex-numbers"
     ],
     "source": "act-template-gen",
-    "contentHash": "7f1b4ec7160318ccbb678b461d01bf52357b3ff659810ea4957e30b0c897c7d2",
+    "contentHash": "aefd19d5d8b051846acc07dd8227c23003e22db73e068717edb82a0759047272",
     "isActive": true
   },
   {
@@ -9758,26 +9755,26 @@
     "options": [
       {
         "label": "A",
-        "text": "35"
-      },
-      {
-        "label": "B",
         "text": "78125"
       },
       {
-        "label": "C",
+        "label": "B",
         "text": "244140625"
       },
       {
+        "label": "C",
+        "text": "35"
+      },
+      {
         "label": "D",
-        "text": "5"
+        "text": "390625"
       },
       {
         "label": "E",
-        "text": "390625"
+        "text": "5"
       }
     ],
-    "correctOption": "B",
+    "correctOption": "A",
     "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
@@ -9790,38 +9787,38 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-exponents-roots-2a8677f3cc",
+    "problemId": "act-act-exponents-roots-956c2c0d5c",
     "skillId": "act-exponents-roots",
-    "prompt": "The expression 3^4 · 3^2 is equal to:",
+    "prompt": "The expression 2^4 · 2^2 is equal to:",
     "answer": {
       "type": "auto",
-      "value": "729",
+      "value": "64",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "9"
+        "text": "128"
       },
       {
         "label": "B",
-        "text": "729"
+        "text": "12"
       },
       {
         "label": "C",
-        "text": "18"
+        "text": "4"
       },
       {
         "label": "D",
-        "text": "2187"
+        "text": "64"
       },
       {
         "label": "E",
-        "text": "6561"
+        "text": "256"
       }
     ],
-    "correctOption": "B",
+    "correctOption": "D",
     "difficulty": 2,
     "gradeBand": "8-12",
     "tags": [
@@ -9830,95 +9827,7 @@
       "act-exponents-roots"
     ],
     "source": "act-template-gen",
-    "contentHash": "2a8677f3cc6f8ca9a341f0c503a04f93fed7f93fc4ba8159b5931ca890ce3380",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-exponents-roots-6643fed0b6",
-    "skillId": "act-exponents-roots",
-    "prompt": "The expression 5^2 · 5^4 is equal to:",
-    "answer": {
-      "type": "auto",
-      "value": "15625",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "30"
-      },
-      {
-        "label": "B",
-        "text": "390625"
-      },
-      {
-        "label": "C",
-        "text": "15625"
-      },
-      {
-        "label": "D",
-        "text": "25"
-      },
-      {
-        "label": "E",
-        "text": "78125"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-exponents-roots"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "6643fed0b62fbf6a8ba7f04192959725b8e13b3610da167d726af534f0fdde4f",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-exponents-roots-ac46a25288",
-    "skillId": "act-exponents-roots",
-    "prompt": "The expression 3^5 · 3^2 is equal to:",
-    "answer": {
-      "type": "auto",
-      "value": "2187",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "27"
-      },
-      {
-        "label": "B",
-        "text": "21"
-      },
-      {
-        "label": "C",
-        "text": "2187"
-      },
-      {
-        "label": "D",
-        "text": "6561"
-      },
-      {
-        "label": "E",
-        "text": "59049"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-exponents-roots"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "ac46a252887133c6257de84297355e29fe2c00d9e581a3c6e838161f25ae359c",
+    "contentHash": "956c2c0d5c0b5a3d8aee984f8a2f70d5b04c7d51585bfa0f5fbb410f54d43e89",
     "isActive": true
   },
   {
@@ -9934,7 +9843,7 @@
     "options": [
       {
         "label": "A",
-        "text": "15625"
+        "text": "1953125"
       },
       {
         "label": "B",
@@ -9942,18 +9851,18 @@
       },
       {
         "label": "C",
-        "text": "78125"
-      },
-      {
-        "label": "D",
         "text": "30"
       },
       {
+        "label": "D",
+        "text": "15625"
+      },
+      {
         "label": "E",
-        "text": "1953125"
+        "text": "78125"
       }
     ],
-    "correctOption": "A",
+    "correctOption": "D",
     "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
@@ -9966,39 +9875,39 @@
     "isActive": true
   },
   {
-    "problemId": "act-act-exponents-roots-1e28d167cb",
+    "problemId": "act-act-exponents-roots-1ef41456de",
     "skillId": "act-exponents-roots",
-    "prompt": "The expression 2^3 · 2^5 is equal to:",
+    "prompt": "The expression 2^4 · 2^5 is equal to:",
     "answer": {
       "type": "auto",
-      "value": "256",
+      "value": "512",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "32768"
+        "text": "512"
       },
       {
         "label": "B",
-        "text": "4"
+        "text": "18"
       },
       {
         "label": "C",
-        "text": "256"
+        "text": "1048576"
       },
       {
         "label": "D",
-        "text": "16"
+        "text": "2"
       },
       {
         "label": "E",
-        "text": "512"
+        "text": "1024"
       }
     ],
-    "correctOption": "C",
-    "difficulty": 4,
+    "correctOption": "A",
+    "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
       "act",
@@ -10006,39 +9915,83 @@
       "act-exponents-roots"
     ],
     "source": "act-template-gen",
-    "contentHash": "1e28d167cb59351b0979d4207d957cc1059b71ec47d5ee5be8c17f4b2f883bf3",
+    "contentHash": "1ef41456de1d2dd5d8458ce4cf0b51661a3e56763b5d725a6c2db220af9b93c7",
     "isActive": true
   },
   {
-    "problemId": "act-act-exponents-roots-65124a2990",
+    "problemId": "act-act-exponents-roots-ff41723e1b",
     "skillId": "act-exponents-roots",
-    "prompt": "The expression 10^6 · 10^2 is equal to:",
+    "prompt": "The expression 5^3 · 5^5 is equal to:",
     "answer": {
       "type": "auto",
-      "value": "100000000",
+      "value": "390625",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "80"
+        "text": "390625"
       },
       {
         "label": "B",
-        "text": "10000"
+        "text": "25"
       },
       {
         "label": "C",
-        "text": "1000000000000"
+        "text": "30517578125"
       },
       {
         "label": "D",
-        "text": "1000000000"
+        "text": "1953125"
       },
       {
         "label": "E",
-        "text": "100000000"
+        "text": "40"
+      }
+    ],
+    "correctOption": "A",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-exponents-roots"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "ff41723e1b2a49899e178284c67c505f3f72fa9a3bd5e634a0723be847a5ef6b",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-exponents-roots-aecd1b3d9d",
+    "skillId": "act-exponents-roots",
+    "prompt": "The expression 5^5 · 5^5 is equal to:",
+    "answer": {
+      "type": "auto",
+      "value": "9765625",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "50"
+      },
+      {
+        "label": "B",
+        "text": "1"
+      },
+      {
+        "label": "C",
+        "text": "48828125"
+      },
+      {
+        "label": "D",
+        "text": "298023223876953150"
+      },
+      {
+        "label": "E",
+        "text": "9765625"
       }
     ],
     "correctOption": "E",
@@ -10050,13 +10003,277 @@
       "act-exponents-roots"
     ],
     "source": "act-template-gen",
-    "contentHash": "65124a29902886d87ec40296757972b522a36b3911dddd4ca93ea513a4023ce0",
+    "contentHash": "aecd1b3d9d42b51e8b099a98ae99f83ee07f3238915a0f68e82d442ab4ee5b29",
     "isActive": true
   },
   {
-    "problemId": "act-act-exponents-roots-0ed6621a1c",
+    "problemId": "act-act-exponents-roots-ad88be80fc",
     "skillId": "act-exponents-roots",
-    "prompt": "The expression 2^2 · 2^4 is equal to:",
+    "prompt": "The expression 2^5 · 2^5 is equal to:",
+    "answer": {
+      "type": "auto",
+      "value": "1024",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "20"
+      },
+      {
+        "label": "B",
+        "text": "33554432"
+      },
+      {
+        "label": "C",
+        "text": "1"
+      },
+      {
+        "label": "D",
+        "text": "2048"
+      },
+      {
+        "label": "E",
+        "text": "1024"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-exponents-roots"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "ad88be80fcdf783fc5d36105af255fbe6dfd3256fd1664080f34bd88aa67b390",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-exponents-roots-96fa05e065",
+    "skillId": "act-exponents-roots",
+    "prompt": "The expression 5^5 · 5^3 is equal to:",
+    "answer": {
+      "type": "auto",
+      "value": "390625",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "40"
+      },
+      {
+        "label": "B",
+        "text": "390625"
+      },
+      {
+        "label": "C",
+        "text": "25"
+      },
+      {
+        "label": "D",
+        "text": "30517578125"
+      },
+      {
+        "label": "E",
+        "text": "1953125"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-exponents-roots"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "96fa05e065c91a43972b91ed65889e2f9fa2ef6d24f70982446ac4af16565210",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-ratios-proportions-percents-238abe121e",
+    "skillId": "act-ratios-proportions-percents",
+    "prompt": "What is 20% of 100?",
+    "answer": {
+      "type": "auto",
+      "value": "20",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "10"
+      },
+      {
+        "label": "B",
+        "text": "2"
+      },
+      {
+        "label": "C",
+        "text": "40"
+      },
+      {
+        "label": "D",
+        "text": "80"
+      },
+      {
+        "label": "E",
+        "text": "20"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-ratios-proportions-percents"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "238abe121ed22119f4c1a4adc61e137fc874b870050a50feda3771c9a0d67da5",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-ratios-proportions-percents-283d43137c",
+    "skillId": "act-ratios-proportions-percents",
+    "prompt": "What is 25% of 60?",
+    "answer": {
+      "type": "auto",
+      "value": "15",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "45"
+      },
+      {
+        "label": "B",
+        "text": "15"
+      },
+      {
+        "label": "C",
+        "text": "1.5"
+      },
+      {
+        "label": "D",
+        "text": "7.5"
+      },
+      {
+        "label": "E",
+        "text": "30"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-ratios-proportions-percents"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "283d43137c4b9332300da2580c2ee6ea56bf3824fbd74065164578be2f3311bb",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-ratios-proportions-percents-ebd9d82c9a",
+    "skillId": "act-ratios-proportions-percents",
+    "prompt": "What is 20% of 40?",
+    "answer": {
+      "type": "auto",
+      "value": "8",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "4"
+      },
+      {
+        "label": "B",
+        "text": "0.8"
+      },
+      {
+        "label": "C",
+        "text": "32"
+      },
+      {
+        "label": "D",
+        "text": "8"
+      },
+      {
+        "label": "E",
+        "text": "16"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-ratios-proportions-percents"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "ebd9d82c9a3a03327dedcafbb1500c0805b33e55b4b5b3562ea2103054d23c87",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-ratios-proportions-percents-12f38260a7",
+    "skillId": "act-ratios-proportions-percents",
+    "prompt": "What is 75% of 180?",
+    "answer": {
+      "type": "auto",
+      "value": "135",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "67.5"
+      },
+      {
+        "label": "B",
+        "text": "45"
+      },
+      {
+        "label": "C",
+        "text": "270"
+      },
+      {
+        "label": "D",
+        "text": "135"
+      },
+      {
+        "label": "E",
+        "text": "13.5"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-ratios-proportions-percents"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "12f38260a7b5f54909a962c100e19ecd9e40698a6de8d7c922261562a5b3e161",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-ratios-proportions-percents-9bd97b73bb",
+    "skillId": "act-ratios-proportions-percents",
+    "prompt": "What is 40% of 160?",
     "answer": {
       "type": "auto",
       "value": "64",
@@ -10066,319 +10283,11 @@
     "options": [
       {
         "label": "A",
-        "text": "4"
-      },
-      {
-        "label": "B",
-        "text": "12"
-      },
-      {
-        "label": "C",
         "text": "128"
       },
       {
-        "label": "D",
-        "text": "256"
-      },
-      {
-        "label": "E",
-        "text": "64"
-      }
-    ],
-    "correctOption": "E",
-    "difficulty": 5,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-exponents-roots"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "0ed6621a1c552caa6a29536d4a47c93b381b64f02f434e0716d0ab2c56e26811",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-ratios-proportions-percents-8478e77a09",
-    "skillId": "act-ratios-proportions-percents",
-    "prompt": "What is 60% of 160?",
-    "answer": {
-      "type": "auto",
-      "value": "96",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "9.6"
-      },
-      {
         "label": "B",
-        "text": "96"
-      },
-      {
-        "label": "C",
-        "text": "48"
-      },
-      {
-        "label": "D",
-        "text": "64"
-      },
-      {
-        "label": "E",
-        "text": "192"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-ratios-proportions-percents"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "8478e77a09e0b90f1a4e88426029cf986a39aff220933c62ef8e4609a0ad5737",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-ratios-proportions-percents-93d2c997ef",
-    "skillId": "act-ratios-proportions-percents",
-    "prompt": "What is 75% of 80?",
-    "answer": {
-      "type": "auto",
-      "value": "60",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "6"
-      },
-      {
-        "label": "B",
-        "text": "120"
-      },
-      {
-        "label": "C",
-        "text": "60"
-      },
-      {
-        "label": "D",
-        "text": "20"
-      },
-      {
-        "label": "E",
-        "text": "30"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-ratios-proportions-percents"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "93d2c997ef0a7247c47a9687da8d02f1946ca35a5a2fc5e063f1b9917d62fb63",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-ratios-proportions-percents-47c362e254",
-    "skillId": "act-ratios-proportions-percents",
-    "prompt": "What is 60% of 40?",
-    "answer": {
-      "type": "auto",
-      "value": "24",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "16"
-      },
-      {
-        "label": "B",
-        "text": "2.4"
-      },
-      {
-        "label": "C",
-        "text": "24"
-      },
-      {
-        "label": "D",
-        "text": "48"
-      },
-      {
-        "label": "E",
-        "text": "12"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-ratios-proportions-percents"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "47c362e254f365620259c921a48dae11bccf4955bf61f8abf43c403b0162038e",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-ratios-proportions-percents-992a96bd75",
-    "skillId": "act-ratios-proportions-percents",
-    "prompt": "What is 25% of 40?",
-    "answer": {
-      "type": "auto",
-      "value": "10",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "5"
-      },
-      {
-        "label": "B",
-        "text": "10"
-      },
-      {
-        "label": "C",
-        "text": "20"
-      },
-      {
-        "label": "D",
-        "text": "1"
-      },
-      {
-        "label": "E",
-        "text": "30"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-ratios-proportions-percents"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "992a96bd7531a6cc63d9dcb7600a0f918e66723a8a8f757fc80078694b8b5aba",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-ratios-proportions-percents-4ee9634e6c",
-    "skillId": "act-ratios-proportions-percents",
-    "prompt": "What is 60% of 100?",
-    "answer": {
-      "type": "auto",
-      "value": "60",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "6"
-      },
-      {
-        "label": "B",
-        "text": "60"
-      },
-      {
-        "label": "C",
-        "text": "120"
-      },
-      {
-        "label": "D",
-        "text": "30"
-      },
-      {
-        "label": "E",
-        "text": "40"
-      }
-    ],
-    "correctOption": "B",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-ratios-proportions-percents"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "4ee9634e6c08043842010fd610a8b9f525c217563f5cf0ac381ead93183ce233",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-ratios-proportions-percents-93102fe62f",
-    "skillId": "act-ratios-proportions-percents",
-    "prompt": "What is 25% of 120?",
-    "answer": {
-      "type": "auto",
-      "value": "30",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "3"
-      },
-      {
-        "label": "B",
-        "text": "90"
-      },
-      {
-        "label": "C",
-        "text": "30"
-      },
-      {
-        "label": "D",
-        "text": "60"
-      },
-      {
-        "label": "E",
-        "text": "15"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-ratios-proportions-percents"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "93102fe62f2f0b1f634a48b01677b0b510db6655a9d031727dad0e691f5b865c",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-ratios-proportions-percents-bd25abad52",
-    "skillId": "act-ratios-proportions-percents",
-    "prompt": "What is 40% of 40?",
-    "answer": {
-      "type": "auto",
-      "value": "16",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "16"
-      },
-      {
-        "label": "B",
-        "text": "8"
+        "text": "6.4"
       },
       {
         "label": "C",
@@ -10386,190 +10295,322 @@
       },
       {
         "label": "D",
+        "text": "64"
+      },
+      {
+        "label": "E",
+        "text": "96"
+      }
+    ],
+    "correctOption": "D",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-ratios-proportions-percents"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "9bd97b73bb0b0c8086d7784e3c62d020265fe6794f52537240aa86b4905ea821",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-ratios-proportions-percents-f8f59099b6",
+    "skillId": "act-ratios-proportions-percents",
+    "prompt": "What is 10% of 120?",
+    "answer": {
+      "type": "auto",
+      "value": "12",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "1.2"
+      },
+      {
+        "label": "B",
         "text": "24"
       },
       {
+        "label": "C",
+        "text": "6"
+      },
+      {
+        "label": "D",
+        "text": "108"
+      },
+      {
         "label": "E",
-        "text": "1.6"
+        "text": "12"
+      }
+    ],
+    "correctOption": "E",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-ratios-proportions-percents"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "f8f59099b62741b9376c294ecd70541fe06de68e065fdcb79bdf242607f58b9c",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-ratios-proportions-percents-8c4c5469ce",
+    "skillId": "act-ratios-proportions-percents",
+    "prompt": "What is 60% of 180?",
+    "answer": {
+      "type": "auto",
+      "value": "108",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "10.8"
+      },
+      {
+        "label": "B",
+        "text": "108"
+      },
+      {
+        "label": "C",
+        "text": "54"
+      },
+      {
+        "label": "D",
+        "text": "72"
+      },
+      {
+        "label": "E",
+        "text": "216"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 4,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-ratios-proportions-percents"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "8c4c5469cee9b4b2c114a0d2657c7225b04fd1d7033e647bc6051467edcceb1c",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-ratios-proportions-percents-6086307a62",
+    "skillId": "act-ratios-proportions-percents",
+    "prompt": "What is 75% of 100?",
+    "answer": {
+      "type": "auto",
+      "value": "75",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "7.5"
+      },
+      {
+        "label": "B",
+        "text": "150"
+      },
+      {
+        "label": "C",
+        "text": "75"
+      },
+      {
+        "label": "D",
+        "text": "25"
+      },
+      {
+        "label": "E",
+        "text": "37.5"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 5,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-ratios-proportions-percents"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "6086307a62f7bb8a1e39ce26a9818e140ca94e579c9048575ca54c0293981cec",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-matrices-vectors-2bfbb036ad",
+    "skillId": "act-matrices-vectors",
+    "prompt": "5 · [1, 3; 6, 2] = ? (scalar multiple of the 2×2 matrix)",
+    "answer": {
+      "type": "auto",
+      "value": "[5, 15; 30, 10]",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "[5, 3; 6, 10]"
+      },
+      {
+        "label": "B",
+        "text": "[1, 3; 6, 2]"
+      },
+      {
+        "label": "C",
+        "text": "[5, 15; 30, 10]"
+      },
+      {
+        "label": "D",
+        "text": "[5, 15; 6, 2]"
+      },
+      {
+        "label": "E",
+        "text": "[6, 8; 11, 7]"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-matrices-vectors"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "2bfbb036ad95e5846d1c948a7036a5ad32312ebe5f5006989d31f2148789bda4",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-matrices-vectors-7581f9867b",
+    "skillId": "act-matrices-vectors",
+    "prompt": "3 · [4, 2; 5, 3] = ? (scalar multiple of the 2×2 matrix)",
+    "answer": {
+      "type": "auto",
+      "value": "[12, 6; 15, 9]",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "[12, 6; 5, 3]"
+      },
+      {
+        "label": "B",
+        "text": "[12, 6; 15, 9]"
+      },
+      {
+        "label": "C",
+        "text": "[12, 2; 5, 9]"
+      },
+      {
+        "label": "D",
+        "text": "[4, 2; 5, 3]"
+      },
+      {
+        "label": "E",
+        "text": "[7, 5; 8, 6]"
+      }
+    ],
+    "correctOption": "B",
+    "difficulty": 2,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-matrices-vectors"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "7581f9867b99c8137977f9c481ea1f6ae2711333c5b91915750fdb25daf8f589",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-matrices-vectors-5e5d114a81",
+    "skillId": "act-matrices-vectors",
+    "prompt": "3 · [3, 3; 6, 1] = ? (scalar multiple of the 2×2 matrix)",
+    "answer": {
+      "type": "auto",
+      "value": "[9, 9; 18, 3]",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "[9, 9; 6, 1]"
+      },
+      {
+        "label": "B",
+        "text": "[6, 6; 9, 4]"
+      },
+      {
+        "label": "C",
+        "text": "[9, 9; 18, 3]"
+      },
+      {
+        "label": "D",
+        "text": "[3, 3; 6, 1]"
+      },
+      {
+        "label": "E",
+        "text": "[9, 3; 6, 3]"
+      }
+    ],
+    "correctOption": "C",
+    "difficulty": 3,
+    "gradeBand": "8-12",
+    "tags": [
+      "act",
+      "act-math",
+      "act-matrices-vectors"
+    ],
+    "source": "act-template-gen",
+    "contentHash": "5e5d114a81cd93d8d6ee0cc4923bdc51fd27768c791d7d203e318dbe6aebfbdc",
+    "isActive": true
+  },
+  {
+    "problemId": "act-act-matrices-vectors-dcaa0aae95",
+    "skillId": "act-matrices-vectors",
+    "prompt": "2 · [6, 3; 4, 6] = ? (scalar multiple of the 2×2 matrix)",
+    "answer": {
+      "type": "auto",
+      "value": "[12, 6; 8, 12]",
+      "equivalents": []
+    },
+    "answerType": "multiple-choice",
+    "options": [
+      {
+        "label": "A",
+        "text": "[12, 6; 8, 12]"
+      },
+      {
+        "label": "B",
+        "text": "[12, 6; 4, 6]"
+      },
+      {
+        "label": "C",
+        "text": "[12, 3; 4, 12]"
+      },
+      {
+        "label": "D",
+        "text": "[6, 3; 4, 6]"
+      },
+      {
+        "label": "E",
+        "text": "[8, 5; 6, 8]"
       }
     ],
     "correctOption": "A",
-    "difficulty": 4,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-ratios-proportions-percents"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "bd25abad52073c758d86ddc675d14691ed43428cc9b1a74a270f16d69c2eaf8a",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-ratios-proportions-percents-b109002742",
-    "skillId": "act-ratios-proportions-percents",
-    "prompt": "What is 25% of 140?",
-    "answer": {
-      "type": "auto",
-      "value": "35",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "3.5"
-      },
-      {
-        "label": "B",
-        "text": "105"
-      },
-      {
-        "label": "C",
-        "text": "35"
-      },
-      {
-        "label": "D",
-        "text": "17.5"
-      },
-      {
-        "label": "E",
-        "text": "70"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 5,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-ratios-proportions-percents"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "b109002742fe189e05d9f8b4d85921eb8a25a9214d856c01de2416fdf402922e",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-matrices-vectors-be59eace07",
-    "skillId": "act-matrices-vectors",
-    "prompt": "5 · [2, 1; 4, 3] = ? (scalar multiple of the 2×2 matrix)",
-    "answer": {
-      "type": "auto",
-      "value": "[10, 5; 20, 15]",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "[10, 1; 4, 15]"
-      },
-      {
-        "label": "B",
-        "text": "[2, 1; 4, 3]"
-      },
-      {
-        "label": "C",
-        "text": "[10, 5; 20, 15]"
-      },
-      {
-        "label": "D",
-        "text": "[7, 6; 9, 8]"
-      },
-      {
-        "label": "E",
-        "text": "[10, 5; 4, 3]"
-      }
-    ],
-    "correctOption": "C",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-matrices-vectors"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "be59eace0762e6df848918175c04b9b17e989f206dbde2e9102358f8c2e8f8c0",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-matrices-vectors-d46422feaf",
-    "skillId": "act-matrices-vectors",
-    "prompt": "4 · [1, 4; 1, 4] = ? (scalar multiple of the 2×2 matrix)",
-    "answer": {
-      "type": "auto",
-      "value": "[4, 16; 4, 16]",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "[5, 8; 5, 8]"
-      },
-      {
-        "label": "B",
-        "text": "[4, 4; 1, 16]"
-      },
-      {
-        "label": "C",
-        "text": "[1, 4; 1, 4]"
-      },
-      {
-        "label": "D",
-        "text": "[4, 16; 4, 16]"
-      },
-      {
-        "label": "E",
-        "text": "[4, 16; 1, 4]"
-      }
-    ],
-    "correctOption": "D",
-    "difficulty": 2,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-matrices-vectors"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "d46422feaf8044213a33b05be140686bb22ae7c7c07d6611b35153aea8e95415",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-matrices-vectors-5c246c80b3",
-    "skillId": "act-matrices-vectors",
-    "prompt": "6 · [2, 6; 6, 2] = ? (scalar multiple of the 2×2 matrix)",
-    "answer": {
-      "type": "auto",
-      "value": "[12, 36; 36, 12]",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "[8, 12; 12, 8]"
-      },
-      {
-        "label": "B",
-        "text": "[2, 6; 6, 2]"
-      },
-      {
-        "label": "C",
-        "text": "[12, 6; 6, 12]"
-      },
-      {
-        "label": "D",
-        "text": "[12, 36; 36, 12]"
-      },
-      {
-        "label": "E",
-        "text": "[12, 36; 6, 2]"
-      }
-    ],
-    "correctOption": "D",
     "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
@@ -10578,42 +10619,42 @@
       "act-matrices-vectors"
     ],
     "source": "act-template-gen",
-    "contentHash": "5c246c80b3891b0ffb333d988453b643dabc0194f9b21213c27b4411271b6b2e",
+    "contentHash": "dcaa0aae952c375f4b8dac2c6468bed060497f705b898230bf7213c5249c177e",
     "isActive": true
   },
   {
-    "problemId": "act-act-matrices-vectors-98a5ea581a",
+    "problemId": "act-act-matrices-vectors-bbb44e4fa8",
     "skillId": "act-matrices-vectors",
-    "prompt": "4 · [3, 4; 1, 4] = ? (scalar multiple of the 2×2 matrix)",
+    "prompt": "3 · [6, 6; 2, 1] = ? (scalar multiple of the 2×2 matrix)",
     "answer": {
       "type": "auto",
-      "value": "[12, 16; 4, 16]",
+      "value": "[18, 18; 6, 3]",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "[12, 16; 1, 4]"
+        "text": "[18, 6; 2, 3]"
       },
       {
         "label": "B",
-        "text": "[12, 4; 1, 16]"
+        "text": "[18, 18; 6, 3]"
       },
       {
         "label": "C",
-        "text": "[3, 4; 1, 4]"
+        "text": "[18, 18; 2, 1]"
       },
       {
         "label": "D",
-        "text": "[12, 16; 4, 16]"
+        "text": "[9, 9; 5, 4]"
       },
       {
         "label": "E",
-        "text": "[7, 8; 5, 8]"
+        "text": "[6, 6; 2, 1]"
       }
     ],
-    "correctOption": "D",
+    "correctOption": "B",
     "difficulty": 3,
     "gradeBand": "8-12",
     "tags": [
@@ -10622,86 +10663,42 @@
       "act-matrices-vectors"
     ],
     "source": "act-template-gen",
-    "contentHash": "98a5ea581abf0ed93cd7e15fa48d8f73c0cef3810df7b2ce17fa9abb00bcd652",
+    "contentHash": "bbb44e4fa8bb7fcb4168329db6a9a715962dde5529bae3a554dfd1ea94931a68",
     "isActive": true
   },
   {
-    "problemId": "act-act-matrices-vectors-208ce320a3",
+    "problemId": "act-act-matrices-vectors-c750c09bb5",
     "skillId": "act-matrices-vectors",
-    "prompt": "2 · [4, 2; 4, 5] = ? (scalar multiple of the 2×2 matrix)",
+    "prompt": "2 · [2, 5; 1, 4] = ? (scalar multiple of the 2×2 matrix)",
     "answer": {
       "type": "auto",
-      "value": "[8, 4; 8, 10]",
+      "value": "[4, 10; 2, 8]",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "[8, 2; 4, 10]"
+        "text": "[4, 7; 3, 6]"
       },
       {
         "label": "B",
-        "text": "[8, 4; 4, 5]"
+        "text": "[4, 10; 1, 4]"
       },
       {
         "label": "C",
-        "text": "[6, 4; 6, 7]"
+        "text": "[4, 5; 1, 8]"
       },
       {
         "label": "D",
-        "text": "[4, 2; 4, 5]"
+        "text": "[2, 5; 1, 4]"
       },
       {
         "label": "E",
-        "text": "[8, 4; 8, 10]"
+        "text": "[4, 10; 2, 8]"
       }
     ],
     "correctOption": "E",
-    "difficulty": 3,
-    "gradeBand": "8-12",
-    "tags": [
-      "act",
-      "act-math",
-      "act-matrices-vectors"
-    ],
-    "source": "act-template-gen",
-    "contentHash": "208ce320a323c144bb4311b70ef0ae20dbb870470ee1dff259a9078769ce6d85",
-    "isActive": true
-  },
-  {
-    "problemId": "act-act-matrices-vectors-2830c4db86",
-    "skillId": "act-matrices-vectors",
-    "prompt": "4 · [2, 4; 3, 1] = ? (scalar multiple of the 2×2 matrix)",
-    "answer": {
-      "type": "auto",
-      "value": "[8, 16; 12, 4]",
-      "equivalents": []
-    },
-    "answerType": "multiple-choice",
-    "options": [
-      {
-        "label": "A",
-        "text": "[8, 4; 3, 4]"
-      },
-      {
-        "label": "B",
-        "text": "[6, 8; 7, 5]"
-      },
-      {
-        "label": "C",
-        "text": "[8, 16; 12, 4]"
-      },
-      {
-        "label": "D",
-        "text": "[2, 4; 3, 1]"
-      },
-      {
-        "label": "E",
-        "text": "[8, 16; 3, 1]"
-      }
-    ],
-    "correctOption": "C",
     "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
@@ -10710,42 +10707,42 @@
       "act-matrices-vectors"
     ],
     "source": "act-template-gen",
-    "contentHash": "2830c4db863e6f553c2f4d36af426cee499643d20a7832da59ac0df2d81ec038",
+    "contentHash": "c750c09bb5ed02a8a34f41e54c631f3fdaa3a9c6cc2c462026c64b056dee1fd4",
     "isActive": true
   },
   {
-    "problemId": "act-act-matrices-vectors-775f6c80f9",
+    "problemId": "act-act-matrices-vectors-ee0c862c0b",
     "skillId": "act-matrices-vectors",
-    "prompt": "5 · [1, 2; 6, 6] = ? (scalar multiple of the 2×2 matrix)",
+    "prompt": "6 · [1, 6; 2, 6] = ? (scalar multiple of the 2×2 matrix)",
     "answer": {
       "type": "auto",
-      "value": "[5, 10; 30, 30]",
+      "value": "[6, 36; 12, 36]",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "[6, 7; 11, 11]"
+        "text": "[6, 6; 2, 36]"
       },
       {
         "label": "B",
-        "text": "[1, 2; 6, 6]"
+        "text": "[6, 36; 12, 36]"
       },
       {
         "label": "C",
-        "text": "[5, 10; 30, 30]"
+        "text": "[1, 6; 2, 6]"
       },
       {
         "label": "D",
-        "text": "[5, 2; 6, 30]"
+        "text": "[7, 12; 8, 12]"
       },
       {
         "label": "E",
-        "text": "[5, 10; 6, 6]"
+        "text": "[6, 36; 2, 6]"
       }
     ],
-    "correctOption": "C",
+    "correctOption": "B",
     "difficulty": 4,
     "gradeBand": "8-12",
     "tags": [
@@ -10754,39 +10751,39 @@
       "act-matrices-vectors"
     ],
     "source": "act-template-gen",
-    "contentHash": "775f6c80f95fc0ff95128bc969a4e6b2cd19b3d618450bdd3a99c743f05d9a40",
+    "contentHash": "ee0c862c0baf50ceb874e0f530820222fe380ffaaa16ff323c2310aefe6436cc",
     "isActive": true
   },
   {
-    "problemId": "act-act-matrices-vectors-c2ce4134d0",
+    "problemId": "act-act-matrices-vectors-4c0d7b8b50",
     "skillId": "act-matrices-vectors",
-    "prompt": "2 · [5, 1; 3, 2] = ? (scalar multiple of the 2×2 matrix)",
+    "prompt": "2 · [2, 3; 3, 4] = ? (scalar multiple of the 2×2 matrix)",
     "answer": {
       "type": "auto",
-      "value": "[10, 2; 6, 4]",
+      "value": "[4, 6; 6, 8]",
       "equivalents": []
     },
     "answerType": "multiple-choice",
     "options": [
       {
         "label": "A",
-        "text": "[10, 1; 3, 4]"
+        "text": "[4, 5; 5, 6]"
       },
       {
         "label": "B",
-        "text": "[7, 3; 5, 4]"
+        "text": "[4, 3; 3, 8]"
       },
       {
         "label": "C",
-        "text": "[5, 1; 3, 2]"
+        "text": "[4, 6; 3, 4]"
       },
       {
         "label": "D",
-        "text": "[10, 2; 3, 2]"
+        "text": "[2, 3; 3, 4]"
       },
       {
         "label": "E",
-        "text": "[10, 2; 6, 4]"
+        "text": "[4, 6; 6, 8]"
       }
     ],
     "correctOption": "E",
@@ -10798,7 +10795,7 @@
       "act-matrices-vectors"
     ],
     "source": "act-template-gen",
-    "contentHash": "c2ce4134d0f003101b10291a51075adc231c9c0ec83854b8d1fedc55d9ca0ed5",
+    "contentHash": "4c0d7b8b50ebf5944f7d3255b1beb57566360c2b1babcfc12f9fc8dade0f94fd",
     "isActive": true
   }
 ]


### PR DESCRIPTION
Two items from live QA of the ACT practice test.

## 1. Fix — degenerate L-shape figure (correctness)
`act-area-perimeter-composite` allowed the cut square to equal or exceed a side of the rectangle — e.g. *"a square of side 4 cut from a 4-by-6 rectangle."* When the cut equals the short side, the remaining region is actually a **rectangle**, but the generated figure still drew an **L**, so the picture contradicted the numbers. Now the cut is constrained strictly smaller than both dimensions, so the shape is always a real L that matches the figure. Verified: **0 degenerate composites** in the regenerated bank.

## 2. New — "Review with my tutor"
The results screen gets a **📤 Review with my tutor** button. It composes a student-voiced summary (estimated score + the two weakest categories) and drops it into the chat as a real message, so the tutor immediately has context and the student can start closing the gaps.

Verified end-to-end in headless Chromium: clicking it composes the summary, lands it in the contenteditable `#user-input`, and fires send. Example it produced:
> *"I just finished an ACT Math practice test — estimated score 33 (56/60 correct). My weakest areas were Algebra (8/10) and Functions (7/8). Can we start reviewing those, one topic at a time?"*

## Verification
Regenerated bank: 245 items, 0 invalid, fills 60/60.

## To apply after merge
`npm run act:seed` (defaults to `--fresh`) to load the corrected bank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTm55BDVTnGaJm3DRVauGZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTm55BDVTnGaJm3DRVauGZ)_