### PR TITLE
feat(act-course): day-one "Take a Practice ACT" card on course entry

### DIFF
--- a/public/js/courseCatalog.js
+++ b/public/js/courseCatalog.js
@@ -933,6 +933,10 @@ class CourseManager {
             // Switch sidebar to course context (hides sessions, leaderboard, quests)
             if (window.sidebar) window.sidebar.setContext('course');
 
+            // Day-one diagnostic nudge for returning students (e.g. ACT-prep student
+            // who never took the practice test) — shown as a standalone card.
+            if (data.diagnostic) this.showDiagnosticCard(data.diagnostic);
+
             // Fire silent course greeting — AI introduces the course/module
             this.sendCourseGreeting();
 
@@ -1092,6 +1096,42 @@ class CourseManager {
     }
 
     // --------------------------------------------------
+    // Day-one diagnostic card (e.g. ACT prep → "Take the Practice ACT"). The CTA
+    // launches the practice test; the button removes whichever card container it
+    // lives in (the welcome splash when embedded, or its own card when standalone).
+    // --------------------------------------------------
+    diagnosticCardHtml(diag) {
+        if (!diag || diag.type !== 'act-practice') return '';
+        return `
+            <div class="course-diagnostic-card" style="margin-top:16px; padding:16px; border-radius:12px; background:linear-gradient(135deg,#eef2ff,#faf5ff); border:1px solid #c7d2fe;">
+                <div style="font-size:14px; font-weight:700; color:#4338ca; margin-bottom:6px;">
+                    <i class="fas fa-clipboard-check" style="margin-right:6px;"></i>${this.escapeHtml(diag.title)}
+                </div>
+                <div style="font-size:12px; color:#555; line-height:1.5; margin-bottom:12px;">${this.escapeHtml(diag.body)}</div>
+                <button class="course-diagnostic-cta" onclick="(this.closest('.course-welcome-splash') || this.closest('.course-diagnostic-wrap') || this.closest('.course-diagnostic-card'))?.remove(); if (window.openActTest) { window.openActTest(); }" style="
+                    width:100%; padding:12px; border:none; border-radius:10px;
+                    background:linear-gradient(135deg,#4f46e5,#7c3aed); color:white;
+                    font-weight:700; font-size:14px; cursor:pointer;
+                "><i class="fas fa-play" style="margin-right:6px;"></i>${this.escapeHtml(diag.cta)}</button>
+            </div>`;
+    }
+
+    // Show the diagnostic card on its own (returning students who re-open the
+    // course from the sidebar, i.e. activateCourse — no welcome splash there).
+    showDiagnosticCard(diag) {
+        const html = this.diagnosticCardHtml(diag);
+        if (!html) return;
+        const chatBox = document.getElementById('chat-messages-container');
+        if (!chatBox) return;
+        if (chatBox.querySelector('.course-diagnostic-card')) return; // don't stack duplicates
+        const wrap = document.createElement('div');
+        wrap.className = 'course-diagnostic-wrap';
+        wrap.style.cssText = 'margin:16px auto; max-width:520px; animation:catalogSlideIn 0.4s ease;';
+        wrap.innerHTML = html;
+        chatBox.appendChild(wrap);
+        wrap.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+
     // Welcome splash (shown in chat after enrollment)
     // --------------------------------------------------
     showWelcomeSplash(welcome, isResume = false) {
@@ -1114,22 +1154,9 @@ class CourseManager {
             </div>`
         ).join('');
 
-        // Day-one diagnostic card (e.g. ACT prep → take a full practice ACT first).
-        // A prominent card with a CTA that launches the practice test; the tutor
-        // then targets the bootcamp to the results. Delivered on the welcome splash.
-        const diag = welcome.diagnostic;
-        const diagnosticHtml = (diag && diag.type === 'act-practice') ? `
-            <div class="course-diagnostic-card" style="margin-top:16px; padding:16px; border-radius:12px; background:linear-gradient(135deg,#eef2ff,#faf5ff); border:1px solid #c7d2fe;">
-                <div style="font-size:14px; font-weight:700; color:#4338ca; margin-bottom:6px;">
-                    <i class="fas fa-clipboard-check" style="margin-right:6px;"></i>${this.escapeHtml(diag.title)}
-                </div>
-                <div style="font-size:12px; color:#555; line-height:1.5; margin-bottom:12px;">${this.escapeHtml(diag.body)}</div>
-                <button class="course-diagnostic-cta" onclick="this.closest('.course-welcome-splash').remove(); if (window.openActTest) { window.openActTest(); }" style="
-                    width:100%; padding:12px; border:none; border-radius:10px;
-                    background:linear-gradient(135deg,#4f46e5,#7c3aed); color:white;
-                    font-weight:700; font-size:14px; cursor:pointer;
-                "><i class="fas fa-play" style="margin-right:6px;"></i>${this.escapeHtml(diag.cta)}</button>
-            </div>` : '';
+        // Day-one diagnostic card (e.g. ACT prep → take a full practice ACT first),
+        // embedded in the welcome splash. See diagnosticCardHtml().
+        const diagnosticHtml = this.diagnosticCardHtml(welcome.diagnostic);
 
         // Course mini-tour tips (shown below the learning path for first-time enrollees)
         const courseTipsHtml = isResume ? '' : `

--- a/public/js/courseCatalog.js
+++ b/public/js/courseCatalog.js
@@ -1114,6 +1114,23 @@ class CourseManager {
             </div>`
         ).join('');
 
+        // Day-one diagnostic card (e.g. ACT prep → take a full practice ACT first).
+        // A prominent card with a CTA that launches the practice test; the tutor
+        // then targets the bootcamp to the results. Delivered on the welcome splash.
+        const diag = welcome.diagnostic;
+        const diagnosticHtml = (diag && diag.type === 'act-practice') ? `
+            <div class="course-diagnostic-card" style="margin-top:16px; padding:16px; border-radius:12px; background:linear-gradient(135deg,#eef2ff,#faf5ff); border:1px solid #c7d2fe;">
+                <div style="font-size:14px; font-weight:700; color:#4338ca; margin-bottom:6px;">
+                    <i class="fas fa-clipboard-check" style="margin-right:6px;"></i>${this.escapeHtml(diag.title)}
+                </div>
+                <div style="font-size:12px; color:#555; line-height:1.5; margin-bottom:12px;">${this.escapeHtml(diag.body)}</div>
+                <button class="course-diagnostic-cta" onclick="this.closest('.course-welcome-splash').remove(); if (window.openActTest) { window.openActTest(); }" style="
+                    width:100%; padding:12px; border:none; border-radius:10px;
+                    background:linear-gradient(135deg,#4f46e5,#7c3aed); color:white;
+                    font-weight:700; font-size:14px; cursor:pointer;
+                "><i class="fas fa-play" style="margin-right:6px;"></i>${this.escapeHtml(diag.cta)}</button>
+            </div>` : '';
+
         // Course mini-tour tips (shown below the learning path for first-time enrollees)
         const courseTipsHtml = isResume ? '' : `
             <div class="course-tips" style="margin-top:16px; border-top:1px solid #f0f0f0; padding-top:14px;">
@@ -1158,15 +1175,20 @@ class CourseManager {
                 ${unitListHtml}
                 ${units.length < welcome.moduleCount ? `<div style="font-size: 12px; color: #aaa; padding: 4px 0 0 32px;">+${welcome.moduleCount - units.length} more modules</div>` : ''}
                 ${courseTipsHtml}
+                ${diagnosticHtml}
                 <div style="margin-top: 16px; padding: 8px 12px; background: #fef9c3; border: 1px solid #fde68a; border-radius: 8px; font-size: 11px; color: #b45309; display: flex; align-items: flex-start; gap: 6px;">
                     <i class="fas fa-circle-exclamation" style="margin-top: 1px; flex-shrink: 0;"></i>
                     <span><strong>Disclaimer:</strong> These courses do not count for academic credit and are not meant to replace in-person instruction.</span>
                 </div>
                 <button onclick="this.closest('.course-welcome-splash').remove()" style="
-                    margin-top: 16px; width: 100%; padding: 12px; border: none; border-radius: 10px;
-                    background: linear-gradient(135deg, #667eea, #764ba2); color: white;
+                    margin-top: 16px; width: 100%; padding: 12px; border-radius: 10px;
+                    ${diagnosticHtml
+                        ? 'border: 1px solid #c7d2fe; background: white; color: #4f46e5;'
+                        : 'border: none; background: linear-gradient(135deg, #667eea, #764ba2); color: white;'}
                     font-weight: 700; font-size: 14px; cursor: pointer;
-                "><i class="fas fa-play" style="margin-right: 6px;"></i>${isResume ? 'Continue Learning' : `Start ${this.escapeHtml(welcome.firstModuleTitle)}`}</button>
+                "><i class="fas fa-play" style="margin-right: 6px;"></i>${diagnosticHtml
+                        ? `Skip for now — start ${this.escapeHtml(welcome.firstModuleTitle)}`
+                        : (isResume ? 'Continue Learning' : `Start ${this.escapeHtml(welcome.firstModuleTitle)}`)}</button>
             </div>
         `;
 

--- a/routes/courseSession.js
+++ b/routes/courseSession.js
@@ -344,7 +344,12 @@ router.post('/:id/activate', async (req, res) => {
       await Conversation.findByIdAndUpdate(session.conversationId, { isActive: true });
     }
 
-    res.json({ success: true, session });
+    // Day-one diagnostic nudge for returning students too (e.g. an ACT-prep
+    // student who enrolled earlier and never took the practice test). Shown as a
+    // card when they re-open the course from the sidebar.
+    const diagnostic = await buildCourseDiagnostic(req.user._id, session.courseId);
+
+    res.json({ success: true, session, diagnostic });
   } catch (err) {
     console.error('[CourseSession] Error activating:', err);
     res.status(500).json({ success: false, message: 'Failed to activate course session' });

--- a/routes/courseSession.js
+++ b/routes/courseSession.js
@@ -9,8 +9,31 @@ const path = require('path');
 const CourseSession = require('../models/courseSession');
 const Conversation = require('../models/conversation');
 const User = require('../models/user');
+const ActTestSession = require('../models/actTestSession');
 const { calculateOverallProgress } = require('../utils/coursePrompt');
 const { buildProgressUpdate } = require('../utils/progressState');
+
+// Day-one diagnostic prompt for the ACT prep course: on entry, nudge the student
+// to take a full practice ACT (delivered as a card in the welcome splash) so the
+// tutor can target the bootcamp to their real gaps. Persists until they've
+// completed one. Returns a descriptor for welcomeData.diagnostic, or null.
+async function buildCourseDiagnostic(userId, courseId) {
+  if (courseId !== 'act-prep') return null;
+  try {
+    const taken = await ActTestSession.countDocuments({ userId, status: 'completed' });
+    if (taken > 0) return null;
+  } catch (err) {
+    console.error('[CourseSession] diagnostic check failed (non-fatal):', err.message);
+    return null;
+  }
+  return {
+    type: 'act-practice',
+    title: 'Start with a full Practice ACT',
+    body: 'Take a timed practice ACT Math test first. Your tutor uses the results to pinpoint '
+      + 'exactly which skills to focus your bootcamp on — so every session targets your real gaps.',
+    cta: 'Take the Practice ACT',
+  };
+}
 
 /* ============================================================
    GET /api/course-sessions/catalog
@@ -178,7 +201,8 @@ router.post('/enroll', async (req, res) => {
         moduleCount: pathwayModules.length,
         units: pathwayModules.slice(0, 6).map(m => m.title || m.moduleId),
         prerequisites: pathway.prerequisites || [],
-        firstModuleTitle: pathwayModules[0]?.title || 'Getting Started'
+        firstModuleTitle: pathwayModules[0]?.title || 'Getting Started',
+        diagnostic: await buildCourseDiagnostic(req.user._id, courseId)
       };
 
       console.log(`📚 [CourseSession] ${req.user.firstName} resumed ${existing.courseName} (${existing.overallProgress}% progress preserved)`);
@@ -275,7 +299,8 @@ router.post('/enroll', async (req, res) => {
       moduleCount: pathwayModules.length,
       units: pathwayModules.slice(0, 6).map(m => m.title || m.moduleId),
       prerequisites: pathway.prerequisites || [],
-      firstModuleTitle: pathwayModules[0]?.title || 'Getting Started'
+      firstModuleTitle: pathwayModules[0]?.title || 'Getting Started',
+      diagnostic: await buildCourseDiagnostic(req.user._id, courseId)
     };
 
     res.json({


### PR DESCRIPTION
## What

On day one of the **ACT prep course**, prompt the student to take a full practice ACT — delivered as a **card on the course welcome splash**. Taking it lets the tutor target the bootcamp to the student's real gaps.

## How

- **`routes/courseSession.js`** — `buildCourseDiagnostic()` adds `welcomeData.diagnostic` for the `act-prep` course when the student **hasn't completed a practice ACT yet** (checks `ActTestSession`), so the nudge persists until they take one. Wired into both the resume and new-enrollment `welcomeData` builds; non-fatal on any error.
- **`public/js/courseCatalog.js`** — `showWelcomeSplash` renders the diagnostic card (title + rationale + a **"Take the Practice ACT"** CTA that launches `window.openActTest()`). When the card is shown, the first-lesson button softens to a secondary **"Skip for now — start {module}"** so the practice test is the clear primary action.

`act-test.js` (which exposes `window.openActTest`) is already loaded on `chat.html`.

## Verification

Rendered the welcome splash with the diagnostic present (headless Chromium): the "Start with a full Practice ACT" card sits above the disclaimer as the primary CTA, with "Skip for now" secondary. Lint clean; backend loads. The card only appears for `act-prep` and disappears once a practice ACT is completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTm55BDVTnGaJm3DRVauGZ)_