### PR TITLE
feat: Animation Studio — sequencer + Producer (topic → finished 60–90s tutor video)

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -57,6 +57,7 @@ const chatRoutes = require('../routes/chat');
 const studentMovesRoutes = require('../routes/studentMoves');
 const conversationsRoutes = require('../routes/conversations');
 const speakRoutes = require('../routes/speak');
+const animationStudioRoutes = require('../routes/animationStudio');
 const voiceRoutes = require('../routes/voice');
 const voiceTestRoutes = require('../routes/voice-test');
 const voiceTutorRoutes = require('../routes/voiceTutor');
@@ -195,6 +196,7 @@ function registerRoutes(app, { authLimiter, signupLimiter }) {
   app.use('/api/student-moves', isAuthenticated, isStudent, aiEndpointLimiter, usageGate, studentMovesRoutes);
   app.use('/api/conversations', isAuthenticated, conversationsRoutes);
   app.use('/api/speak', isAuthenticated, speakRoutes);
+  app.use('/api/animation-studio', isAuthenticated, aiEndpointLimiter, animationStudioRoutes);
   app.use('/api/voice', isAuthenticated, aiEndpointLimiter, premiumFeatureGate('Voice chat'), voiceRoutes);
   app.use('/api/voice', isAuthenticated, voiceTestRoutes);
   app.use('/api/voice-tutor', isAuthenticated, aiEndpointLimiter, premiumFeatureGate('Voice chat'), voiceTutorRoutes);

--- a/docs/ANIMATION_STUDIO.md
+++ b/docs/ANIMATION_STUDIO.md
@@ -68,6 +68,26 @@ rig packages, and export them as WebM videos (the tutor-cam format in
    — drop the WebM next to the existing tutor videos in `public/videos/`. Video and
    PNG exports render at 2× and downscale for crisper edges.
 
+## Producer — topic in, finished video out
+
+The Agent-Opus-style flow, using the app's own AI stack. The **Producer** panel
+(teacher/admin login required — it calls the authed API):
+
+1. Type a topic, pick grade level, length (60/75/90s), and a tutor voice.
+2. **Write script** → `POST /api/animation-studio/script`
+   (`routes/animationStudio.js`, teacher/admin-gated, `aiEndpointLimiter`) uses
+   the LLM gateway (gpt-4o-mini, structured output) to write TTS-safe narration
+   in the persona's voice, split into segments with gesture cues. The script
+   appears as editable `gesture | text` lines.
+3. **Voice & assemble** → each segment is voiced via the existing
+   `POST /api/speak` (Cartesia, the tutor's real voice), stitched client-side
+   into one WAV (0.35s pauses), handed to the sequencer, lip-synced, and the
+   gesture clips are scheduled at each segment's actual start time.
+4. Preview / export as any sequence — WebM with the voiceover muxed in.
+
+Costs are your own OpenAI + Cartesia usage (fractions of a cent per video),
+with no per-clip vendor fees or length caps.
+
 ## Sequences — 60–90s (and longer) videos
 
 Clips are seconds long; full videos are **sequences**: a looping base clip with

--- a/docs/ANIMATION_STUDIO.md
+++ b/docs/ANIMATION_STUDIO.md
@@ -68,6 +68,28 @@ rig packages, and export them as WebM videos (the tutor-cam format in
    — drop the WebM next to the existing tutor videos in `public/videos/`. Video and
    PNG exports render at 2× and downscale for crisper edges.
 
+## Sequences — 60–90s (and longer) videos
+
+Clips are seconds long; full videos are **sequences**: a looping base clip with
+clips scheduled on top, plus an optional voiceover. The right-panel
+**Sequence · long video** section drives it:
+
+- Pick a base loop (usually `idle`) and a duration (no upper limit in the
+  engine; UI caps at 600s).
+- Schedule clip events: start time per event, and an `until` bound for looping
+  clips (`talk` from 5s to 12s). One-shots (`wave`, `nod`) just play once.
+- Load a voiceover audio file (e.g. a Cartesia TTS export) and click
+  **Generate lip-sync** — the studio RMS-analyzes the audio and builds a
+  `lipsync` clip (auto-thresholded, hysteresis, long holds split into flaps)
+  scheduled at 0:00. Regenerate any time; tweak it like any other clip.
+- **Preview sequence** plays the whole composition with audio in the viewport;
+  **Export sequence video** renders a WebM with the voiceover muxed in
+  (VP9+Opus). The export loop is wall-clock-driven: machines that can't render
+  30fps drop frames but stay in audio sync, and the tab never blocks.
+
+Sequence JSON evaluates through `RigCore.evaluateSequence(seq, clips, t)`, so
+the runtime can play the same composition live later.
+
 ## The life layers (what makes it not look like a puppet)
 
 Two procedural layers run during playback and export (viewport toggles

--- a/public/animation-studio.html
+++ b/public/animation-studio.html
@@ -139,6 +139,35 @@
           <label class="toggle"><input type="checkbox" id="clipLoop"> Loop</label>
         </div>
 
+        <h3>Producer · topic → video</h3>
+        <div class="producer">
+          <textarea id="prodTopic" rows="2" placeholder="Topic, e.g. Adding fractions with unlike denominators"></textarea>
+          <div class="prod-row">
+            <label class="field">
+              <span>Grade</span>
+              <input type="text" id="prodGrade" value="middle school" size="10">
+            </label>
+            <label class="field">
+              <span>Length</span>
+              <select id="prodLength">
+                <option value="60">60s</option>
+                <option value="75" selected>75s</option>
+                <option value="90">90s</option>
+              </select>
+            </label>
+          </div>
+          <label class="field wide">
+            <span>Voice</span>
+            <select id="prodTutor"></select>
+          </label>
+          <button id="btnProdScript" class="wide">✍️ Write script</button>
+          <textarea id="prodScript" rows="7" hidden
+            placeholder="gesture | narration — one segment per line"></textarea>
+          <button id="btnProdAssemble" class="wide primary" hidden
+            title="Voice each segment with the tutor's TTS voice, build the voiceover, generate lip-sync, and schedule the gestures">🎙 Voice &amp; assemble</button>
+          <div id="prodStatus" class="export-status"></div>
+        </div>
+
         <h3>Sequence · long video</h3>
         <div class="seq">
           <label class="field">

--- a/public/animation-studio.html
+++ b/public/animation-studio.html
@@ -138,6 +138,29 @@
           </label>
           <label class="toggle"><input type="checkbox" id="clipLoop"> Loop</label>
         </div>
+
+        <h3>Sequence · long video</h3>
+        <div class="seq">
+          <label class="field">
+            <span>Base loop</span>
+            <select id="seqBase"></select>
+          </label>
+          <label class="field">
+            <span>Duration (s)</span>
+            <input type="number" id="seqDuration" step="1" min="1" max="600">
+          </label>
+          <div id="seqEvents" class="seq-events"></div>
+          <button id="btnSeqAdd" class="wide">＋ Add clip event</button>
+          <label class="field wide seq-audio">
+            <span>Voiceover</span>
+            <input type="file" id="seqAudio" accept="audio/*">
+          </label>
+          <div id="seqAudioInfo" class="muted"></div>
+          <button id="btnSeqLipsync" class="wide" title="Analyze the voiceover and generate a lip-sync clip scheduled at 0:00">👄 Generate lip-sync from audio</button>
+          <button id="btnSeqPreview" class="wide" title="Play the whole sequence (with audio) in the viewport">▶ Preview sequence</button>
+          <button id="btnSeqExport" class="wide primary" title="Render the full sequence to WebM with the voiceover muxed in. Uses the current framing and background.">🎬 Export sequence video</button>
+          <div id="seqStatus" class="export-status"></div>
+        </div>
       </aside>
     </div>
 

--- a/public/css/animation-studio.css
+++ b/public/css/animation-studio.css
@@ -167,6 +167,16 @@ input[type="color"] { border: 1px solid var(--border); border-radius: 6px; backg
 .timeline-host { height: 190px; overflow-y: auto; overflow-x: hidden; position: relative; }
 #timeline { display: block; width: 100%; }
 
+/* ---------------------------------------------------------------- producer */
+.producer { display: flex; flex-direction: column; gap: 7px; }
+.producer textarea {
+  background: var(--bg-inset); color: var(--text);
+  border: 1px solid var(--border); border-radius: 6px;
+  padding: 6px 8px; font: inherit; font-size: 12px; resize: vertical;
+}
+.prod-row { display: flex; gap: 10px; }
+.prod-row input[type="text"] { width: 90px; }
+
 /* --------------------------------------------------------------- sequencer */
 .seq { display: flex; flex-direction: column; gap: 7px; }
 .seq-events { display: flex; flex-direction: column; gap: 4px; }

--- a/public/css/animation-studio.css
+++ b/public/css/animation-studio.css
@@ -167,6 +167,21 @@ input[type="color"] { border: 1px solid var(--border); border-radius: 6px; backg
 .timeline-host { height: 190px; overflow-y: auto; overflow-x: hidden; position: relative; }
 #timeline { display: block; width: 100%; }
 
+/* --------------------------------------------------------------- sequencer */
+.seq { display: flex; flex-direction: column; gap: 7px; }
+.seq-events { display: flex; flex-direction: column; gap: 4px; }
+.seq-event {
+  display: grid; grid-template-columns: 52px 1fr 52px 24px;
+  gap: 4px; align-items: center;
+}
+.seq-event input[type="number"] { width: 100%; padding: 3px 4px; font-size: 12px; }
+.seq-event select { min-width: 0; font-size: 12px; padding: 3px 4px; }
+.seq-event .rm {
+  width: 22px; height: 22px; padding: 0; border-radius: 5px;
+  font-size: 11px; line-height: 1; color: #ffb3b3;
+}
+.seq-audio input[type="file"] { width: 100%; font-size: 11px; color: var(--text-dim); }
+
 /* ------------------------------------------------------------------ modals */
 .modal-backdrop {
   position: fixed; inset: 0; background: rgba(5, 8, 12, 0.65);

--- a/public/js/animation-studio.js
+++ b/public/js/animation-studio.js
@@ -48,6 +48,11 @@
     playClock: 0,          // monotonic playback clock (never wraps) for life layers
     springs: {},           // spring state for follow-through preview
     springClock: null,
+    sequence: null,        // long-form composition: {base, duration, events[]}
+    seqPlay: null,         // active sequence preview: {start, audio?}
+    seqAudioBuf: null,     // decoded voiceover AudioBuffer
+    seqAudioFile: null,
+    seqAudioUrl: null,
   };
 
   const $ = (id) => document.getElementById(id);
@@ -66,6 +71,8 @@
     'exportModal', 'exportFraming', 'exportFps', 'exportBg', 'exportLoops', 'exportBase',
     'exportBlink', 'exportStatus', 'btnExportCancel', 'btnExportGo',
     'helpModal', 'btnHelpClose',
+    'seqBase', 'seqDuration', 'seqEvents', 'btnSeqAdd', 'seqAudio', 'seqAudioInfo',
+    'btnSeqLipsync', 'btnSeqPreview', 'btnSeqExport', 'seqStatus',
   ].forEach((id) => { els[id] = $(id); });
 
   // ------------------------------------------------------------- clip utils
@@ -186,16 +193,16 @@
     clearTimeout(S.dirtySaveTimer);
     S.dirtySaveTimer = setTimeout(() => {
       try {
-        localStorage.setItem(storageKey(), JSON.stringify({ clips: S.clips }));
+        localStorage.setItem(storageKey(), JSON.stringify({ clips: S.clips, sequence: S.sequence }));
       } catch { /* storage full — non-fatal */ }
     }, 400);
   }
 
-  function loadStoredClips() {
+  function loadStored() {
     try {
       const raw = localStorage.getItem(storageKey());
       if (!raw) return {};
-      return JSON.parse(raw).clips || {};
+      return JSON.parse(raw) || {};
     } catch { return {}; }
   }
 
@@ -233,7 +240,10 @@
     for (const [name, clip] of Object.entries(S.presets)) {
       S.clips[name] = JSON.parse(JSON.stringify(clip));
     }
-    Object.assign(S.clips, loadStoredClips());
+    const stored = loadStored();
+    Object.assign(S.clips, stored.clips || {});
+    S.sequence = stored.sequence
+      || { base: S.presets.idle ? 'idle' : null, duration: 75, events: [] };
     S.idleClip = S.presets.idle || S.clips.idle || null;
 
     selectClip(S.clips.idle ? 'idle' : Object.keys(S.clips)[0]);
@@ -539,10 +549,17 @@
       if (next !== undefined) renderPoseGhost(ctx, displayPose(next), 0.18);
     }
 
-    let pose = displayPose();
+    let pose;
+    if (S.seqPlay) {
+      const seqT = S.playClock - S.seqPlay.start;
+      pose = injectBlink(Core.evaluateSequence(S.sequence, S.clips, seqT), seqT);
+      if (seqT >= sequenceDuration()) stopSequencePreview();
+    } else {
+      pose = displayPose();
+    }
     // life layers run during playback only — editing shows the exact pose
     const rig = S.player.rig;
-    if (S.playing) {
+    if (S.playing || S.seqPlay) {
       if (els.microToggle.checked && rig.microMotion) {
         pose = Core.applyMicroMotion(rig, pose, S.playClock);
       }
@@ -563,7 +580,7 @@
 
   function drawSelection(ctx, pose) {
     const part = S.selectedPart;
-    if (!part || part === 'root' || S.playing) return;
+    if (!part || part === 'root' || S.playing || S.seqPlay) return;
     const rig = S.player.rig;
     const def = rig.parts[part];
     if (!def) return;
@@ -922,6 +939,7 @@
 
   // ------------------------------------------------------------ transport --
   function setPlaying(on) {
+    if (on) stopSequencePreview();
     S.playing = on;
     els.btnPlay.textContent = on ? '⏸' : '▶';
     if (on && !S.clip.loop && S.time >= S.clip.duration - EPS) S.time = 0;
@@ -964,14 +982,16 @@
     requestAnimationFrame(frame);
     const dt = lastTs ? Math.min(0.1, (ts - lastTs) / 1000) : 0;
     lastTs = ts;
+    if (S.playing || S.seqPlay) {
+      S.playClock += dt; // never wraps — feeds the life layers + sequence clock
+      needsUiRefresh = true;
+    }
     if (S.playing) {
       S.time += dt;
-      S.playClock += dt; // never wraps — feeds the life layers
       if (S.time > S.clip.duration) {
         if (S.clip.loop) S.time %= S.clip.duration;
         else { S.time = S.clip.duration; setPlaying(false); }
       }
-      needsUiRefresh = true;
     }
     renderViewport();
     if (needsUiRefresh) {
@@ -1119,6 +1139,310 @@
     a.download = filename;
     a.click();
     setTimeout(() => URL.revokeObjectURL(a.href), 30000);
+  }
+
+  // ------------------------------------------------ sequencer (long video) --
+  // A sequence is a looping base clip with clips scheduled on top plus an
+  // optional voiceover — this is how 60–90s explainer videos are made.
+
+  function injectBlink(pose, t) {
+    if (pose['slots.eye_L'] !== undefined || pose['slots.eye_R'] !== undefined) return pose;
+    const phase = (t - 1.2) % 2.8; // deterministic: 140ms every 2.8s
+    if (t >= 1.2 && phase >= 0 && phase < 0.14) {
+      return { ...pose, 'slots.eye_L': 'closed', 'slots.eye_R': 'closed' };
+    }
+    return pose;
+  }
+
+  function sequenceDuration() {
+    const audio = S.seqAudioBuf ? S.seqAudioBuf.duration : 0;
+    return Math.max(S.sequence.duration || 0, audio);
+  }
+
+  function buildSequencer() {
+    const names = Object.keys(S.clips).sort();
+    // base select
+    els.seqBase.innerHTML = '';
+    for (const name of names) {
+      const opt = document.createElement('option');
+      opt.value = name; opt.textContent = name;
+      if (name === S.sequence.base) opt.selected = true;
+      els.seqBase.appendChild(opt);
+    }
+    if (els.seqDuration !== document.activeElement) {
+      els.seqDuration.value = S.sequence.duration;
+    }
+    // event rows
+    els.seqEvents.innerHTML = '';
+    S.sequence.events.forEach((ev, i) => {
+      const row = document.createElement('div');
+      row.className = 'seq-event';
+      const tIn = document.createElement('input');
+      tIn.type = 'number'; tIn.step = '0.1'; tIn.min = '0'; tIn.value = ev.t;
+      tIn.title = 'Start time (s)';
+      tIn.addEventListener('change', () => {
+        const v = parseFloat(tIn.value);
+        if (Number.isFinite(v) && v >= 0) { ev.t = v; scheduleSave(); }
+      });
+      const clipSel = document.createElement('select');
+      for (const name of names) {
+        const opt = document.createElement('option');
+        opt.value = name; opt.textContent = name;
+        if (name === ev.clip) opt.selected = true;
+        clipSel.appendChild(opt);
+      }
+      clipSel.addEventListener('change', () => {
+        ev.clip = clipSel.value;
+        scheduleSave();
+        buildSequencer(); // until-field enablement may change
+      });
+      const untilIn = document.createElement('input');
+      untilIn.type = 'number'; untilIn.step = '0.1'; untilIn.min = '0';
+      untilIn.placeholder = 'until';
+      untilIn.title = 'End time for looping clips (s)';
+      const clip = S.clips[ev.clip];
+      untilIn.disabled = !(clip && clip.loop);
+      if (ev.until !== undefined) untilIn.value = ev.until;
+      untilIn.addEventListener('change', () => {
+        const v = parseFloat(untilIn.value);
+        if (Number.isFinite(v) && v > ev.t) ev.until = v;
+        else delete ev.until;
+        scheduleSave();
+      });
+      const rm = document.createElement('button');
+      rm.className = 'rm'; rm.textContent = '✕';
+      rm.addEventListener('click', () => {
+        S.sequence.events.splice(i, 1);
+        scheduleSave();
+        buildSequencer();
+      });
+      row.append(tIn, clipSel, untilIn, rm);
+      els.seqEvents.appendChild(row);
+    });
+    els.seqAudioInfo.textContent = S.seqAudioBuf
+      ? `${S.seqAudioFile.name} — ${S.seqAudioBuf.duration.toFixed(1)}s`
+      : 'No voiceover loaded.';
+  }
+
+  function stopSequencePreview() {
+    if (!S.seqPlay) return;
+    if (S.seqPlay.audio) S.seqPlay.audio.pause();
+    S.seqPlay = null;
+    els.btnSeqPreview.textContent = '▶ Preview sequence';
+    refreshSoon();
+  }
+
+  function toggleSequencePreview() {
+    if (S.seqPlay) { stopSequencePreview(); return; }
+    setPlaying(false);
+    S.seqPlay = { start: S.playClock };
+    if (S.seqAudioUrl) {
+      S.seqPlay.audio = new Audio(S.seqAudioUrl);
+      S.seqPlay.audio.play().catch(() => { /* autoplay policies — visuals still run */ });
+    }
+    els.btnSeqPreview.textContent = '■ Stop preview';
+  }
+
+  async function loadSeqAudio(file) {
+    const actx = new (window.AudioContext || window.webkitAudioContext)();
+    try {
+      S.seqAudioBuf = await actx.decodeAudioData(await file.arrayBuffer());
+      S.seqAudioFile = file;
+      if (S.seqAudioUrl) URL.revokeObjectURL(S.seqAudioUrl);
+      S.seqAudioUrl = URL.createObjectURL(file);
+      if (S.seqAudioBuf.duration > S.sequence.duration) {
+        S.sequence.duration = Math.ceil(S.seqAudioBuf.duration);
+        scheduleSave();
+      }
+      els.seqStatus.textContent = '';
+    } catch {
+      els.seqStatus.textContent = 'Could not decode that audio file.';
+    } finally {
+      actx.close();
+      buildSequencer();
+    }
+  }
+
+  function generateLipSync() {
+    if (!S.seqAudioBuf) {
+      els.seqStatus.textContent = 'Load a voiceover first.';
+      return;
+    }
+    const buf = S.seqAudioBuf;
+    const hopSec = 0.03;
+    const hop = Math.max(1, Math.round(buf.sampleRate * hopSec));
+    const channels = [];
+    for (let c = 0; c < buf.numberOfChannels; c++) channels.push(buf.getChannelData(c));
+    const windows = Math.floor(buf.length / hop);
+    const rms = new Array(windows);
+    for (let w = 0; w < windows; w++) {
+      let sum = 0;
+      for (const data of channels) {
+        for (let i = w * hop; i < (w + 1) * hop; i++) sum += data[i] * data[i];
+      }
+      rms[w] = Math.sqrt(sum / (hop * channels.length));
+    }
+    const keys = Core.lipSyncFromRms(rms, hopSec);
+    if (!keys.length) {
+      els.seqStatus.textContent = 'No speech detected in the audio.';
+      return;
+    }
+    S.clips.lipsync = {
+      name: 'lipsync',
+      duration: Math.ceil(buf.duration * 10) / 10,
+      loop: false,
+      fps: 30,
+      tracks: { 'slots.mouth': keys },
+    };
+    if (!S.sequence.events.some((ev) => ev.clip === 'lipsync')) {
+      S.sequence.events.push({ clip: 'lipsync', t: 0 });
+    }
+    scheduleSave();
+    buildClipSelect();
+    buildSequencer();
+    const flaps = keys.filter((k) => k.v === 'ah').length;
+    els.seqStatus.textContent = `Lip-sync generated: ${flaps} mouth flaps over ${buf.duration.toFixed(1)}s.`;
+  }
+
+  async function exportSequence() {
+    if (exporting) return;
+    const errors = Core.validateSequence(S.sequence, S.clips);
+    if (errors.length) {
+      els.seqStatus.textContent = 'Fix sequence first: ' + errors[0];
+      return;
+    }
+    const rig = S.player.rig;
+    const framing = rig.framings[els.framingSelect.value]
+      || { width: rig.canvas[0], height: rig.canvas[1], view: [0, 0, rig.canvas[0], rig.canvas[1]] };
+    const outFps = 30;
+    const duration = sequenceDuration();
+    const bg = S.background === 'checker' ? '#ffffff' : S.background;
+    const wantAudio = !!S.seqAudioBuf;
+
+    const candidates = wantAudio
+      ? ['video/webm;codecs=vp9,opus', 'video/webm;codecs=vp8,opus', 'video/webm']
+      : ['video/webm;codecs=vp9', 'video/webm;codecs=vp8', 'video/webm'];
+    const mime = candidates.find((m) => window.MediaRecorder && MediaRecorder.isTypeSupported(m));
+    if (!mime) {
+      els.seqStatus.textContent = 'MediaRecorder WebM is not supported in this browser.';
+      return;
+    }
+
+    const canvas = document.createElement('canvas');
+    canvas.width = framing.width; canvas.height = framing.height;
+    const ctx = canvas.getContext('2d');
+    ctx.imageSmoothingEnabled = true;
+    ctx.imageSmoothingQuality = 'high';
+    const ss = document.createElement('canvas');
+    ss.width = framing.width * 2; ss.height = framing.height * 2;
+    const ssCtx = ss.getContext('2d');
+    const savedView = [...S.player.view];
+    S.player.view = [...framing.view];
+
+    exporting = true;
+    els.btnSeqExport.disabled = true;
+    stopSequencePreview();
+
+    const stream = canvas.captureStream(0);
+    const track = stream.getVideoTracks()[0];
+    let audioEl = null; let actx = null;
+    if (wantAudio) {
+      actx = new (window.AudioContext || window.webkitAudioContext)();
+      audioEl = new Audio(S.seqAudioUrl);
+      const src = actx.createMediaElementSource(audioEl);
+      const dest = actx.createMediaStreamDestination();
+      src.connect(dest); // recorder-only; not routed to speakers
+      stream.addTrack(dest.stream.getAudioTracks()[0]);
+      await actx.resume();
+    }
+    const recorder = new MediaRecorder(stream, { mimeType: mime, videoBitsPerSecond: 8_000_000 });
+    const chunks = [];
+    recorder.ondataavailable = (e) => { if (e.data.size) chunks.push(e.data); };
+    const done = new Promise((resolve) => { recorder.onstop = resolve; });
+
+    const springs = Core.newSpringState();
+    const poseAt = (t, dt) => {
+      let pose = injectBlink(Core.evaluateSequence(S.sequence, S.clips, t), t);
+      pose = Core.applyMicroMotion(rig, pose, t);
+      pose = Core.stepSecondaryMotion(rig, pose, springs, dt);
+      return pose;
+    };
+
+    recorder.start();
+    if (audioEl) audioEl.play();
+    // Wall-clock-driven loop: the audio plays in real time, so frames are
+    // rendered for "now" rather than a fixed grid — a machine that can't
+    // hit 30fps drops frames but stays in sync, and the loop ALWAYS yields
+    // so the tab never freezes.
+    const t0 = performance.now();
+    const frameMs = 1000 / outFps;
+    let prevT = null;
+    let lastStatus = -1;
+    for (;;) {
+      const t = Math.min((performance.now() - t0) / 1000, duration);
+      const dt = prevT === null ? 1 / outFps : Math.max(0.001, t - prevT);
+      prevT = t;
+      ssCtx.setTransform(1, 0, 0, 1, 0, 0);
+      ssCtx.fillStyle = bg;
+      ssCtx.fillRect(0, 0, ss.width, ss.height);
+      S.player.draw(ssCtx, poseAt(t, dt), { clear: false });
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
+      ctx.drawImage(ss, 0, 0, canvas.width, canvas.height);
+      track.requestFrame();
+      if (t - lastStatus >= 0.5) {
+        lastStatus = t;
+        els.seqStatus.textContent = `Rendering ${t.toFixed(1)}s / ${duration.toFixed(1)}s…`;
+      }
+      if (t >= duration) break;
+      const sincePrev = (performance.now() - t0) % frameMs;
+      await new Promise((r) => setTimeout(r, Math.max(4, frameMs - sincePrev)));
+    }
+    if (audioEl) audioEl.pause();
+    recorder.stop();
+    await done;
+    if (actx) actx.close();
+    S.player.view = savedView;
+    exporting = false;
+    els.btnSeqExport.disabled = false;
+
+    const blob = new Blob(chunks, { type: 'video/webm' });
+    downloadBlob(blob, `${S.rigId}_sequence.webm`);
+    els.seqStatus.textContent =
+      `Done — ${(blob.size / 1024 / 1024).toFixed(1)} MB, ${duration.toFixed(1)}s`
+      + `${wantAudio ? ' with audio' : ''} (${mime.includes('vp9') ? 'VP9' : 'VP8'}).`;
+  }
+
+  function bindSequencer() {
+    buildSequencer();
+    els.seqBase.addEventListener('change', () => {
+      S.sequence.base = els.seqBase.value;
+      scheduleSave();
+    });
+    els.seqDuration.addEventListener('change', () => {
+      const v = parseFloat(els.seqDuration.value);
+      if (Number.isFinite(v) && v > 0) { S.sequence.duration = v; scheduleSave(); }
+    });
+    els.btnSeqAdd.addEventListener('click', () => {
+      const last = S.sequence.events[S.sequence.events.length - 1];
+      const names = Object.keys(S.clips).sort();
+      S.sequence.events.push({
+        clip: names.includes('wave') ? 'wave' : names[0],
+        t: last ? Math.round((last.t + 3) * 10) / 10 : 2,
+      });
+      scheduleSave();
+      buildSequencer();
+    });
+    els.seqAudio.addEventListener('change', () => {
+      const file = els.seqAudio.files[0];
+      if (file) loadSeqAudio(file);
+    });
+    els.btnSeqLipsync.addEventListener('click', generateLipSync);
+    els.btnSeqPreview.addEventListener('click', toggleSequencePreview);
+    els.btnSeqExport.addEventListener('click', () => exportSequence().catch((e) => {
+      exporting = false;
+      els.btnSeqExport.disabled = false;
+      els.seqStatus.textContent = 'Export failed: ' + e.message;
+    }));
   }
 
   // --------------------------------------------------------------- UI wiring
@@ -1332,6 +1656,8 @@
         if (ev.shiftKey) redo(); else undo();
       }
     });
+
+    bindSequencer();
 
     new ResizeObserver(refreshSoon).observe(els.viewportHost);
     new ResizeObserver(refreshSoon).observe(els.timelineHost);

--- a/public/js/animation-studio.js
+++ b/public/js/animation-studio.js
@@ -73,6 +73,8 @@
     'helpModal', 'btnHelpClose',
     'seqBase', 'seqDuration', 'seqEvents', 'btnSeqAdd', 'seqAudio', 'seqAudioInfo',
     'btnSeqLipsync', 'btnSeqPreview', 'btnSeqExport', 'seqStatus',
+    'prodTopic', 'prodGrade', 'prodLength', 'prodTutor', 'btnProdScript',
+    'prodScript', 'btnProdAssemble', 'prodStatus',
   ].forEach((id) => { els[id] = $(id); });
 
   // ------------------------------------------------------------- clip utils
@@ -1412,6 +1414,171 @@
       + `${wantAudio ? ' with audio' : ''} (${mime.includes('vp9') ? 'VP9' : 'VP8'}).`;
   }
 
+  // --------------------------------------------- producer (topic → video) --
+  // The Agent-Opus-style flow: topic → LLM script (server, tutor persona) →
+  // per-segment TTS in the tutor's voice → stitched voiceover → lip-sync →
+  // gestures scheduled at segment starts → ready to preview/export.
+
+  function csrfToken() {
+    const m = document.cookie.match(/(?:^|;\s*)_csrf=([^;]+)/);
+    return m ? decodeURIComponent(m[1]) : '';
+  }
+
+  async function api(path, body) {
+    const opts = { credentials: 'same-origin' };
+    if (body !== undefined) {
+      opts.method = 'POST';
+      opts.headers = { 'Content-Type': 'application/json', 'x-csrf-token': csrfToken() };
+      opts.body = JSON.stringify(body);
+    }
+    const res = await fetch(path, opts);
+    if (res.status === 401 || res.status === 403) {
+      throw new Error('Not authorized — log in as a teacher/admin at /login.html in this tab, then retry.');
+    }
+    if (!res.ok) {
+      let msg = 'Request failed (' + res.status + ')';
+      try { msg = (await res.json()).message || msg; } catch { /* non-JSON */ }
+      throw new Error(msg);
+    }
+    return res;
+  }
+
+  const scriptToText = (segments) => segments
+    .map((s) => `${s.gesture} | ${s.text}`).join('\n');
+
+  function textToSegments(text) {
+    return text.split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => {
+        const m = /^([a-z]+)\s*\|\s*(.+)$/.exec(line);
+        return m ? { gesture: m[1], text: m[2] } : { gesture: 'none', text: line };
+      })
+      .filter((s) => s.text.length > 0);
+  }
+
+  async function producerInit() {
+    try {
+      const res = await api('/api/animation-studio/tutors');
+      const { tutors } = await res.json();
+      els.prodTutor.innerHTML = '';
+      for (const t of tutors) {
+        const opt = document.createElement('option');
+        opt.value = t.voiceId;
+        opt.dataset.tutorId = t.id;
+        opt.textContent = t.name;
+        if (t.id === 'mr-nappier') opt.selected = true;
+        els.prodTutor.appendChild(opt);
+      }
+    } catch (e) {
+      els.prodStatus.textContent = e.message;
+    }
+  }
+
+  async function producerScript() {
+    const topic = els.prodTopic.value.trim();
+    if (!topic) { els.prodStatus.textContent = 'Enter a topic first.'; return; }
+    els.btnProdScript.disabled = true;
+    els.prodStatus.textContent = 'Writing script…';
+    try {
+      const sel = els.prodTutor.selectedOptions[0];
+      const res = await api('/api/animation-studio/script', {
+        topic,
+        gradeLevel: els.prodGrade.value.trim() || 'middle school',
+        targetSeconds: parseInt(els.prodLength.value, 10) || 75,
+        tutorId: sel ? sel.dataset.tutorId : 'mr-nappier',
+      });
+      const { title, segments } = await res.json();
+      els.prodScript.value = scriptToText(segments);
+      els.prodScript.hidden = false;
+      els.btnProdAssemble.hidden = false;
+      els.prodStatus.textContent = `Script ready: "${title}" — edit lines, then Voice & assemble.`;
+    } catch (e) {
+      els.prodStatus.textContent = e.message;
+    } finally {
+      els.btnProdScript.disabled = false;
+    }
+  }
+
+  // 16-bit PCM mono WAV so the sequencer's decode/lip-sync path treats the
+  // stitched voiceover exactly like an uploaded file.
+  function encodeWavPcm16(samples, sampleRate) {
+    const buf = new ArrayBuffer(44 + samples.length * 2);
+    const view = new DataView(buf);
+    const writeStr = (off, str) => { for (let i = 0; i < str.length; i++) view.setUint8(off + i, str.charCodeAt(i)); };
+    writeStr(0, 'RIFF'); view.setUint32(4, 36 + samples.length * 2, true); writeStr(8, 'WAVE');
+    writeStr(12, 'fmt '); view.setUint32(16, 16, true); view.setUint16(20, 1, true);
+    view.setUint16(22, 1, true); view.setUint32(24, sampleRate, true);
+    view.setUint32(28, sampleRate * 2, true); view.setUint16(32, 2, true); view.setUint16(34, 16, true);
+    writeStr(36, 'data'); view.setUint32(40, samples.length * 2, true);
+    for (let i = 0; i < samples.length; i++) {
+      const v = Math.max(-1, Math.min(1, samples[i]));
+      view.setInt16(44 + i * 2, Math.round(v * 32767), true);
+    }
+    return buf;
+  }
+
+  async function producerAssemble() {
+    const segments = textToSegments(els.prodScript.value);
+    if (!segments.length) { els.prodStatus.textContent = 'Script is empty.'; return; }
+    const voiceId = els.prodTutor.value;
+    els.btnProdAssemble.disabled = true;
+    const actx = new (window.AudioContext || window.webkitAudioContext)();
+    try {
+      // 1. voice each segment
+      const buffers = [];
+      for (let i = 0; i < segments.length; i++) {
+        els.prodStatus.textContent = `Voicing segment ${i + 1} / ${segments.length}…`;
+        const res = await api('/api/speak', { text: segments[i].text, voiceId });
+        buffers.push(await actx.decodeAudioData(await res.arrayBuffer()));
+      }
+      // 2. stitch mono with pauses, recording each segment's start time
+      const rate = buffers[0].sampleRate;
+      const gap = Math.round(rate * 0.35);
+      const total = buffers.reduce((n, b) => n + b.length, 0) + gap * (buffers.length - 1);
+      const samples = new Float32Array(total);
+      const starts = [];
+      let offset = 0;
+      for (const b of buffers) {
+        starts.push(offset / rate);
+        for (let c = 0; c < b.numberOfChannels; c++) {
+          const data = b.getChannelData(c);
+          for (let i = 0; i < b.length; i++) samples[offset + i] += data[i] / b.numberOfChannels;
+        }
+        offset += b.length + gap;
+      }
+      // 3. hand the stitched voiceover to the sequencer + lip-sync
+      const wav = new File([encodeWavPcm16(samples, rate)], 'producer-voiceover.wav', { type: 'audio/wav' });
+      await loadSeqAudio(wav);
+      // 4. rebuild the sequence: idle base + gestures at segment starts
+      const events = [];
+      for (let i = 0; i < segments.length; i++) {
+        const g = segments[i].gesture;
+        if (g === 'none' || !S.clips[g]) continue;
+        const ev = { clip: g, t: Math.round(starts[i] * 10) / 10 };
+        if (S.clips[g].loop) ev.until = Math.round((starts[i] + 3.5) * 10) / 10;
+        events.push(ev);
+      }
+      S.sequence.base = S.clips.idle ? 'idle' : S.sequence.base;
+      S.sequence.duration = Math.ceil(total / rate + 1);
+      S.sequence.events = events;
+      generateLipSync(); // adds the lipsync clip + event, saves, rebuilds UI
+      els.prodStatus.textContent =
+        `Assembled: ${segments.length} segments, ${(total / rate).toFixed(1)}s. Preview or Export below.`;
+    } catch (e) {
+      els.prodStatus.textContent = e.message;
+    } finally {
+      actx.close();
+      els.btnProdAssemble.disabled = false;
+    }
+  }
+
+  function bindProducer() {
+    producerInit();
+    els.btnProdScript.addEventListener('click', producerScript);
+    els.btnProdAssemble.addEventListener('click', () => producerAssemble());
+  }
+
   function bindSequencer() {
     buildSequencer();
     els.seqBase.addEventListener('change', () => {
@@ -1658,6 +1825,7 @@
     });
 
     bindSequencer();
+    bindProducer();
 
     new ResizeObserver(refreshSoon).observe(els.viewportHost);
     new ResizeObserver(refreshSoon).observe(els.timelineHost);

--- a/public/js/rig/rig-core.js
+++ b/public/js/rig/rig-core.js
@@ -406,6 +406,109 @@
     return out;
   }
 
+  // ------------------------------------------------------ sequences --------
+  // A sequence is a long-form composition: a looping base clip with clips
+  // scheduled on top, e.g. a 90s explainer (idle + talk 4–12s + wave at 2s).
+  //   { name, duration, base: 'idle',
+  //     events: [{ clip, t, until? }] }   — `until` bounds LOOPING clips;
+  //                                         one-shots always play once.
+  // Evaluation is pure layering: base first, events in array order on top.
+  function evaluateSequence(seq, clipsByName, t) {
+    let pose = {};
+    const base = seq && seq.base && clipsByName[seq.base];
+    if (base) pose = sampleClip(base, t);
+    if (!seq || !seq.events) return pose;
+    for (const ev of seq.events) {
+      const clip = clipsByName[ev.clip];
+      if (!clip) continue;
+      const local = t - ev.t;
+      if (local < 0) continue;
+      const dur = clipDuration(clip);
+      const active = clip.loop
+        ? t < (ev.until !== undefined ? ev.until : ev.t + dur)
+        : local <= dur;
+      if (active) pose = composePose(pose, sampleClip(clip, local));
+    }
+    return pose;
+  }
+
+  function validateSequence(seq, clipsByName) {
+    const errors = [];
+    if (!seq || typeof seq !== 'object') return ['sequence is not an object'];
+    if (!(Number.isFinite(seq.duration) && seq.duration > 0)) {
+      errors.push('sequence.duration must be a positive number');
+    }
+    if (seq.base && !clipsByName[seq.base]) errors.push(`unknown base clip: ${seq.base}`);
+    for (const [i, ev] of (seq.events || []).entries()) {
+      if (!clipsByName[ev.clip]) errors.push(`event ${i}: unknown clip "${ev.clip}"`);
+      if (!Number.isFinite(ev.t) || ev.t < 0) errors.push(`event ${i}: bad start time`);
+      if (ev.until !== undefined && !(Number.isFinite(ev.until) && ev.until > ev.t)) {
+        errors.push(`event ${i}: until must be after t`);
+      }
+    }
+    return errors;
+  }
+
+  // ------------------------------------------------------- lip sync --------
+  // Turn a windowed RMS envelope of a voiceover into a slots.mouth track.
+  // rms: array of per-window RMS values; windowSec: seconds per window.
+  // Auto-thresholds from the envelope (noise floor → speech), applies
+  // hysteresis, drops blips, and splits long holds into flaps so sustained
+  // speech reads as talking rather than a frozen open mouth.
+  function lipSyncFromRms(rms, windowSec, opts = {}) {
+    if (!rms || rms.length === 0) return [];
+    const sorted = [...rms].sort((a, b) => a - b);
+    const q = (p) => sorted[Math.min(sorted.length - 1, Math.floor(p * sorted.length))];
+    const floor = q(0.2);
+    const peak = q(0.95);
+    if (peak - floor < 1e-6) return []; // silence or constant tone
+    const open = opts.threshold !== undefined ? opts.threshold : floor + 0.22 * (peak - floor);
+    const close = open * (opts.hysteresis !== undefined ? opts.hysteresis : 0.7);
+    const minOpen = opts.minOpen !== undefined ? opts.minOpen : 0.06;
+    const minClose = opts.minClose !== undefined ? opts.minClose : 0.05;
+    const maxHold = opts.maxHold !== undefined ? opts.maxHold : 0.28;
+    const flapGap = opts.flapGap !== undefined ? opts.flapGap : 0.07;
+
+    // 1. raw open/close spans with hysteresis
+    const spans = [];
+    let openAt = null;
+    for (let i = 0; i < rms.length; i++) {
+      const t = i * windowSec;
+      if (openAt === null && rms[i] >= open) openAt = t;
+      else if (openAt !== null && rms[i] < close) { spans.push([openAt, t]); openAt = null; }
+    }
+    if (openAt !== null) spans.push([openAt, rms.length * windowSec]);
+
+    // 2. merge tiny gaps, drop tiny blips
+    const merged = [];
+    for (const span of spans) {
+      const last = merged[merged.length - 1];
+      if (last && span[0] - last[1] < minClose) last[1] = span[1];
+      else merged.push([...span]);
+    }
+    const clean = merged.filter(([a, b]) => b - a >= minOpen);
+
+    // 3. split sustained spans into flaps, emit step keys
+    const keys = [];
+    let cursor = 0; // last emitted state end; rest is implicit before first key
+    for (const [a, b] of clean) {
+      if (keys.length === 0 || a > cursor) keys.push({ t: a, v: 'ah', e: 'step' });
+      else keys.push({ t: cursor, v: 'ah', e: 'step' });
+      let pos = a;
+      while (b - pos > maxHold + flapGap + minOpen) {
+        pos += maxHold;
+        keys.push({ t: pos, v: 'rest', e: 'step' });
+        pos += flapGap;
+        keys.push({ t: pos, v: 'ah', e: 'step' });
+      }
+      keys.push({ t: b, v: 'rest', e: 'step' });
+      cursor = b;
+    }
+    // ensure the track starts closed if speech starts late
+    if (keys.length && keys[0].t > 0.01) keys.unshift({ t: 0, v: 'rest', e: 'step' });
+    return keys;
+  }
+
   return {
     CHANNELS,
     CHANNEL_DEFAULTS,
@@ -434,5 +537,8 @@
     stepSecondaryMotion,
     applyMicroMotion,
     solveIK,
+    evaluateSequence,
+    validateSequence,
+    lipSyncFromRms,
   };
 });

--- a/routes/animationStudio.js
+++ b/routes/animationStudio.js
@@ -1,0 +1,123 @@
+// routes/animationStudio.js
+// Producer endpoints for the rig Animation Studio (/animation-studio.html):
+// tutor list + LLM script generation for explainer videos. Voiceover TTS
+// reuses POST /api/speak; everything downstream (lip-sync, gestures, WebM
+// export) runs client-side in the studio.
+const express = require('express');
+const router = express.Router();
+const { callLLMStructured } = require('../utils/llmGateway');
+const TUTOR_CONFIG = require('../utils/tutorConfig');
+
+// Teacher/admin only — the script endpoint spends LLM tokens and the studio
+// is an authoring tool, not a student surface. Mirrors middleware/auth
+// hasRole(): roles[] first, legacy role string as fallback.
+function isTeacherOrAdmin(req, res, next) {
+  const user = req.user;
+  const has = (role) => {
+    if (!user) return false;
+    if (user.roles && user.roles.length > 0) return user.roles.includes(role);
+    return String(user.role) === role;
+  };
+  if (req.isAuthenticated && req.isAuthenticated() && (has('teacher') || has('admin'))) {
+    return next();
+  }
+  return res.status(403).json({ success: false, message: 'Forbidden: Teachers or admins only.' });
+}
+
+const GESTURES = ['none', 'wave', 'nod', 'thinking', 'celebrate'];
+
+const SCRIPT_FORMAT = {
+  type: 'json_schema',
+  json_schema: {
+    name: 'explainer_script',
+    strict: true,
+    schema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        title: { type: 'string' },
+        segments: {
+          type: 'array',
+          items: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              text: { type: 'string' },
+              gesture: { type: 'string', enum: GESTURES },
+            },
+            required: ['text', 'gesture'],
+          },
+        },
+      },
+      required: ['title', 'segments'],
+    },
+  },
+};
+
+// GET /api/animation-studio/tutors — personas the Producer can voice.
+router.get('/tutors', isTeacherOrAdmin, (req, res) => {
+  const tutors = Object.entries(TUTOR_CONFIG).map(([id, t]) => ({
+    id,
+    name: t.name,
+    voiceId: t.voiceId,
+  }));
+  res.json({ tutors });
+});
+
+// POST /api/animation-studio/script
+// { topic, gradeLevel?, targetSeconds?, tutorId? } →
+// { title, segments: [{ text, gesture }] }
+router.post('/script', isTeacherOrAdmin, async (req, res) => {
+  const topic = String(req.body.topic || '').trim().slice(0, 500);
+  if (!topic) return res.status(400).json({ success: false, message: 'Missing topic.' });
+  const gradeLevel = String(req.body.gradeLevel || 'middle school').slice(0, 40);
+  const targetSeconds = Math.min(180, Math.max(30, parseInt(req.body.targetSeconds, 10) || 75));
+  const tutorId = TUTOR_CONFIG[req.body.tutorId] ? req.body.tutorId : 'mr-nappier';
+  const persona = TUTOR_CONFIG[tutorId];
+  const targetWords = Math.round(targetSeconds * 2.4); // ≈ narration pace
+
+  const messages = [
+    {
+      role: 'system',
+      content:
+        'You write spoken narration scripts for short animated K-12 math explainer videos. '
+        + 'The narration is read aloud by a text-to-speech voice, so: no stage directions, no '
+        + 'markdown, no LaTeX — spell out math in words (say "three fourths", not "3/4"). '
+        + 'Return 5 to 8 segments. Each segment is a few sentences of narration plus one gesture '
+        + 'cue for the animated character: "wave" only on the greeting segment, "thinking" when '
+        + 'posing a question to the viewer, "nod" for affirmations, "celebrate" only on the final '
+        + 'wrap-up segment, otherwise "none".',
+    },
+    {
+      role: 'user',
+      content:
+        `Write the narration for a ${targetSeconds}-second (about ${targetWords} words total) `
+        + `explainer video on: "${topic}". Audience: ${gradeLevel} students. `
+        + `The speaker is ${persona.name}. Persona: ${String(persona.about || '').slice(0, 300)} `
+        + 'Keep the tone warm, concrete, and encouraging, with one simple worked example.',
+    },
+  ];
+
+  try {
+    const raw = await callLLMStructured('gpt-4o-mini', messages, SCRIPT_FORMAT, {
+      temperature: 0.7,
+      max_tokens: 1500,
+    });
+    const segments = (Array.isArray(raw.segments) ? raw.segments : [])
+      .map((s) => ({
+        text: String(s.text || '').trim(),
+        gesture: GESTURES.includes(s.gesture) ? s.gesture : 'none',
+      }))
+      .filter((s) => s.text.length > 0)
+      .slice(0, 12);
+    if (!segments.length) {
+      return res.status(502).json({ success: false, message: 'Script generation returned nothing usable.' });
+    }
+    res.json({ title: String(raw.title || topic).slice(0, 120), segments, tutorId });
+  } catch (err) {
+    console.error('[animation-studio] script generation failed:', err.message);
+    res.status(502).json({ success: false, message: 'Script generation failed.' });
+  }
+});
+
+module.exports = router;

--- a/tests/unit/animationStudioRoute.test.js
+++ b/tests/unit/animationStudioRoute.test.js
@@ -1,0 +1,108 @@
+// tests/unit/animationStudioRoute.test.js
+// The Animation Studio producer endpoints (routes/animationStudio.js):
+// role guard, input validation, and script sanitization. The LLM gateway is
+// mocked — no network, no DB.
+
+jest.mock('../../utils/llmGateway', () => ({
+  callLLMStructured: jest.fn(),
+}));
+
+const express = require('express');
+const request = require('supertest');
+const { callLLMStructured } = require('../../utils/llmGateway');
+const router = require('../../routes/animationStudio');
+
+function appAs(user) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, res, next) => {
+    req.user = user;
+    req.isAuthenticated = () => !!user;
+    next();
+  });
+  app.use('/api/animation-studio', router);
+  return app;
+}
+
+const teacher = { roles: ['teacher'], firstName: 'Pat' };
+const student = { roles: ['student'] };
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('role guard', () => {
+  test('students are rejected', async () => {
+    const res = await request(appAs(student)).get('/api/animation-studio/tutors');
+    expect(res.status).toBe(403);
+  });
+
+  test('unauthenticated is rejected', async () => {
+    const res = await request(appAs(null)).get('/api/animation-studio/tutors');
+    expect(res.status).toBe(403);
+  });
+
+  test('legacy single-role admin passes', async () => {
+    const res = await request(appAs({ role: 'admin' })).get('/api/animation-studio/tutors');
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('GET /tutors', () => {
+  test('lists personas with id, name, and voiceId', async () => {
+    const res = await request(appAs(teacher)).get('/api/animation-studio/tutors');
+    expect(res.status).toBe(200);
+    const ids = res.body.tutors.map((t) => t.id);
+    expect(ids).toEqual(expect.arrayContaining(['bob', 'maya', 'ms-maria', 'mr-nappier']));
+    for (const t of res.body.tutors) {
+      expect(typeof t.name).toBe('string');
+      expect(typeof t.voiceId).toBe('string');
+    }
+  });
+});
+
+describe('POST /script', () => {
+  test('requires a topic', async () => {
+    const res = await request(appAs(teacher))
+      .post('/api/animation-studio/script').send({});
+    expect(res.status).toBe(400);
+    expect(callLLMStructured).not.toHaveBeenCalled();
+  });
+
+  test('returns sanitized segments and clamps inputs', async () => {
+    callLLMStructured.mockResolvedValue({
+      title: 'Adding Fractions',
+      segments: [
+        { text: '  Hey everyone!  ', gesture: 'wave' },
+        { text: 'Bad gesture becomes none', gesture: 'backflip' },
+        { text: '', gesture: 'nod' }, // dropped: empty text
+        { text: 'Wrap up!', gesture: 'celebrate' },
+      ],
+    });
+    const res = await request(appAs(teacher))
+      .post('/api/animation-studio/script')
+      .send({ topic: 'fractions', targetSeconds: 9999, tutorId: 'no-such-tutor' });
+    expect(res.status).toBe(200);
+    expect(res.body.tutorId).toBe('mr-nappier'); // unknown tutor falls back
+    expect(res.body.segments).toEqual([
+      { text: 'Hey everyone!', gesture: 'wave' },
+      { text: 'Bad gesture becomes none', gesture: 'none' },
+      { text: 'Wrap up!', gesture: 'celebrate' },
+    ]);
+    // targetSeconds clamped into [30, 180] before it reaches the prompt
+    const userMsg = callLLMStructured.mock.calls[0][1].find((m) => m.role === 'user').content;
+    expect(userMsg).toContain('180-second');
+  });
+
+  test('LLM failure maps to 502, not a crash', async () => {
+    callLLMStructured.mockRejectedValue(new Error('rate limited'));
+    const res = await request(appAs(teacher))
+      .post('/api/animation-studio/script').send({ topic: 'x' });
+    expect(res.status).toBe(502);
+  });
+
+  test('empty usable output maps to 502', async () => {
+    callLLMStructured.mockResolvedValue({ title: 't', segments: [{ text: '', gesture: 'nod' }] });
+    const res = await request(appAs(teacher))
+      .post('/api/animation-studio/script').send({ topic: 'x' });
+    expect(res.status).toBe(502);
+  });
+});

--- a/tests/unit/rigCore.test.js
+++ b/tests/unit/rigCore.test.js
@@ -409,6 +409,112 @@ describe('solveIK (CCD)', () => {
   });
 });
 
+describe('evaluateSequence (long-form composition)', () => {
+  const clips = {
+    idle: {
+      name: 'idle', duration: 2, loop: true,
+      tracks: { 'torso.y': [{ t: 0, v: 0, e: 'linear' }, { t: 2, v: -4 }] },
+    },
+    wave: {
+      name: 'wave', duration: 1, loop: false,
+      tracks: { 'forearm.rotation': [{ t: 0, v: 0, e: 'linear' }, { t: 1, v: -50 }] },
+    },
+    talk: {
+      name: 'talk', duration: 0.5, loop: true,
+      tracks: { 'slots.mouth': [{ t: 0, v: 'ah', e: 'step' }, { t: 0.25, v: 'rest', e: 'step' }] },
+    },
+  };
+  const seq = {
+    name: 'explainer', duration: 90, base: 'idle',
+    events: [
+      { clip: 'wave', t: 2 },
+      { clip: 'talk', t: 5, until: 12 },
+    ],
+  };
+
+  test('base loops for the whole duration', () => {
+    expect(Core.evaluateSequence(seq, clips, 0)['torso.y']).toBeCloseTo(0);
+    expect(Core.evaluateSequence(seq, clips, 61)['torso.y']).toBeCloseTo(-2); // 61 % 2 = 1
+  });
+
+  test('one-shot event plays at its local time then ends', () => {
+    expect(Core.evaluateSequence(seq, clips, 1.9)['forearm.rotation']).toBeUndefined();
+    expect(Core.evaluateSequence(seq, clips, 2.5)['forearm.rotation']).toBeCloseTo(-25);
+    expect(Core.evaluateSequence(seq, clips, 3.5)['forearm.rotation']).toBeUndefined();
+  });
+
+  test('looping event runs until `until` then stops', () => {
+    expect(Core.evaluateSequence(seq, clips, 5.1)['slots.mouth']).toBe('ah');
+    expect(Core.evaluateSequence(seq, clips, 11.9)['slots.mouth']).toBeDefined();
+    expect(Core.evaluateSequence(seq, clips, 12.1)['slots.mouth']).toBeUndefined();
+  });
+
+  test('events override the base track-by-track', () => {
+    const pose = Core.evaluateSequence(seq, clips, 2.5);
+    expect(pose['torso.y']).toBeCloseTo(-1); // base still there
+    expect(pose['forearm.rotation']).toBeCloseTo(-25); // overlay on top
+  });
+
+  test('validateSequence catches unknown clips and bad times', () => {
+    const bad = {
+      duration: -1, base: 'ghost',
+      events: [{ clip: 'nope', t: -2 }, { clip: 'talk', t: 5, until: 3 }],
+    };
+    const errors = Core.validateSequence(bad, clips);
+    expect(errors.some((e) => e.includes('duration'))).toBe(true);
+    expect(errors.some((e) => e.includes('ghost'))).toBe(true);
+    expect(errors.some((e) => e.includes('nope'))).toBe(true);
+    expect(errors.some((e) => e.includes('until'))).toBe(true);
+    expect(Core.validateSequence(seq, clips)).toEqual([]);
+  });
+});
+
+describe('lipSyncFromRms', () => {
+  const WINDOW = 0.03;
+  // helper: silence + speech + silence envelope
+  const envelope = (spans, totalSec) => {
+    const n = Math.round(totalSec / WINDOW);
+    const rms = new Array(n).fill(0.01);
+    for (const [a, b] of spans) {
+      for (let i = Math.round(a / WINDOW); i < Math.round(b / WINDOW); i++) rms[i] = 0.4;
+    }
+    return rms;
+  };
+
+  test('opens during speech, closed in silence', () => {
+    const keys = Core.lipSyncFromRms(envelope([[1, 2]], 3), WINDOW);
+    const at = (t) => Core.sampleTrack(keys, t);
+    expect(at(0.5)).toBe('rest');
+    expect(at(1.05)).toBe('ah');
+    expect(at(2.5)).toBe('rest');
+  });
+
+  test('long speech is split into flaps (not one frozen open mouth)', () => {
+    const keys = Core.lipSyncFromRms(envelope([[0.5, 3.5]], 4), WINDOW);
+    const opens = keys.filter((k) => k.v === 'ah').length;
+    expect(opens).toBeGreaterThan(3); // several flaps across 3s of speech
+  });
+
+  test('ignores blips shorter than minOpen', () => {
+    const keys = Core.lipSyncFromRms(envelope([[1, 1.03]], 2), WINDOW);
+    expect(keys.filter((k) => k.v === 'ah')).toHaveLength(0);
+  });
+
+  test('silence or empty input produces no keys', () => {
+    expect(Core.lipSyncFromRms([], WINDOW)).toEqual([]);
+    expect(Core.lipSyncFromRms(new Array(100).fill(0.02), WINDOW)).toEqual([]);
+  });
+
+  test('keys are step-eased, chronological, and deterministic', () => {
+    const rms = envelope([[0.5, 1.2], [2, 2.6]], 3);
+    const a = Core.lipSyncFromRms(rms, WINDOW);
+    const b = Core.lipSyncFromRms(rms, WINDOW);
+    expect(a).toEqual(b);
+    for (let i = 1; i < a.length; i++) expect(a[i].t).toBeGreaterThanOrEqual(a[i - 1].t);
+    for (const k of a) expect(k.e).toBe('step');
+  });
+});
+
 describe('shipped rig + preset clips', () => {
   const fs = require('fs');
   const path = require('path');


### PR DESCRIPTION
## What this is

Follow-up to #1219: the studio now produces **full-length videos (60–90s and beyond)** end-to-end — the Agent-Opus-style flow, but on our own stack with no per-clip vendor fees or length caps. Two layers:

### 1. Sequencer (long-form composition)
A video is a **sequence**: a looping base clip (idle) with clip events scheduled on top plus an optional voiceover.

- **`rig-core.js`**: `evaluateSequence` (pure layered evaluation: looping base, one-shots play once, looping events honor `until`), `validateSequence`, and `lipSyncFromRms` — converts a windowed RMS envelope of a voiceover into a `slots.mouth` step track (auto-threshold, hysteresis, blip removal, sustained speech split into flaps).
- **Studio "Sequence · long video" panel**: base/duration/event editor (persisted per-rig), audio load, one-click lip-sync, preview with audio, and export to WebM with the voiceover muxed in (VP9+Opus via canvas `captureStream` + `MediaElementSource`).
- **Export hardening**: the export loop is wall-clock-driven and always yields — slow machines drop frames but keep audio sync; the tab never freezes (first cut spun synchronously when rendering fell behind real time; caught by the headless harness as a hard renderer freeze).

### 2. Producer (topic in, video out)
- **`routes/animationStudio.js`** (`/api/animation-studio`, `isAuthenticated` + `aiEndpointLimiter`, teacher/admin-gated): `GET /tutors` lists personas + voice ids; `POST /script` writes TTS-safe narration via the LLM gateway (gpt-4o-mini, strict structured output) in the chosen tutor's persona, split into segments with gesture cues, sanitized server-side.
- **Studio "Producer" panel**: topic + grade + length + tutor voice → editable `gesture | text` script → **Voice & assemble**: each segment voiced through the existing `POST /api/speak` (Cartesia, the tutor's real voice), stitched client-side into one WAV, lip-synced, and gesture clips scheduled at each segment's actual start time. CSRF double-submit handled.

## Verification

- Sequencer harness (synthesized 20s voiceover): 60 lip-sync flaps, wave/nod events, 21s export containing both `V_VP9` and `A_OPUS` tracks, zero console errors.
- Producer harness (stubbed APIs, real WAV per segment): 5-segment script → voiced + stitched to 12.4s → 45 flaps → gestures at segment starts (wave 0s, thinking 5.1–8.6s, nod 7.7s, celebrate 10.2s) → 14s VP9+Opus export, zero console errors.
- `npm run test:unit`: 3812/3812 green (18 new across both commits). ESLint clean on all new/changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5ZVV6w4tMuNdL8Jh71uXY