### PR TITLE
chore(sat): stage the validated SAT Math bank source

### DIFF
--- a/seeds/sat-math/SAT_SPEC.fable.md
+++ b/seeds/sat-math/SAT_SPEC.fable.md
@@ -1,0 +1,71 @@
+# Mathmatix Digital SAT Math Bootcamp — Assessment Authoring Spec (v1, author-provided)
+
+## 1. The real test (align to this)
+Digital SAT Math: 70 min, 44 questions, two 22-question adaptive modules (35 min each).
+~75% MC (4 choices A–D) + ~25% student-produced response (SPR/grid-in, typed answer).
+Calculator allowed on every question. Scored 200–800.
+Domain weights: Algebra ~35% (13–15/44) · Advanced Math ~35% (13–15) ·
+Problem-Solving & Data Analysis ~15% (5–7) · Geometry & Trigonometry ~15% (5–7).
+All domains appear in every module; items run roughly easiest → hardest within a module.
+
+## 2. Bootcamp structure
+5 weekly diagnostics, auto-scored (MC by key, SPR by exact/equivalent match). No FRQ grading.
+W1 "Heart of Algebra" — Algebra-heavy — 22 items
+W2 "Advanced Math" — Advanced-Math-heavy — 22
+W3 "Data & Problem-Solving" — PSDA-heavy — 22
+W4 "Geometry & Trig + retention" — Geo/Trig-heavy, ALG/ADV retention — 22
+W5 "Exit (full section)" — all domains at real weights — 44 (≈15 ALG, 15 ADV, 7 PSDA, 7 GEO; ≈33 MC + 11 SPR; add "module":1|2 per item)
+Per 22-item diagnostic: ~17 MC + ~5 SPR. Difficulty ≈ 7 E / 10 M / 5 H (scale for W5).
+
+## 3. Domains → skills (tag every item; domain ∈ ALG, ADV, PSDA, GEO)
+ALG: linear equations in one variable · linear equations in two variables · linear functions ·
+systems of two linear equations · linear inequalities (one/two variables).
+ADV: equivalent expressions · nonlinear equations & systems · nonlinear functions
+(quadratic, exponential, polynomial, rational, radical).
+PSDA: ratios/rates/proportional relationships & units · percentages · one-variable data
+(center & spread) · two-variable data (scatterplots & models) · probability & conditional
+probability · inference & margin of error · evaluating statistical claims.
+GEO: area & volume · lines, angles & triangles · right triangles & trigonometry · circles.
+
+## 4. Question types
+"mc": exactly 4 choices A–D; "answer" = 0-based index.
+"spr": no choices; encode canonical "spr_answer" + "equivalents" (all accepted forms) +
+"answer_any" (array) when multiple values are correct.
+Grid-in entry rules (author answers to these):
+- numeric only — no %, $, commas, units, π
+- fractions AND decimals accepted; author both when either is clean ("7/2" + ["3.5"])
+- no mixed numbers (5/2 not 2 1/2)
+- field fits 5 chars positive / 6 with leading '-'; if a fraction doesn't fit give the
+  truncated/rounded decimal that fills the field and list every accepted rounding
+  (2/3 → "2/3", equivalents [".6666",".6667",".667"])
+- negatives allowed with leading '-'
+
+## 5. Notation: plain text + Unicode (x², √, ≤, ≥, ≠, −, °, π, ≈, a/b, f(x), 2^x, |x|). NO LaTeX.
+Currency/units in stem prose only, never in an SPR answer.
+
+## 6. Figures — fixed library only, ≤5 figure items per diagnostic
+"fgraph": {"expr":"2*x-3","xmin":-10,"xmax":10,"ymin":-10,"ymax":10}  (numpy expr in x)
+"scatter": {"pts":[[x,y],...],"xlabel":"...","ylabel":"...","line":{"slope":..,"yint":..}}  (line optional)
+"bar": {"labels":[...],"values":[...],"xlabel":"...","ylabel":"..."}
+"table": {"headers":[...],"rows":[[...]]}
+"geometry": {"shape":"triangle"|"rectangle"|"circle"|"lines","labels":{...},"marks":{...}}
+"numberline": {"min":..,"max":..}
+PSDA staples (scatterplots, two-way tables, bar plots) encouraged.
+
+## 7. Output JSON — one file per week: sat_w{N}.json
+{"week":1,"title":"Heart of Algebra","items":[{"n":1,"domain":"ALG",
+ "skill":"Linear equations in two variables","difficulty":"E","type":"mc",
+ "stem":"...","choices":["...","...","...","..."],"answer":2,
+ "spr_answer":null,"equivalents":[],"answer_any":null,
+ "explanation":"2–4 sentence worked solution.","verify":"sympy snippet or null","figure":null}]}
+W5: same schema, 44 items, plus "module":1|2 per item.
+
+## 8. Hard rules
+- verify sympy snippet wherever computable; for SPR the snippet must reproduce the canonical
+  value AND confirm each listed equivalent is numerically equal.
+- Distractors model real SAT errors (sign slips, slope-for-intercept, part-vs-whole percent,
+  divide-instead-of-multiply rate, reversed ratio, forgot to distribute, misread trend).
+- Difficulty honesty (E/M/H); order items roughly easy→hard within a diagnostic.
+- No duplicate skill+structure within a diagnostic; fresh contexts per week, none reused across weeks.
+- Calculator-fair: solvable exactly; calculator helps but doesn't trivialize.
+- SPR realism per §4. Answer-letter balance ≈ even A/B/C/D per MC set.

--- a/seeds/sat-math/sat_w1.json
+++ b/seeds/sat-math/sat_w1.json
@@ -1,0 +1,531 @@
+{
+ "week": 1,
+ "title": "Heart of Algebra",
+ "items": [
+  {
+   "n": 1,
+   "domain": "ALG",
+   "skill": "Linear equations in one variable",
+   "difficulty": "E",
+   "type": "mc",
+   "stem": "If 4x − 9 = 19, what is the value of x?",
+   "choices": [
+    "2.5",
+    "7",
+    "10",
+    "28"
+   ],
+   "answer": 1,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Add 9 to both sides to get 4x = 28, then divide both sides by 4 to get x = 7. Choice A results from subtracting 9 instead of adding; choice C results from stopping at 19 − 9; choice D results from forgetting to divide by 4.",
+   "verify": "from sympy import *; x=symbols('x'); assert solve(Eq(4*x-9,19),x)==[7]",
+   "figure": null
+  },
+  {
+   "n": 2,
+   "domain": "ALG",
+   "skill": "Linear functions",
+   "difficulty": "E",
+   "type": "mc",
+   "stem": "A streaming service charges a one-time sign-up fee plus a fixed monthly rate. The total cost C(m), in dollars, for the first m months of the subscription is given by C(m) = 9m + 15. What is the best interpretation of the number 9 in this context?",
+   "choices": [
+    "The one-time sign-up fee, in dollars",
+    "The total cost, in dollars, for the first month",
+    "The fixed monthly rate, in dollars",
+    "The number of months in the subscription"
+   ],
+   "answer": 2,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "In C(m) = 9m + 15, the coefficient 9 is multiplied by the number of months m, so it is the amount added for each month: the fixed monthly rate. The constant 15 is the one-time sign-up fee (choice A), and C(1) = 24 is the total cost for the first month (choice B).",
+   "verify": null,
+   "figure": null
+  },
+  {
+   "n": 3,
+   "domain": "PSDA",
+   "skill": "Ratios, rates, proportional relationships & units",
+   "difficulty": "E",
+   "type": "mc",
+   "stem": "A food delivery driver completed 12 deliveries in 3 hours. At this rate, how many deliveries will the driver complete in 8 hours?",
+   "choices": [
+    "32",
+    "4",
+    "24",
+    "96"
+   ],
+   "answer": 0,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The rate is 12 ÷ 3 = 4 deliveries per hour, so in 8 hours the driver completes 4 × 8 = 32 deliveries. Choice B is the hourly rate itself, choice C doubles 12 instead of using the rate, and choice D multiplies 12 × 8 without dividing by 3.",
+   "verify": "assert 12/3*8==32",
+   "figure": null
+  },
+  {
+   "n": 4,
+   "domain": "ALG",
+   "skill": "Linear equations in two variables",
+   "difficulty": "E",
+   "type": "mc",
+   "stem": "In the xy-plane, the graph of the equation y = 2x − 6 crosses the x-axis at the point (a, 0). What is the value of a?",
+   "choices": [
+    "−6",
+    "−3",
+    "2",
+    "3"
+   ],
+   "answer": 3,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The graph crosses the x-axis where y = 0, so set 0 = 2x − 6, giving 2x = 6 and x = 3. Choice A is the y-intercept, choice B is a sign slip on the intercept, and choice C is the slope.",
+   "verify": "from sympy import *; x=symbols('x'); assert solve(Eq(2*x-6,0),x)==[3]",
+   "figure": null
+  },
+  {
+   "n": 5,
+   "domain": "GEO",
+   "skill": "Area & volume",
+   "difficulty": "E",
+   "type": "spr",
+   "stem": "A plant nursery is building a rectangular garden bed with a length of 12 feet and a width of 7.5 feet. What is the area, in square feet, of the garden bed?",
+   "choices": null,
+   "answer": null,
+   "spr_answer": "90",
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The area of a rectangle is length times width. Here the area is 12 × 7.5 = 90 square feet.",
+   "verify": "assert abs(12*7.5-90)<1e-9; vals=['90']; assert all(abs(float(v)-90)<1e-9 for v in vals)",
+   "figure": null
+  },
+  {
+   "n": 6,
+   "domain": "ALG",
+   "skill": "Linear inequalities in one variable",
+   "difficulty": "E",
+   "type": "mc",
+   "stem": "A gym membership requires a one-time enrollment fee of $20 plus $30 per month. Marcus can spend at most $200 in total on the membership. Which inequality gives all possible numbers of months m for which Marcus can afford the membership?",
+   "choices": [
+    "m ≤ 6",
+    "m ≥ 6",
+    "m ≤ 22/3",
+    "m ≤ 5"
+   ],
+   "answer": 0,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The total cost is 30m + 20, and it must satisfy 30m + 20 ≤ 200. Subtracting 20 gives 30m ≤ 180, so m ≤ 6. Choice B reverses the inequality, choice C comes from adding the fee instead of subtracting it (220/30), and choice D comes from subtracting both the fee and one month's charge before dividing.",
+   "verify": "from sympy import *; m=symbols('m'); assert solveset(30*m+20<=200, m, S.Reals)==Interval(-oo,6)",
+   "figure": null
+  },
+  {
+   "n": 7,
+   "domain": "PSDA",
+   "skill": "Percentages",
+   "difficulty": "E",
+   "type": "mc",
+   "stem": "Students at a school fundraiser car wash washed 60 vehicles on Saturday. Of these vehicles, 45% were SUVs. How many of the vehicles washed on Saturday were SUVs?",
+   "choices": [
+    "15",
+    "27",
+    "33",
+    "45"
+   ],
+   "answer": 1,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "45% of 60 is 0.45 × 60 = 27, so 27 of the vehicles were SUVs. Choice A subtracts 45 from 60, choice C is the number of vehicles that were NOT SUVs (55% of 60), and choice D treats the percent as a count.",
+   "verify": "assert abs(0.45*60-27)<1e-9",
+   "figure": null
+  },
+  {
+   "n": 8,
+   "domain": "ALG",
+   "skill": "Linear functions",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "The function f is linear. If f(2) = 11 and f(5) = 26, what is the value of f(8)?",
+   "choices": [
+    "31",
+    "37",
+    "40",
+    "41"
+   ],
+   "answer": 3,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The slope is (26 − 11)/(5 − 2) = 5, so f(x) = 5x + b. Using f(2) = 11 gives b = 1, so f(x) = 5x + 1 and f(8) = 41. Choice A adds the slope only once to 26, choice B adds the two outputs' difference incorrectly, and choice C computes 5 × 8 but forgets the constant term.",
+   "verify": "m=(26-11)/(5-2); b=11-m*2; assert m*8+b==41",
+   "figure": null
+  },
+  {
+   "n": 9,
+   "domain": "ALG",
+   "skill": "Systems of two linear equations",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "On a commuter train line, 2 adult tickets and 3 student tickets cost a total of $33, and 4 adult tickets and 2 student tickets cost a total of $46. What is the cost, in dollars, of 1 student ticket?",
+   "choices": [
+    "6.60",
+    "9",
+    "5",
+    "14"
+   ],
+   "answer": 2,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Let a be the adult price and s the student price: 2a + 3s = 33 and 4a + 2s = 46. Doubling the first equation gives 4a + 6s = 66; subtracting the second gives 4s = 20, so s = 5 (and a = 9). Choice A divides $33 by 5 total tickets, choice B is the adult ticket price, and choice D is the cost of one adult plus one student ticket.",
+   "verify": "from sympy import *; a,s=symbols('a s'); sol=solve([Eq(2*a+3*s,33),Eq(4*a+2*s,46)],[a,s]); assert sol[s]==5 and sol[a]==9",
+   "figure": null
+  },
+  {
+   "n": 10,
+   "domain": "ADV",
+   "skill": "Equivalent expressions",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "Which expression is equivalent to (2x − 3)²?",
+   "choices": [
+    "4x² − 12x + 9",
+    "4x² + 9",
+    "4x² − 9",
+    "2x² − 12x + 9"
+   ],
+   "answer": 0,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Expand: (2x − 3)² = (2x)² − 2(2x)(3) + 3² = 4x² − 12x + 9. Choice B forgets the middle term, choice C treats the square as a difference of squares, and choice D fails to square the coefficient 2.",
+   "verify": "from sympy import *; x=symbols('x'); assert expand((2*x-3)**2)==4*x**2-12*x+9",
+   "figure": null
+  },
+  {
+   "n": 11,
+   "domain": "ALG",
+   "skill": "Systems of two linear equations",
+   "difficulty": "M",
+   "type": "spr",
+   "stem": "If 3x + 2y = 25 and x − 2y = 7, what is the value of x?",
+   "choices": null,
+   "answer": null,
+   "spr_answer": "8",
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Adding the two equations eliminates y: (3x + 2y) + (x − 2y) = 25 + 7, so 4x = 32 and x = 8.",
+   "verify": "from sympy import *; x,y=symbols('x y'); sol=solve([Eq(3*x+2*y,25),Eq(x-2*y,7)],[x,y]); assert sol[x]==8; vals=['8']; assert all(abs(float(v)-8)<1e-9 for v in vals)",
+   "figure": null
+  },
+  {
+   "n": 12,
+   "domain": "PSDA",
+   "skill": "Two-variable data: scatterplots & models",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "The scatterplot shows the height, in centimeters, of each of 8 seedlings at a plant nursery plotted against its age, in weeks, along with a line of best fit. Based on the line of best fit, what is the predicted height, in centimeters, of a seedling that is 10 weeks old?",
+   "choices": [
+    "20",
+    "23",
+    "25",
+    "30"
+   ],
+   "answer": 1,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The line of best fit has slope 2 and y-intercept 3, so the predicted height is h = 2(10) + 3 = 23 centimeters. Choice A uses the slope but omits the intercept, choice D swaps the slope and intercept (3 × 10), and choice C misreads the trend.",
+   "verify": "assert 2*10+3==23",
+   "figure": {
+    "kind": "scatter",
+    "params": {
+     "pts": [
+      [
+       1,
+       5
+      ],
+      [
+       2,
+       6
+      ],
+      [
+       3,
+       9
+      ],
+      [
+       4,
+       10
+      ],
+      [
+       5,
+       13
+      ],
+      [
+       6,
+       14
+      ],
+      [
+       7,
+       16
+      ],
+      [
+       8,
+       19
+      ]
+     ],
+     "xlabel": "Age (weeks)",
+     "ylabel": "Height (cm)",
+     "line": {
+      "slope": 2,
+      "yint": 3
+     }
+    }
+   }
+  },
+  {
+   "n": 13,
+   "domain": "ALG",
+   "skill": "Linear equations in two variables",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "The graph of line ℓ in the xy-plane is shown. Line ℓ passes through the points (0, 4) and (8, 0). Which equation defines line ℓ?",
+   "choices": [
+    "y = −2x + 4",
+    "y = (1/2)x + 4",
+    "y = −(1/2)x + 4",
+    "y = −(1/2)x − 4"
+   ],
+   "answer": 2,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The slope is (0 − 4)/(8 − 0) = −1/2, and the y-intercept is 4, so the equation is y = −(1/2)x + 4. Choice A inverts the slope, choice B drops the negative sign, and choice D uses the wrong sign on the intercept.",
+   "verify": "from sympy import *; x=symbols('x'); f=-x/2+4; assert f.subs(x,0)==4 and f.subs(x,8)==0",
+   "figure": {
+    "kind": "fgraph",
+    "params": {
+     "expr": "-x/2 + 4",
+     "xmin": -10,
+     "xmax": 10,
+     "ymin": -10,
+     "ymax": 10
+    }
+   }
+  },
+  {
+   "n": 14,
+   "domain": "GEO",
+   "skill": "Lines, angles & triangles",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "The measures of the interior angles of a triangle are x°, 2x°, and 3x°. What is the measure, in degrees, of the largest interior angle of the triangle?",
+   "choices": [
+    "30",
+    "60",
+    "80",
+    "90"
+   ],
+   "answer": 3,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The angle measures sum to 180°, so x + 2x + 3x = 180, giving 6x = 180 and x = 30. The largest angle is 3x = 90°. Choice A is x itself and choice B is the middle angle 2x.",
+   "verify": "from sympy import *; x=symbols('x'); s=solve(Eq(x+2*x+3*x,180),x)[0]; assert s==30 and 3*s==90",
+   "figure": null
+  },
+  {
+   "n": 15,
+   "domain": "ALG",
+   "skill": "Linear functions",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "A T-shirt printing company charges a one-time setup fee plus a fixed price per shirt. The table shows the total cost C(n), in dollars, to print n shirts for three order sizes. Which equation defines C(n)?",
+   "choices": [
+    "C(n) = 7.5n + 20",
+    "C(n) = 9.5n",
+    "C(n) = 7.5n",
+    "C(n) = 20n + 7.5"
+   ],
+   "answer": 0,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The cost increases by 75 dollars for every 10 additional shirts, so the price per shirt is 7.50 and C(n) = 7.5n + b. Using C(10) = 95 gives b = 20, the setup fee, so C(n) = 7.5n + 20. Choice B divides 95 by 10 and treats the result as a per-shirt price with no fee, choice C omits the setup fee, and choice D swaps the fee and the per-shirt price.",
+   "verify": "assert all(7.5*n+20==c for n,c in [(10,95),(20,170),(30,245)])",
+   "figure": {
+    "kind": "table",
+    "params": {
+     "headers": [
+      "n (shirts)",
+      "C(n) (dollars)"
+     ],
+     "rows": [
+      [
+       "10",
+       "95"
+      ],
+      [
+       "20",
+       "170"
+      ],
+      [
+       "30",
+       "245"
+      ]
+     ]
+    }
+   }
+  },
+  {
+   "n": 16,
+   "domain": "ADV",
+   "skill": "Nonlinear equations",
+   "difficulty": "M",
+   "type": "spr",
+   "stem": "What is the sum of the solutions to the equation x² − 7x + 10 = 0?",
+   "choices": null,
+   "answer": null,
+   "spr_answer": "7",
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Factoring gives (x − 2)(x − 5) = 0, so the solutions are x = 2 and x = 5. Their sum is 2 + 5 = 7 (equivalently, the sum of the roots of x² + bx + c = 0 is −b = 7).",
+   "verify": "from sympy import *; x=symbols('x'); r=solve(Eq(x**2-7*x+10,0),x); assert sum(r)==7; vals=['7']; assert all(abs(float(v)-7)<1e-9 for v in vals)",
+   "figure": null
+  },
+  {
+   "n": 17,
+   "domain": "ALG",
+   "skill": "Linear inequalities in two variables",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "Which ordered pair (x, y) satisfies both of the inequalities y ≤ −x + 5 and y > 2?",
+   "choices": [
+    "(4, 3)",
+    "(1, 3)",
+    "(1, 2)",
+    "(6, −1)"
+   ],
+   "answer": 1,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "For (1, 3): 3 ≤ −1 + 5 = 4 is true and 3 > 2 is true, so (1, 3) satisfies both. Choice A fails the first inequality (3 > 1), choice C fails the strict inequality y > 2, and choice D fails y > 2.",
+   "verify": "ok=lambda x,y: y<=-x+5 and y>2; assert ok(1,3) and not ok(4,3) and not ok(1,2) and not ok(6,-1)",
+   "figure": null
+  },
+  {
+   "n": 18,
+   "domain": "ALG",
+   "skill": "Systems of two linear equations",
+   "difficulty": "H",
+   "type": "mc",
+   "stem": "In the system of equations below, k is a constant.\n2x + 3y = 14\n4x + ky = 21\nFor which value of k does the system have no solution?",
+   "choices": [
+    "−6",
+    "3",
+    "6",
+    "8"
+   ],
+   "answer": 2,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The system has no solution when the lines are parallel: the left sides must be proportional but the right sides not. Since 4 = 2 × 2, we need k = 3 × 2 = 6; then 2(2x + 3y) = 28 ≠ 21, so the lines are parallel and distinct. Choice B copies the coefficient 3 without scaling, and choice A is a sign slip.",
+   "verify": "from sympy import *; x,y=symbols('x y'); assert linsolve([Eq(2*x+3*y,14),Eq(4*x+6*y,21)],x,y)==S.EmptySet",
+   "figure": null
+  },
+  {
+   "n": 19,
+   "domain": "GEO",
+   "skill": "Right triangles & trigonometry",
+   "difficulty": "H",
+   "type": "mc",
+   "stem": "In right triangle ABC shown, the right angle is at C. If sin A = 3/5, what is the value of tan B?",
+   "choices": [
+    "3/5",
+    "3/4",
+    "4/5",
+    "4/3"
+   ],
+   "answer": 3,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Since sin A = 3/5, the side opposite angle A can be taken as 3 and the hypotenuse as 5, so the remaining leg is √(25 − 9) = 4. Angle B is opposite the leg of length 4 and adjacent to the leg of length 3, so tan B = 4/3. Choice B is tan A, choice C is cos A (= sin B), and choice A is sin A itself.",
+   "verify": "from sympy import *; a,b,c=3,4,5; assert a**2+b**2==c**2 and Rational(a,c)==Rational(3,5) and Rational(b,a)==Rational(4,3)",
+   "figure": {
+    "kind": "geometry",
+    "params": {
+     "shape": "triangle",
+     "labels": {
+      "A": "A",
+      "B": "B",
+      "C": "C"
+     },
+     "marks": {
+      "right_angle_at": "C"
+     }
+    }
+   }
+  },
+  {
+   "n": 20,
+   "domain": "ADV",
+   "skill": "Nonlinear functions (exponential)",
+   "difficulty": "H",
+   "type": "spr",
+   "stem": "The function f is defined by f(x) = a·b^x, where a and b are positive constants. If f(0) = 5 and f(3) = 320, what is the value of b?",
+   "choices": null,
+   "answer": null,
+   "spr_answer": "4",
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Since f(0) = a·b⁰ = a, we have a = 5. Then f(3) = 5b³ = 320, so b³ = 64 and b = 4.",
+   "verify": "from sympy import *; b=symbols('b',positive=True); assert solve(Eq(5*b**3,320),b)==[4]; vals=['4']; assert all(abs(float(v)-4)<1e-9 for v in vals)",
+   "figure": null
+  },
+  {
+   "n": 21,
+   "domain": "ALG",
+   "skill": "Linear equations in two variables",
+   "difficulty": "H",
+   "type": "spr",
+   "stem": "In the xy-plane, line j passes through the points (−2, 5) and (4, −7). Line k is parallel to line j and passes through the point (0, 1). If the point (3, y) is on line k, what is the value of y?",
+   "choices": null,
+   "answer": null,
+   "spr_answer": "-5",
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The slope of line j is (−7 − 5)/(4 − (−2)) = −12/6 = −2, so line k also has slope −2. Since line k passes through (0, 1), its equation is y = −2x + 1. At x = 3, y = −2(3) + 1 = −5.",
+   "verify": "from sympy import *; m=Rational(-7-5,4-(-2)); assert m==-2; y=m*3+1; assert y==-5; vals=['-5']; assert all(abs(float(v)-(-5))<1e-9 for v in vals)",
+   "figure": null
+  },
+  {
+   "n": 22,
+   "domain": "ADV",
+   "skill": "Nonlinear equations & systems",
+   "difficulty": "H",
+   "type": "mc",
+   "stem": "In the xy-plane, the graph of y = x² − 4x + c, where c is a constant, intersects the line y = 2 at exactly one point. What is the value of c?",
+   "choices": [
+    "6",
+    "4",
+    "2",
+    "−6"
+   ],
+   "answer": 0,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Setting x² − 4x + c = 2 gives x² − 4x + (c − 2) = 0, which has exactly one solution when the discriminant is zero: 16 − 4(c − 2) = 0. Solving gives c − 2 = 4, so c = 6. Choice B forgets to add back the 2 from the line, choice C is the line's y-value, and choice D is a sign slip.",
+   "verify": "from sympy import *; c=symbols('c'); assert solve(Eq((-4)**2-4*(c-2),0),c)==[6]",
+   "figure": null
+  }
+ ]
+}

--- a/seeds/sat-math/sat_w2.json
+++ b/seeds/sat-math/sat_w2.json
@@ -1,0 +1,506 @@
+{
+ "week": 2,
+ "title": "Advanced Math",
+ "items": [
+  {
+   "n": 1,
+   "domain": "ADV",
+   "skill": "Equivalent expressions",
+   "difficulty": "E",
+   "type": "mc",
+   "stem": "Which expression is equivalent to (x + 3)(x − 5)?",
+   "choices": [
+    "x² − 2x − 15",
+    "x² + 2x − 15",
+    "x² − 2x + 15",
+    "x² − 15"
+   ],
+   "answer": 0,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Distribute each term: (x + 3)(x − 5) = x² − 5x + 3x − 15 = x² − 2x − 15. Choice B flips the sign of the middle term, choice C flips the sign of the constant, and choice D drops the middle term entirely.",
+   "verify": "import sympy as sp; x=sp.symbols('x'); assert sp.expand((x+3)*(x-5))==x**2-2*x-15",
+   "figure": null
+  },
+  {
+   "n": 2,
+   "domain": "ADV",
+   "skill": "Nonlinear functions (exponential)",
+   "difficulty": "E",
+   "type": "mc",
+   "stem": "A bacteria culture starts with 500 cells, and the population doubles every hour. The number of cells t hours after the culture is started is given by P(t) = 500·2^t. How many cells are in the culture 3 hours after it is started?",
+   "choices": [
+    "1,500",
+    "3,000",
+    "4,000",
+    "8,000"
+   ],
+   "answer": 2,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Substitute t = 3: P(3) = 500·2³ = 500·8 = 4,000 cells. Choice A multiplies 500 by 3, choice B multiplies 500 by 2 and then by 3 instead of using the exponent, and choice D doubles one extra time (500·2⁴).",
+   "verify": "assert 500*2**3==4000",
+   "figure": null
+  },
+  {
+   "n": 3,
+   "domain": "ALG",
+   "skill": "Linear functions",
+   "difficulty": "E",
+   "type": "mc",
+   "stem": "The percent charge remaining in a drone battery t minutes after takeoff is given by B(t) = 100 − 8t. How many minutes after takeoff will the battery charge be 36%?",
+   "choices": [
+    "4.5",
+    "8",
+    "12.5",
+    "17"
+   ],
+   "answer": 1,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Set 100 − 8t = 36. Subtracting 100 from both sides gives −8t = −64, so t = 8 minutes. Choice A divides 36 by 8, choice C divides 100 by 8 (the time to fully drain), and choice D adds 36 to 100 instead of subtracting.",
+   "verify": "import sympy as sp; t=sp.symbols('t'); assert sp.solve(sp.Eq(100-8*t,36),t)==[8]",
+   "figure": null
+  },
+  {
+   "n": 4,
+   "domain": "ADV",
+   "skill": "Nonlinear functions (quadratic)",
+   "difficulty": "E",
+   "type": "mc",
+   "stem": "The graph of the quadratic function f is shown, where y = f(x). At which values of x does the graph cross the x-axis?",
+   "choices": [
+    "−1 and 5",
+    "1 and −5",
+    "2 and −9",
+    "−3 and 3"
+   ],
+   "answer": 0,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The graph crosses the x-axis where y = 0, which occurs at x = −1 and x = 5. Choice B flips both signs, choice C mistakes the vertex coordinates (2, −9) for intercepts, and choice D assumes the intercepts are symmetric about x = 0 instead of about the axis of symmetry x = 2.",
+   "verify": "import sympy as sp; x=sp.symbols('x'); assert sp.solve((x-2)**2-9,x)==[-1,5]",
+   "figure": {
+    "kind": "fgraph",
+    "params": {
+     "expr": "(x-2)**2-9",
+     "xmin": -6,
+     "xmax": 8,
+     "ymin": -10,
+     "ymax": 10
+    }
+   }
+  },
+  {
+   "n": 5,
+   "domain": "PSDA",
+   "skill": "Percentages",
+   "difficulty": "E",
+   "type": "mc",
+   "stem": "In May, a rooftop solar panel array produced 240 kilowatt-hours of energy. In June, the same array produced 300 kilowatt-hours. The June output is what percent greater than the May output?",
+   "choices": [
+    "20%",
+    "25%",
+    "60%",
+    "125%"
+   ],
+   "answer": 1,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The increase is 300 − 240 = 60 kilowatt-hours. Percent increase compares the change to the original amount: 60/240 = 0.25 = 25%. Choice A divides by the new value 300 instead of the original, choice C treats the raw difference 60 as a percent, and choice D gives the ratio 300/240 as a percent instead of the percent increase.",
+   "verify": "assert (300-240)/240*100==25",
+   "figure": null
+  },
+  {
+   "n": 6,
+   "domain": "GEO",
+   "skill": "Circles (area)",
+   "difficulty": "E",
+   "type": "mc",
+   "stem": "A circular tidal basin has a radius of 6 meters. What is the area, in square meters, of the surface of the basin?",
+   "choices": [
+    "12π",
+    "36",
+    "144π",
+    "36π"
+   ],
+   "answer": 3,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The area of a circle is A = πr². With r = 6, the area is π(6²) = 36π square meters. Choice A is the circumference 2πr, choice B forgets the factor of π, and choice C uses the diameter 12 in place of the radius.",
+   "verify": "import sympy as sp; assert sp.pi*6**2==36*sp.pi",
+   "figure": null
+  },
+  {
+   "n": 7,
+   "domain": "ADV",
+   "skill": "Nonlinear equations (radical)",
+   "difficulty": "E",
+   "type": "spr",
+   "stem": "If √(x + 7) = 5, what is the value of x?",
+   "choices": null,
+   "answer": null,
+   "spr_answer": "18",
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Square both sides of the equation: x + 7 = 25. Subtracting 7 from both sides gives x = 18. Checking: √(18 + 7) = √25 = 5, so the solution is not extraneous.",
+   "verify": "import sympy as sp; x=sp.symbols('x'); s=sp.solve(sp.sqrt(x+7)-5,x); assert s==[18]; assert float('18')==18.0",
+   "figure": null
+  },
+  {
+   "n": 8,
+   "domain": "ADV",
+   "skill": "Equivalent expressions (rational)",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "Which expression is equivalent to (2x² + 7x − 15)/(x + 5) for x ≠ −5?",
+   "choices": [
+    "x − 3",
+    "2x + 3",
+    "2x − 3",
+    "2x − 5"
+   ],
+   "answer": 2,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Factor the numerator: 2x² + 7x − 15 = (2x − 3)(x + 5). Dividing out the common factor (x + 5) leaves 2x − 3. Choice B flips the sign of the constant, choice A drops the leading coefficient, and choice D mixes up the factor pair.",
+   "verify": "import sympy as sp; x=sp.symbols('x'); assert sp.simplify((2*x**2+7*x-15)/(x+5)-(2*x-3))==0",
+   "figure": null
+  },
+  {
+   "n": 9,
+   "domain": "ALG",
+   "skill": "Linear functions (interpretation)",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "The value, in dollars, of a car t years after it is purchased is modeled by V(t) = 24,500 − 1,800t. Which of the following is the best interpretation of the number 1,800 in this model?",
+   "choices": [
+    "The car was purchased for $1,800.",
+    "The car's value decreases by an average of $1,800 per year.",
+    "The car's value decreases by an average of $1,800 per month.",
+    "The car's value t years after purchase is 1,800t dollars."
+   ],
+   "answer": 1,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "In a linear model V(t) = 24,500 − 1,800t, the coefficient of t is the constant rate of change: the value drops by $1,800 for each 1-year increase in t. Choice A confuses the rate with the purchase price 24,500 (the initial value), choice C uses the wrong time unit, and choice D mistakes the total decrease 1,800t for the car's value.",
+   "verify": null,
+   "figure": null
+  },
+  {
+   "n": 10,
+   "domain": "ALG",
+   "skill": "Systems of two linear equations",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "If 2x + y = 17 and x − y = 4, what is the value of x?",
+   "choices": [
+    "3",
+    "4",
+    "13",
+    "7"
+   ],
+   "answer": 3,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Adding the two equations eliminates y: (2x + y) + (x − y) = 17 + 4, so 3x = 21 and x = 7. Then y = x − 4 = 3. Choice A is the value of y, choice C subtracts the right-hand sides (17 − 4) without eliminating properly, and choice B repeats the constant from the second equation.",
+   "verify": "import sympy as sp; x,y=sp.symbols('x y'); s=sp.solve([sp.Eq(2*x+y,17),sp.Eq(x-y,4)],[x,y]); assert s[x]==7 and s[y]==3",
+   "figure": null
+  },
+  {
+   "n": 11,
+   "domain": "ADV",
+   "skill": "Nonlinear functions (quadratic maximum)",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "A projectile is launched upward from a platform. Its height above the ground, in feet, t seconds after launch is given by h(t) = −16t² + 64t + 80. What is the maximum height, in feet, that the projectile reaches?",
+   "choices": [
+    "2",
+    "80",
+    "128",
+    "144"
+   ],
+   "answer": 3,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The maximum occurs at the vertex, where t = −b/(2a) = −64/(2·(−16)) = 2 seconds. Then h(2) = −16(4) + 64(2) + 80 = −64 + 128 + 80 = 144 feet. Choice A is the time of the maximum, not the height; choice B is the platform height h(0); choice C omits the initial height of 80 feet.",
+   "verify": "import sympy as sp; t=sp.symbols('t'); h=-16*t**2+64*t+80; tv=sp.solve(sp.diff(h,t),t)[0]; assert tv==2 and h.subs(t,tv)==144",
+   "figure": null
+  },
+  {
+   "n": 12,
+   "domain": "ADV",
+   "skill": "Nonlinear equations (exponential)",
+   "difficulty": "M",
+   "type": "spr",
+   "stem": "A bacteria culture contains 200 cells, and the population doubles every 3 hours, so the population t hours from now is given by P(t) = 200·2^(t/3). After how many hours will the population reach 6,400 cells?",
+   "choices": null,
+   "answer": null,
+   "spr_answer": "15",
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Set 200·2^(t/3) = 6,400 and divide both sides by 200 to get 2^(t/3) = 32. Since 32 = 2⁵, the exponents must be equal: t/3 = 5, so t = 15 hours.",
+   "verify": "import sympy as sp; t=sp.symbols('t'); s=sp.solve(200*2**(t/3)-6400,t); assert s==[15]; assert 200*2**(15/3)==6400; assert float('15')==15.0",
+   "figure": null
+  },
+  {
+   "n": 13,
+   "domain": "PSDA",
+   "skill": "Two-variable data (scatterplots & models)",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "The scatterplot shows the daily energy output, in kilowatt-hours (kWh), of a solar panel array versus the number of peak sun hours that day, along with a line of best fit. The equation of the line is y = 2.5x + 1. Based on the line of best fit, what is the predicted output, in kWh, on a day with 6 peak sun hours?",
+   "choices": [
+    "8.5",
+    "15",
+    "16",
+    "17.5"
+   ],
+   "answer": 2,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Substitute x = 6 into the equation of the line of best fit: y = 2.5(6) + 1 = 15 + 1 = 16 kWh. Choice B forgets to add the y-intercept, choice D adds 1 to x before multiplying, and choice A adds the slope and x-value instead of multiplying.",
+   "verify": "assert 2.5*6+1==16",
+   "figure": {
+    "kind": "scatter",
+    "params": {
+     "pts": [
+      [
+       2,
+       6.2
+      ],
+      [
+       3,
+       8.4
+      ],
+      [
+       3,
+       9.1
+      ],
+      [
+       4,
+       10.8
+      ],
+      [
+       4,
+       11.5
+      ],
+      [
+       5,
+       13.2
+      ],
+      [
+       5,
+       14.0
+      ],
+      [
+       6,
+       15.7
+      ],
+      [
+       7,
+       18.3
+      ],
+      [
+       8,
+       21.2
+      ]
+     ],
+     "xlabel": "Peak sun hours",
+     "ylabel": "Energy output (kWh)",
+     "line": {
+      "slope": 2.5,
+      "yint": 1
+     }
+    }
+   }
+  },
+  {
+   "n": 14,
+   "domain": "GEO",
+   "skill": "Right triangles & trigonometry",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "A drone hovers directly above a point on level ground. An observer stands 60 meters from that point, and the angle of elevation from the observer to the drone is 60°. What is the height of the drone above the ground, in meters?",
+   "choices": [
+    "20√3",
+    "30√3",
+    "60√3",
+    "120"
+   ],
+   "answer": 2,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The height h is the side opposite the 60° angle, and the 60-meter ground distance is adjacent, so tan 60° = h/60. Thus h = 60·tan 60° = 60√3 meters. Choice A divides by √3 instead of multiplying (as if the angle were 30°), choice B halves the correct height, and choice D is the observer-to-drone distance 60/cos 60°, the hypotenuse.",
+   "verify": "import sympy as sp; assert sp.simplify(60*sp.tan(sp.pi/3)-60*sp.sqrt(3))==0",
+   "figure": null
+  },
+  {
+   "n": 15,
+   "domain": "ADV",
+   "skill": "Nonlinear functions (exponential growth)",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "A savings account earns 3% annual interest, compounded once per year. The balance, in dollars, t years after the account is opened with $1,200 is given by A(t) = 1,200(1.03)^t. By what percent does the balance increase over the first 2 years?",
+   "choices": [
+    "3%",
+    "6%",
+    "6.09%",
+    "9%"
+   ],
+   "answer": 2,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Over 2 years the balance is multiplied by (1.03)² = 1.0609, an increase of 0.0609, or 6.09%. Choice B ignores compounding by simply doubling 3%, choice A is the one-year rate, and choice D triples the annual rate. The starting amount $1,200 does not affect the percent increase.",
+   "verify": "assert abs((1.03**2-1)*100-6.09)<1e-9",
+   "figure": null
+  },
+  {
+   "n": 16,
+   "domain": "ADV",
+   "skill": "Nonlinear functions (polynomial)",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "The function f is defined by f(x) = x³ − 4x² + x + 6. Which of the following is a factor of f(x)?",
+   "choices": [
+    "x − 3",
+    "x − 1",
+    "x + 2",
+    "x + 3"
+   ],
+   "answer": 0,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "By the factor theorem, (x − c) is a factor of f(x) exactly when f(c) = 0. Testing c = 3: f(3) = 27 − 36 + 3 + 6 = 0, so (x − 3) is a factor. For the other choices, f(1) = 4, f(−2) = −20, and f(−3) = −60, none of which is 0. In fact, f(x) = (x + 1)(x − 2)(x − 3).",
+   "verify": "import sympy as sp; x=sp.symbols('x'); f=x**3-4*x**2+x+6; assert f.subs(x,3)==0 and f.subs(x,1)!=0 and f.subs(x,-2)!=0 and f.subs(x,-3)!=0; assert sp.expand((x+1)*(x-2)*(x-3))==f",
+   "figure": null
+  },
+  {
+   "n": 17,
+   "domain": "ADV",
+   "skill": "Nonlinear equations (rational)",
+   "difficulty": "M",
+   "type": "spr",
+   "stem": "The function f is defined by f(x) = (x + 4)/(x − 1). If f(a) = 3, what is the value of a?",
+   "choices": null,
+   "answer": null,
+   "spr_answer": "7/2",
+   "equivalents": [
+    "3.5"
+   ],
+   "answer_any": null,
+   "explanation": "Set (a + 4)/(a − 1) = 3 and multiply both sides by (a − 1): a + 4 = 3a − 3. Then 7 = 2a, so a = 7/2 = 3.5. Since 7/2 ≠ 1, the denominator is nonzero and the solution is valid.",
+   "verify": "import sympy as sp; x=sp.symbols('x'); s=sp.solve((x+4)/(x-1)-3,x); assert s==[sp.Rational(7,2)]; assert abs(float(sp.Rational(7,2))-3.5)<1e-12",
+   "figure": null
+  },
+  {
+   "n": 18,
+   "domain": "ADV",
+   "skill": "Nonlinear systems (discriminant)",
+   "difficulty": "H",
+   "type": "mc",
+   "stem": "In the xy-plane, the graph of y = x² + 2x + 7 intersects the graph of y = 2x + k, where k is a constant, at exactly one point. What is the value of k?",
+   "choices": [
+    "7",
+    "−7",
+    "2",
+    "8"
+   ],
+   "answer": 0,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Set the expressions equal: x² + 2x + 7 = 2x + k. The 2x terms cancel, leaving x² + 7 − k = 0, so x² = k − 7. This has exactly one solution (x = 0) when k − 7 = 0, so k = 7. Choice B flips the sign, choice C grabs the linear coefficient, and choice D would give x² = 1, which has two solutions.",
+   "verify": "import sympy as sp; x,k=sp.symbols('x k'); d=sp.discriminant(x**2+2*x+7-(2*x+k),x); assert sp.solve(sp.Eq(d,0),k)==[7]; assert len(sp.solve(x**2+2*x+7-(2*x+7),x))==1",
+   "figure": null
+  },
+  {
+   "n": 19,
+   "domain": "GEO",
+   "skill": "Circles (equation in the xy-plane)",
+   "difficulty": "H",
+   "type": "mc",
+   "stem": "In the xy-plane, the graph of x² + y² − 6x + 4y = 12 is a circle. What is the radius of the circle?",
+   "choices": [
+    "2√3",
+    "5",
+    "12",
+    "25"
+   ],
+   "answer": 1,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Complete the square in both variables: (x² − 6x + 9) + (y² + 4y + 4) = 12 + 9 + 4, which gives (x − 3)² + (y + 2)² = 25. The radius is √25 = 5. Choice A takes √12 without completing the square, choice D is r², and choice C is the constant from the original equation.",
+   "verify": "import sympy as sp; x,y=sp.symbols('x y'); assert sp.simplify((x**2+y**2-6*x+4*y-12)-((x-3)**2+(y+2)**2-25))==0; assert sp.sqrt(25)==5",
+   "figure": null
+  },
+  {
+   "n": 20,
+   "domain": "PSDA",
+   "skill": "Inference & margin of error",
+   "difficulty": "H",
+   "type": "mc",
+   "stem": "Quality engineers tested a random sample of 200 drone batteries from a production run. The mean flight time of the batteries in the sample was 24 minutes, with an associated margin of error of 1.5 minutes. Which of the following is the most appropriate conclusion?",
+   "choices": [
+    "The mean flight time of all batteries in the production run is exactly 24 minutes.",
+    "The flight time of each battery in the sample was within 1.5 minutes of 24 minutes.",
+    "Every battery in the production run has a flight time between 22.5 minutes and 25.5 minutes.",
+    "It is plausible that the mean flight time of all batteries in the production run is between 22.5 minutes and 25.5 minutes."
+   ],
+   "answer": 3,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "A margin of error describes uncertainty in an estimate of a population mean: plausible values of the population mean lie within 24 ± 1.5, that is, between 22.5 and 25.5 minutes. Choice A claims false certainty about the exact mean, and choices B and C wrongly apply the interval to individual batteries rather than to the mean.",
+   "verify": null,
+   "figure": null
+  },
+  {
+   "n": 21,
+   "domain": "ALG",
+   "skill": "Systems of two linear equations (infinitely many solutions)",
+   "difficulty": "H",
+   "type": "spr",
+   "stem": "In the system of equations below, a is a constant.\n3x − 5y = 12\nax − 20y = 48\nIf the system has infinitely many solutions, what is the value of a?",
+   "choices": null,
+   "answer": null,
+   "spr_answer": "12",
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "A system has infinitely many solutions when the two equations are equivalent. The y-coefficients and constants of the second equation are 4 times those of the first (−20 = 4·(−5) and 48 = 4·12), so the second equation must be 4 times the first. Therefore a = 4·3 = 12.",
+   "verify": "import sympy as sp; a=sp.symbols('a'); assert sp.Rational(-20,-5)==4 and sp.Rational(48,12)==4; assert sp.solve(sp.Eq(a,4*3),a)==[12]; x,y=sp.symbols('x y'); assert sp.simplify(4*(3*x-5*y-12)-(12*x-20*y-48))==0; assert float('12')==12.0",
+   "figure": null
+  },
+  {
+   "n": 22,
+   "domain": "ADV",
+   "skill": "Equivalent expressions (identifying constants)",
+   "difficulty": "H",
+   "type": "spr",
+   "stem": "The equation (2x + b)(x − 3) = 2x² + cx − 15 is true for all values of x, where b and c are constants. What is the value of c?",
+   "choices": null,
+   "answer": null,
+   "spr_answer": "-1",
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Expanding the left side gives 2x² + (b − 6)x − 3b. Matching constant terms, −3b = −15, so b = 5. Matching the x-coefficients, c = b − 6 = 5 − 6 = −1.",
+   "verify": "import sympy as sp; x,b,c=sp.symbols('x b c'); diff=sp.expand((2*x+b)*(x-3))-(2*x**2+c*x-15); sol=sp.solve([diff.coeff(x,0), diff.coeff(x,1)],[b,c]); assert sol[b]==5 and sol[c]==-1; assert float('-1')==-1.0",
+   "figure": null
+  }
+ ]
+}

--- a/seeds/sat-math/sat_w3.json
+++ b/seeds/sat-math/sat_w3.json
@@ -1,0 +1,547 @@
+{
+ "week": 3,
+ "title": "Data & Problem-Solving",
+ "items": [
+  {
+   "n": 1,
+   "domain": "PSDA",
+   "skill": "Ratios, rates, proportional relationships, and units",
+   "difficulty": "E",
+   "type": "mc",
+   "stem": "A rider in a city bike-share program rode 12 miles in 45 minutes. What was the rider's average speed, in miles per hour?",
+   "choices": [
+    "9",
+    "12",
+    "16",
+    "36"
+   ],
+   "answer": 2,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Convert 45 minutes to 0.75 hour. Average speed = distance ÷ time = 12 ÷ 0.75 = 16 miles per hour. Choosing 9 comes from multiplying 12 by 0.75 instead of dividing.",
+   "verify": "from sympy import Rational\nassert Rational(12)/Rational(45,60)==16",
+   "figure": null
+  },
+  {
+   "n": 2,
+   "domain": "PSDA",
+   "skill": "Percentages",
+   "difficulty": "E",
+   "type": "mc",
+   "stem": "A coffee shop sold 250 drinks on Saturday, and 34% of the drinks sold were iced. How many of the drinks sold were not iced?",
+   "choices": [
+    "34",
+    "85",
+    "165",
+    "216"
+   ],
+   "answer": 2,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "If 34% of the drinks were iced, then 100% − 34% = 66% were not iced. 0.66 × 250 = 165 drinks. Choosing 85 answers the wrong question (the number of iced drinks), a part-versus-whole error, and 216 comes from subtracting 34 from 250.",
+   "verify": "from sympy import Rational\nassert 250*Rational(66,100)==165",
+   "figure": null
+  },
+  {
+   "n": 3,
+   "domain": "PSDA",
+   "skill": "One-variable data: center and spread",
+   "difficulty": "E",
+   "type": "mc",
+   "stem": "The list gives the wait times, in minutes, of five patients at a hospital clinic: 35, 10, 45, 40, 20. What is the median wait time, in minutes, for the five patients?",
+   "choices": [
+    "10",
+    "20",
+    "30",
+    "35"
+   ],
+   "answer": 3,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Order the times: 10, 20, 35, 40, 45. The median is the middle value of the ordered list, which is 35. Choosing 30 gives the mean instead of the median, and 45 comes from taking the middle value of the unordered list.",
+   "verify": "d=[35,10,45,40,20]\ns=sorted(d)\nassert s[2]==35\nassert sum(d)/len(d)==30",
+   "figure": null
+  },
+  {
+   "n": 4,
+   "domain": "PSDA",
+   "skill": "One-variable data: center and spread",
+   "difficulty": "E",
+   "type": "mc",
+   "stem": "Each student in a class voted for one field-trip destination, and the results are shown in the bar graph. How many more students voted for the zoo than voted for the museum?",
+   "choices": [
+    "6",
+    "8",
+    "14",
+    "22"
+   ],
+   "answer": 0,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Read the bar heights: 14 students voted for the zoo and 8 voted for the museum. The difference is 14 − 8 = 6. Choosing 14 or 8 reports a single bar instead of the difference, and 22 gives the sum of the two bars.",
+   "verify": "labels=['Museum','Zoo','Aquarium','Park']\nvalues=[8,14,11,7]\nv=dict(zip(labels,values))\nassert v['Zoo']-v['Museum']==6",
+   "figure": {
+    "kind": "bar",
+    "params": {
+     "labels": [
+      "Museum",
+      "Zoo",
+      "Aquarium",
+      "Park"
+     ],
+     "values": [
+      8,
+      14,
+      11,
+      7
+     ],
+     "xlabel": "Destination",
+     "ylabel": "Number of votes"
+    }
+   }
+  },
+  {
+   "n": 5,
+   "domain": "ALG",
+   "skill": "Linear equations in one variable",
+   "difficulty": "E",
+   "type": "mc",
+   "stem": "A city bike-share program charges $3.00 to unlock a bike plus $0.20 per minute of riding. The equation 3 + 0.20m = 9.40 models a ride of m minutes that cost $9.40 total. How many minutes long was the ride?",
+   "choices": [
+    "6.40",
+    "32",
+    "47",
+    "62"
+   ],
+   "answer": 1,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Subtract 3 from both sides to get 0.20m = 6.40, then divide by 0.20 to get m = 32 minutes. Choosing 47 comes from dividing 9.40 by 0.20 without first subtracting the $3.00 unlock fee, and 6.40 stops after the subtraction step.",
+   "verify": "from sympy import symbols, Eq, solve, Rational\nm=symbols('m')\nassert solve(Eq(3+Rational(1,5)*m, Rational(94,10)), m)==[32]",
+   "figure": null
+  },
+  {
+   "n": 6,
+   "domain": "PSDA",
+   "skill": "Probability and conditional probability",
+   "difficulty": "E",
+   "type": "spr",
+   "stem": "In a survey about streaming habits, 32 of the 80 people surveyed said they stream music every day. If one of the 80 people is selected at random, what is the probability that the selected person streams music every day?",
+   "choices": [],
+   "answer": null,
+   "spr_answer": "2/5",
+   "equivalents": [
+    "0.4",
+    ".4",
+    "32/80",
+    "4/10"
+   ],
+   "answer_any": null,
+   "explanation": "The probability is the number of people who stream every day divided by the total number surveyed: 32/80. This simplifies to 2/5, which equals 0.4.",
+   "verify": "from fractions import Fraction\nc=Fraction(2,5)\nassert Fraction(32,80)==c\nfor e in ['0.4','.4','32/80','4/10']:\n    v=Fraction(e) if '/' in e else Fraction(str(float(e)))\n    assert v==c",
+   "figure": null
+  },
+  {
+   "n": 7,
+   "domain": "GEO",
+   "skill": "Area and volume",
+   "difficulty": "E",
+   "type": "mc",
+   "stem": "The rectangular seating patio at a coffee shop is 12 feet long and 9 feet wide. What is the area, in square feet, of the patio?",
+   "choices": [
+    "21",
+    "42",
+    "54",
+    "108"
+   ],
+   "answer": 3,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The area of a rectangle is length × width = 12 × 9 = 108 square feet. Choosing 42 gives the perimeter, 21 gives the sum of the two dimensions, and 54 comes from halving the product as if using the triangle area formula.",
+   "verify": "assert 12*9==108\nassert 2*(12+9)==42",
+   "figure": null
+  },
+  {
+   "n": 8,
+   "domain": "ALG",
+   "skill": "Linear functions",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "At a weather station, the relative humidity h(t), as a percent, t hours after noon on a certain day is modeled by h(t) = 62 − 1.5t, where 0 ≤ t ≤ 8. Which of the following is the best interpretation of the number 1.5 in this context?",
+   "choices": [
+    "The relative humidity at noon was 1.5%.",
+    "The relative humidity increased by 1.5 percentage points each hour after noon.",
+    "The relative humidity 8 hours after noon was 1.5%.",
+    "The relative humidity decreased by 1.5 percentage points each hour after noon."
+   ],
+   "answer": 3,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The model is linear with slope −1.5, so each 1-hour increase in t changes h by −1.5. That means the humidity decreased by 1.5 percentage points per hour after noon. The number 62, not 1.5, gives the humidity at noon.",
+   "verify": "from sympy import symbols, diff, Rational\nt=symbols('t')\nh=62-Rational(3,2)*t\nassert diff(h,t)==Rational(-3,2)\nassert h.subs(t,0)==62",
+   "figure": null
+  },
+  {
+   "n": 9,
+   "domain": "PSDA",
+   "skill": "Probability and conditional probability",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "The table summarizes the responses of 120 people in a streaming-habits survey, classified by age group and subscription plan. If one respondent who is under 25 years old is selected at random, what is the probability that the selected respondent has an ad-free plan?",
+   "choices": [
+    "1/4",
+    "2/5",
+    "1/2",
+    "5/8"
+   ],
+   "answer": 1,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Restrict attention to the 75 respondents under 25. Of these, 30 have an ad-free plan, so the conditional probability is 30/75 = 2/5. Choosing 1/4 divides by all 120 respondents instead of only those under 25, and 1/2 conditions on having an ad-free plan instead of on age.",
+   "verify": "from sympy import Rational\nassert 45+30==75 and 15+30==45 and 75+45==120 and 45+15==60 and 30+30==60\nassert Rational(30,75)==Rational(2,5)",
+   "figure": {
+    "kind": "table",
+    "params": {
+     "headers": [
+      "",
+      "Ad-supported",
+      "Ad-free",
+      "Total"
+     ],
+     "rows": [
+      [
+       "Under 25",
+       45,
+       30,
+       75
+      ],
+      [
+       "25 and older",
+       15,
+       30,
+       45
+      ],
+      [
+       "Total",
+       60,
+       60,
+       120
+      ]
+     ]
+    }
+   }
+  },
+  {
+   "n": 10,
+   "domain": "PSDA",
+   "skill": "Percentages",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "A coffee shop's total sales were $3,000 in May and $2,400 in June. By what percent did total sales decrease from May to June?",
+   "choices": [
+    "20%",
+    "25%",
+    "75%",
+    "80%"
+   ],
+   "answer": 0,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The decrease is 3,000 − 2,400 = 600 dollars. Percent decrease uses the original (May) amount as the base: 600/3,000 = 0.20, or 20%. Choosing 25% incorrectly uses the June amount as the base, and 80% gives the ratio 2,400/3,000 rather than the percent change.",
+   "verify": "from sympy import Rational\nassert Rational(3000-2400,3000)*100==20\nassert Rational(600,2400)*100==25",
+   "figure": null
+  },
+  {
+   "n": 11,
+   "domain": "PSDA",
+   "skill": "Ratios, rates, proportional relationships, and units",
+   "difficulty": "M",
+   "type": "spr",
+   "stem": "In a wildlife tagging study, a tagged elk traveled at an average speed of 2.5 meters per second for 2 hours. How many kilometers did the elk travel during the 2 hours? (1 kilometer = 1,000 meters)",
+   "choices": [],
+   "answer": null,
+   "spr_answer": "18",
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Two hours is 2 × 3,600 = 7,200 seconds, so the elk traveled 2.5 × 7,200 = 18,000 meters. Dividing by 1,000 converts this distance to 18 kilometers.",
+   "verify": "from sympy import Rational\nm=Rational(5,2)*2*3600\nassert m==18000\nassert m/1000==18",
+   "figure": null
+  },
+  {
+   "n": 12,
+   "domain": "PSDA",
+   "skill": "Two-variable data: scatterplots and models",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "The scatterplot shows the air temperature and the relative humidity recorded at a weather station on 9 afternoons, along with a line of best fit, y = −2x + 95. Which of the following is closest to the relative humidity, as a percent, predicted by the line of best fit for an afternoon with a temperature of 30°C?",
+   "choices": [
+    "35",
+    "65",
+    "95",
+    "155"
+   ],
+   "answer": 0,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Use the line of best fit, not an individual data point. At x = 30, y = −2(30) + 95 = 35, so the predicted relative humidity is 35%. Choosing 95 confuses the y-intercept with the prediction, and 155 comes from a sign error, computing 2(30) + 95.",
+   "verify": "assert -2*30+95==35\nassert 2*30+95==155",
+   "figure": {
+    "kind": "scatter",
+    "params": {
+     "pts": [
+      [
+       20,
+       56
+      ],
+      [
+       22,
+       53
+      ],
+      [
+       24,
+       45
+      ],
+      [
+       25,
+       47
+      ],
+      [
+       27,
+       40
+      ],
+      [
+       29,
+       38
+      ],
+      [
+       30,
+       33
+      ],
+      [
+       32,
+       29
+      ],
+      [
+       34,
+       26
+      ]
+     ],
+     "xlabel": "Temperature (°C)",
+     "ylabel": "Relative humidity (%)",
+     "line": {
+      "slope": -2,
+      "yint": 95
+     }
+    }
+   }
+  },
+  {
+   "n": 13,
+   "domain": "PSDA",
+   "skill": "One-variable data: center and spread",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "A hospital recorded the wait times, in minutes, of 15 patients. The mean of the 15 wait times is 42, and the median is 34. The longest recorded wait time, 180 minutes, is discovered to be a data-entry error and is removed from the data set. Which of the following best describes how removing this value affects the mean and the median?",
+   "choices": [
+    "The mean and the median will both stay approximately the same.",
+    "The mean will decrease much more than the median will.",
+    "The median will decrease much more than the mean will.",
+    "The mean will increase, and the median will decrease."
+   ],
+   "answer": 1,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The value 180 is a high outlier, far above the mean of 42. Removing it lowers the total substantially, so the mean drops by several minutes. The median, the middle value of the ordered list, shifts position by at most half a step, so it changes very little. Therefore the mean decreases much more than the median.",
+   "verify": "d=[20,22,25,28,30,31,33,34,35,36,36,38,40,42,180]\nassert len(d)==15 and sum(d)/15==42 and sorted(d)[7]==34 and max(d)==180\nr=sorted(d)[:-1]\nmean_drop=42-sum(r)/14\nmed_drop=34-(r[6]+r[7])/2\nassert mean_drop>5\nassert 0<=med_drop<=1\nassert mean_drop>med_drop",
+   "figure": null
+  },
+  {
+   "n": 14,
+   "domain": "ALG",
+   "skill": "Systems of two linear equations",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "For a class field trip, museum tickets cost $9 for each student and $14 for each chaperone. The group bought a total of 30 tickets for a total of $300. How many student tickets did the group buy?",
+   "choices": [
+    "6",
+    "15",
+    "21",
+    "24"
+   ],
+   "answer": 3,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Let s and a be the numbers of student and chaperone tickets: s + a = 30 and 9s + 14a = 300. Multiplying the first equation by 9 gives 9s + 9a = 270; subtracting yields 5a = 30, so a = 6 and s = 24. Choosing 6 solves for the chaperone tickets instead of the student tickets.",
+   "verify": "from sympy import symbols, Eq, solve\ns,a=symbols('s a')\nsol=solve([Eq(s+a,30),Eq(9*s+14*a,300)],[s,a])\nassert sol[s]==24 and sol[a]==6",
+   "figure": null
+  },
+  {
+   "n": 15,
+   "domain": "ADV",
+   "skill": "Nonlinear functions (exponential)",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "At the start of a wildlife tagging study, biologists estimated that 240 birds lived in a preserve. The population is estimated to increase by 5% each year. Which of the following functions models the estimated population P(t), where t is the number of years after the start of the study?",
+   "choices": [
+    "P(t) = 240(1.05)^t",
+    "P(t) = 240(1.5)^t",
+    "P(t) = 240 + 0.05t",
+    "P(t) = 0.05(240)^t"
+   ],
+   "answer": 0,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Growth by a fixed 5% each year is exponential with growth factor 1 + 0.05 = 1.05 and initial value 240, so P(t) = 240(1.05)^t. Choosing 240(1.5)^t misreads 5% as a factor of 1.5, and 240 + 0.05t models linear, not exponential, growth.",
+   "verify": "from sympy import symbols, Rational\nt=symbols('t')\nP=240*Rational(105,100)**t\nassert P.subs(t,0)==240\nassert P.subs(t,1)/P.subs(t,0)==Rational(21,20)",
+   "figure": null
+  },
+  {
+   "n": 16,
+   "domain": "PSDA",
+   "skill": "Inference and margin of error",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "A city's transportation department surveyed 400 randomly selected members of its bike-share program. Of those surveyed, 62% said they ride at least once per week, with an associated margin of error of 4%. Which of the following is the most appropriate conclusion from these results?",
+   "choices": [
+    "Exactly 62% of all members of the bike-share program ride at least once per week.",
+    "More than 66% of all members of the bike-share program likely ride at least once per week.",
+    "It is plausible that between 58% and 66% of all members of the bike-share program ride at least once per week.",
+    "Between 58% and 66% of the 400 members surveyed ride at least once per week."
+   ],
+   "answer": 2,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "A margin of error gives a plausible range for the population value: 62% ± 4% is 58% to 66% for all members. It does not give an exact population value, and it does not describe the sample itself, since exactly 62% of the surveyed members gave that response.",
+   "verify": "assert 62-4==58 and 62+4==66",
+   "figure": null
+  },
+  {
+   "n": 17,
+   "domain": "ADV",
+   "skill": "Nonlinear equations (quadratic)",
+   "difficulty": "M",
+   "type": "spr",
+   "stem": "The function p(x) = −x² + 20x − 64 models a coffee shop's daily profit, in hundreds of dollars, when the shop charges x dollars per pound for its house-blend coffee beans, where 0 < x < 20. What is one possible price per pound, in dollars, at which the shop's daily profit would be exactly 0?",
+   "choices": [],
+   "answer": null,
+   "spr_answer": "4",
+   "equivalents": [],
+   "answer_any": [
+    "4",
+    "16"
+   ],
+   "explanation": "Set −x² + 20x − 64 = 0, which is equivalent to x² − 20x + 64 = 0. This factors as (x − 4)(x − 16) = 0, so the profit is 0 when x = 4 or x = 16. Either value may be entered.",
+   "verify": "from sympy import symbols, solve\nx=symbols('x')\nassert set(solve(-x**2+20*x-64,x))=={4,16}\nfor e in ['4','16']:\n    v=float(e)\n    assert -v**2+20*v-64==0",
+   "figure": null
+  },
+  {
+   "n": 18,
+   "domain": "PSDA",
+   "skill": "Evaluating statistical claims",
+   "difficulty": "H",
+   "type": "mc",
+   "stem": "Researchers reviewed the records of 500 randomly selected patients who visited one hospital's emergency department last year. They found that patients who arrived on weekday mornings generally had shorter wait times than patients who arrived on weekend evenings. Which of the following is the most appropriate conclusion?",
+   "choices": [
+    "Arriving on a weekday morning causes shorter wait times at hospitals in general.",
+    "Arriving on a weekday morning causes shorter wait times at this hospital.",
+    "Arrival time and wait time are associated at hospitals in general.",
+    "At this hospital, arrival time is associated with wait time, but a cause-and-effect relationship cannot be determined."
+   ],
+   "answer": 3,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Patients were not randomly assigned arrival times, so this observational review can establish only an association, not causation. Because the records were randomly selected from this hospital alone, the finding generalizes to this hospital's patients but should not be extended to hospitals in general.",
+   "verify": null,
+   "figure": null
+  },
+  {
+   "n": 19,
+   "domain": "GEO",
+   "skill": "Right triangles and trigonometry",
+   "difficulty": "H",
+   "type": "mc",
+   "stem": "A straight access ramp at a hospital entrance makes an angle θ with the level ground such that sin θ = 3/5. The ramp is 40 feet long. What is the horizontal distance, in feet, covered by the ramp?",
+   "choices": [
+    "24",
+    "30",
+    "32",
+    "50"
+   ],
+   "answer": 2,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Since sin θ = 3/5, the ramp is the hypotenuse of a 3-4-5 right triangle, so cos θ = 4/5. The horizontal distance is 40 × cos θ = 40 × 4/5 = 32 feet. Choosing 24 uses sin θ, which gives the vertical rise, and 50 comes from dividing 40 by 4/5 instead of multiplying.",
+   "verify": "from sympy import Rational, sqrt\nc=sqrt(1-Rational(3,5)**2)\nassert c==Rational(4,5)\nassert 40*c==32\nassert 40*Rational(3,5)==24",
+   "figure": null
+  },
+  {
+   "n": 20,
+   "domain": "ALG",
+   "skill": "Linear inequalities in one or two variables",
+   "difficulty": "H",
+   "type": "spr",
+   "stem": "A commuter's bike-share membership costs $12 per month and includes 8 free rides; each ride after the first 8 costs $0.75. The commuter budgets at most $27 for bike-share in a month. What is the greatest number of rides the commuter can take that month without exceeding the budget?",
+   "choices": [],
+   "answer": null,
+   "spr_answer": "28",
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "For r rides with r > 8, the monthly cost is 12 + 0.75(r − 8) dollars. Solving 12 + 0.75(r − 8) ≤ 27 gives 0.75(r − 8) ≤ 15, so r − 8 ≤ 20 and r ≤ 28. The greatest number of rides is 28.",
+   "verify": "from sympy import Rational\nassert (27-12)/Rational(3,4)==20\nassert 12+Rational(3,4)*(28-8)==27\nassert 12+Rational(3,4)*(29-8)>27",
+   "figure": null
+  },
+  {
+   "n": 21,
+   "domain": "GEO",
+   "skill": "Area and volume",
+   "difficulty": "H",
+   "type": "mc",
+   "stem": "A cylindrical coffee urn has a volume of 720π cubic centimeters and a diameter of 12 centimeters. What is the height, in centimeters, of the urn?",
+   "choices": [
+    "5",
+    "20",
+    "60",
+    "120"
+   ],
+   "answer": 1,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The diameter is 12 centimeters, so the radius is 6 centimeters. From V = πr²h, 720π = π(6²)h = 36πh, so h = 720π/36π = 20 centimeters. Choosing 5 uses the diameter in place of the radius, and 60 divides 720 by 12 as if the formula were V = πrh.",
+   "verify": "from sympy import pi, Rational\nassert 720*pi/(pi*6**2)==20\nassert Rational(720,12**2)==5\nassert Rational(720,12)==60",
+   "figure": null
+  },
+  {
+   "n": 22,
+   "domain": "ADV",
+   "skill": "Nonlinear equations (exponential)",
+   "difficulty": "H",
+   "type": "spr",
+   "stem": "In a wildlife tagging study, the number of active tracking tags is modeled by N(t) = 512(1/2)^(t/3), where t is the number of months after the tags are activated. After how many months will exactly 64 tags be active?",
+   "choices": [],
+   "answer": null,
+   "spr_answer": "9",
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Solve 512(1/2)^(t/3) = 64. Dividing both sides by 512 gives (1/2)^(t/3) = 64/512 = 1/8 = (1/2)³. So t/3 = 3, and t = 9 months.",
+   "verify": "from sympy import symbols, solve, Rational\nt=symbols('t')\nsol=solve(512*Rational(1,2)**(t/3)-64,t)\nassert 9 in sol\nassert abs(512*0.5**(9/3)-64)<1e-9",
+   "figure": null
+  }
+ ]
+}

--- a/seeds/sat-math/sat_w4.json
+++ b/seeds/sat-math/sat_w4.json
@@ -1,0 +1,504 @@
+{
+ "week": 4,
+ "title": "Geometry & Trig + retention",
+ "items": [
+  {
+   "n": 1,
+   "domain": "GEO",
+   "skill": "Lines, angles, and triangles",
+   "difficulty": "E",
+   "type": "mc",
+   "stem": "In the figure, lines p and q are parallel and are cut by a transversal t. One of the angles formed measures 65°. What is the value of x?",
+   "choices": [
+    "65",
+    "115",
+    "25",
+    "125"
+   ],
+   "answer": 1,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The 65° angle and the angle marked x° are same-side interior angles between the parallel lines, so they are supplementary. Therefore x = 180 − 65 = 115. Choosing 65 confuses supplementary angles with corresponding (equal) angles, and 25 treats the pair as complementary.",
+   "verify": "assert 180 - 65 == 115",
+   "figure": {
+    "kind": "geometry",
+    "params": {
+     "shape": "lines",
+     "labels": {
+      "line1": "p",
+      "line2": "q",
+      "transversal": "t",
+      "angle1": "65°",
+      "angle2": "x°"
+     },
+     "marks": {
+      "parallel": [
+       "p",
+       "q"
+      ],
+      "angle_positions": {
+       "65°": "above line p, right of t",
+       "x°": "below line q, right of t"
+      }
+     }
+    }
+   }
+  },
+  {
+   "n": 2,
+   "domain": "GEO",
+   "skill": "Area and volume",
+   "difficulty": "E",
+   "type": "mc",
+   "stem": "The side panel of a small skate ramp is a triangle with a base of 8 feet and a height of 3.5 feet, as shown. What is the area, in square feet, of the side panel?",
+   "choices": [
+    "5.75",
+    "11.5",
+    "14",
+    "28"
+   ],
+   "answer": 2,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The area of a triangle is (1/2) × base × height. So the area is (1/2)(8)(3.5) = 14 square feet. Choosing 28 forgets the factor of 1/2, and 11.5 adds the base and height instead of multiplying.",
+   "verify": "assert 0.5 * 8 * 3.5 == 14",
+   "figure": {
+    "kind": "geometry",
+    "params": {
+     "shape": "triangle",
+     "labels": {
+      "base": "8 ft",
+      "height": "3.5 ft"
+     },
+     "marks": {
+      "right_angle": "between base and height"
+     }
+    }
+   }
+  },
+  {
+   "n": 3,
+   "domain": "ALG",
+   "skill": "Linear equations in one variable",
+   "difficulty": "E",
+   "type": "mc",
+   "stem": "If 3(x − 4) = 18, what is the value of x?",
+   "choices": [
+    "14/3",
+    "6",
+    "22/3",
+    "10"
+   ],
+   "answer": 3,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Divide both sides by 3 to get x − 4 = 6, then add 4 to get x = 10. Choosing 6 forgets to add 4 back, and 22/3 comes from failing to distribute the 3 to the −4 (solving 3x − 4 = 18).",
+   "verify": "from sympy import symbols, solve, Eq, Rational\nx = symbols('x')\nassert solve(Eq(3*(x - 4), 18)) == [10]",
+   "figure": null
+  },
+  {
+   "n": 4,
+   "domain": "ALG",
+   "skill": "Linear functions",
+   "difficulty": "E",
+   "type": "mc",
+   "stem": "The graph of the linear function f passes through the points (2, 5) and (6, 17) in the xy-plane. What is the slope of the graph of f?",
+   "choices": [
+    "3",
+    "1/3",
+    "−3",
+    "12"
+   ],
+   "answer": 0,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Slope is the change in y divided by the change in x: (17 − 5)/(6 − 2) = 12/4 = 3. Choosing 1/3 inverts the ratio (Δx over Δy), and 12 uses only the change in y.",
+   "verify": "from sympy import Rational\nassert Rational(17 - 5, 6 - 2) == 3",
+   "figure": null
+  },
+  {
+   "n": 5,
+   "domain": "GEO",
+   "skill": "Lines, angles, and triangles",
+   "difficulty": "E",
+   "type": "spr",
+   "stem": "The measures of the three interior angles of a triangle are x°, 2x°, and 75°. What is the value of x?",
+   "choices": null,
+   "answer": null,
+   "spr_answer": "35",
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The interior angles of a triangle sum to 180°, so x + 2x + 75 = 180. Then 3x = 105, so x = 35.",
+   "verify": "from sympy import symbols, solve, Eq\nx = symbols('x')\nsol = solve(Eq(x + 2*x + 75, 180))\nassert sol == [35]\ncanonical = float('35')\nassert canonical == 35\nfor eq in []:\n    assert abs(float(eq) - canonical) < 1e-9",
+   "figure": null
+  },
+  {
+   "n": 6,
+   "domain": "ADV",
+   "skill": "Equivalent expressions",
+   "difficulty": "E",
+   "type": "mc",
+   "stem": "Which expression is equivalent to (x + 5)(x − 2)?",
+   "choices": [
+    "x² + 3x − 10",
+    "x² − 3x − 10",
+    "x² + 3x + 10",
+    "x² − 10"
+   ],
+   "answer": 0,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Expanding gives x² − 2x + 5x − 10 = x² + 3x − 10. Choosing x² − 10 forgets the middle terms, and x² − 3x − 10 makes a sign error when combining −2x and 5x.",
+   "verify": "from sympy import symbols, expand\nx = symbols('x')\nassert expand((x + 5)*(x - 2)) == x**2 + 3*x - 10",
+   "figure": null
+  },
+  {
+   "n": 7,
+   "domain": "PSDA",
+   "skill": "Ratios, rates, proportional relationships, and units",
+   "difficulty": "E",
+   "type": "mc",
+   "stem": "An artist is designing a tile mosaic that uses blue tiles and white tiles in a ratio of 3 to 5. If the mosaic uses 120 blue tiles, how many white tiles does it use?",
+   "choices": [
+    "40",
+    "72",
+    "320",
+    "200"
+   ],
+   "answer": 3,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Each group of the ratio has 3 blue and 5 white tiles, and 120 blue tiles means 120/3 = 40 groups. So there are 40 × 5 = 200 white tiles. Choosing 72 reverses the ratio (120 × 3/5), and 320 gives the total number of tiles instead.",
+   "verify": "from sympy import Rational\nassert Rational(120, 3) * 5 == 200",
+   "figure": null
+  },
+  {
+   "n": 8,
+   "domain": "GEO",
+   "skill": "Area and volume",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "A grain silo is in the shape of a right circular cylinder with an interior radius of 4 meters and an interior height of 10 meters. The silo is completely filled with grain that weighs 700 kilograms per cubic meter. Which of the following is closest to the total weight, in kilograms, of the grain in the silo?",
+   "choices": [
+    "88,000",
+    "176,000",
+    "352,000",
+    "1,407,000"
+   ],
+   "answer": 2,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The volume of the cylinder is πr²h = π(4²)(10) = 160π ≈ 502.65 cubic meters. Multiplying by the density gives 502.65 × 700 ≈ 351,858, so about 352,000 kilograms. Choosing 88,000 uses r instead of r² in the volume formula, and 1,407,000 uses the diameter squared.",
+   "verify": "from sympy import pi\nw = float(pi * 4**2 * 10 * 700)\nassert abs(w - 351858) < 100\nassert round(w, -3) == 352000",
+   "figure": null
+  },
+  {
+   "n": 9,
+   "domain": "GEO",
+   "skill": "Lines, angles, and triangles",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "A vertical pole 6 feet tall casts a shadow 4 feet long on level ground. At the same time, a grain silo on the same ground casts a shadow 30 feet long. The triangles formed by each object and its shadow are similar. What is the height, in feet, of the silo?",
+   "choices": [
+    "20",
+    "45",
+    "120",
+    "180"
+   ],
+   "answer": 1,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Because the triangles are similar, height/shadow is the same for both objects: 6/4 = h/30. Solving gives h = 30 × 6/4 = 45 feet. Choosing 20 reverses the ratio (30 × 4/6), and 180 multiplies 6 by 30 without dividing.",
+   "verify": "from sympy import Rational\nassert Rational(6, 4) * 30 == 45",
+   "figure": null
+  },
+  {
+   "n": 10,
+   "domain": "GEO",
+   "skill": "Right triangles and trigonometry",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "A guy-wire supports a cell tower. The wire is anchored to level ground at a point 9 meters from the base of the tower and is attached to the tower at a point 12 meters above the ground, as shown. What is the length, in meters, of the guy-wire?",
+   "choices": [
+    "3",
+    "15",
+    "21",
+    "√63"
+   ],
+   "answer": 1,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The tower, the ground, and the wire form a right triangle with legs 9 and 12, and the wire is the hypotenuse. By the Pythagorean theorem, the length is √(9² + 12²) = √225 = 15 meters. Choosing 21 adds the legs, and √63 subtracts the squares as if the wire were a leg.",
+   "verify": "from sympy import sqrt\nassert sqrt(9**2 + 12**2) == 15",
+   "figure": {
+    "kind": "geometry",
+    "params": {
+     "shape": "triangle",
+     "labels": {
+      "vertical_leg": "12 m (tower)",
+      "horizontal_leg": "9 m (ground)",
+      "hypotenuse": "guy-wire"
+     },
+     "marks": {
+      "right_angle": "between tower and ground"
+     }
+    }
+   }
+  },
+  {
+   "n": 11,
+   "domain": "ALG",
+   "skill": "Systems of two linear equations",
+   "difficulty": "M",
+   "type": "spr",
+   "stem": "2x + 3y = 24\nx − y = 2\nIf (x, y) is the solution to the system of equations above, what is the value of x?",
+   "choices": null,
+   "answer": null,
+   "spr_answer": "6",
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "From the second equation, x = y + 2. Substituting into the first equation gives 2(y + 2) + 3y = 24, so 5y + 4 = 24 and y = 4. Then x = 4 + 2 = 6.",
+   "verify": "from sympy import symbols, solve, Eq\nx, y = symbols('x y')\nsol = solve([Eq(2*x + 3*y, 24), Eq(x - y, 2)], [x, y])\nassert sol[x] == 6 and sol[y] == 4\ncanonical = float('6')\nassert canonical == float(sol[x])\nfor eq in []:\n    assert abs(float(eq) - canonical) < 1e-9",
+   "figure": null
+  },
+  {
+   "n": 12,
+   "domain": "GEO",
+   "skill": "Right triangles and trigonometry",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "A person is flying a kite on level ground. The 50-meter string is fully extended and pulled taut, and it makes an angle of 37° with the horizontal, as shown. Which expression gives the height, in meters, of the kite above the level of the person's hand?",
+   "choices": [
+    "50 sin 37°",
+    "50 cos 37°",
+    "50 tan 37°",
+    "50/sin 37°"
+   ],
+   "answer": 0,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The string is the hypotenuse of a right triangle, and the height is the side opposite the 37° angle. Since sin = opposite/hypotenuse, the height is 50 sin 37°. Choosing 50 cos 37° gives the horizontal distance instead, and 50/sin 37° inverts the ratio.",
+   "verify": "from sympy import sin, cos, rad\nh = float(50*sin(rad(37)))\nassert abs(h - 30.09) < 0.01\nassert h < float(50*cos(rad(37))) + 10 and h < 50",
+   "figure": {
+    "kind": "geometry",
+    "params": {
+     "shape": "triangle",
+     "labels": {
+      "hypotenuse": "50 m (string)",
+      "angle": "37°",
+      "vertical_leg": "h"
+     },
+     "marks": {
+      "right_angle": "between vertical leg and ground",
+      "angle_position": "between string and horizontal"
+     }
+    }
+   }
+  },
+  {
+   "n": 13,
+   "domain": "PSDA",
+   "skill": "Percentages",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "A tile mosaic kit is on sale for $102.00, which is 15% off its original price. What was the original price of the kit?",
+   "choices": [
+    "$86.70",
+    "$117.30",
+    "$120.00",
+    "$122.40"
+   ],
+   "answer": 2,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The sale price is 85% of the original price p, so 0.85p = 102. Dividing gives p = 102/0.85 = 120, so the original price was $120.00. Choosing $117.30 incorrectly adds 15% of the sale price (102 × 1.15), and $86.70 takes 15% off the sale price again.",
+   "verify": "assert abs(102 / 0.85 - 120) < 1e-9\nassert abs(120 * 0.85 - 102) < 1e-9",
+   "figure": null
+  },
+  {
+   "n": 14,
+   "domain": "GEO",
+   "skill": "Circles",
+   "difficulty": "M",
+   "type": "spr",
+   "stem": "In a circle with radius 9 centimeters, an arc has length 6π centimeters. What is the measure, in degrees, of the central angle that intercepts this arc?",
+   "choices": null,
+   "answer": null,
+   "spr_answer": "120",
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The circumference of the circle is 2π(9) = 18π centimeters. The arc is 6π/18π = 1/3 of the circle, so the central angle is (1/3)(360°) = 120°.",
+   "verify": "from sympy import pi, Rational\nangle = (6*pi / (2*pi*9)) * 360\nassert angle == 120\ncanonical = float('120')\nassert canonical == float(angle)\nfor eq in []:\n    assert abs(float(eq) - canonical) < 1e-9",
+   "figure": null
+  },
+  {
+   "n": 15,
+   "domain": "ADV",
+   "skill": "Nonlinear functions",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "A jet of water in a city park fountain follows a parabolic path. The height of the water, in feet, at a horizontal distance of x feet from the nozzle is given by h(x) = −x² + 6x. What is the maximum height, in feet, reached by the water?",
+   "choices": [
+    "3",
+    "6",
+    "9",
+    "12"
+   ],
+   "answer": 2,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The parabola opens downward, so the maximum occurs at the vertex, where x = −b/(2a) = −6/(2)(−1) = 3. Then h(3) = −9 + 18 = 9 feet. Choosing 3 gives the x-coordinate of the vertex instead of the height, and 6 gives the distance where the water lands.",
+   "verify": "from sympy import symbols, diff, solve\nx = symbols('x')\nh = -x**2 + 6*x\nxv = solve(diff(h, x))[0]\nassert xv == 3 and h.subs(x, xv) == 9",
+   "figure": null
+  },
+  {
+   "n": 16,
+   "domain": "ALG",
+   "skill": "Linear inequalities in one or two variables",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "A community group is building a skate ramp. Renting a workshop space costs a flat fee of $40 plus $15 per hour. The group can spend at most $250 on the rental. What is the greatest whole number of hours the group can rent the workshop?",
+   "choices": [
+    "13",
+    "14",
+    "15",
+    "16"
+   ],
+   "answer": 1,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The cost for h hours is 40 + 15h, so the group needs 40 + 15h ≤ 250. Subtracting 40 and dividing by 15 gives h ≤ 210/15 = 14, so the greatest whole number of hours is 14. Choosing 16 ignores the $40 flat fee (250/15 rounded down).",
+   "verify": "assert 40 + 15*14 <= 250 and 40 + 15*15 > 250",
+   "figure": null
+  },
+  {
+   "n": 17,
+   "domain": "ADV",
+   "skill": "Nonlinear functions",
+   "difficulty": "M",
+   "type": "mc",
+   "stem": "A grain silo initially holds 2,400 bushels of grain. Each day, 20% of the grain remaining in the silo is removed. Which function g gives the number of bushels remaining after d days?",
+   "choices": [
+    "g(d) = 2,400(0.8)^d",
+    "g(d) = 2,400(0.2)^d",
+    "g(d) = 2,400(1.2)^d",
+    "g(d) = 2,400 − 480d"
+   ],
+   "answer": 0,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Removing 20% each day leaves 80% of the previous day's amount, so the amount is multiplied by 0.8 each day: g(d) = 2,400(0.8)^d. Choosing (0.2)^d keeps only 20% instead of removing 20%, and 2,400 − 480d treats the decrease as a constant 480 bushels per day rather than 20% of the remaining amount.",
+   "verify": "g = lambda d: 2400 * 0.8**d\nassert g(1) == 2400 - 0.2*2400\nassert abs(g(2) - 0.8*g(1)) < 1e-9",
+   "figure": null
+  },
+  {
+   "n": 18,
+   "domain": "GEO",
+   "skill": "Circles",
+   "difficulty": "H",
+   "type": "mc",
+   "stem": "The graph of x² + y² − 6x + 4y − 12 = 0 in the xy-plane is a circle. What is the radius of the circle?",
+   "choices": [
+    "2√3",
+    "5",
+    "12",
+    "25"
+   ],
+   "answer": 1,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Completing the square gives (x² − 6x + 9) + (y² + 4y + 4) = 12 + 9 + 4, or (x − 3)² + (y + 2)² = 25. The radius is √25 = 5. Choosing 25 gives r² instead of r, and 2√3 takes the square root of the constant 12 without completing the square.",
+   "verify": "from sympy import symbols, expand\nx, y = symbols('x y')\nassert expand((x - 3)**2 + (y + 2)**2 - 25) == expand(x**2 + y**2 - 6*x + 4*y - 12)\nassert 25**0.5 == 5",
+   "figure": null
+  },
+  {
+   "n": 19,
+   "domain": "ADV",
+   "skill": "Nonlinear equations and systems",
+   "difficulty": "H",
+   "type": "spr",
+   "stem": "y = x² − 4x + 5\ny = 2x − 3\nThe graphs of the equations above intersect at two points in the xy-plane. What is the sum of the x-coordinates of the two points of intersection?",
+   "choices": null,
+   "answer": null,
+   "spr_answer": "6",
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Setting the expressions for y equal gives x² − 4x + 5 = 2x − 3, so x² − 6x + 8 = 0. Factoring gives (x − 2)(x − 4) = 0, so x = 2 or x = 4, and the sum is 2 + 4 = 6. (Equivalently, the sum of the roots of x² − 6x + 8 = 0 is −(−6)/1 = 6.)",
+   "verify": "from sympy import symbols, solve, Eq\nx = symbols('x')\nroots = solve(Eq(x**2 - 4*x + 5, 2*x - 3))\nassert sorted(roots) == [2, 4]\ncanonical = float('6')\nassert canonical == float(sum(roots))\nfor eq in []:\n    assert abs(float(eq) - canonical) < 1e-9",
+   "figure": null
+  },
+  {
+   "n": 20,
+   "domain": "GEO",
+   "skill": "Right triangles and trigonometry",
+   "difficulty": "H",
+   "type": "mc",
+   "stem": "A Ferris wheel has a radius of 20 meters, and its center is 25 meters above the ground. A car starts at the lowest point of the wheel and travels 150° around the circle. What is the height, in meters, of the car above the ground at that position?",
+   "choices": [
+    "25 − 10√3",
+    "25 + 10√2",
+    "45",
+    "25 + 10√3"
+   ],
+   "answer": 3,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "After rotating 150° from the bottom, the car's height above the center's level is −20 cos 150° = 20(√3/2) = 10√3, since the vertical position relative to the center is −r cos θ measured from the lowest point. So the height above the ground is 25 + 10√3 ≈ 42.3 meters. Choosing 25 − 10√3 puts the car below the center (a sign error), and 45 assumes the car reached the top of the wheel.",
+   "verify": "from sympy import cos, rad, sqrt, simplify\nh = 25 - 20*cos(rad(150))\nassert simplify(h - (25 + 10*sqrt(3))) == 0\nassert abs(float(h) - 42.32) < 0.01",
+   "figure": null
+  },
+  {
+   "n": 21,
+   "domain": "ALG",
+   "skill": "Systems of two linear equations",
+   "difficulty": "H",
+   "type": "spr",
+   "stem": "kx − 6y = 10\n2x − 3y = 5\nIn the system of equations above, k is a constant. If the system has infinitely many solutions, what is the value of k?",
+   "choices": null,
+   "answer": null,
+   "spr_answer": "4",
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "For infinitely many solutions, the two equations must be equivalent. Multiplying the second equation by 2 gives 4x − 6y = 10, which matches the first equation when k = 4. Equivalently, the ratios must all be equal: k/2 = −6/−3 = 10/5 = 2, so k = 4.",
+   "verify": "from sympy import symbols, expand\nx, y = symbols('x y')\nk = 4\nassert expand(k*x - 6*y - 10 - 2*(2*x - 3*y - 5)) == 0\ncanonical = float('4')\nassert canonical == 4.0\nfor eq in []:\n    assert abs(float(eq) - canonical) < 1e-9",
+   "figure": null
+  },
+  {
+   "n": 22,
+   "domain": "ADV",
+   "skill": "Nonlinear equations and systems",
+   "difficulty": "H",
+   "type": "mc",
+   "stem": "What is the solution set of the equation √(2x + 7) = x + 2?",
+   "choices": [
+    "{−3}",
+    "{−3, 1}",
+    "The equation has no real solutions.",
+    "{1}"
+   ],
+   "answer": 3,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Squaring both sides gives 2x + 7 = x² + 4x + 4, so x² + 2x − 3 = 0 and (x + 3)(x − 1) = 0, giving candidates x = −3 and x = 1. Checking x = −3: √(1) = 1 but x + 2 = −1, so it is extraneous; checking x = 1: √9 = 3 = 1 + 2, which works. The solution set is {1}; choosing {−3, 1} forgets to check for extraneous solutions.",
+   "verify": "from sympy import symbols, solve, Eq, sqrt\nx = symbols('x')\nsol = solve(Eq(sqrt(2*x + 7), x + 2))\nassert sol == [1]\nassert (2*(-3) + 7)**0.5 != -3 + 2",
+   "figure": null
+  }
+ ]
+}

--- a/seeds/sat-math/sat_w5.json
+++ b/seeds/sat-math/sat_w5.json
@@ -1,0 +1,1027 @@
+{
+ "week": 5,
+ "title": "Exit (full section)",
+ "items": [
+  {
+   "n": 1,
+   "domain": "ALG",
+   "skill": "Linear equations in one variable",
+   "difficulty": "E",
+   "type": "mc",
+   "module": 1,
+   "stem": "If 3x + 7 = 25, what is the value of x?",
+   "choices": [
+    "4/3",
+    "6",
+    "32/3",
+    "18"
+   ],
+   "answer": 1,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Subtract 7 from both sides to get 3x = 18, then divide by 3 to get x = 6. Choice C comes from adding 7 instead of subtracting, and choice D comes from forgetting to divide by 3.",
+   "verify": "import sympy as sp; x=sp.symbols('x'); assert sp.solve(sp.Eq(3*x+7,25))==[6]",
+   "figure": null
+  },
+  {
+   "n": 2,
+   "domain": "ADV",
+   "skill": "Equivalent expressions (binomial product)",
+   "difficulty": "E",
+   "type": "mc",
+   "module": 1,
+   "stem": "Which expression is equivalent to (x + 5)(x − 3)?",
+   "choices": [
+    "x² + 2x − 15",
+    "x² − 2x − 15",
+    "x² − 15",
+    "x² + 8x − 15"
+   ],
+   "answer": 0,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Distribute: (x + 5)(x − 3) = x² − 3x + 5x − 15 = x² + 2x − 15. Choice C forgets the middle terms, and choice B makes a sign error when combining −3x and 5x.",
+   "verify": "import sympy as sp; x=sp.symbols('x'); assert sp.expand((x+5)*(x-3))==x**2+2*x-15",
+   "figure": null
+  },
+  {
+   "n": 3,
+   "domain": "ALG",
+   "skill": "Linear functions (evaluation)",
+   "difficulty": "E",
+   "type": "mc",
+   "module": 1,
+   "stem": "The function f is defined by f(x) = 4x − 9. What is the value of f(5)?",
+   "choices": [
+    "−29",
+    "11",
+    "20",
+    "29"
+   ],
+   "answer": 1,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Substitute x = 5: f(5) = 4(5) − 9 = 20 − 9 = 11. Choice D adds 9 instead of subtracting, and choice C ignores the −9 entirely.",
+   "verify": "assert 4*5-9==11",
+   "figure": null
+  },
+  {
+   "n": 4,
+   "domain": "ADV",
+   "skill": "Equivalent expressions (exponent rules)",
+   "difficulty": "E",
+   "type": "mc",
+   "module": 1,
+   "stem": "Which expression is equivalent to (3x²)(2x³)?",
+   "choices": [
+    "5x⁵",
+    "5x⁶",
+    "6x⁵",
+    "6x⁶"
+   ],
+   "answer": 2,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Multiply the coefficients and add the exponents: 3 · 2 = 6 and x² · x³ = x⁵, so the product is 6x⁵. Choices A and B add the coefficients, and choices B and D multiply the exponents.",
+   "verify": "import sympy as sp; x=sp.symbols('x'); assert sp.simplify((3*x**2)*(2*x**3)-6*x**5)==0",
+   "figure": null
+  },
+  {
+   "n": 5,
+   "domain": "GEO",
+   "skill": "Area and volume",
+   "difficulty": "E",
+   "type": "mc",
+   "module": 1,
+   "stem": "The rectangular stage of a community theater is 24 feet long and 15 feet wide. What is the area of the stage, in square feet?",
+   "choices": [
+    "39",
+    "78",
+    "180",
+    "360"
+   ],
+   "answer": 3,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The area of a rectangle is length times width: 24 · 15 = 360 square feet. Choice B (78) is the perimeter, and choice A (39) is the sum of the two dimensions.",
+   "verify": "assert 24*15==360",
+   "figure": null
+  },
+  {
+   "n": 6,
+   "domain": "ALG",
+   "skill": "Linear equations in one variable (distribution)",
+   "difficulty": "E",
+   "type": "spr",
+   "module": 1,
+   "stem": "If 4(x − 3) = 18, what is the value of x?",
+   "choices": null,
+   "answer": null,
+   "spr_answer": "7.5",
+   "equivalents": [
+    "15/2"
+   ],
+   "answer_any": null,
+   "explanation": "Distribute to get 4x − 12 = 18, so 4x = 30 and x = 30/4 = 7.5. Equivalently, divide both sides by 4 first: x − 3 = 4.5, so x = 7.5.",
+   "verify": "import sympy as sp; x=sp.symbols('x'); s=sp.solve(sp.Eq(4*(x-3),18))[0]; assert s==sp.Rational(15,2); assert abs(float('7.5')-float(s))<1e-9 and sp.Rational('15/2')==s",
+   "figure": null
+  },
+  {
+   "n": 7,
+   "domain": "PSDA",
+   "skill": "Percentages",
+   "difficulty": "E",
+   "type": "mc",
+   "module": 1,
+   "stem": "A used bookstore reduces the price of a $16.00 book by 25%. What is the sale price of the book?",
+   "choices": [
+    "$4.00",
+    "$12.00",
+    "$15.75",
+    "$20.00"
+   ],
+   "answer": 1,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "A 25% discount means the book sells for 75% of its original price: 0.75 · 16 = $12.00. Choice A is the amount of the discount, not the sale price, and choice C subtracts 25 cents instead of 25 percent.",
+   "verify": "assert abs(16*0.75-12.0)<1e-9",
+   "figure": null
+  },
+  {
+   "n": 8,
+   "domain": "ADV",
+   "skill": "Nonlinear functions (exponential evaluation)",
+   "difficulty": "E",
+   "type": "mc",
+   "module": 1,
+   "stem": "An aquaponics farm starts with 50 fish, and the fish population doubles every year. The population t years after opening is modeled by P(t) = 50(2)^t. According to the model, how many fish will there be 3 years after opening?",
+   "choices": [
+    "150",
+    "400",
+    "450",
+    "800"
+   ],
+   "answer": 1,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Evaluate P(3) = 50 · 2³ = 50 · 8 = 400. Choice A multiplies 50 by 3 (linear growth), choice C uses 3² instead of 2³, and choice D doubles one extra time.",
+   "verify": "assert 50*2**3==400",
+   "figure": null
+  },
+  {
+   "n": 9,
+   "domain": "ALG",
+   "skill": "Systems of two linear equations (word problem)",
+   "difficulty": "M",
+   "type": "mc",
+   "module": 1,
+   "stem": "A community theater sold 12 tickets to a show for a total of $143. Adult tickets cost $14 each and student tickets cost $9 each. How many adult tickets were sold?",
+   "choices": [
+    "5",
+    "6",
+    "7",
+    "9"
+   ],
+   "answer": 2,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Let a and s be the numbers of adult and student tickets: a + s = 12 and 14a + 9s = 143. Substituting s = 12 − a gives 14a + 108 − 9a = 143, so 5a = 35 and a = 7. Choice A (5) is the number of student tickets.",
+   "verify": "import sympy as sp; a,s=sp.symbols('a s'); sol=sp.solve([sp.Eq(a+s,12),sp.Eq(14*a+9*s,143)]); assert sol[a]==7 and sol[s]==5",
+   "figure": null
+  },
+  {
+   "n": 10,
+   "domain": "ALG",
+   "skill": "Linear functions (interpretation of slope)",
+   "difficulty": "M",
+   "type": "mc",
+   "module": 1,
+   "stem": "A 3D-printing shop charges C = 2.5g + 40 dollars for a custom print that uses g grams of material. What is the best interpretation of the number 2.5 in this equation?",
+   "choices": [
+    "Each additional gram of material increases the total cost by $2.50.",
+    "The shop charges $2.50 for a print that uses no material.",
+    "Each additional gram of material increases the total cost by $40.00.",
+    "The total cost of every print decreases by $2.50 per gram."
+   ],
+   "answer": 0,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "In C = 2.5g + 40, the coefficient 2.5 is the rate of change of cost with respect to grams: each additional gram adds $2.50 to the cost. The constant 40 is the base charge when g = 0, which choice B confuses with 2.5.",
+   "verify": null,
+   "figure": null
+  },
+  {
+   "n": 11,
+   "domain": "ADV",
+   "skill": "Nonlinear equations (quadratic by factoring)",
+   "difficulty": "M",
+   "type": "spr",
+   "module": 1,
+   "stem": "What is one solution to the equation x² − 5x − 24 = 0?",
+   "choices": null,
+   "answer": null,
+   "spr_answer": "8",
+   "equivalents": [],
+   "answer_any": [
+    "8",
+    "-3"
+   ],
+   "explanation": "Factor the quadratic: x² − 5x − 24 = (x − 8)(x + 3) = 0, so x = 8 or x = −3. Either value may be entered.",
+   "verify": "import sympy as sp; x=sp.symbols('x'); r=set(sp.solve(x**2-5*x-24)); assert r=={8,-3}; assert float('8') in {float(v) for v in r} and float('-3') in {float(v) for v in r}",
+   "figure": null
+  },
+  {
+   "n": 12,
+   "domain": "PSDA",
+   "skill": "Probability and conditional probability (two-way table)",
+   "difficulty": "M",
+   "type": "mc",
+   "module": 1,
+   "stem": "The two-way table summarizes whether the adults and students surveyed by a community theater attended at least one show last season. If one of the surveyed students is selected at random, what is the probability that the student attended at least one show?",
+   "choices": [
+    "7/15",
+    "35/80",
+    "35/150",
+    "75/150"
+   ],
+   "answer": 0,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The condition restricts the selection to the 75 students, of whom 35 attended, so the probability is 35/75 = 7/15. Choice B divides by all attendees (80), and choice C divides by all 150 people surveyed instead of only students.",
+   "verify": "import sympy as sp; assert sp.Rational(35,75)==sp.Rational(7,15)",
+   "figure": {
+    "kind": "table",
+    "params": {
+     "headers": [
+      "",
+      "Attended",
+      "Did not attend",
+      "Total"
+     ],
+     "rows": [
+      [
+       "Adults",
+       "45",
+       "30",
+       "75"
+      ],
+      [
+       "Students",
+       "35",
+       "40",
+       "75"
+      ],
+      [
+       "Total",
+       "80",
+       "70",
+       "150"
+      ]
+     ]
+    }
+   }
+  },
+  {
+   "n": 13,
+   "domain": "ALG",
+   "skill": "Linear inequalities in one variable",
+   "difficulty": "M",
+   "type": "spr",
+   "module": 1,
+   "stem": "Kavi's marathon training plan requires him to run at least 40 miles this week. He has run 26.5 miles so far and plans to complete additional runs of 4.5 miles each. What is the least number of additional runs Kavi needs in order to meet the requirement?",
+   "choices": null,
+   "answer": null,
+   "spr_answer": "3",
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Solve 26.5 + 4.5n ≥ 40, which gives 4.5n ≥ 13.5, so n ≥ 3. Since 3 is already a whole number, the least number of additional runs is 3.",
+   "verify": "assert 26.5+4.5*3>=40 and 26.5+4.5*2<40; assert float('3')==3",
+   "figure": null
+  },
+  {
+   "n": 14,
+   "domain": "ADV",
+   "skill": "Nonlinear equations (exponential, equal bases)",
+   "difficulty": "M",
+   "type": "mc",
+   "module": 1,
+   "stem": "If 2^(3x) = 2^(x + 8), what is the value of x?",
+   "choices": [
+    "2",
+    "8/3",
+    "4",
+    "8"
+   ],
+   "answer": 2,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Since the bases are equal, the exponents must be equal: 3x = x + 8, so 2x = 8 and x = 4. Choice B (8/3) comes from setting 3x = 8 and forgetting the x on the right side.",
+   "verify": "assert 2**(3*4)==2**(4+8)",
+   "figure": null
+  },
+  {
+   "n": 15,
+   "domain": "GEO",
+   "skill": "Right triangles and trigonometry (ratios)",
+   "difficulty": "M",
+   "type": "mc",
+   "module": 1,
+   "stem": "In a physics lab, a cart rolls down a straight ramp. As shown, the ramp, the floor, and a vertical support form a right triangle: the ramp is 13 meters long, the support is 5 meters tall, and the base along the floor is 12 meters. What is the sine of the angle the ramp makes with the floor?",
+   "choices": [
+    "5/13",
+    "5/12",
+    "12/13",
+    "13/5"
+   ],
+   "answer": 0,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The angle at the floor has opposite side 5 (the vertical support) and hypotenuse 13 (the ramp), so its sine is 5/13. Choice B (5/12) is the tangent of the angle, and choice C (12/13) is its cosine.",
+   "verify": "import math; assert 5**2+12**2==13**2 and abs(5/13-math.sin(math.atan2(5,12)))<1e-9",
+   "figure": {
+    "kind": "geometry",
+    "params": {
+     "shape": "triangle",
+     "labels": {
+      "hypotenuse": "13 m (ramp)",
+      "vertical_leg": "5 m (support)",
+      "horizontal_leg": "12 m (floor)"
+     },
+     "marks": {
+      "right_angle": "between floor and support"
+     }
+    }
+   }
+  },
+  {
+   "n": 16,
+   "domain": "PSDA",
+   "skill": "Two-variable data: scatterplots and models",
+   "difficulty": "M",
+   "type": "mc",
+   "module": 1,
+   "stem": "The scatterplot shows the weekly lettuce yield y, in kilograms, of an aquaponics farm x weeks after planting, along with the line of best fit y = 2.5x + 4. Based on the line of best fit, what is the predicted yield, in kilograms, 8 weeks after planting?",
+   "choices": [
+    "12",
+    "20",
+    "24",
+    "26.5"
+   ],
+   "answer": 2,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Substitute x = 8 into the line of best fit: y = 2.5(8) + 4 = 20 + 4 = 24. Choice B uses the slope term only and forgets the intercept, and choice A adds 8 to the intercept instead of multiplying by the slope.",
+   "verify": "assert 2.5*8+4==24",
+   "figure": {
+    "kind": "scatter",
+    "params": {
+     "pts": [
+      [
+       1,
+       6
+      ],
+      [
+       2,
+       9.5
+      ],
+      [
+       3,
+       11
+      ],
+      [
+       4,
+       14.5
+      ],
+      [
+       5,
+       16
+      ],
+      [
+       6,
+       19.5
+      ],
+      [
+       7,
+       21.5
+      ]
+     ],
+     "xlabel": "Weeks after planting",
+     "ylabel": "Lettuce yield (kg)",
+     "line": {
+      "slope": 2.5,
+      "yint": 4
+     }
+    }
+   }
+  },
+  {
+   "n": 17,
+   "domain": "ADV",
+   "skill": "Nonlinear equations (radical)",
+   "difficulty": "M",
+   "type": "spr",
+   "module": 1,
+   "stem": "What is the solution to the equation √(2x + 7) = 5?",
+   "choices": null,
+   "answer": null,
+   "spr_answer": "9",
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Square both sides: 2x + 7 = 25, so 2x = 18 and x = 9. Checking, √(2·9 + 7) = √25 = 5, so the solution is not extraneous.",
+   "verify": "import sympy as sp; x=sp.symbols('x'); assert sp.solve(sp.sqrt(2*x+7)-5)==[9]; assert float('9')==9",
+   "figure": null
+  },
+  {
+   "n": 18,
+   "domain": "ALG",
+   "skill": "Linear equations in two variables (equation from two points)",
+   "difficulty": "M",
+   "type": "mc",
+   "module": 1,
+   "stem": "In the xy-plane, a line passes through the points (2, 5) and (6, 17). Which equation defines the line?",
+   "choices": [
+    "y = (1/3)x − 1",
+    "y = 3x + 1",
+    "y = 4x − 3",
+    "y = 3x − 1"
+   ],
+   "answer": 3,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The slope is (17 − 5)/(6 − 2) = 12/4 = 3. Using (2, 5): 5 = 3(2) + b gives b = −1, so y = 3x − 1. Choice B has the wrong sign on the intercept, and choice A inverts the slope.",
+   "verify": "assert (17-5)/(6-2)==3 and 5==3*2-1 and 17==3*6-1",
+   "figure": null
+  },
+  {
+   "n": 19,
+   "domain": "ALG",
+   "skill": "Systems of two linear equations (no solution)",
+   "difficulty": "H",
+   "type": "mc",
+   "module": 1,
+   "stem": "3x − 6y = 12\nax + 8y = −20\nIn the system above, a is a constant. For which value of a does the system have no solution?",
+   "choices": [
+    "−16",
+    "−4",
+    "4",
+    "16"
+   ],
+   "answer": 1,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "A system has no solution when the lines are parallel: the coefficient ratios must satisfy a/3 = 8/(−6), so a = 3 · 8/(−6) = −4. With a = −4 the constant terms are not in the same ratio (12/(−20) ≠ 3/(−4)), so the lines are distinct and parallel.",
+   "verify": "import sympy as sp; x,y=sp.symbols('x y'); assert sp.solve([sp.Eq(3*x-6*y,12),sp.Eq(-4*x+8*y,-20)])==[]",
+   "figure": null
+  },
+  {
+   "n": 20,
+   "domain": "ADV",
+   "skill": "Nonlinear systems (tangency via discriminant)",
+   "difficulty": "H",
+   "type": "mc",
+   "module": 1,
+   "stem": "In the xy-plane, the graphs of y = x² and y = 2x + k intersect at exactly one point, where k is a constant. What is the value of k?",
+   "choices": [
+    "−1",
+    "0",
+    "1",
+    "2"
+   ],
+   "answer": 0,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Setting x² = 2x + k gives x² − 2x − k = 0. Exactly one intersection requires the discriminant to be zero: (−2)² − 4(1)(−k) = 4 + 4k = 0, so k = −1. Then x² − 2x + 1 = (x − 1)² touches at the single point (1, 1).",
+   "verify": "import sympy as sp; x=sp.symbols('x'); assert sp.discriminant(x**2-2*x-(-1),x)==0",
+   "figure": null
+  },
+  {
+   "n": 21,
+   "domain": "GEO",
+   "skill": "Circles (equation, completing the square)",
+   "difficulty": "H",
+   "type": "spr",
+   "module": 1,
+   "stem": "In the xy-plane, the equation x² + y² − 6x + 4y = 23 defines a circle. What is the radius of the circle?",
+   "choices": null,
+   "answer": null,
+   "spr_answer": "6",
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Complete the square: (x² − 6x + 9) + (y² + 4y + 4) = 23 + 9 + 4, so (x − 3)² + (y + 2)² = 36. The radius is √36 = 6.",
+   "verify": "import sympy as sp; x,y=sp.symbols('x y'); assert sp.simplify((x**2+y**2-6*x+4*y-23)-((x-3)**2+(y+2)**2-36))==0; assert float('6')==6",
+   "figure": null
+  },
+  {
+   "n": 22,
+   "domain": "PSDA",
+   "skill": "Inference and margin of error",
+   "difficulty": "H",
+   "type": "mc",
+   "module": 1,
+   "stem": "A neighborhood solar co-op surveyed a random sample of 400 households in a city and found that 62% of the sampled households support building a shared solar array, with an associated margin of error of 4%. Which conclusion is the most appropriate based on these results?",
+   "choices": [
+    "Exactly 62% of all households in the city support building the array.",
+    "Surveying more households would have increased the percent who support the array.",
+    "The survey proves that a majority of households in every neighborhood of the city support the array.",
+    "It is plausible that between 58% and 66% of all households in the city support building the array."
+   ],
+   "answer": 3,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The margin of error gives a plausible range for the population percent: 62% ± 4%, or 58% to 66%. The sample statistic does not pin down the population value exactly (choice A), and the survey supports a citywide estimate, not a claim about every neighborhood (choice C).",
+   "verify": null,
+   "figure": null
+  },
+  {
+   "n": 23,
+   "domain": "ALG",
+   "skill": "Linear equations in two variables (intercepts)",
+   "difficulty": "E",
+   "type": "mc",
+   "module": 2,
+   "stem": "In the xy-plane, the graph of 3x + 5y = 30 crosses the x-axis at the point (a, 0). What is the value of a?",
+   "choices": [
+    "6",
+    "10",
+    "15",
+    "30"
+   ],
+   "answer": 1,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "On the x-axis, y = 0, so 3a = 30 and a = 10. Choice A (6) is the y-intercept, found by setting x = 0 instead.",
+   "verify": "assert 3*10+5*0==30",
+   "figure": null
+  },
+  {
+   "n": 24,
+   "domain": "ADV",
+   "skill": "Nonlinear functions (quadratic evaluation)",
+   "difficulty": "E",
+   "type": "mc",
+   "module": 2,
+   "stem": "The function f is defined by f(x) = x² − 3x. What is the value of f(−2)?",
+   "choices": [
+    "−10",
+    "−2",
+    "2",
+    "10"
+   ],
+   "answer": 3,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Substitute x = −2: f(−2) = (−2)² − 3(−2) = 4 + 6 = 10. Choice B treats (−2)² as −4, and choice C computes 4 − 6 by mishandling the sign of −3(−2).",
+   "verify": "assert (-2)**2-3*(-2)==10",
+   "figure": null
+  },
+  {
+   "n": 25,
+   "domain": "PSDA",
+   "skill": "One-variable data (bar graph)",
+   "difficulty": "E",
+   "type": "mc",
+   "module": 2,
+   "stem": "The bar graph shows the number of books a used bookstore sold last month in each of four genres. How many more mystery books than science-fiction books were sold?",
+   "choices": [
+    "7",
+    "13",
+    "14",
+    "27"
+   ],
+   "answer": 2,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "From the graph, 42 mystery books and 28 science-fiction books were sold, so the difference is 42 − 28 = 14. Choice A compares mystery with romance, and choice D compares mystery with poetry.",
+   "verify": "assert 42-28==14",
+   "figure": {
+    "kind": "bar",
+    "params": {
+     "labels": [
+      "Mystery",
+      "Romance",
+      "Sci-Fi",
+      "Poetry"
+     ],
+     "values": [
+      42,
+      35,
+      28,
+      15
+     ],
+     "xlabel": "Genre",
+     "ylabel": "Books sold"
+    }
+   }
+  },
+  {
+   "n": 26,
+   "domain": "GEO",
+   "skill": "Lines, angles, and triangles",
+   "difficulty": "E",
+   "type": "mc",
+   "module": 2,
+   "stem": "The measures of the three interior angles of a triangle are x°, 2x°, and 3x°. What is the measure, in degrees, of the smallest angle?",
+   "choices": [
+    "30",
+    "60",
+    "90",
+    "120"
+   ],
+   "answer": 0,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The angle measures sum to 180°: x + 2x + 3x = 6x = 180, so x = 30. The smallest angle measures 30°; choice C (90) is the largest angle.",
+   "verify": "assert 30+60+90==180 and min(30,60,90)==30",
+   "figure": null
+  },
+  {
+   "n": 27,
+   "domain": "ALG",
+   "skill": "Linear equations in one variable (variable on both sides)",
+   "difficulty": "E",
+   "type": "spr",
+   "module": 2,
+   "stem": "If 4x − 9 = 2x + 5, what is the value of x?",
+   "choices": null,
+   "answer": null,
+   "spr_answer": "7",
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Subtract 2x from both sides to get 2x − 9 = 5, so 2x = 14 and x = 7.",
+   "verify": "import sympy as sp; x=sp.symbols('x'); assert sp.solve(sp.Eq(4*x-9,2*x+5))==[7]; assert float('7')==7",
+   "figure": null
+  },
+  {
+   "n": 28,
+   "domain": "ADV",
+   "skill": "Nonlinear functions (choosing an exponential model)",
+   "difficulty": "E",
+   "type": "mc",
+   "module": 2,
+   "stem": "In its first year, a 3D-printing shop earned $5,000 in revenue, and its annual revenue has doubled every year since. Which function models the shop's revenue R(t), in dollars, t years after the first year?",
+   "choices": [
+    "R(t) = 5,000 + 2t",
+    "R(t) = 5,000t²",
+    "R(t) = 2(5,000)^t",
+    "R(t) = 5,000(2)^t"
+   ],
+   "answer": 3,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Doubling every year is exponential growth with initial value 5,000 and growth factor 2, so R(t) = 5,000(2)^t. Choice A grows by a constant amount (linear), and choice C swaps the initial value with the growth factor.",
+   "verify": "assert 5000*2**0==5000 and (5000*2**3)/(5000*2**2)==2",
+   "figure": null
+  },
+  {
+   "n": 29,
+   "domain": "PSDA",
+   "skill": "One-variable data: center and spread (outlier effect)",
+   "difficulty": "M",
+   "type": "mc",
+   "module": 2,
+   "stem": "In a physics lab, a student records the time, in seconds, for a cart to travel down a track in each of 7 trials: 2.1, 2.2, 2.2, 2.3, 2.4, 2.5, 4.8. Which statement about these data is true?",
+   "choices": [
+    "The mean is less than the median.",
+    "The mean is equal to the median.",
+    "The relationship between the mean and the median cannot be determined.",
+    "The mean is greater than the median."
+   ],
+   "answer": 3,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The median is the middle value, 2.3, while the mean is 18.5/7 ≈ 2.64. The single large value 4.8 pulls the mean above the median, so the mean is greater.",
+   "verify": "import statistics as st; d=[2.1,2.2,2.2,2.3,2.4,2.5,4.8]; assert st.mean(d)>st.median(d)",
+   "figure": null
+  },
+  {
+   "n": 30,
+   "domain": "ALG",
+   "skill": "Systems of two linear equations (substitution)",
+   "difficulty": "M",
+   "type": "spr",
+   "module": 2,
+   "stem": "3x + 2y = 21\nx = 2y − 1\nIf (x, y) is the solution to the system of equations above, what is the value of x?",
+   "choices": null,
+   "answer": null,
+   "spr_answer": "5",
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Substitute x = 2y − 1 into the first equation: 3(2y − 1) + 2y = 21, so 8y − 3 = 21 and y = 3. Then x = 2(3) − 1 = 5.",
+   "verify": "import sympy as sp; x,y=sp.symbols('x y'); sol=sp.solve([sp.Eq(3*x+2*y,21),sp.Eq(x,2*y-1)]); assert sol[x]==5 and sol[y]==3; assert float('5')==5",
+   "figure": null
+  },
+  {
+   "n": 31,
+   "domain": "ADV",
+   "skill": "Nonlinear equations (rational)",
+   "difficulty": "M",
+   "type": "mc",
+   "module": 2,
+   "stem": "If (x + 1)/(x − 3) = 5, what is the value of x?",
+   "choices": [
+    "−4",
+    "8/3",
+    "7/2",
+    "4"
+   ],
+   "answer": 3,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Multiply both sides by (x − 3): x + 1 = 5x − 15, so 16 = 4x and x = 4. Checking, (4 + 1)/(4 − 3) = 5. Choice A comes from a sign error when moving the −15.",
+   "verify": "import sympy as sp; x=sp.symbols('x'); assert sp.solve(sp.Eq((x+1)/(x-3),5))==[4]",
+   "figure": null
+  },
+  {
+   "n": 32,
+   "domain": "GEO",
+   "skill": "Area and volume (cylinder)",
+   "difficulty": "M",
+   "type": "mc",
+   "module": 2,
+   "stem": "The cylindrical fish tank at an aquaponics farm has an inside radius of 3 feet and a height of 10 feet. What is the volume of the tank, in cubic feet?",
+   "choices": [
+    "30π",
+    "60π",
+    "90π",
+    "300π"
+   ],
+   "answer": 2,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The volume of a cylinder is V = πr²h = π(3²)(10) = 90π cubic feet. Choice A forgets to square the radius, and choice B is the lateral surface area 2πrh.",
+   "verify": "import sympy as sp; assert sp.pi*3**2*10==90*sp.pi",
+   "figure": null
+  },
+  {
+   "n": 33,
+   "domain": "ALG",
+   "skill": "Linear inequalities in two variables",
+   "difficulty": "M",
+   "type": "mc",
+   "module": 2,
+   "stem": "An airport shuttle company will send x sedans and y vans to pick up a large group. Each sedan can carry 3 passengers and each van can carry 7 passengers. Which inequality represents the numbers of sedans and vans that together can carry at least 42 passengers?",
+   "choices": [
+    "3x + 7y ≤ 42",
+    "3x + 7y ≥ 42",
+    "7x + 3y ≥ 42",
+    "7x + 3y ≤ 42"
+   ],
+   "answer": 1,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The sedans carry 3x passengers and the vans carry 7y passengers, so the total is 3x + 7y, and \"at least 42\" means 3x + 7y ≥ 42. Choice A reverses the inequality, and choice C swaps the coefficients.",
+   "verify": null,
+   "figure": null
+  },
+  {
+   "n": 34,
+   "domain": "ADV",
+   "skill": "Nonlinear functions (quadratic maximum)",
+   "difficulty": "M",
+   "type": "spr",
+   "module": 2,
+   "stem": "In a physics lab experiment, a ball is launched straight up, and its height, in feet, t seconds after launch is modeled by h(t) = −16t² + 64t. According to the model, what is the maximum height of the ball, in feet?",
+   "choices": null,
+   "answer": null,
+   "spr_answer": "64",
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The vertex of h(t) = −16t² + 64t occurs at t = −64/(2 · (−16)) = 2 seconds. The maximum height is h(2) = −16(4) + 64(2) = −64 + 128 = 64 feet.",
+   "verify": "import sympy as sp; t=sp.symbols('t'); h=-16*t**2+64*t; tv=sp.solve(sp.diff(h,t))[0]; assert tv==2 and h.subs(t,2)==64; assert float('64')==64",
+   "figure": null
+  },
+  {
+   "n": 35,
+   "domain": "ADV",
+   "skill": "Equivalent expressions (squaring a binomial)",
+   "difficulty": "M",
+   "type": "mc",
+   "module": 2,
+   "stem": "Which expression is equivalent to (2x − 3)²?",
+   "choices": [
+    "4x² + 9",
+    "4x² − 9",
+    "4x² − 6x + 9",
+    "4x² − 12x + 9"
+   ],
+   "answer": 3,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Expand: (2x − 3)² = (2x)² − 2(2x)(3) + 3² = 4x² − 12x + 9. Choice A drops the middle term entirely, and choice C uses −6x instead of doubling the product.",
+   "verify": "import sympy as sp; x=sp.symbols('x'); assert sp.expand((2*x-3)**2)==4*x**2-12*x+9",
+   "figure": null
+  },
+  {
+   "n": 36,
+   "domain": "ALG",
+   "skill": "Linear functions (perpendicular lines)",
+   "difficulty": "M",
+   "type": "mc",
+   "module": 2,
+   "stem": "In the xy-plane, line k is perpendicular to the graph of y = (2/5)x + 3 and passes through the point (0, −4). Which equation defines line k?",
+   "choices": [
+    "y = −(5/2)x − 4",
+    "y = −(2/5)x − 4",
+    "y = (2/5)x − 4",
+    "y = (5/2)x − 4"
+   ],
+   "answer": 0,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "A perpendicular line has slope equal to the negative reciprocal of 2/5, which is −5/2. Since line k passes through (0, −4), its y-intercept is −4, so y = −(5/2)x − 4. Choice B only negates the slope without taking the reciprocal.",
+   "verify": "assert (2/5)*(-5/2)==-1.0 and -(5/2)*0-4==-4",
+   "figure": null
+  },
+  {
+   "n": 37,
+   "domain": "ADV",
+   "skill": "Nonlinear systems (line and parabola)",
+   "difficulty": "M",
+   "type": "mc",
+   "module": 2,
+   "stem": "In the xy-plane, the graphs of y = x² − 4 and y = 3x intersect at two points. What is the sum of the x-coordinates of the two points of intersection?",
+   "choices": [
+    "−3",
+    "−1",
+    "3",
+    "4"
+   ],
+   "answer": 2,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Set x² − 4 = 3x, so x² − 3x − 4 = 0, which factors as (x − 4)(x + 1) = 0, giving x = 4 and x = −1. The sum is 4 + (−1) = 3, which also equals −b/a for the quadratic. Choices B and D are the individual solutions.",
+   "verify": "import sympy as sp; x=sp.symbols('x'); r=sp.solve(sp.Eq(x**2-4,3*x)); assert set(r)=={4,-1} and sum(r)==3",
+   "figure": null
+  },
+  {
+   "n": 38,
+   "domain": "GEO",
+   "skill": "Right triangles (Pythagorean theorem)",
+   "difficulty": "M",
+   "type": "spr",
+   "module": 2,
+   "stem": "During a marathon training run, Amara cuts diagonally across a rectangular field that is 240 meters long and 100 meters wide, running in a straight line from one corner to the opposite corner. How many meters long is her diagonal path across the field?",
+   "choices": null,
+   "answer": null,
+   "spr_answer": "260",
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The diagonal is the hypotenuse of a right triangle with legs 240 and 100. By the Pythagorean theorem, the diagonal is √(240² + 100²) = √(57,600 + 10,000) = √67,600 = 260 meters.",
+   "verify": "assert 240**2+100**2==260**2; assert float('260')==260",
+   "figure": null
+  },
+  {
+   "n": 39,
+   "domain": "ALG",
+   "skill": "Linear equations in one variable (infinitely many solutions)",
+   "difficulty": "H",
+   "type": "mc",
+   "module": 2,
+   "stem": "4(2x − 1) − 3x = 5x + k\nIn the equation above, k is a constant. If the equation has infinitely many solutions, what is the value of k?",
+   "choices": [
+    "−4",
+    "−1",
+    "0",
+    "4"
+   ],
+   "answer": 0,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Simplify the left side: 8x − 4 − 3x = 5x − 4. The equation 5x − 4 = 5x + k holds for every x only when k = −4. Choice B uses the constant from inside the parentheses without distributing the 4.",
+   "verify": "import sympy as sp; x=sp.symbols('x'); assert sp.simplify(4*(2*x-1)-3*x-(5*x-4))==0",
+   "figure": null
+  },
+  {
+   "n": 40,
+   "domain": "ADV",
+   "skill": "Nonlinear equations (quadratic, relation between roots)",
+   "difficulty": "H",
+   "type": "spr",
+   "module": 2,
+   "stem": "The equation x² + 10x + c = 0, where c is a constant, has two solutions that differ by 4. What is the value of c?",
+   "choices": null,
+   "answer": null,
+   "spr_answer": "21",
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The solutions sum to −10, and they differ by 4, so they are −3 and −7. The constant c is their product: (−3)(−7) = 21, and indeed x² + 10x + 21 = (x + 3)(x + 7).",
+   "verify": "import sympy as sp; x=sp.symbols('x'); r=sorted(sp.solve(x**2+10*x+21)); assert r==[-7,-3] and r[1]-r[0]==4 and r[0]+r[1]==-10; assert float('21')==21",
+   "figure": null
+  },
+  {
+   "n": 41,
+   "domain": "PSDA",
+   "skill": "Percentages (successive percent change)",
+   "difficulty": "H",
+   "type": "mc",
+   "module": 2,
+   "stem": "A neighborhood solar co-op's monthly energy production increased by 20% from May to June and then decreased by 15% from June to July. How does the co-op's July production compare with its May production?",
+   "choices": [
+    "It increased by 5%.",
+    "It increased by 2%.",
+    "It is unchanged.",
+    "It decreased by 3%."
+   ],
+   "answer": 1,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Apply the changes multiplicatively: 1.20 · 0.85 = 1.02, so July production is 102% of May production, a 2% increase. Choice A incorrectly adds the percent changes (20% − 15% = 5%).",
+   "verify": "assert abs(1.20*0.85-1.02)<1e-9",
+   "figure": null
+  },
+  {
+   "n": 42,
+   "domain": "GEO",
+   "skill": "Right triangles and trigonometry (complementary angles)",
+   "difficulty": "H",
+   "type": "mc",
+   "module": 2,
+   "stem": "In a right triangle, the measures of the two acute angles are (2a)° and (3a + 10)°. If sin(2a)° = cos(3a + 10)°, what is the value of a?",
+   "choices": [
+    "−10",
+    "16",
+    "18",
+    "20"
+   ],
+   "answer": 1,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "The sine of an angle equals the cosine of its complement, so 2a + (3a + 10) = 90. Then 5a = 80 and a = 16. Choice A comes from setting the two angle measures equal to each other, and choice C forgets the 10 when summing to 90.",
+   "verify": "import math; assert 2*16+(3*16+10)==90 and abs(math.sin(math.radians(32))-math.cos(math.radians(58)))<1e-9",
+   "figure": null
+  },
+  {
+   "n": 43,
+   "domain": "ADV",
+   "skill": "Nonlinear functions (quadratic model, zeros)",
+   "difficulty": "H",
+   "type": "mc",
+   "module": 2,
+   "stem": "A 3D-printing shop's monthly profit, in dollars, from selling x custom parts is modeled by P(x) = −2x² + 120x − 1,000. The shop breaks even when P(x) = 0. What is the larger of the two values of x at which the shop breaks even?",
+   "choices": [
+    "10",
+    "30",
+    "50",
+    "60"
+   ],
+   "answer": 2,
+   "spr_answer": null,
+   "equivalents": [],
+   "answer_any": null,
+   "explanation": "Divide P(x) = 0 by −2 to get x² − 60x + 500 = 0, which factors as (x − 10)(x − 50) = 0, so x = 10 or x = 50; the larger is 50. Choice B (30) is the vertex, where profit is greatest, and choice D (60) is the sum of the two break-even values.",
+   "verify": "import sympy as sp; x=sp.symbols('x'); r=sp.solve(-2*x**2+120*x-1000); assert set(r)=={10,50} and max(r)==50",
+   "figure": null
+  },
+  {
+   "n": 44,
+   "domain": "ALG",
+   "skill": "Linear functions (rate from two data points)",
+   "difficulty": "H",
+   "type": "spr",
+   "module": 2,
+   "stem": "An airport shuttle service charges a fixed booking fee plus a constant rate for each mile driven. An 8-mile trip costs $20.50, and a 15-mile trip costs $32.75. What is the rate per mile, in dollars?",
+   "choices": null,
+   "answer": null,
+   "spr_answer": "1.75",
+   "equivalents": [
+    "7/4"
+   ],
+   "answer_any": null,
+   "explanation": "The 7 extra miles cost 32.75 − 20.50 = 12.25 dollars, so the rate per mile is 12.25/7 = 1.75 dollars. (The booking fee is then 20.50 − 8(1.75) = 6.50 dollars, consistent with both trips.)",
+   "verify": "import sympy as sp; f,m=sp.symbols('f m'); sol=sp.solve([sp.Eq(f+8*m,sp.Rational(2050,100)),sp.Eq(f+15*m,sp.Rational(3275,100))]); assert sol[m]==sp.Rational(7,4); assert abs(float('1.75')-float(sol[m]))<1e-12 and sp.Rational('7/4')==sol[m]",
+   "figure": null
+  }
+ ]
+}


### PR DESCRIPTION
The Fable-authored Digital SAT Math bank (5 weekly diagnostics, 132 items: 101 MC + 31 grid-in SPR, all 4 domains) + Fable's returned spec. Validated: 125/125 sympy verify snippets pass. Source-preservation only — ingest under the unified taxonomy is the next commit.


Claude-Session: https://claude.ai/code/session_01PTm55BDVTnGaJm3DRVauGZ