### PR TITLE
feat(act): exact weak skills, pretest personalization, and no look-alike problems

### DIFF
--- a/public/js/act-test.js
+++ b/public/js/act-test.js
@@ -262,16 +262,24 @@
     // Compose a student-voiced results summary and hand it to the chat tutor so
     // the conversation has context and remediation can start on the weak areas.
     buildTutorMessage(r) {
+      const head = `I just finished an ACT Math practice test — estimated score ${r.scaledScore != null ? r.scaledScore : '?'} (${r.rawScore}/${r.totalItems} correct).`;
+
+      // Prefer EXACT skills (e.g. "Quadratic Equations") over broad categories.
+      const skills = (r.weakSkills || []).slice(0, 5);
+      if (skills.length) {
+        const list = skills.map(s => `${s.name} (missed ${s.missed}/${s.total})`).join(', ');
+        return `${head} The specific skills I missed questions on: ${list}. Can we work through those one at a time, starting with the weakest?`;
+      }
+
+      // Fallback: category level (if the backend didn't send per-skill data).
       const cats = Object.entries(r.byCategory || {})
         .map(([k, v]) => ({ name: CATEGORY_LABELS[k] || k, correct: v.correct, total: v.total, pct: v.total ? v.correct / v.total : 1 }))
-        .sort((a, b) => a.pct - b.pct);
-      const weak = cats.filter(c => c.correct < c.total).slice(0, 2);
-      const head = `I just finished an ACT Math practice test — estimated score ${r.scaledScore != null ? r.scaledScore : '?'} (${r.rawScore}/${r.totalItems} correct).`;
-      if (!weak.length) {
+        .sort((a, b) => a.pct - b.pct)
+        .filter(c => c.correct < c.total).slice(0, 2);
+      if (!cats.length) {
         return `${head} I got everything right — what should I work on to push my score even higher?`;
       }
-      const list = weak.map(c => `${c.name} (${c.correct}/${c.total})`).join(' and ');
-      return `${head} My weakest areas were ${list}. Can we start reviewing those, one topic at a time?`;
+      return `${head} My weakest areas were ${cats.map(c => `${c.name} (${c.correct}/${c.total})`).join(' and ')}. Can we start reviewing those, one topic at a time?`;
     }
 
     sendToTutor(r) {

--- a/public/js/act-test.js
+++ b/public/js/act-test.js
@@ -244,6 +244,7 @@
             <div class="actt-score">${r.scaledScore != null ? r.scaledScore : '—'}</div>
             <div class="actt-scorelab">Estimated ACT Math score${r.scaledApproximate ? ' (approx.)' : ''}</div>
             <div class="actt-sub">${r.rawScore}/${r.totalItems} correct · ${r.accuracy}% · ${r.durationMinutes != null ? r.durationMinutes + ' min' : ''}</div>
+            ${r.plannedSkills ? `<div style="font-size:13px;color:#8b6fd6;margin-top:2px">✓ Your tutor will now focus on your ${r.plannedSkills} weakest skill${r.plannedSkills > 1 ? 's' : ''}.</div>` : ''}
           </div>
           <div style="max-width:520px;margin:0 auto">${cats}</div>
           <div style="text-align:center;margin-top:22px;display:flex;gap:10px;justify-content:center;flex-wrap:wrap">

--- a/routes/actTest.js
+++ b/routes/actTest.js
@@ -21,6 +21,18 @@ const ActTestSession = require('../models/actTestSession');
 const Problem = require('../models/problem');
 const { assembleForm, rawToScaled, getBlueprint } = require('../utils/actTestAssembler');
 
+// skillId → human-readable name, so the report can name EXACT weak skills
+// (e.g. "Quadratic Equations") rather than just the broad category.
+const ACT_SKILL_NAMES = (() => {
+  try {
+    const seed = require('../seeds/skills-act-math-prep.json');
+    const arr = Array.isArray(seed) ? seed : (seed.skills || []);
+    const map = {};
+    for (const s of arr) map[s.skillId] = s.displayName || s.skillId;
+    return map;
+  } catch { return {}; }
+})();
+
 // ── POST /start ─────────────────────────────────────────────
 router.post('/', async (req, res) => {
   return res.status(404).json({ message: 'Use POST /api/act-test/start' });
@@ -183,12 +195,29 @@ router.post('/complete', async (req, res) => {
 
     // Per-category breakdown — the diagnostic signal that drives the boot-camp plan.
     const byCategory = {};
+    const bySkill = {};
     for (const r of session.responses) {
       const c = r.category || 'unknown';
       byCategory[c] = byCategory[c] || { correct: 0, total: 0 };
       byCategory[c].total += 1;
       if (r.correct) byCategory[c].correct += 1;
+
+      const s = r.skillId || 'unknown';
+      bySkill[s] = bySkill[s] || { correct: 0, total: 0 };
+      bySkill[s].total += 1;
+      if (r.correct) bySkill[s].correct += 1;
     }
+
+    // Exact weak skills (by name), worst first — the precise remediation targets.
+    const weakSkills = Object.entries(bySkill)
+      .filter(([, v]) => v.correct < v.total)
+      .map(([skillId, v]) => ({
+        skillId,
+        name: ACT_SKILL_NAMES[skillId] || skillId,
+        missed: v.total - v.correct,
+        total: v.total,
+      }))
+      .sort((a, b) => (b.missed / b.total) - (a.missed / a.total) || b.missed - a.missed);
 
     session.status = 'completed';
     session.completedAt = new Date();
@@ -205,6 +234,7 @@ router.post('/complete', async (req, res) => {
         scaledApproximate: true,
         accuracy: total ? Math.round((raw / total) * 100) : 0,
         byCategory,
+        weakSkills,
         durationMinutes: session.startedAt
           ? Math.round((session.completedAt - session.startedAt) / 60000)
           : null,

--- a/routes/actTest.js
+++ b/routes/actTest.js
@@ -225,6 +225,29 @@ router.post('/complete', async (req, res) => {
     session.scaledScore = scaled ? scaled.scaled : null;
     await session.save();
 
+    // ── Personalize from the pretest ──
+    // Seed the exact weak skills into the student's tutor plan (worst first), so
+    // structured teaching automatically targets THIS student's gaps. Additive
+    // and non-fatal. resolveSkill tolerates act-* skills not yet in the catalog.
+    let plannedSkills = 0;
+    try {
+      const { loadOrCreatePlan, addSkillToFocus } = require('../utils/tutorPlanManager');
+      const plan = await loadOrCreatePlan(req.user._id, { user: req.user });
+      for (const s of weakSkills.slice(0, 8)) {
+        addSkillToFocus(plan, {
+          skillId: s.skillId,
+          displayName: s.name,
+          reason: 'assessment-identified',
+          familiarity: 'developing',                              // seen it, missed it → guided mode
+          priority: Math.min(10, 6 + Math.round((s.missed / s.total) * 3)), // 6–9 by miss rate
+        });
+        plannedSkills += 1;
+      }
+      if (plannedSkills > 0) await plan.save();
+    } catch (planErr) {
+      console.error('[actTest] plan seed error (non-fatal):', planErr.message);
+    }
+
     return res.json({
       success: true,
       report: {
@@ -235,6 +258,7 @@ router.post('/complete', async (req, res) => {
         accuracy: total ? Math.round((raw / total) * 100) : 0,
         byCategory,
         weakSkills,
+        plannedSkills,
         durationMinutes: session.startedAt
           ? Math.round((session.completedAt - session.startedAt) / 60000)
           : null,

--- a/tests/unit/actTestAssembler.test.js
+++ b/tests/unit/actTestAssembler.test.js
@@ -105,3 +105,47 @@ describe('actTestAssembler.difficultyForPosition', () => {
     expect(A.difficultyForPosition(bp, 55)).toBe(4);
   });
 });
+
+describe('actTestAssembler diversity (no look-alike problems in one form)', () => {
+  test('promptSignature blanks numbers so same-wording items collapse', () => {
+    const a = A.promptSignature('A cyclist rides at 5 mph for 3 hours');
+    const b = A.promptSignature('A cyclist rides at 8 mph for 2 hours');
+    expect(a).toBe(b); // same shape, different numbers
+    const c = A.promptSignature('A printer prints at 5 ppm for 3 minutes');
+    expect(c).not.toBe(a); // different shape
+  });
+
+  test('pickDiverse avoids a shape already used in the form', () => {
+    const pool = [
+      { problemId: '1', prompt: 'A cyclist rides at 5 mph for 3 hours' },
+      { problemId: '2', prompt: 'A printer prints at 5 ppm for 3 minutes' },
+    ];
+    const used = new Map([[A.promptSignature(pool[0].prompt), 1]]);
+    expect(A.pickDiverse(pool, used).problemId).toBe('2');
+  });
+
+  test('four draws of one skill spread across four distinct shapes', () => {
+    const pool = [
+      { problemId: '1', prompt: 'A cyclist rides at 5 mph for 3 hours, then 6 for 3' },
+      { problemId: '2', prompt: 'A cyclist rides at 8 mph for 2 hours, then 4 for 3' },
+      { problemId: '3', prompt: 'A delivery van drives at 5 mph for 3 hours, then 6 for 2' },
+      { problemId: '4', prompt: 'A printer prints at 5 ppm for 3 minutes, then 6 for 2' },
+      { problemId: '5', prompt: 'An assembly line produces at 5 uph for 3 hours, then 6 for 2' },
+    ];
+    const used = new Map();
+    const picks = [];
+    for (let i = 0; i < 4; i++) {
+      const avail = pool.filter(p => !picks.includes(p.problemId));
+      const p = A.pickDiverse(avail, used);
+      picks.push(p.problemId);
+      const sig = A.promptSignature(p.prompt);
+      used.set(sig, (used.get(sig) || 0) + 1);
+    }
+    const shapes = new Set(picks.map(id => A.promptSignature(pool.find(p => p.problemId === id).prompt)));
+    expect(shapes.size).toBe(4); // no look-alikes
+  });
+
+  test('pickDiverse returns null on an empty pool', () => {
+    expect(A.pickDiverse([], new Map())).toBeNull();
+  });
+});

--- a/utils/actTestAssembler.js
+++ b/utils/actTestAssembler.js
@@ -107,6 +107,30 @@ function toClientItem(slot, problem) {
   };
 }
 
+/**
+ * A prompt's "shape" — the wording with all numbers blanked — so two problems
+ * that read the same except for their numbers collapse to one signature. Used
+ * to keep a single form from repeating the same-looking question.
+ */
+function promptSignature(s) {
+  return String(s || '').replace(/\d+(\.\d+)?/g, '#').replace(/\s+/g, ' ').trim().slice(0, 90);
+}
+
+/**
+ * From a candidate pool, pick the problem whose shape has appeared LEAST in the
+ * form so far — so repeated draws of the same skill surface different wordings.
+ */
+function pickDiverse(candidates, usedSignatures) {
+  if (!candidates || !candidates.length) return null;
+  let best = candidates[0], bestCount = Infinity;
+  for (const c of candidates) {
+    const count = usedSignatures.get(promptSignature(c.prompt)) || 0;
+    if (count < bestCount) { best = c; bestCount = count; }
+    if (bestCount === 0) break; // an unused shape — take it immediately
+  }
+  return best;
+}
+
 /** A spec the problem generator can fulfill for an unfillable slot. */
 function toGenerationSpec(slot) {
   return {
@@ -137,6 +161,7 @@ async function assembleForm(opts = {}) {
   const Problem = require('../models/problem');
   const slots = buildSlots(blueprint, rng);
   const usedProblemIds = [];
+  const usedSignatures = new Map();   // prompt-shape -> count, to avoid look-alikes
   const items = [];
   const gaps = [];
 
@@ -144,18 +169,31 @@ async function assembleForm(opts = {}) {
     if (!slot.skillId) { gaps.push(toGenerationSpec(slot)); continue; }
     let problem = null;
     try {
-      problem = await Problem.findNearDifficulty(
-        slot.skillId,
-        slot.targetDifficulty,
-        usedProblemIds,
-        { preferMultipleChoice: true }
-      );
+      // Fetch a POOL of candidates near the target difficulty, then pick the
+      // one whose wording-shape is least-used so far — this is what prevents
+      // the same-looking question appearing 3-4 times in one form.
+      const lo = Math.max(1, slot.targetDifficulty - 1);
+      const hi = Math.min(5, slot.targetDifficulty + 1);
+      let candidates = await Problem.find({
+        skillId: slot.skillId,
+        isActive: true,
+        answerType: 'multiple-choice',
+        difficulty: { $gte: lo, $lte: hi },
+        problemId: { $nin: usedProblemIds },
+      }).limit(16).lean();
+      if (!candidates.length) {
+        // Widen: any difficulty for this skill, still excluding used items.
+        const p = await Problem.findNearDifficulty(slot.skillId, slot.targetDifficulty, usedProblemIds, { preferMultipleChoice: true });
+        candidates = p ? [p] : [];
+      }
+      problem = pickDiverse(candidates, usedSignatures);
     } catch (err) {
       // DB/query error — treat as a gap, keep assembling the rest.
       problem = null;
     }
     if (!problem) { gaps.push(toGenerationSpec(slot)); continue; }
     usedProblemIds.push(problem.problemId);
+    usedSignatures.set(promptSignature(problem.prompt), (usedSignatures.get(promptSignature(problem.prompt)) || 0) + 1);
     items.push(toClientItem(slot, problem));
   }
 
@@ -197,5 +235,7 @@ module.exports = {
   skillPool,
   rawToScaled,
   difficultyForPosition,
+  promptSignature,
+  pickDiverse,
   getBlueprint: () => DEFAULT_BLUEPRINT,
 };


### PR DESCRIPTION
ACT practice-test polish, building on the merged test.

## 1. Tutor gets exact weak skills (not just the category)
`/complete` returns `weakSkills` (skillId + human name + missed/total); the "Review with my tutor" message leads with them (e.g. "Quadratic Equations (missed 2/2)").

## 2. Pretest personalizes the tutor plan
On `/complete`, the student's exact weak skills (worst first, up to 8) are seeded into `tutorPlan.skillFocus` (`assessment-identified`, priority by miss rate), so the structured tutor automatically works *that student's* gaps. Results screen shows "Your tutor will now focus on your N weakest skills." Additive + non-fatal; `resolveSkill` tolerates skills not yet in the catalog.

## 3. No look-alike problems in one form
The essential-skills category needs ~16 items from only 5 skills, so each was drawn 3-4× per form — same wording, different numbers. The assembler now fetches a **candidate pool** per slot and picks the one whose **shape** (prompt with numbers blanked) is least-used so far. Four draws of one skill now come out as four visibly different problems. Unit-tested (signature collapsing, shape avoidance, 4-draw spread).

## Verified
Exact-skill message + personalization note confirmed in headless Chromium; diversity logic unit-tested.

## To apply after merge
- `npm run act:seed` — **required** so the bank carries the scenario variety the diversity picker leans on (and to load all the above item fixes).
- `scripts/seed-curriculum.js` once, so `act-*` skills carry full teaching guidance for the personalized plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTm55BDVTnGaJm3DRVauGZ