### PR TITLE
fix(board): re-pose when the TUTOR poses a new problem over a pinned one

### DIFF
--- a/tests/unit/boardSynthesizer.test.js
+++ b/tests/unit/boardSynthesizer.test.js
@@ -255,6 +255,57 @@ describe('boardSynthesizer — full turns', () => {
     expect(pose.tex).toMatch(/4x.*3.*27/);
   });
 
+  // ──────────────────────────────────────────────────────────────
+  // Tutor poses a NEW problem while one is already PINNED (live bug):
+  // board + grader's pinnedProblemTex went stale, so a correct answer to
+  // the new problem was graded against the old one.
+  // ──────────────────────────────────────────────────────────────
+
+  describe('tutor re-poses a new problem over a pinned one', () => {
+    const PIN = 'x^2 - 5x + 6 = 0';
+
+    test('THE FIX: tutor poses harder quadratic with a cue → clear + pose the new one', () => {
+      const cards = synthesizeBoardCommands({
+        studentMessage: '1/2 and -3',
+        tutorResponse: "Alright, un poco más picante this time.\n2x^2 + 5x - 3 = 0\nLeading coefficient isn't 1 anymore, so factoring's trickier. What's your first move?",
+        diagnosis: {}, observation: {},
+        lastBoardAction: 'pose',
+        pinnedProblem: PIN,
+      });
+      const pose = cards.find(c => c.action === 'pose');
+      expect(pose).toBeTruthy();
+      expect(pose.tex).toMatch(/2x.*5x.*3/);
+      expect(cards.some(c => c.action === 'clear')).toBe(true); // replaces the old board
+    });
+
+    test('GUARD: multi-line worked scratch of the CURRENT problem does NOT re-pose', () => {
+      const cards = synthesizeBoardCommands({
+        studentMessage: 'ok',
+        tutorResponse: 'So x^2 - 5x + 6 = 0 becomes\n(x-2)(x-3) = 0\nso x = 2 or x = 3',
+        diagnosis: {}, observation: {}, lastBoardAction: 'pose', pinnedProblem: PIN,
+      });
+      expect(cards.some(c => c.action === 'pose')).toBe(false);
+    });
+
+    test('GUARD: tutor restating the SAME problem (even with a cue) does NOT re-pose', () => {
+      const cards = synthesizeBoardCommands({
+        studentMessage: 'ok',
+        tutorResponse: "Let's try x^2 - 5x + 6 = 0 again. What's the first move?",
+        diagnosis: {}, observation: {}, lastBoardAction: 'pose', pinnedProblem: PIN,
+      });
+      expect(cards.some(c => c.action === 'pose')).toBe(false);
+    });
+
+    test('GUARD: a new equation mentioned WITHOUT a pose cue does NOT re-pose (conservative)', () => {
+      const cards = synthesizeBoardCommands({
+        studentMessage: 'ok',
+        tutorResponse: 'Remember, 2x^2 + 5x - 3 = 0 is also a quadratic.',
+        diagnosis: {}, observation: {}, lastBoardAction: 'pose', pinnedProblem: PIN,
+      });
+      expect(cards.some(c => c.action === 'pose')).toBe(false);
+    });
+  });
+
   test('Final answer turn: student "x=6" + math engine confirms → verify even when tutor hedges', () => {
     // The bug B scenario: math engine confirms x=6, but the tutor's
     // prose says "Hmm, let's double-check that last step." The board

--- a/utils/pipeline/boardSynthesizer.js
+++ b/utils/pipeline/boardSynthesizer.js
@@ -423,6 +423,13 @@ function looksLikeProblemStatement(text) {
 // a new problem to re-pose.
 const NEW_PROBLEM_CUE = /\b(solve|factor|simplify|expand|evaluate|graph|compute|calculate|find|what\s+is|new\s+problem|next\s+problem|another\s+(?:one|problem))\b/i;
 
+// How a TUTOR introduces a fresh problem ("un poco más picante this time —
+// 2x^2+5x-3=0", "try this one", "here's another", "how about"). The student
+// path uses NEW_PROBLEM_CUE; the tutor phrases it differently. Requiring a cue
+// here is deliberately conservative — without one we do NOT re-pose, so the
+// tutor's own intermediate scratch work never gets mistaken for a new problem.
+const TUTOR_NEW_PROBLEM_CUE = /\b(this\s+time|try\s+(?:this|one|another|the\s+next)|here'?s\s+(?:a|one|another|the\s+next)|next\s+(?:one|problem)|how\s+about|let'?s\s+(?:try|do)|another\s+(?:one|problem)|new\s+(?:one|problem)|round\s+\d|level\s+up)\b/i;
+
 // ---------------------------------------------------------------------------
 // Geometry pose fallback — when parseCleanProblem can't see a problem.
 //
@@ -598,6 +605,22 @@ function synthesizeBoardCommands({
         && normalizeForCompare(fresh.tex) !== normalizeForCompare(pinnedProblem)) {
       cards.push({ action: 'clear' });
       cards.push({ action: 'pose', tex: fresh.tex });
+    } else {
+      // The TUTOR may have posed a NEW problem ("un poco más picante this
+      // time — 2x^2+5x-3=0"). The student-pose path above never sees that, so
+      // the board — and the grader's pinnedProblemTex (conversation.boardProblem.tex)
+      // — go stale, and the student's next answer gets checked against the OLD
+      // problem (a correct answer graded wrong). Detect a tutor-posed new
+      // problem too, gated: a fresh, solvable, DIFFERENT problem, stated as a
+      // single ask (not multi-line worked scratch), with a tutor pose cue.
+      const tutorFresh = detectPosedProblem(tutorResponse);
+      if (tutorFresh
+          && TUTOR_NEW_PROBLEM_CUE.test(tutorResponse)
+          && looksLikeProblemStatement(tutorResponse)
+          && normalizeForCompare(tutorFresh.tex) !== normalizeForCompare(pinnedProblem)) {
+        cards.push({ action: 'clear' });
+        cards.push({ action: 'pose', tex: tutorFresh.tex });
+      }
     }
   } else if (cycleIsClosed) {
     // Empty board. Prefer the student's message — if they introduced


### PR DESCRIPTION
Live bug (from a prod screenshot): a problem was pinned (x^2-5x+6=0) and the tutor posed a harder one ("un poco más picante this time — 2x^2+5x-3=0"). The board — and the grader's pinnedProblemTex (conversation.boardProblem.tex) — stayed on the OLD problem, because synthesizeBoardCommands only checked the STUDENT's message for a new problem when one was already pinned, never the tutor's. Result: the student's correct answer (1/2 and -3, the exact roots of 2x^2+5x-3) was graded against x^2-5x+6 and drew a "hold on…" doubt. Reproduced: synthesizeBoardCommands returned [] for that turn.

Fix: in the pinned branch, if the student didn't introduce a new problem, also detect a tutor-posed one and clear+pose it. Gated conservatively to avoid latching onto the tutor's own scratch work: requires a fresh solvable problem, DIFFERENT from the pin, stated as a single ask (looksLikeProblemStatement, so multi-line worked solutions are excluded), AND a TUTOR_NEW_PROBLEM_CUE ("this time", "try this", "here's another", "how about", …). No cue -> no re-pose (a safe miss, never a false pose onto intermediate work).

This keeps boardProblem current, so both the board display and the grader use the problem actually being worked. 119 boardSynthesizer tests green (4 new: the fix + 3 guards), all existing guards intact, eslint clean.