### PR TITLE
feat(courses): extend the day-one diagnostic card to more bootcamps

### DIFF
--- a/public/js/courseCatalog.js
+++ b/public/js/courseCatalog.js
@@ -1101,14 +1101,24 @@ class CourseManager {
     // lives in (the welcome splash when embedded, or its own card when standalone).
     // --------------------------------------------------
     diagnosticCardHtml(diag) {
-        if (!diag || diag.type !== 'act-practice') return '';
+        if (!diag || !diag.type) return '';
+        // type → the client launcher invoked by the CTA. Starting Point mirrors
+        // the existing inline-CTA path (floatingScreener, falling back to
+        // window.openStartingPoint). Unknown types render nothing.
+        const launchers = {
+            'act-practice': 'if (window.openActTest) { window.openActTest(); }',
+            'starting-point': "if (window.floatingScreener) { Promise.resolve(window.floatingScreener.checkAssessmentStatus()).then(function(){ window.floatingScreener.open(); }).catch(function(){}); } else if (window.openStartingPoint) { window.openStartingPoint(); }",
+        };
+        const launch = launchers[diag.type];
+        if (!launch) return '';
+        const dismiss = "(this.closest('.course-welcome-splash') || this.closest('.course-diagnostic-wrap') || this.closest('.course-diagnostic-card'))?.remove();";
         return `
             <div class="course-diagnostic-card" style="margin-top:16px; padding:16px; border-radius:12px; background:linear-gradient(135deg,#eef2ff,#faf5ff); border:1px solid #c7d2fe;">
                 <div style="font-size:14px; font-weight:700; color:#4338ca; margin-bottom:6px;">
                     <i class="fas fa-clipboard-check" style="margin-right:6px;"></i>${this.escapeHtml(diag.title)}
                 </div>
                 <div style="font-size:12px; color:#555; line-height:1.5; margin-bottom:12px;">${this.escapeHtml(diag.body)}</div>
-                <button class="course-diagnostic-cta" onclick="(this.closest('.course-welcome-splash') || this.closest('.course-diagnostic-wrap') || this.closest('.course-diagnostic-card'))?.remove(); if (window.openActTest) { window.openActTest(); }" style="
+                <button class="course-diagnostic-cta" onclick="${dismiss} ${launch}" style="
                     width:100%; padding:12px; border:none; border-radius:10px;
                     background:linear-gradient(135deg,#4f46e5,#7c3aed); color:white;
                     font-weight:700; font-size:14px; cursor:pointer;

--- a/routes/courseSession.js
+++ b/routes/courseSession.js
@@ -13,26 +13,51 @@ const ActTestSession = require('../models/actTestSession');
 const { calculateOverallProgress } = require('../utils/coursePrompt');
 const { buildProgressUpdate } = require('../utils/progressState');
 
-// Day-one diagnostic prompt for the ACT prep course: on entry, nudge the student
-// to take a full practice ACT (delivered as a card in the welcome splash) so the
-// tutor can target the bootcamp to their real gaps. Persists until they've
-// completed one. Returns a descriptor for welcomeData.diagnostic, or null.
-async function buildCourseDiagnostic(userId, courseId) {
-  if (courseId !== 'act-prep') return null;
-  try {
-    const taken = await ActTestSession.countDocuments({ userId, status: 'completed' });
-    if (taken > 0) return null;
-  } catch (err) {
-    console.error('[CourseSession] diagnostic check failed (non-fatal):', err.message);
-    return null;
-  }
-  return {
+// Day-one diagnostic prompt shown as a card on course entry, so the tutor can
+// target the course to the student's real level. Per course:
+//   - ACT prep → a full practice ACT (window.openActTest), gated on having taken one.
+//   - Algebra / Calculus / Precalc → the adaptive Starting Point placement
+//     (window.openStartingPoint), gated on user.assessmentCompleted.
+// Persists until the student completes it. Returns a welcomeData.diagnostic
+// descriptor, or null. Extend by adding a course entry below.
+const STARTING_POINT_CARD = {
+  type: 'starting-point',
+  title: 'Find your Starting Point',
+  body: 'Take a short adaptive placement first — no studying needed. Your tutor uses it to '
+    + 'start you at exactly the right level and focus each session on what you actually need.',
+  cta: 'Take the Starting Point',
+};
+const COURSE_DIAGNOSTICS = {
+  'act-prep': {
     type: 'act-practice',
     title: 'Start with a full Practice ACT',
     body: 'Take a timed practice ACT Math test first. Your tutor uses the results to pinpoint '
       + 'exactly which skills to focus your bootcamp on — so every session targets your real gaps.',
     cta: 'Take the Practice ACT',
-  };
+  },
+  'algebra-1': STARTING_POINT_CARD,
+  'algebra-2': STARTING_POINT_CARD,
+  'ap-calculus-ab': STARTING_POINT_CARD,
+  'calculus-bc': STARTING_POINT_CARD,
+  'precalculus': STARTING_POINT_CARD,
+};
+
+async function buildCourseDiagnostic(user, courseId) {
+  const card = COURSE_DIAGNOSTICS[courseId];
+  if (!card || !user) return null;
+  try {
+    if (card.type === 'act-practice') {
+      const taken = await ActTestSession.countDocuments({ userId: user._id, status: 'completed' });
+      if (taken > 0) return null;                 // already took a practice ACT
+    } else if (card.type === 'starting-point') {
+      const expired = user.assessmentExpiresAt && new Date(user.assessmentExpiresAt) < new Date();
+      if (user.assessmentCompleted && !expired) return null; // already placed (and current)
+    }
+  } catch (err) {
+    console.error('[CourseSession] diagnostic check failed (non-fatal):', err.message);
+    return null;
+  }
+  return { type: card.type, title: card.title, body: card.body, cta: card.cta };
 }
 
 /* ============================================================
@@ -202,7 +227,7 @@ router.post('/enroll', async (req, res) => {
         units: pathwayModules.slice(0, 6).map(m => m.title || m.moduleId),
         prerequisites: pathway.prerequisites || [],
         firstModuleTitle: pathwayModules[0]?.title || 'Getting Started',
-        diagnostic: await buildCourseDiagnostic(req.user._id, courseId)
+        diagnostic: await buildCourseDiagnostic(req.user, courseId)
       };
 
       console.log(`📚 [CourseSession] ${req.user.firstName} resumed ${existing.courseName} (${existing.overallProgress}% progress preserved)`);
@@ -300,7 +325,7 @@ router.post('/enroll', async (req, res) => {
       units: pathwayModules.slice(0, 6).map(m => m.title || m.moduleId),
       prerequisites: pathway.prerequisites || [],
       firstModuleTitle: pathwayModules[0]?.title || 'Getting Started',
-      diagnostic: await buildCourseDiagnostic(req.user._id, courseId)
+      diagnostic: await buildCourseDiagnostic(req.user, courseId)
     };
 
     res.json({
@@ -347,7 +372,7 @@ router.post('/:id/activate', async (req, res) => {
     // Day-one diagnostic nudge for returning students too (e.g. an ACT-prep
     // student who enrolled earlier and never took the practice test). Shown as a
     // card when they re-open the course from the sidebar.
-    const diagnostic = await buildCourseDiagnostic(req.user._id, session.courseId);
+    const diagnostic = await buildCourseDiagnostic(req.user, session.courseId);
 
     res.json({ success: true, session, diagnostic });
   } catch (err) {


### PR DESCRIPTION
## What

Part 2 of "both" — generalize the ACT-only day-one card so **each bootcamp course prompts the right diagnostic on entry**.

## How

- **`routes/courseSession.js`** — a `COURSE_DIAGNOSTICS` config map:
  - `act-prep` → **practice ACT** (`window.openActTest`), gated on a completed `ActTestSession`.
  - `algebra-1`, `algebra-2`, `ap-calculus-ab`, `calculus-bc`, `precalculus` → the adaptive **Starting Point** placement (`window.openStartingPoint`), gated on `user.assessmentCompleted` (respecting the annual expiry).
  - `buildCourseDiagnostic` now takes the user doc; adding a course is a one-line entry.
- **`public/js/courseCatalog.js`** — `diagnosticCardHtml` dispatches the CTA by `type`: `act-practice` → `openActTest`; `starting-point` → `window.floatingScreener` (falling back to `window.openStartingPoint`), mirroring chat's existing `launch-starting-point` inline-CTA path. Both entry paths — welcome splash **and** sidebar re-entry — already share this renderer, so returning students are covered too.

Each card persists until the student completes that diagnostic, then disappears.

## Verification

Rendered the Starting Point card variant (headless Chromium); lint clean; backend loads. The launchers used (`openActTest`, `floatingScreener`/`openStartingPoint`) are both available on the chat page.

## Note

AP Calc AB currently uses the general **Starting Point** placement (it's the available launchable diagnostic). A dedicated client runner that launches the new AP Calc **weekly bootcamp rail** (`/api/calc-bootcamp`, shipped in #1217) can replace it later — at which point AP Calc's entry in the config swaps to a `calc-bootcamp` type. The mechanism is built for exactly that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTm55BDVTnGaJm3DRVauGZ)_