### PR TITLE
test(billing): pin AI_TIME_FLOOR_SECONDS in fair-time floor tests

### DIFF
--- a/tests/unit/pipelineIntegration.test.js
+++ b/tests/unit/pipelineIntegration.test.js
@@ -285,45 +285,64 @@ describe('Pipeline Integration: runPipeline', () => {
     expect(result._pipeline.signalStats.total).toBeGreaterThanOrEqual(0);
   });
 
-  test('fair-time floor: a fast turn still bills at least the floor', async () => {
-    // A single gpt-4o-mini turn returns in well under a second, so raw
-    // aiProcessingSeconds ≈ 0. Without the floor, a dense multi-turn session
-    // meters to near-zero ("2 minutes" for 10+ real minutes of tutoring).
-    const user = mockUser({ weeklyAISeconds: 0 });
-    const conversation = mockConversation([
-      { role: 'assistant', content: 'What is 6 + 6?', problemResult: null },
-      { role: 'user', content: '12' },
-    ]);
+  describe('fair-time floor', () => {
+    // persist.js reads AI_TIME_FLOOR_SECONDS at call time, so an ambient
+    // value (shell export, sourced .env) leaks into the run. Mirroring
+    // process.env in the assertions made these tests fail on values the
+    // billing code handles fine (e.g. a fractional 0.5 → billed 1s because
+    // elapsed is ceil'd to whole seconds). Pin the floor so the tests are
+    // deterministic in any environment.
+    const FLOOR = 30;
+    let savedFloor;
 
-    mockLLMResponse('Nice! 12 is correct. <PROBLEM_RESULT:correct>');
-
-    // aiProcessingStartTime = now → raw elapsed rounds to ~0s, so the floor governs.
-    const result = await runPipeline('12', buildCtx(user, conversation));
-
-    const FLOOR = Number(process.env.AI_TIME_FLOOR_SECONDS) || 30;
-    expect(result.aiTimeUsed).toBe(FLOOR);
-  });
-
-  test('fair-time floor: a slow turn still bills its true (higher) latency', async () => {
-    // A slow vision-grading turn on gpt-4o exceeds the floor — bill real latency,
-    // don't clamp down to it.
-    const user = mockUser({ weeklyAISeconds: 0 });
-    const conversation = mockConversation([
-      { role: 'assistant', content: 'What is 6 + 6?', problemResult: null },
-      { role: 'user', content: '12' },
-    ]);
-
-    mockLLMResponse('Nice! 12 is correct. <PROBLEM_RESULT:correct>');
-
-    const FLOOR = Number(process.env.AI_TIME_FLOOR_SECONDS) || 30;
-    // Backdate the start so raw elapsed is ~90s — well above the floor.
-    const ctx = buildCtx(user, conversation, {
-      aiProcessingStartTime: Date.now() - 90_000,
+    beforeAll(() => {
+      savedFloor = process.env.AI_TIME_FLOOR_SECONDS;
+      process.env.AI_TIME_FLOOR_SECONDS = String(FLOOR);
     });
-    const result = await runPipeline('12', ctx);
 
-    expect(result.aiTimeUsed).toBeGreaterThan(FLOOR);
-    expect(result.aiTimeUsed).toBeGreaterThanOrEqual(89);
+    afterAll(() => {
+      if (savedFloor === undefined) delete process.env.AI_TIME_FLOOR_SECONDS;
+      else process.env.AI_TIME_FLOOR_SECONDS = savedFloor;
+    });
+
+    test('a fast turn still bills at least the floor', async () => {
+      // A single gpt-4o-mini turn returns in well under a second, so raw
+      // aiProcessingSeconds ≈ 0. Without the floor, a dense multi-turn session
+      // meters to near-zero ("2 minutes" for 10+ real minutes of tutoring).
+      const user = mockUser({ weeklyAISeconds: 0 });
+      const conversation = mockConversation([
+        { role: 'assistant', content: 'What is 6 + 6?', problemResult: null },
+        { role: 'user', content: '12' },
+      ]);
+
+      mockLLMResponse('Nice! 12 is correct. <PROBLEM_RESULT:correct>');
+
+      // aiProcessingStartTime = now → raw elapsed rounds to ~0s, so the floor governs.
+      const result = await runPipeline('12', buildCtx(user, conversation));
+
+      expect(result.aiTimeUsed).toBe(FLOOR);
+    });
+
+    test('a slow turn still bills its true (higher) latency', async () => {
+      // A slow vision-grading turn on gpt-4o exceeds the floor — bill real latency,
+      // don't clamp down to it.
+      const user = mockUser({ weeklyAISeconds: 0 });
+      const conversation = mockConversation([
+        { role: 'assistant', content: 'What is 6 + 6?', problemResult: null },
+        { role: 'user', content: '12' },
+      ]);
+
+      mockLLMResponse('Nice! 12 is correct. <PROBLEM_RESULT:correct>');
+
+      // Backdate the start so raw elapsed is ~90s — well above the floor.
+      const ctx = buildCtx(user, conversation, {
+        aiProcessingStartTime: Date.now() - 90_000,
+      });
+      const result = await runPipeline('12', ctx);
+
+      expect(result.aiTimeUsed).toBeGreaterThan(FLOOR);
+      expect(result.aiTimeUsed).toBeGreaterThanOrEqual(89);
+    });
   });
 
   test('persists session mood to conversation document', async () => {


### PR DESCRIPTION
The two fair-time floor tests mirrored whatever AI_TIME_FLOOR_SECONDS happened to be in the ambient environment (shell export, sourced .env), so certain leaked values made the assertions internally inconsistent:

- a fractional value like 0.5 fails the fast-turn test — elapsed is Math.ceil'd to whole seconds in the pipeline, so max(1, 0.5) bills 1s while the test expects 0.5
- a value >= ~90 fails the slow-turn test — billed equals the floor, so toBeGreaterThan(FLOOR) fails

The billing code in utils/pipeline/persist.js is correct in all these cases; only the test was env-sensitive. Pin the floor to 30 for the two tests (saved/restored in beforeAll/afterAll) so they are deterministic in any environment. Verified green with AI_TIME_FLOOR_SECONDS unset, 0.5, -5, 120, and 0.