### PR TITLE
fix(voice): render voice board output onto the Living Workspace deriv…

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -114,7 +114,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
        LivingWorkspace flag is dev|beta|live (?livingWorkspace=dev). When on,
        it lazy-loads the workspace and mirrors the tutor's board output onto
        the new surface beside the old board. Default OFF → zero impact. -->
-  <script defer src="/js/living-workspace/chat-workspace.js?v=20260714"></script>
+  <script defer src="/js/living-workspace/chat-workspace.js?v=20260715"></script>
   <!-- Final safety net: strips any inline visual tag no renderer handled -->
   <script defer src="/js/stripVisualTags.js"></script>
   <!-- Non-core libs (lazy-loaded after first interaction) -->

--- a/public/js/living-workspace/chat-workspace.js
+++ b/public/js/living-workspace/chat-workspace.js
@@ -47,6 +47,7 @@
   var api = {
     isOn: function () { return ON; },
     applyBoardCommands: function () {},
+    applyVoiceBoard: function () {},
     setContext: function (c) { if (c && typeof c === 'object') { if (c.conversationId != null) ctx.conversationId = c.conversationId; if (c.workspaceId != null) ctx.workspaceId = c.workspaceId; } },
   };
   window.LWS_CHAT = api;
@@ -56,7 +57,7 @@
   // public/ with a 7-day cache and no content hashing, so bump this whenever
   // any living-workspace asset changes (and the chat.html <script ?v=> tag to
   // match, so this file itself refreshes). See project_asset_cache_busting.
-  var ASSET_V = '?v=20260714';
+  var ASSET_V = '?v=20260715';
   var BASE = '/js/living-workspace/';
   var SCRIPTS = [
     'core/flags.js', 'core/viewport.js', 'core/elementRegistry.js',
@@ -65,7 +66,7 @@
     'dom/tileElement.js', 'dom/numberLineElement.js', 'dom/graphElement.js',
     'dom/noteElement.js', 'dom/imageElement.js', 'dom/studentMoveClient.js',
     'dom/interactionController.js', 'dom/shell.js', 'dom/legacyBoardAdapter.js',
-    'dom/derivationView.js',
+    'dom/derivationView.js', 'dom/voiceBoardTranslate.js',
   ];
 
   // Build brick #1: the chat board renders as a FOCUSED DERIVATION
@@ -184,6 +185,18 @@
   api.applyBoardCommands = function (cmds) {
     if (!Array.isArray(cmds) || cmds.length === 0) return;
     render(cmds);
+  };
+
+  // Voice turns speak the legacy board protocol (mathSteps / boardActions).
+  // Translate to boardCommands and render, so the derivation view updates live
+  // during a voice session instead of freezing after the first (text-posed)
+  // problem. No-op if the translator or payload is empty.
+  api.applyVoiceBoard = function (payload) {
+    if (!window.LWS || typeof window.LWS.voiceToBoardCommands !== 'function') return;
+    var cmds;
+    try { cmds = window.LWS.voiceToBoardCommands(payload); }
+    catch (e) { console.error('[LWS_CHAT] voice translate failed', e); return; }
+    if (Array.isArray(cmds) && cmds.length) render(cmds);
   };
 
   function boot() {

--- a/public/js/living-workspace/dom/voiceBoardTranslate.js
+++ b/public/js/living-workspace/dom/voiceBoardTranslate.js
@@ -1,0 +1,82 @@
+/* ============================================================
+   voiceBoardTranslate.js — voice board payload -> LWS boardCommands.
+
+   Voice mode predates the Living Workspace and speaks the legacy board
+   protocol: response_final carries `mathSteps` (structured [{latex,text,visual}])
+   and `boardActions` ([WRITE:x,y,text] / circle / arrow / clear). The LWS
+   derivation view speaks boardCommands (pose/resolve/verify/graph/clear via the
+   P5 adapter). Without a bridge, voice turns drive only the (now hidden) legacy
+   board and the derivation view freezes after the first (text-posed) problem.
+
+   This translates one voice turn's payload into boardCommands so
+   LWS_CHAT.applyVoiceBoard can render it. Fidelity is intentionally
+   conservative: structured math steps become derivation lines; annotations
+   (circle/arrow/highlight) have no derivation equivalent and are dropped.
+   ============================================================ */
+(function (root) {
+  'use strict';
+  var LWS = root.LWS = root.LWS || {};
+
+  function clean(s) { return String(s == null ? '' : s).trim(); }
+
+  // A legacy [WRITE:...] payload is only board-worthy if it's actually math —
+  // freeform prose the tutor "writes" is narration, not a derivation line.
+  function looksLikeMath(s) {
+    if (!s) return false;
+    return /=/.test(s)
+      || /[a-zA-Z]\s*\^?\s*\d/.test(s)          // x^2, 3x
+      || /\d\s*[+\-*/^]\s*\d/.test(s)           // 2 + 3
+      || /\\frac|\\sqrt|\\int|\\sum/.test(s);   // latex math
+  }
+
+  /**
+   * Translate one voice turn's board payload into LWS boardCommands.
+   * @param {{mathSteps?: Array, boardActions?: Array}} payload
+   * @returns {Array<object>} boardCommands for applyBoardCommands
+   */
+  function voiceToBoardCommands(payload) {
+    payload = payload || {};
+    var cmds = [];
+    var lastTex = null;
+    function pushStep(tex) {
+      tex = clean(tex);
+      if (!tex || tex === lastTex) return;   // drop empties + consecutive dupes
+      cmds.push({ action: 'resolve', tex: tex });
+      lastTex = tex;
+    }
+
+    // Preferred source: structured math steps (math-steps / orchestrated mode).
+    var steps = Array.isArray(payload.mathSteps) ? payload.mathSteps : [];
+    if (steps.length) {
+      for (var i = 0; i < steps.length; i++) {
+        var s = steps[i];
+        if (!s) continue;
+        if (s.visual && (s.visual.fn || s.visual.query)) {
+          if (s.visual.fn) cmds.push({ action: 'graph', fn: s.visual.fn, caption: s.visual.caption });
+          else cmds.push({ action: 'image', query: s.visual.query, caption: s.visual.caption });
+          lastTex = null;
+          continue;
+        }
+        if (s.latex) pushStep(s.latex);
+        // text-only steps are spoken narration, not board content — skip.
+      }
+      return cmds;
+    }
+
+    // Fallback: legacy [WRITE:...] board actions (board-actions mode).
+    var actions = Array.isArray(payload.boardActions) ? payload.boardActions : [];
+    for (var j = 0; j < actions.length; j++) {
+      var a = actions[j];
+      if (!a || !a.type) continue;
+      if (a.type === 'clear') { cmds.push({ action: 'clear' }); lastTex = null; continue; }
+      if (a.type === 'write' && looksLikeMath(a.text)) pushStep(a.text);
+      // circle / arrow / highlight: annotations with no derivation equivalent — drop.
+    }
+    return cmds;
+  }
+
+  LWS.voiceToBoardCommands = voiceToBoardCommands;
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { voiceToBoardCommands: voiceToBoardCommands };
+  }
+})(typeof self !== 'undefined' ? self : this);

--- a/public/js/voice-controller.js
+++ b/public/js/voice-controller.js
@@ -186,7 +186,9 @@ class VoiceController {
 
             case 'board_actions':
                 if (this.config.enableBoardCommands && Array.isArray(ev.boardActions)) {
-                    this.executeBoardActions(ev.boardActions);
+                    // When LWS owns the board, defer to response_final (the full
+                    // turn) so partial + final don't render duplicate lines.
+                    if (!this._lwsOwnsBoard()) this.executeBoardActions(ev.boardActions);
                 }
                 break;
 
@@ -194,8 +196,12 @@ class VoiceController {
                 if (ev.text && window.appendMessage) {
                     window.appendMessage(ev.text, 'ai');
                 }
-                if (this.config.enableBoardCommands && Array.isArray(ev.boardActions) && ev.boardActions.length) {
-                    this.executeBoardActions(ev.boardActions);
+                if (this.config.enableBoardCommands) {
+                    if (this._lwsOwnsBoard()) {
+                        this._renderVoiceBoardToLWS({ mathSteps: ev.mathSteps, boardActions: ev.boardActions });
+                    } else if (Array.isArray(ev.boardActions) && ev.boardActions.length) {
+                        this.executeBoardActions(ev.boardActions);
+                    }
                 }
                 this._pendingResponseText = '';
                 break;
@@ -981,7 +987,8 @@ class VoiceController {
                     boardContextData = phase.boardContext || null;
 
                     if (phase.boardActions && this.config.enableBoardCommands) {
-                        this.executeBoardActions(phase.boardActions);
+                        if (this._lwsOwnsBoard()) this._renderVoiceBoardToLWS({ boardActions: phase.boardActions });
+                        else this.executeBoardActions(phase.boardActions);
                     }
 
                     if (responseText && window.appendMessage) {
@@ -1025,7 +1032,8 @@ class VoiceController {
         }
         if (data.response) {
             if (data.boardActions && this.config.enableBoardCommands) {
-                await this.executeBoardActions(data.boardActions);
+                if (this._lwsOwnsBoard()) this._renderVoiceBoardToLWS({ boardActions: data.boardActions });
+                else await this.executeBoardActions(data.boardActions);
             }
             if (window.appendMessage) {
                 window.appendMessage(data.response, 'ai', null, data.isMasteryQuiz);
@@ -1084,6 +1092,22 @@ class VoiceController {
         };
 
         return context;
+    }
+
+    // When the Living Workspace owns the board slot, the legacy whiteboard is
+    // hidden — so voice board output must be translated onto the LWS derivation
+    // view instead, or it renders into an invisible board (the "board froze
+    // after the first problem" bug). See js/living-workspace/dom/voiceBoardTranslate.js.
+    _lwsOwnsBoard() {
+        return !!(window.LWS_CHAT && typeof window.LWS_CHAT.isOn === 'function' && window.LWS_CHAT.isOn());
+    }
+
+    // Render one voice turn's board payload (mathSteps + boardActions) onto the
+    // LWS derivation view. Called at turn-final only (not on streaming partials)
+    // so lines don't render twice.
+    _renderVoiceBoardToLWS(payload) {
+        try { window.LWS_CHAT.applyVoiceBoard(payload); }
+        catch (e) { console.error('[Voice] LWS board render failed', e); }
     }
 
     async executeBoardActions(actions) {

--- a/tests/unit/voiceBoardTranslate.test.js
+++ b/tests/unit/voiceBoardTranslate.test.js
@@ -1,0 +1,74 @@
+/**
+ * voiceBoardTranslate — voice board payload (mathSteps / boardActions) -> LWS
+ * boardCommands. Pure translation; this is what unfreezes the derivation view
+ * during a voice session (it previously only saw the hidden legacy board).
+ */
+const { voiceToBoardCommands } = require('../../public/js/living-workspace/dom/voiceBoardTranslate');
+
+describe('voiceToBoardCommands — mathSteps (preferred source)', () => {
+  it('maps latex steps to resolve commands in order', () => {
+    const cmds = voiceToBoardCommands({ mathSteps: [{ latex: '2x + 4 = 20' }, { latex: '2x = 16' }, { latex: 'x = 8' }] });
+    expect(cmds).toEqual([
+      { action: 'resolve', tex: '2x + 4 = 20' },
+      { action: 'resolve', tex: '2x = 16' },
+      { action: 'resolve', tex: 'x = 8' },
+    ]);
+  });
+
+  it('drops consecutive duplicate lines and empties', () => {
+    const cmds = voiceToBoardCommands({ mathSteps: [{ latex: '2x = 16' }, { latex: '2x = 16' }, { latex: '' }, { latex: 'x = 8' }] });
+    expect(cmds.map(c => c.tex)).toEqual(['2x = 16', 'x = 8']);
+  });
+
+  it('maps a visual step to a graph/image command', () => {
+    expect(voiceToBoardCommands({ mathSteps: [{ visual: { fn: 'x^2' } }] }))
+      .toEqual([{ action: 'graph', fn: 'x^2', caption: undefined }]);
+    expect(voiceToBoardCommands({ mathSteps: [{ visual: { query: 'unit circle' } }] }))
+      .toEqual([{ action: 'image', query: 'unit circle', caption: undefined }]);
+  });
+
+  it('skips text-only (narration) steps', () => {
+    const cmds = voiceToBoardCommands({ mathSteps: [{ text: 'Now we subtract 4.' }, { latex: '2x = 16' }] });
+    expect(cmds).toEqual([{ action: 'resolve', tex: '2x = 16' }]);
+  });
+
+  it('prefers mathSteps and ignores boardActions when both are present', () => {
+    const cmds = voiceToBoardCommands({
+      mathSteps: [{ latex: 'x = 8' }],
+      boardActions: [{ type: 'write', text: '9x = 81' }],
+    });
+    expect(cmds).toEqual([{ action: 'resolve', tex: 'x = 8' }]);
+  });
+});
+
+describe('voiceToBoardCommands — boardActions fallback', () => {
+  it('maps a math write action to a resolve command', () => {
+    expect(voiceToBoardCommands({ boardActions: [{ type: 'write', text: '3x - 5 = 16' }] }))
+      .toEqual([{ action: 'resolve', tex: '3x - 5 = 16' }]);
+  });
+
+  it('skips a prose write action (narration, not math)', () => {
+    expect(voiceToBoardCommands({ boardActions: [{ type: 'write', text: 'Great start, keep going!' }] }))
+      .toEqual([]);
+  });
+
+  it('drops annotations (circle / arrow / highlight) that have no derivation equivalent', () => {
+    const cmds = voiceToBoardCommands({ boardActions: [
+      { type: 'circle', objectId: 'a' }, { type: 'arrow', fromId: 'a' }, { type: 'highlight', objectId: 'b' },
+    ] });
+    expect(cmds).toEqual([]);
+  });
+
+  it('maps a clear action', () => {
+    expect(voiceToBoardCommands({ boardActions: [{ type: 'clear' }] })).toEqual([{ action: 'clear' }]);
+  });
+});
+
+describe('voiceToBoardCommands — edge cases', () => {
+  it('returns [] for empty / missing / malformed input (never throws)', () => {
+    expect(voiceToBoardCommands()).toEqual([]);
+    expect(voiceToBoardCommands({})).toEqual([]);
+    expect(voiceToBoardCommands({ mathSteps: null, boardActions: null })).toEqual([]);
+    expect(voiceToBoardCommands({ mathSteps: [null, undefined] })).toEqual([]);
+  });
+});


### PR DESCRIPTION
…ation view

Live bug: in voice mode the board froze after the first problem. Voice speaks the legacy board protocol (response_final's mathSteps + [WRITE:...] boardActions) and the client rendered it to the LEGACY whiteboard — which the Living Workspace hides ("owns the board slot"). So every voice turn's board output landed in a hidden board; the derivation view only updated on SSE/text turns and froze after the first (text-posed) problem.

Fix: bridge voice board output onto the LWS boardCommands rail.
  • new voiceBoardTranslate.js — pure translator: mathSteps/boardActions ->
    boardCommands (pose/resolve/verify/graph/clear). Structured math steps become
    derivation lines; annotations (circle/arrow/highlight) have no derivation
    equivalent and are dropped; consecutive dupes/empties removed.
  • chat-workspace.js exposes LWS_CHAT.applyVoiceBoard(payload) (translate+render).
  • voice-controller.js: when LWS owns the board, route board output to the
    workspace instead of the hidden legacy whiteboard. Renders once per turn at
    response_final (using the richer mathSteps); streaming partials are skipped
    for LWS so lines don't render twice — matching the text path's per-turn render.

Guarded at all four board call sites (streaming partial, response_final, orchestrated phase, legacy JSON). Legacy behavior unchanged when LWS is off. 10 translator unit tests; client files syntax-checked; eslint clean. Cache-bust: bumped chat-workspace.js ?v= + LWS ASSET_V to 20260715.