### PR TITLE
feat(calc): AP Calculus AB bootcamp weekly rail

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -76,6 +76,7 @@ const screenerRoutes = require('../routes/screener');
 const checkpointRoutes = require('../routes/checkpoint');
 const growthCheckRoutes = require('../routes/growthCheck');
 const actTestRoutes = require('../routes/actTest');
+const calcBootcampRoutes = require('../routes/calcBootcamp');
 const masteryRoutes = require('../routes/mastery');
 const nudgeRoutes = require('../routes/nudges');
 // masteryChat: REMOVED — mastery mode consolidated into /api/chat with { mastery: true }
@@ -241,6 +242,7 @@ function registerRoutes(app, { authLimiter, signupLimiter }) {
   app.use('/api/growth-check', isAuthenticated, growthCheckRoutes);
   // ACT Math practice test — free (boot-camp on-ramp), fixed-form, no AI at request time.
   app.use('/api/act-test', isAuthenticated, actTestRoutes);
+  app.use('/api/calc-bootcamp', isAuthenticated, calcBootcampRoutes);
   app.use('/api/mastery', isAuthenticated, masteryRoutes);
   app.use('/api/nudges', isAuthenticated, nudgeRoutes);
   // masteryChat route REMOVED — mastery mode consolidated into /api/chat

--- a/docs/APCALCAB_BOOTCAMP_DESIGN.md
+++ b/docs/APCALCAB_BOOTCAMP_DESIGN.md
@@ -94,5 +94,13 @@ small, then scale the bank.
   `scripts/calcSkillMap.py`). 75 MC → `Problem` docs mapped to existing catalog skills
   (BKT-wired for free), 5 weekly FRQs preserved in `seeds/calc-assessment-map.json`,
   94/94 verify snippets pass, all figures render.
-- **Weekly bootcamp rail — follow-up.** Weekly delivery, auto-MC + rubric-FRQ scoring,
-  priority-scored plan, AP-band projection. The assessment map is the rail's input.
+- **Weekly bootcamp rail — SHIPPED.** `routes/calcBootcamp.js` (`/api/calc-bootcamp`)
+  + `models/calcBootcampSession.js` + `utils/calcBootcamp.js` (scoring core, unit-tested).
+  The loop: `start-week` freezes a week's 15 MC + FRQ (client-safe, no keys/solutions);
+  `submit-mc` auto-scores and returns accuracy by unit / practice / calculator plus the
+  miss explanations; `submit-frq` AI-scores the response against the rubric (through the
+  LLM gateway, falling back to MC-only if unparseable); `complete-week` computes the
+  composite (MC 50% + FRQ 50%), projects an AP band (1–5), ranks weak skills by
+  priority = (1 − accuracy) × exam weight × recency, commits a ≤3-topic plan with one
+  retrospective, and seeds the student's `tutorPlan.skillFocus`; `progress` returns the
+  week-over-week band trajectory.

--- a/models/calcBootcampSession.js
+++ b/models/calcBootcampSession.js
@@ -1,0 +1,120 @@
+// models/calcBootcampSession.js
+// One weekly AP Calculus AB bootcamp diagnostic attempt (15 MC + one 9-point
+// FRQ). The item sequence is frozen at start from the weekly assessment map
+// (seeds/calc-assessment-map.json). MC is auto-scored by re-fetching Problems
+// server-side (keys never stored on the session); the FRQ is rubric-scored
+// (AI/tutor). Completing a week seeds the student's tutorPlan with the
+// priority-ranked weak skills. See utils/calcBootcamp.js + the design doc.
+
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+// A frozen MC item (client-safe payload — no answer key).
+const mcItemSchema = new Schema({
+  n: { type: Number },
+  problemId: { type: String, required: true },
+  unit: { type: String },
+  skill: { type: String },
+  skillId: { type: String },
+  practice: { type: String },
+  calc: { type: Boolean, default: false },
+  content: { type: String },
+  svg: { type: String },
+  options: [{ label: String, text: String }],
+}, { _id: false });
+
+const mcResponseSchema = new Schema({
+  problemId: { type: String },
+  n: { type: Number },
+  unit: { type: String },
+  skillId: { type: String },
+  practice: { type: String },
+  calc: { type: Boolean },
+  answer: { type: String },
+  correct: { type: Boolean },
+  answeredAt: { type: Date, default: Date.now },
+}, { _id: false });
+
+// The FRQ prompt (client-safe — rubric point descriptors are fine to show, but
+// worked solutions are not sent until after scoring).
+const frqPromptSchema = new Schema({
+  unit: { type: String },
+  skill: { type: String },
+  skillId: { type: String },
+  calc: { type: Boolean, default: false },
+  context: { type: String },
+  svg: { type: String },
+  parts: [{
+    label: String,
+    prompt: String,
+    points: Number,
+    rubric: [String],
+  }],
+}, { _id: false });
+
+const frqResponseSchema = new Schema({
+  submitted: { type: String },                 // the student's written work
+  partScores: [{
+    label: String,
+    pointsEarned: Number,
+    pointsPossible: Number,
+    feedback: String,
+  }],
+  totalEarned: { type: Number },
+  totalPossible: { type: Number },
+  scoredBy: { type: String, enum: ['ai', 'tutor'], default: 'ai' },
+  scoredAt: { type: Date },
+}, { _id: false });
+
+const calcBootcampSessionSchema = new Schema({
+  userId: { type: Schema.Types.ObjectId, ref: 'User', required: true, index: true },
+  week: { type: Number, required: true, min: 1, max: 5 },
+  title: { type: String },
+
+  mcItems: [mcItemSchema],
+  frq: frqPromptSchema,
+
+  mcResponses: [mcResponseSchema],
+  frqResponse: frqResponseSchema,
+
+  status: {
+    type: String,
+    enum: ['in_progress', 'mc_submitted', 'completed', 'abandoned'],
+    default: 'in_progress',
+    index: true,
+  },
+
+  timeLimitMinutes: { type: Number, default: 60 },
+  startedAt: { type: Date, default: Date.now },
+  completedAt: { type: Date },
+
+  // Scored at completion
+  mcCorrect: { type: Number },
+  mcTotal: { type: Number },
+  frqEarned: { type: Number },
+  frqPossible: { type: Number },
+  composite: { type: Number },                 // 0–100
+  apBand: { type: Number },                     // 1–5 (approximate)
+
+  // The committed ≤3-topic weekly plan (+ one retrospective).
+  plannedSkills: [{
+    skillId: String,
+    name: String,
+    unit: String,
+    kind: { type: String, enum: ['target', 'retrospective'] },
+    accuracy: Number,
+    priority: Number,
+  }],
+}, { timestamps: true });
+
+calcBootcampSessionSchema.index({ userId: 1, week: 1, status: 1 });
+
+calcBootcampSessionSchema.statics.getActiveSession = function (userId) {
+  return this.findOne({ userId, status: { $in: ['in_progress', 'mc_submitted'] } })
+    .sort({ createdAt: -1 });
+};
+
+const CalcBootcampSession = mongoose.models.CalcBootcampSession
+  || mongoose.model('CalcBootcampSession', calcBootcampSessionSchema);
+
+module.exports = CalcBootcampSession;

--- a/routes/calcBootcamp.js
+++ b/routes/calcBootcamp.js
@@ -1,0 +1,388 @@
+// routes/calcBootcamp.js
+// AP Calculus AB bootcamp weekly-diagnostic rail. Each week = 15 MC (auto-scored)
+// + one 9-point FRQ (rubric-scored by the AI tutor). Completing a week projects
+// an AP band, ranks weak skills by priority, commits a ≤3-topic plan, and seeds
+// the student's tutorPlan so structured teaching targets those gaps.
+//
+// Mounted at /api/calc-bootcamp (see config/routes.js). Design:
+// docs/APCALCAB_BOOTCAMP_DESIGN.md · scoring core: utils/calcBootcamp.js.
+
+const express = require('express');
+const router = express.Router();
+
+const CalcBootcampSession = require('../models/calcBootcampSession');
+const {
+  weeklyComposite, projectBand, rankWeakSkills, buildWeeklyPlan,
+} = require('../utils/calcBootcamp');
+
+const ASSESSMENT_MAP = require('../seeds/calc-assessment-map.json');
+
+// skillId → display name (for readable weak-skill / plan output).
+const SKILL_NAMES = (() => {
+  const map = {};
+  try {
+    const cat = require('../seeds/skills-ap-calculus-ab.json');
+    const arr = Array.isArray(cat) ? cat : (cat.skills || []);
+    for (const s of arr) map[s.skillId] = s.displayName || s.skillId;
+  } catch { /* names optional */ }
+  return map;
+})();
+const nameOf = (id) => SKILL_NAMES[id] || id;
+
+// ── POST /start-week ────────────────────────────────────────
+router.post('/start-week', async (req, res) => {
+  try {
+    const week = Number(req.body && req.body.week);
+    if (!Number.isInteger(week) || week < 1 || week > 5) {
+      return res.status(400).json({ message: 'week must be 1–5.' });
+    }
+    const wk = ASSESSMENT_MAP[String(week)];
+    if (!wk) return res.status(404).json({ message: `Week ${week} not found.` });
+
+    // Reuse an in-flight attempt for this week if one exists.
+    const existing = await CalcBootcampSession.findOne({
+      userId: req.user._id, week, status: { $in: ['in_progress', 'mc_submitted'] },
+    }).sort({ createdAt: -1 });
+    if (existing) return res.json(clientSession(existing));
+
+    const Problem = require('../models/problem');
+    const pids = wk.mc.map(m => m.problemId);
+    const problems = await Problem.find({ problemId: { $in: pids } }).lean();
+    const byId = Object.fromEntries(problems.map(p => [p.problemId, p]));
+
+    const mcItems = wk.mc.map(m => {
+      const p = byId[m.problemId] || {};
+      return {
+        n: m.n, problemId: m.problemId, unit: m.unit, skill: m.skill, skillId: m.skillId,
+        practice: m.practice, calc: m.calc,
+        content: p.prompt, svg: p.svg || undefined,
+        options: p.options || [],
+      };
+    });
+
+    // Client-safe FRQ: prompt + rubric point descriptors, but NOT the solutions.
+    const frq = {
+      unit: wk.frq.unit, skill: wk.frq.skill, skillId: wk.frq.skillId, calc: wk.frq.calc,
+      context: wk.frq.context, svg: wk.frq.svg || undefined,
+      parts: (wk.frq.parts || []).map(p => ({
+        label: p.label, prompt: p.prompt, points: p.points, rubric: p.rubric || [],
+      })),
+    };
+
+    const session = await CalcBootcampSession.create({
+      userId: req.user._id, week, title: wk.title,
+      mcItems, frq,
+      status: 'in_progress',
+      mcTotal: mcItems.length,
+      frqPossible: wk.frqPoints,
+    });
+
+    return res.json(clientSession(session));
+  } catch (err) {
+    console.error('[calcBootcamp] start-week error:', err.message);
+    return res.status(500).json({ message: 'Could not start this week’s diagnostic.' });
+  }
+});
+
+// ── POST /submit-mc ─────────────────────────────────────────
+// body: { sessionId, answers: { [problemId]: 'A'|'B'|'C'|'D' } }
+router.post('/submit-mc', async (req, res) => {
+  try {
+    const { sessionId, answers } = req.body || {};
+    const session = await loadOwned(sessionId, req.user._id, res);
+    if (!session) return;
+    const picks = answers || {};
+
+    const Problem = require('../models/problem');
+    const pids = session.mcItems.map(i => i.problemId);
+    const keyDocs = await Problem.find({ problemId: { $in: pids } }, 'problemId correctOption explanation').lean();
+    const keyById = Object.fromEntries(keyDocs.map(p => [p.problemId, p]));
+
+    const responses = [];
+    const results = [];
+    for (const item of session.mcItems) {
+      const answer = picks[item.problemId] || null;
+      const key = keyById[item.problemId] || {};
+      const correct = !!answer && answer === key.correctOption;
+      responses.push({
+        problemId: item.problemId, n: item.n, unit: item.unit, skillId: item.skillId,
+        practice: item.practice, calc: item.calc, answer, correct,
+      });
+      results.push({
+        problemId: item.problemId, n: item.n, answer, correct,
+        correctOption: key.correctOption,
+        explanation: correct ? undefined : key.explanation, // teach only on a miss
+      });
+    }
+
+    session.mcResponses = responses;
+    session.mcCorrect = responses.filter(r => r.correct).length;
+    session.status = 'mc_submitted';
+    await session.save();
+
+    return res.json({
+      success: true,
+      mcCorrect: session.mcCorrect,
+      mcTotal: session.mcTotal,
+      byUnit: tally(responses, r => r.unit),
+      byPractice: tally(responses, r => r.practice),
+      byCalc: tally(responses, r => (r.calc ? 'calculator' : 'no-calculator')),
+      results,
+      frq: clientFrq(session.frq),   // hand the FRQ back so the student can attempt it
+    });
+  } catch (err) {
+    console.error('[calcBootcamp] submit-mc error:', err.message);
+    return res.status(500).json({ message: 'Could not score the multiple-choice section.' });
+  }
+});
+
+// ── POST /submit-frq ────────────────────────────────────────
+// body: { sessionId, response: '<student work>' }  → AI rubric-scores it
+router.post('/submit-frq', async (req, res) => {
+  try {
+    const { sessionId, response } = req.body || {};
+    const session = await loadOwned(sessionId, req.user._id, res);
+    if (!session) return;
+    if (!response || !String(response).trim()) {
+      return res.status(400).json({ message: 'Enter your FRQ work to be scored.' });
+    }
+
+    const wk = ASSESSMENT_MAP[String(session.week)];
+    const partScores = await gradeFrq(wk.frq, String(response), req.user);
+    const totalEarned = partScores.reduce((a, p) => a + p.pointsEarned, 0);
+    const totalPossible = partScores.reduce((a, p) => a + p.pointsPossible, 0);
+
+    session.frqResponse = {
+      submitted: String(response), partScores,
+      totalEarned, totalPossible, scoredBy: 'ai', scoredAt: new Date(),
+    };
+    session.frqEarned = totalEarned;
+    await session.save();
+
+    return res.json({ success: true, partScores, totalEarned, totalPossible });
+  } catch (err) {
+    console.error('[calcBootcamp] submit-frq error:', err.message);
+    return res.status(500).json({ message: 'Could not score your free-response answer.' });
+  }
+});
+
+// ── POST /complete-week ─────────────────────────────────────
+router.post('/complete-week', async (req, res) => {
+  try {
+    const { sessionId } = req.body || {};
+    const session = await loadOwned(sessionId, req.user._id, res);
+    if (!session) return;
+    if (!session.mcResponses || session.mcResponses.length === 0) {
+      return res.status(400).json({ message: 'Submit the multiple-choice section first.' });
+    }
+
+    // Only weight the FRQ into the composite if it was actually scored; otherwise
+    // fall back to MC-only (don't penalize an un-submitted FRQ as 0/9).
+    const frqScored = session.frqEarned != null;
+    const composite = weeklyComposite(
+      session.mcCorrect || 0, session.mcTotal || 0,
+      frqScored ? session.frqEarned : 0,
+      frqScored ? (session.frqPossible || 0) : 0,
+    );
+    const { band } = projectBand(composite);
+
+    // Per-skill accuracy from this week's MC → priority-ranked weak skills.
+    const bySkill = {};
+    for (const r of session.mcResponses) {
+      const id = r.skillId || 'unknown';
+      bySkill[id] = bySkill[id] || { correct: 0, total: 0, unit: r.unit, name: nameOf(id) };
+      bySkill[id].total += 1;
+      if (r.correct) bySkill[id].correct += 1;
+    }
+    const weak = rankWeakSkills(bySkill);
+
+    // Retrospective: a still-relevant weak skill from an earlier completed week.
+    const priorWeak = await priorWeakSkills(req.user._id, session.week);
+    const plan = buildWeeklyPlan(weak, priorWeak).map(s => ({
+      skillId: s.skillId, name: s.name, unit: s.unit, kind: s.kind,
+      accuracy: s.accuracy, priority: s.priority,
+    }));
+
+    session.composite = composite;
+    session.apBand = band;
+    session.plannedSkills = plan;
+    session.status = 'completed';
+    session.completedAt = new Date();
+    await session.save();
+
+    // Seed the tutor plan with the weekly targets (worst first) — non-fatal.
+    let seeded = 0;
+    try {
+      const { loadOrCreatePlan, addSkillToFocus } = require('../utils/tutorPlanManager');
+      const tPlan = await loadOrCreatePlan(req.user._id, { user: req.user });
+      for (const s of plan) {
+        addSkillToFocus(tPlan, {
+          skillId: s.skillId, displayName: s.name,
+          reason: 'assessment-identified', familiarity: 'developing',
+          priority: Math.min(10, 6 + Math.round((1 - (s.accuracy || 0)) * 3)),
+        });
+        seeded += 1;
+      }
+      if (seeded > 0) await tPlan.save();
+    } catch (planErr) {
+      console.error('[calcBootcamp] plan seed error (non-fatal):', planErr.message);
+    }
+
+    return res.json({
+      success: true,
+      report: {
+        week: session.week, title: session.title,
+        mcCorrect: session.mcCorrect, mcTotal: session.mcTotal,
+        frqEarned: session.frqEarned || 0, frqPossible: session.frqPossible || 0,
+        frqScored: session.frqEarned != null,
+        composite, apBand: band, apBandApproximate: true,
+        plannedSkills: plan, seededToTutorPlan: seeded,
+        byUnit: tally(session.mcResponses, r => r.unit),
+      },
+    });
+  } catch (err) {
+    console.error('[calcBootcamp] complete-week error:', err.message);
+    return res.status(500).json({ message: 'Could not complete this week.' });
+  }
+});
+
+// ── GET /progress — trajectory across the 5 weeks ───────────
+router.get('/progress', async (req, res) => {
+  try {
+    const done = await CalcBootcampSession.find({ userId: req.user._id, status: 'completed' })
+      .sort({ week: 1, completedAt: 1 }).lean();
+
+    // Latest completion per week (a week can be retaken).
+    const byWeek = {};
+    for (const s of done) byWeek[s.week] = s;
+    const trajectory = Object.values(byWeek)
+      .sort((a, b) => a.week - b.week)
+      .map(s => ({
+        week: s.week, title: s.title, composite: s.composite, apBand: s.apBand,
+        mcCorrect: s.mcCorrect, mcTotal: s.mcTotal,
+        frqEarned: s.frqEarned, frqPossible: s.frqPossible,
+        plannedSkills: s.plannedSkills || [],
+        completedAt: s.completedAt,
+      }));
+
+    const latest = trajectory[trajectory.length - 1];
+    return res.json({
+      weeksCompleted: trajectory.length,
+      currentBand: latest ? latest.apBand : null,
+      bandApproximate: true,
+      trajectory,
+    });
+  } catch (err) {
+    console.error('[calcBootcamp] progress error:', err.message);
+    return res.status(500).json({ message: 'Could not load your bootcamp progress.' });
+  }
+});
+
+// ── helpers ─────────────────────────────────────────────────
+
+async function loadOwned(sessionId, userId, res) {
+  if (!sessionId) { res.status(400).json({ message: 'sessionId is required.' }); return null; }
+  const session = await CalcBootcampSession.findById(sessionId);
+  if (!session) { res.status(404).json({ message: 'Bootcamp session not found.' }); return null; }
+  if (String(session.userId) !== String(userId)) { res.status(403).json({ message: 'Not your session.' }); return null; }
+  return session;
+}
+
+// Weak skills from earlier completed weeks, ranked — the retrospective pool.
+async function priorWeakSkills(userId, currentWeek) {
+  const prior = await CalcBootcampSession.find({
+    userId, status: 'completed', week: { $lt: currentWeek },
+  }).lean();
+  const bySkill = {};
+  for (const s of prior) {
+    for (const r of (s.mcResponses || [])) {
+      const id = r.skillId || 'unknown';
+      bySkill[id] = bySkill[id] || { correct: 0, total: 0, unit: r.unit, name: nameOf(id) };
+      bySkill[id].total += 1;
+      if (r.correct) bySkill[id].correct += 1;
+    }
+  }
+  return rankWeakSkills(bySkill);
+}
+
+function clientSession(session) {
+  return {
+    sessionId: session._id,
+    week: session.week,
+    title: session.title,
+    timeLimitMinutes: session.timeLimitMinutes,
+    status: session.status,
+    mcItems: session.mcItems,           // already key-free
+    frq: clientFrq(session.frq),
+  };
+}
+
+function clientFrq(frq) {
+  if (!frq) return null;
+  return {
+    unit: frq.unit, skill: frq.skill, calc: frq.calc,
+    context: frq.context, svg: frq.svg || undefined,
+    parts: (frq.parts || []).map(p => ({
+      label: p.label, prompt: p.prompt, points: p.points, rubric: p.rubric || [],
+    })),
+  };
+}
+
+function tally(responses, keyFn) {
+  const out = {};
+  for (const r of responses) {
+    const k = keyFn(r) || 'unknown';
+    out[k] = out[k] || { correct: 0, total: 0 };
+    out[k].total += 1;
+    if (r.correct) out[k].correct += 1;
+  }
+  return out;
+}
+
+/**
+ * AI rubric-scores an FRQ against its point-by-point rubric (and reference
+ * solution), through the LLM gateway (PII anonymized). Returns one entry per
+ * part with earned points clamped to the part's max and a one-line rationale.
+ * Falls back to 0 points (with a note) if the model output can't be parsed, so
+ * the week can still complete on an MC-weighted band.
+ */
+async function gradeFrq(frq, studentText, user) {
+  const parts = frq.parts || [];
+  const fallback = () => parts.map(p => ({
+    label: p.label, pointsEarned: 0, pointsPossible: p.points || 0,
+    feedback: 'Not scored automatically — ask your tutor to review this part.',
+  }));
+
+  const rubricBlock = parts.map(p => (
+    `Part (${p.label}) — ${p.points} points\n`
+    + `Prompt: ${p.prompt}\n`
+    + `Reference solution: ${p.solution || '(none)'}\n`
+    + `Rubric:\n${(p.rubric || []).map(r => `  - ${r}`).join('\n')}`
+  )).join('\n\n');
+
+  const prompt = `You are an AP Calculus AB reader scoring one free-response question against its official rubric. Award each rubric point strictly: give the point only if the student's work earns it. Partial credit follows the rubric exactly.\n\n`
+    + `FRQ context: ${frq.context || ''}\n\n${rubricBlock}\n\n`
+    + `STUDENT RESPONSE:\n${studentText}\n\n`
+    + `Return ONLY valid JSON, no prose, of the form:\n`
+    + `{"parts":[{"label":"a","pointsEarned":<int>,"feedback":"<one sentence>"}, ...]}\n`
+    + `Include every part. pointsEarned must be an integer between 0 and that part's maximum.`;
+
+  try {
+    const { reason } = require('../utils/llmGateway');
+    const raw = await reason(prompt, { user, temperature: 0, maxTokens: 700 });
+    const jsonStr = raw.slice(raw.indexOf('{'), raw.lastIndexOf('}') + 1);
+    const parsed = JSON.parse(jsonStr);
+    const byLabel = Object.fromEntries((parsed.parts || []).map(p => [String(p.label), p]));
+    return parts.map(p => {
+      const g = byLabel[String(p.label)] || {};
+      const max = p.points || 0;
+      const earned = Math.max(0, Math.min(max, Math.round(Number(g.pointsEarned) || 0)));
+      return { label: p.label, pointsEarned: earned, pointsPossible: max, feedback: g.feedback || '' };
+    });
+  } catch (err) {
+    console.error('[calcBootcamp] FRQ grading fell back:', err.message);
+    return fallback();
+  }
+}
+
+module.exports = router;

--- a/seeds/calc-ab/README.md
+++ b/seeds/calc-ab/README.md
@@ -52,9 +52,10 @@ area between curves), `table` — to SVG (matplotlib for graphs, crisp SVG for
 tables). Ingestion bakes each into `Problem.svg` / the FRQ's `svg`. Run
 `python3 scripts/calcFigureRenderer.py` for a preview of every figure in the bank.
 
-## Deferred (follow-up PR)
+## Weekly bootcamp rail (shipped)
 
-The **weekly bootcamp rail**: weekly diagnostic delivery, auto-scored MC +
-tutor-scored FRQ against the rubric, priority-scored ≤3-topic weekly plan, and an
-AP 1–5 band projection with a week-over-week trajectory. The assessment map is the
-rail's input contract.
+`calc-assessment-map.json` is the input contract for `routes/calcBootcamp.js`
+(`/api/calc-bootcamp`): `start-week` → `submit-mc` (auto-scored) → `submit-frq`
+(AI rubric-scored) → `complete-week` (AP-band projection, priority-scored ≤3-topic
+plan seeded into `tutorPlan.skillFocus`) → `progress` (band trajectory). Scoring
+core in `utils/calcBootcamp.js` (unit-tested); state in `models/calcBootcampSession.js`.

--- a/tests/unit/calcBootcamp.test.js
+++ b/tests/unit/calcBootcamp.test.js
@@ -1,0 +1,85 @@
+// tests/unit/calcBootcamp.test.js
+// Unit tests for the AP Calc bootcamp scoring core (pure, DB-free).
+
+const B = require('../../utils/calcBootcamp');
+
+describe('weeklyComposite', () => {
+  test('MC + FRQ each weighted 50%', () => {
+    // 12/15 MC = 80%, 6/9 FRQ = 66.67% → (80 + 66.67)/2 = 73.3
+    expect(B.weeklyComposite(12, 15, 6, 9)).toBeCloseTo(73.3, 1);
+  });
+  test('falls back to MC-only when the FRQ is not scored yet', () => {
+    expect(B.weeklyComposite(9, 15, 0, 0)).toBeCloseTo(60, 1);
+  });
+  test('perfect and zero', () => {
+    expect(B.weeklyComposite(15, 15, 9, 9)).toBe(100);
+    expect(B.weeklyComposite(0, 15, 0, 9)).toBe(0);
+  });
+});
+
+describe('projectBand', () => {
+  test('maps composites into 1–5 monotonically', () => {
+    expect(B.projectBand(90).band).toBe(5);
+    expect(B.projectBand(60).band).toBe(4);
+    expect(B.projectBand(50).band).toBe(3);
+    expect(B.projectBand(35).band).toBe(2);
+    expect(B.projectBand(10).band).toBe(1);
+  });
+  test('is flagged approximate and never leaves 1–5', () => {
+    for (let c = 0; c <= 100; c += 5) {
+      const { band, approximate } = B.projectBand(c);
+      expect(approximate).toBe(true);
+      expect(band).toBeGreaterThanOrEqual(1);
+      expect(band).toBeLessThanOrEqual(5);
+    }
+  });
+});
+
+describe('priorityScore', () => {
+  test('rises with lower accuracy and higher exam weight', () => {
+    expect(B.priorityScore(0.5, 18)).toBeGreaterThan(B.priorityScore(0.5, 6));
+    expect(B.priorityScore(0.2, 10)).toBeGreaterThan(B.priorityScore(0.8, 10));
+  });
+  test('a mastered skill has zero priority', () => {
+    expect(B.priorityScore(1, 18)).toBe(0);
+  });
+});
+
+describe('rankWeakSkills', () => {
+  const bySkill = {
+    'chain-rule': { correct: 1, total: 3, unit: 'U3', name: 'Chain rule' },       // acc .33, w 11
+    ftc: { correct: 3, total: 4, unit: 'U6', name: 'FTC' },                        // acc .75, w 18
+    optimization: { correct: 2, total: 2, unit: 'U5', name: 'Optimization' },      // mastered → dropped
+    'related-rates': { correct: 0, total: 2, unit: 'U4', name: 'Related rates' },  // acc 0, w 12
+  };
+  test('drops mastered skills and ranks by priority', () => {
+    const ranked = B.rankWeakSkills(bySkill);
+    expect(ranked.map(s => s.skillId)).not.toContain('optimization');
+    // related-rates: (1-0)*12 = 12 is the top priority here
+    expect(ranked[0].skillId).toBe('related-rates');
+    expect(ranked.every(s => s.accuracy < 1)).toBe(true);
+  });
+});
+
+describe('buildWeeklyPlan', () => {
+  const ranked = [
+    { skillId: 'related-rates', priority: 12 },
+    { skillId: 'chain-rule', priority: 7.3 },
+    { skillId: 'ftc', priority: 4.5 },
+    { skillId: 'u-substitution', priority: 3 },
+  ];
+  test('takes ≤3 targets plus one retrospective from prior weeks', () => {
+    const prior = [{ skillId: 'limits-at-infinity', priority: 5 }];
+    const plan = B.buildWeeklyPlan(ranked, prior, 3);
+    expect(plan.filter(p => p.kind === 'target')).toHaveLength(3);
+    const retro = plan.filter(p => p.kind === 'retrospective');
+    expect(retro).toHaveLength(1);
+    expect(retro[0].skillId).toBe('limits-at-infinity');
+  });
+  test('retrospective never duplicates a chosen target', () => {
+    const prior = [{ skillId: 'related-rates', priority: 9 }, { skillId: 'mvt-evt', priority: 4 }];
+    const plan = B.buildWeeklyPlan(ranked, prior, 3);
+    expect(plan.filter(p => p.skillId === 'related-rates')).toHaveLength(1);
+    expect(plan.find(p => p.kind === 'retrospective').skillId).toBe('mvt-evt');
+  });
+});

--- a/utils/calcBootcamp.js
+++ b/utils/calcBootcamp.js
@@ -1,0 +1,101 @@
+/**
+ * AP CALCULUS AB BOOTCAMP — scoring core (pure, DB-free, unit-tested).
+ *
+ * The weekly loop: auto-score MC + rubric-score FRQ → weekly composite → AP band
+ * projection; rank weak skills by priority = (1 − accuracy) × exam weight × recency
+ * and commit a ≤3-topic weekly plan. See docs/APCALCAB_BOOTCAMP_DESIGN.md.
+ *
+ * @module utils/calcBootcamp
+ */
+
+// Approximate AP Calculus AB Section I unit weights (relative, from the CED).
+// Used only to prioritize remediation — not a scaled score.
+const UNIT_WEIGHT = {
+  U1: 6, U2: 6, U3: 11, U4: 12, U5: 17, U6: 18, U7: 9, U8: 13,
+};
+
+// Approximate composite(%) → AP band (1–5). Practice-feedback only; the real
+// cut scores shift year to year, so this is surfaced with a caveat.
+const BAND_TABLE = [
+  { min: 68, band: 5 },
+  { min: 55, band: 4 },
+  { min: 42, band: 3 },
+  { min: 30, band: 2 },
+  { min: 0, band: 1 },
+];
+
+/** Weekly composite 0–100: MC accuracy (50%) + FRQ rubric fraction (50%). */
+function weeklyComposite(mcCorrect, mcTotal, frqEarned, frqPossible) {
+  const mcPct = mcTotal > 0 ? (mcCorrect / mcTotal) : 0;
+  const frqPct = frqPossible > 0 ? (frqEarned / frqPossible) : 0;
+  // If the FRQ isn't scored yet, fall back to MC-only so a band still shows.
+  const composite = frqPossible > 0 ? (mcPct * 0.5 + frqPct * 0.5) : mcPct;
+  return Math.round(composite * 1000) / 10; // one decimal
+}
+
+/** Map a composite(%) to an approximate AP band (1–5). */
+function projectBand(composite) {
+  const row = BAND_TABLE.find(r => composite >= r.min) || BAND_TABLE[BAND_TABLE.length - 1];
+  return { band: row.band, approximate: true };
+}
+
+/**
+ * Priority score for a skill's remediation value.
+ * @param {number} accuracy 0..1 on the skill this week
+ * @param {number} examWeight relative unit weight (UNIT_WEIGHT)
+ * @param {number} recency 1 for this week, decaying for older misses (0..1]
+ */
+function priorityScore(accuracy, examWeight, recency = 1) {
+  return (1 - accuracy) * (examWeight || 1) * (recency || 1);
+}
+
+/**
+ * Rank weak skills (accuracy < 1) worst-value first.
+ * @param {Object} bySkill { skillId: {correct,total,unit,name} }
+ * @param {Object} [opts] { recencyBySkill?: {skillId:recency} }
+ * @returns {Array<{skillId,name,unit,correct,total,accuracy,priority}>}
+ */
+function rankWeakSkills(bySkill, opts = {}) {
+  const recency = opts.recencyBySkill || {};
+  return Object.entries(bySkill)
+    .map(([skillId, v]) => {
+      const accuracy = v.total > 0 ? v.correct / v.total : 0;
+      return {
+        skillId,
+        name: v.name || skillId,
+        unit: v.unit || null,
+        correct: v.correct,
+        total: v.total,
+        accuracy,
+        priority: priorityScore(accuracy, UNIT_WEIGHT[v.unit], recency[skillId]),
+      };
+    })
+    .filter(s => s.accuracy < 1)
+    .sort((a, b) => b.priority - a.priority);
+}
+
+/**
+ * Commit the weekly plan: the top-N weak skills plus one mandatory retrospective
+ * (a still-weak skill from a prior week, if supplied) — the design's "≤3-topic
+ * plan with one mandatory retrospective item".
+ * @param {Array} weakSkills ranked (rankWeakSkills output)
+ * @param {Array} [priorWeak] ranked weak skills carried from earlier weeks
+ * @param {number} [maxNew=3]
+ */
+function buildWeeklyPlan(weakSkills, priorWeak = [], maxNew = 3) {
+  const plan = weakSkills.slice(0, maxNew).map(s => ({ ...s, kind: 'target' }));
+  const chosen = new Set(plan.map(s => s.skillId));
+  const retro = (priorWeak || []).find(s => !chosen.has(s.skillId));
+  if (retro) plan.push({ ...retro, kind: 'retrospective' });
+  return plan;
+}
+
+module.exports = {
+  UNIT_WEIGHT,
+  BAND_TABLE,
+  weeklyComposite,
+  projectBand,
+  priorityScore,
+  rankWeakSkills,
+  buildWeeklyPlan,
+};


### PR DESCRIPTION
## What

The **weekly delivery loop** for the AP Calc AB bootcamp — the follow-up to the content foundation (#1212). Drives the design's assess → diagnose → plan → teach cycle end-to-end.

## The loop (`/api/calc-bootcamp`)

- **`start-week`** — freezes a week's 15 MC + FRQ from `calc-assessment-map.json` into a session (client-safe: **no answer keys, no FRQ solutions**); reuses an in-flight attempt.
- **`submit-mc`** — auto-scores by re-fetching keys server-side; returns accuracy **by unit / Mathematical Practice / calculator status** plus the miss explanations (distractor analysis), then hands back the FRQ.
- **`submit-frq`** — the AI tutor **rubric-scores** the student's work against the point-by-point rubric + reference solution, through the **LLM gateway** (PII-anonymized), clamped to each part's max; falls back to MC-only if the model output can't be parsed.
- **`complete-week`** — composite (MC 50% + FRQ 50%) → **AP band (1–5)**; ranks weak skills by **priority = (1 − accuracy) × exam weight × recency**; commits a **≤3-topic plan + one retrospective** and seeds `tutorPlan.skillFocus` so structured teaching targets the gaps.
- **`progress`** — week-over-week **band trajectory**.

## Pieces

- **`utils/calcBootcamp.js`** — pure scoring core (composite, band, priority, rank, plan). **Unit-tested 10/10** (`tests/unit/calcBootcamp.test.js`).
- **`models/calcBootcampSession.js`** — one weekly attempt; schema stores **no keys/solutions**.
- **`routes/calcBootcamp.js`** + mount in `config/routes.js` (behind `isAuthenticated`).

## Verification

- Scoring core: 10/10 unit tests (composite weighting, band monotonicity/clamping, priority, plan + retrospective).
- **No leakage:** verified the session schema strips FRQ solutions and MC items carry no `correctOption`, while the assessment map keeps solutions server-side for grading.
- **Fairness:** an un-submitted FRQ falls back to an MC-only composite rather than scoring 0/9.
- Modules load; lint clean.

## Notes

- FRQ scoring is AI-rubric-grading via the gateway (the self-serve path the design calls for); it's isolated in one helper and degrades gracefully. A client runner UI (like `act-test.js`) can follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTm55BDVTnGaJm3DRVauGZ)_