### PR TITLE
fix(verify): auto-detect the equation's unknown (not just x); verify …

### DIFF
--- a/tests/unit/symbolicVerifier.test.js
+++ b/tests/unit/symbolicVerifier.test.js
@@ -149,4 +149,24 @@ describe('symbolicVerifier — equation-solution verification (substitute & chec
     // an integral problemTex must still take the antiderivative path, not equation
     expect(symbolicVerify({ studentAnswer: 'x^6 + C', problemTex: '\\int 6x^5\\,dx' }).method).toBe('antiderivative');
   });
+
+  // Regression: the verifier used to assume the unknown was always 'x', so any
+  // problem in m/p/b/t/… returned null and fell through to the LLM. Now it
+  // auto-detects the variable from the equation.
+  it('auto-detects the unknown for non-x variables (m, p, t, …)', () => {
+    expect(verifyEquationSolution('p = 60', 'p/12 + 3 = 8')).toBe(true);       // #6
+    expect(verifyEquationSolution('p = 50', 'p/12 + 3 = 8')).toBe(false);
+    expect(verifyEquationSolution('m = 25', '(1/5)m + 6 = 11')).toBe(true);    // #2
+    expect(verifyEquationSolution('t = 12', '50t = 60(t - 2)')).toBe(true);    // #5 setup
+    expect(symbolicVerify({ studentAnswer: 'p = 60', problemTex: 'p/12 + 3 = 8' }).isCorrect).toBe(true);
+  });
+
+  it('verifies absolute-value equations (|…| -> abs), including both roots', () => {
+    expect(verifyEquationSolution('b = 2 or b = -3', '|2b + 1| = 5')).toBe(true);  // #8
+    expect(verifyEquationSolution('b = 4', '|2b + 1| = 5')).toBe(false);
+  });
+
+  it('still declines a multi-variable / literal equation (no single value to check)', () => {
+    expect(verifyEquationSolution('d = 2', 't = 5d')).toBeNull();
+  });
 });

--- a/utils/pipeline/symbolicVerifier.js
+++ b/utils/pipeline/symbolicVerifier.js
@@ -46,6 +46,9 @@ function latexToExpr(input) {
     .replace(/\\([a-zA-Z]+)/g, '$1')                                     // \ln \sin -> ln sin
     .replace(/[{}]/g, '')
     .replace(/−/g, '-').replace(/×/g, '*').replace(/÷/g, '/').replace(/·/g, '*');
+  // |2b + 1| -> abs(2b + 1) so absolute-value equations are checkable (\left|
+  // \right| already stripped above, leaving bare | … |). Non-greedy, single level.
+  s = s.replace(/\|\s*([^|]+?)\s*\|/g, 'abs($1)');
   return s.trim();
 }
 
@@ -141,7 +144,15 @@ function claimedSolutionValues(text, variable) {
 function verifyEquationSolution(studentAnswer, equationTex, variable) {
   const eq = extractEquation(equationTex);
   if (!eq) return null;
-  const v = variable || 'x';
+  // Auto-detect the unknown from the equation (m, p, t, b, …) instead of
+  // assuming x — a problem in 'p' with a "p = 60" answer must still verify.
+  // Only when there's exactly ONE single-letter variable; otherwise fall back
+  // to x (a multi-variable/literal equation has no single value to check).
+  let v = variable;
+  if (!v) {
+    const found = collectVars('(' + eq.lhs + ')-(' + eq.rhs + ')').filter(function (x) { return x.length === 1; });
+    v = found.length === 1 ? found[0] : 'x';
+  }
   const vals = claimedSolutionValues(studentAnswer, v);
   if (!vals.length) return null;
   const diff = compile('(' + eq.lhs + ')-(' + eq.rhs + ')');


### PR DESCRIPTION
…abs-value

Found on a real Algebra 1 worksheet: half the problems use variables other than x (m, p, b, t, d), and symbolicVerify assumed the unknown was always 'x' — so "p/12+3=8 -> p=60" came back unverifiable and dropped to the (less reliable) LLM verifier, exactly where premature-verdict false-flags creep in.

Fix: verifyEquationSolution now auto-detects the unknown from the equation via collectVars — using it only when there's exactly ONE single-letter variable, so a multi-variable/literal equation (t = 5d) still declines safely. Bonus: latexToExpr converts |…| -> abs(…), so absolute-value equations (|2b+1|=5 -> b=2 or -3) verify too, both roots.

The intermediate-step guard is intact (a bare number still returns null, never a false "wrong"). 225 verifier+pipeline tests green (5 new cases: non-x vars, abs-value both-roots, multivar-declines), eslint clean.