### PR TITLE
feat(migration): canonicalize skillId at the mastery boundary (Alg1 → unified)

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -13,6 +13,7 @@ const User = require('../models/user');
 const Conversation = require('../models/conversation');
 const EnrollmentCode = require('../models/enrollmentCode');
 const { isAdmin } = require('../middleware/auth');
+const { canonicalSkillId } = require('../utils/skillCanonicalizer');
 const { logRecordAccess } = require('../middleware/ferpaAccessLog');
 const { checkConsent } = require('../utils/consentManager');
 const { requireActiveConsent } = require('../middleware/consentGate');
@@ -2530,9 +2531,12 @@ router.post('/merge-accounts', isAdmin, async (req, res) => {
     if (smStrategy === 'merge' && source.skillMastery) {
       if (!target.skillMastery) target.skillMastery = new Map();
       for (const [skillId, sourceSkill] of source.skillMastery) {
-        const targetSkill = target.skillMastery.get(skillId);
+        // canonicalize on merge so legacy + unified entries for one concept
+        // collapse onto a single unified key instead of duplicating
+        const key = canonicalSkillId(skillId);
+        const targetSkill = target.skillMastery.get(key);
         if (!targetSkill || (sourceSkill.masteryScore || 0) > (targetSkill.masteryScore || 0)) {
-          target.skillMastery.set(skillId, sourceSkill);
+          target.skillMastery.set(key, sourceSkill);
         }
       }
       audit.changes.push('Merged skill mastery data (kept highest scores)');

--- a/routes/assessment.js
+++ b/routes/assessment.js
@@ -5,6 +5,7 @@ const Skill = require('../models/skill');
 const Conversation = require('../models/conversation');
 const aiService = require('../services/aiService');
 const { calculateBaselineModifier } = require('../utils/adaptiveFluency');
+const { canonicalSkillId } = require('../utils/skillCanonicalizer');
 
 // Grade-to-skill mapping for starting point
 const GRADE_STARTING_SKILLS = {
@@ -304,9 +305,9 @@ async function completeAssessment(user, conversation, aiResponse) {
       });
     }
 
-    // Update user's skill mastery
-    for (const skillId of masteredSkills) {
-      user.skillMastery.set(skillId, {
+    // Update user's skill mastery (canonical unified skill ids)
+    for (const rawId of masteredSkills) {
+      user.skillMastery.set(canonicalSkillId(rawId), {
         status: 'mastered',
         masteryScore: 1.0,
         masteredDate: new Date(),
@@ -314,8 +315,8 @@ async function completeAssessment(user, conversation, aiResponse) {
       });
     }
 
-    for (const skillId of learningSkills) {
-      user.skillMastery.set(skillId, {
+    for (const rawId of learningSkills) {
+      user.skillMastery.set(canonicalSkillId(rawId), {
         status: 'learning',
         masteryScore: 0.5,
         learningStarted: new Date(),
@@ -323,8 +324,8 @@ async function completeAssessment(user, conversation, aiResponse) {
       });
     }
 
-    for (const skillId of readySkills) {
-      user.skillMastery.set(skillId, {
+    for (const rawId of readySkills) {
+      user.skillMastery.set(canonicalSkillId(rawId), {
         status: 'ready',
         masteryScore: 0,
         notes: 'Prerequisites met, ready to learn'

--- a/routes/mastery.js
+++ b/routes/mastery.js
@@ -17,7 +17,18 @@ const { generatePhaseProblem, recordPhaseAttempt, getPhaseInstructions } = requi
 const { generateHint, trackHintUsage, analyzeHintUsage, shouldReteach } = require('../utils/hintSystem'); // TEACHING ENHANCEMENT
 const { analyzeError, generateReteaching, recordMisconception, markMisconceptionAddressed, analyzeMisconceptionPattern } = require('../utils/misconceptionDetector'); // TEACHING ENHANCEMENT
 const { getUnpluggedBadgeProgress } = require('../utils/unpluggedBadges');
-const { isSkillMastered } = require('../utils/masteryGuard');
+const { isSkillMastered, resolveMasteryKey } = require('../utils/masteryGuard');
+const { canonicalSkillId } = require('../utils/skillCanonicalizer');
+
+// Read a mastery entry from a Map|object by canonical (unified) skill id, falling
+// back to a legacy key so historical data still resolves during the migration.
+// Used for milestone/tier checks whose skillIds come from pattern-badge config.
+function readMasteryEntry(store, skillId) {
+  if (!store || !skillId) return null;
+  const get = (k) => (typeof store.get === 'function' ? store.get(k) : store[k]);
+  const canon = canonicalSkillId(skillId);
+  return get(canon) ?? (canon !== skillId ? get(skillId) : null) ?? null;
+}
 // ============================================================================
 // MASTERY BADGES
 // ============================================================================
@@ -1311,12 +1322,13 @@ router.post('/record-mastery-attempt', isAuthenticated, async (req, res) => {
       return res.status(404).json({ error: 'User not found' });
     }
 
-    // Get skill data
-    let skillMastery = user.skillMastery.get(skillId);
+    // Get skill data (canonical unified key, legacy fallback, for a clean read/write)
+    const masteryKey = resolveMasteryKey(user, skillId);
+    let skillMastery = user.skillMastery.get(masteryKey);
     if (!skillMastery) {
       // Initialize skill mastery if not exists
       const { initializeSkillMastery } = require('../utils/masteryEngine');
-      skillMastery = initializeSkillMastery(skillId);
+      skillMastery = initializeSkillMastery(masteryKey);
       skillMastery.status = 'ready';
     }
 
@@ -1335,7 +1347,7 @@ router.post('/record-mastery-attempt', isAuthenticated, async (req, res) => {
     updatedSkill.status = calculateMasteryState(updatedSkill, user.skillMastery);
 
     // Update user's skill mastery
-    user.skillMastery.set(skillId, updatedSkill);
+    user.skillMastery.set(masteryKey, updatedSkill);
 
     // Update streak tracking
     updateStreakTracking(user);
@@ -1381,7 +1393,7 @@ router.get('/skill-mastery/:skillId', isAuthenticated, async (req, res) => {
       return res.status(404).json({ error: 'User not found' });
     }
 
-    const skillMastery = user.skillMastery.get(skillId);
+    const skillMastery = readMasteryEntry(user.skillMastery, skillId);
     if (!skillMastery) {
       return res.status(404).json({ error: 'Skill mastery not found' });
     }
@@ -1618,7 +1630,8 @@ router.post('/retention-check', isAuthenticated, async (req, res) => {
       return res.status(404).json({ error: 'User not found' });
     }
 
-    const skillMastery = user.skillMastery.get(skillId);
+    const masteryKey = resolveMasteryKey(user, skillId);
+    const skillMastery = user.skillMastery.get(masteryKey);
     if (!skillMastery) {
       return res.status(404).json({ error: 'Skill mastery not found' });
     }
@@ -1633,7 +1646,7 @@ router.post('/retention-check', isAuthenticated, async (req, res) => {
     });
 
     // Update user
-    user.skillMastery.set(skillId, updatedSkill);
+    user.skillMastery.set(masteryKey, updatedSkill);
     await user.save();
 
     res.json({
@@ -1849,12 +1862,12 @@ router.get('/pattern/:patternId', isAuthenticated, async (req, res) => {
     for (const tier of pattern.tiers) {
       for (const milestone of tier.milestones) {
         const completed = milestone.skillIds.every(skillId => {
-          const mastery = user.skillMastery.get(skillId);
+          const mastery = readMasteryEntry(user.skillMastery, skillId);
           return mastery && (mastery.status === 'mastered' || mastery.masteryType === 'inferred');
         });
 
         const masteryType = milestone.skillIds.some(skillId => {
-          const mastery = user.skillMastery.get(skillId);
+          const mastery = readMasteryEntry(user.skillMastery, skillId);
           return mastery && mastery.masteryType === 'inferred';
         }) ? 'inferred' : 'verified';
 
@@ -1914,7 +1927,7 @@ router.post('/update-pattern-progress', isAuthenticated, async (req, res) => {
     }
 
     const patternId = skill.patternId;
-    const skillMastery = user.skillMastery.get(skillId);
+    const skillMastery = readMasteryEntry(user.skillMastery, skillId);
 
     // Check if should trigger inference
     if (shouldTriggerInference(skillMastery)) {
@@ -2085,7 +2098,7 @@ function getPatternProgress(patternId, skillMastery) {
     tier.milestones.forEach(milestone => {
       totalMilestones++;
       const allSkillsMastered = milestone.skillIds.every(skillId => {
-        const mastery = skillMastery[skillId] || skillMastery.get?.(skillId);
+        const mastery = readMasteryEntry(skillMastery, skillId);
         return mastery && (mastery.status === 'mastered' || mastery.masteryType === 'inferred');
       });
       if (allSkillsMastered) {
@@ -2128,7 +2141,7 @@ function getMilestoneProgress(patternId, milestoneId, skillMastery) {
   let masteredSkills = 0;
 
   milestone.skillIds.forEach(skillId => {
-    const mastery = skillMastery[skillId] || skillMastery.get?.(skillId);
+    const mastery = readMasteryEntry(skillMastery, skillId);
     if (mastery && (mastery.status === 'mastered' || mastery.masteryType === 'inferred')) {
       masteredSkills++;
     }

--- a/routes/review.js
+++ b/routes/review.js
@@ -23,6 +23,7 @@ const {
   assessQuality
 } = require('../utils/spacedRepetition');
 const { buildSmartQueue, getReviewSummary } = require('../utils/smartReviewQueue');
+const { resolveMasteryKey } = require('../utils/masteryGuard');
 const logger = require('../utils/catLogger');
 
 // ===========================================================================
@@ -259,7 +260,10 @@ router.post('/submit', isAuthenticated, async (req, res) => {
       return res.status(404).json({ error: 'User not found' });
     }
 
-    const skillData = user.skillMastery.get(skillId);
+    // resolve to the stored key (canonical unified id, or a legacy key if that's
+    // where this user's historical entry lives) for a duplicate-free read/write
+    const masteryKey = resolveMasteryKey(user, skillId);
+    const skillData = user.skillMastery.get(masteryKey);
     if (!skillData) {
       return res.status(404).json({ error: 'Skill not found in mastery data' });
     }
@@ -300,7 +304,7 @@ router.post('/submit', isAuthenticated, async (req, res) => {
       skillData.status = 'mastered';
     }
 
-    user.skillMastery.set(skillId, skillData);
+    user.skillMastery.set(masteryKey, skillData);
     user.markModified('skillMastery');
     await user.save();
 
@@ -347,7 +351,8 @@ router.post('/skip', isAuthenticated, async (req, res) => {
       return res.status(404).json({ error: 'User not found' });
     }
 
-    const skillData = user.skillMastery.get(skillId);
+    const masteryKey = resolveMasteryKey(user, skillId);
+    const skillData = user.skillMastery.get(masteryKey);
     if (!skillData?.reviewSchedule) {
       return res.status(404).json({ error: 'No review schedule for this skill' });
     }
@@ -357,7 +362,7 @@ router.post('/skip', isAuthenticated, async (req, res) => {
     tomorrow.setDate(tomorrow.getDate() + 1);
     skillData.reviewSchedule.nextReviewDate = tomorrow;
 
-    user.skillMastery.set(skillId, skillData);
+    user.skillMastery.set(masteryKey, skillData);
     user.markModified('skillMastery');
     await user.save();
 

--- a/routes/screener.js
+++ b/routes/screener.js
@@ -30,6 +30,7 @@ const { assessOptions } = require('../utils/distractorQuality');
 const { selectSkill, formatScoringLog } = require('../utils/skillSelector');
 const { calculateProgress } = require('../utils/catConvergence');
 const { getSkillSelectionData, warmupCache } = require('../utils/catCache');
+const { canonicalSkillId } = require('../utils/skillCanonicalizer');
 
 // Warm up cache on module load
 warmupCache().catch(err => console.error('[Screener] Cache warmup failed:', err));
@@ -724,9 +725,10 @@ router.post('/complete', isAuthenticated, async (req, res) => {
     report.gradeLevel = gradeLevelResult.gradeLevel;
     report.gradeLevelDescription = gradeLevelResult.description;
 
-    // Update user's skill mastery based on screener results
-    for (const skillId of report.masteredSkills) {
-      user.skillMastery.set(skillId, {
+    // Update user's skill mastery based on screener results (keyed on the
+    // canonical unified skill id so placement shares the tutor's mastery keys)
+    for (const rawId of report.masteredSkills) {
+      user.skillMastery.set(canonicalSkillId(rawId), {
         status: 'mastered',
         masteryScore: 1.0,
         masteredDate: new Date(),
@@ -734,8 +736,8 @@ router.post('/complete', isAuthenticated, async (req, res) => {
       });
     }
 
-    for (const skillId of report.learningSkills) {
-      user.skillMastery.set(skillId, {
+    for (const rawId of report.learningSkills) {
+      user.skillMastery.set(canonicalSkillId(rawId), {
         status: 'learning',
         masteryScore: 0.5,
         learningStarted: new Date(),
@@ -743,8 +745,8 @@ router.post('/complete', isAuthenticated, async (req, res) => {
       });
     }
 
-    for (const skillId of report.readySkills) {
-      user.skillMastery.set(skillId, {
+    for (const rawId of report.readySkills) {
+      user.skillMastery.set(canonicalSkillId(rawId), {
         status: 'ready',
         masteryScore: 0,
         notes: 'Ready to learn based on screener'

--- a/routes/student.js
+++ b/routes/student.js
@@ -14,6 +14,7 @@ const mongoose = require('mongoose');
 const { computeWeeklyAccuracy } = require('../utils/weeklyAccuracy');
 const { deriveProgressCardState } = require('../utils/progressCardState');
 const { getReviewSummary } = require('../utils/smartReviewQueue');
+const { resolveMasteryKey } = require('../utils/masteryGuard');
 
 // Helper function to generate a unique short code for student-to-parent linking
 async function generateUniqueStudentLinkCode() {
@@ -564,8 +565,9 @@ router.post('/start-skill', isAuthenticated, isStudent, async (req, res) => {
             student.skillMastery = new Map();
         }
 
-        // Check current status
-        const currentStatus = student.skillMastery.get(skillId);
+        // Check current status (canonical unified key, legacy fallback)
+        const masteryKey = resolveMasteryKey(student, skillId);
+        const currentStatus = student.skillMastery.get(masteryKey);
 
         if (currentStatus?.status === 'mastered') {
             return res.json({
@@ -575,7 +577,7 @@ router.post('/start-skill', isAuthenticated, isStudent, async (req, res) => {
         }
 
         // Set to learning
-        student.skillMastery.set(skillId, {
+        student.skillMastery.set(masteryKey, {
             status: 'learning',
             masteryScore: currentStatus?.masteryScore || 0.1,
             learningStarted: currentStatus?.learningStarted || new Date(),

--- a/scripts/backfillUnifiedMasteryKeys.js
+++ b/scripts/backfillUnifiedMasteryKeys.js
@@ -1,0 +1,153 @@
+// scripts/backfillUnifiedMasteryKeys.js
+//
+// One-time migration: rewrite every user's per-skill state keys from legacy
+// kebab skill ids to canonical unified "Map of Mathmatix" ids, so historical
+// data matches what the canonicalized read/write boundary now stores.
+//
+// Runtime code already canonicalizes at the mastery boundary (utils/skillCanonicalizer
+// via masteryGuard / persist / pipeline), so this backfill is OPTIONAL — reads
+// fall back to legacy keys, so nothing is broken without it. Running it just makes
+// stored keys uniform (one node per concept) and collapses any legacy+unified
+// duplicates a user accumulated across the transition.
+//
+// Rewrites, per user:
+//   - skillMastery                (Map<skillId, entry>)
+//   - learningEngines.bkt         (object keyed by skillId)
+//   - learningEngines.fsrs        (object keyed by skillId)
+//   - learningEngines.consistency (object keyed by skillId)
+//
+// Collision policy (a legacy key and its unified key both present):
+//   - skillMastery: keep the "stronger" entry — mastered wins, else higher
+//     masteryScore, else the entry already under the canonical key.
+//   - learningEngines: keep an existing canonical entry; otherwise move legacy.
+//
+// Usage:
+//   node scripts/backfillUnifiedMasteryKeys.js            # DRY RUN (default) — reports, writes nothing
+//   node scripts/backfillUnifiedMasteryKeys.js --apply    # apply changes
+
+require('dotenv').config();
+const mongoose = require('mongoose');
+const { canonicalSkillId } = require('../utils/skillCanonicalizer');
+
+const APPLY = process.argv.includes('--apply');
+
+function stronger(a, b) {
+  // return the mastery entry to keep when two collide
+  const rank = (e) => (e?.status === 'mastered' ? 1e9 : 0) + (Number(e?.masteryScore) || 0);
+  return rank(a) >= rank(b) ? a : b;
+}
+
+// Rewrite a Map's keys to canonical ids. Returns { next: Map, remapped, merged }.
+function remapMap(map, mergeFn) {
+  const next = new Map();
+  let remapped = 0;
+  let merged = 0;
+  for (const [key, val] of map) {
+    const canon = canonicalSkillId(key);
+    if (canon !== key) remapped += 1;
+    if (next.has(canon)) {
+      merged += 1;
+      next.set(canon, mergeFn(next.get(canon), val));
+    } else {
+      next.set(canon, val);
+    }
+  }
+  return { next, remapped, merged };
+}
+
+// Rewrite a plain object's keys to canonical ids. On collision keep the value
+// already under the canonical key (don't clobber engine state we can't merge).
+function remapObject(obj) {
+  const next = {};
+  let remapped = 0;
+  let merged = 0;
+  for (const [key, val] of Object.entries(obj)) {
+    const canon = canonicalSkillId(key);
+    if (canon !== key) remapped += 1;
+    if (Object.prototype.hasOwnProperty.call(next, canon)) {
+      merged += 1;
+      // prefer an existing canonical entry; only fill from legacy if canonical absent
+      if (canon === key) next[canon] = val;
+    } else {
+      next[canon] = val;
+    }
+  }
+  return { next, remapped, merged };
+}
+
+async function main() {
+  if (!process.env.MONGO_URI) {
+    console.error('MONGO_URI not set.');
+    process.exit(1);
+  }
+  await mongoose.connect(process.env.MONGO_URI);
+  const User = require('../models/user');
+
+  console.log(`\nBackfill unified mastery keys — ${APPLY ? 'APPLY (writing)' : 'DRY RUN (no writes)'}\n`);
+
+  const cursor = User.find(
+    {},
+    { skillMastery: 1, learningEngines: 1 },
+  ).cursor();
+
+  const totals = { users: 0, usersChanged: 0, sm: 0, smMerged: 0, eng: 0, engMerged: 0 };
+
+  for (let user = await cursor.next(); user != null; user = await cursor.next()) {
+    totals.users += 1;
+    let changed = false;
+
+    // skillMastery (Mongoose Map)
+    if (user.skillMastery && typeof user.skillMastery.forEach === 'function' && user.skillMastery.size) {
+      const { next, remapped, merged } = remapMap(user.skillMastery, stronger);
+      if (remapped || merged) {
+        totals.sm += remapped;
+        totals.smMerged += merged;
+        changed = true;
+        if (APPLY) {
+          user.skillMastery = next;
+          user.markModified('skillMastery');
+        }
+      }
+    }
+
+    // learningEngines.{bkt,fsrs,consistency} (plain objects, sometimes Maps)
+    if (user.learningEngines) {
+      for (const engine of ['bkt', 'fsrs', 'consistency']) {
+        let store = user.learningEngines[engine];
+        if (store instanceof Map) store = Object.fromEntries(store);
+        if (store && typeof store === 'object' && Object.keys(store).length) {
+          const { next, remapped, merged } = remapObject(store);
+          if (remapped || merged) {
+            totals.eng += remapped;
+            totals.engMerged += merged;
+            changed = true;
+            if (APPLY) {
+              user.learningEngines[engine] = next;
+              user.markModified('learningEngines');
+            }
+          }
+        }
+      }
+    }
+
+    if (changed) {
+      totals.usersChanged += 1;
+      if (APPLY) await user.save();
+    }
+  }
+
+  console.log(`Users scanned          : ${totals.users}`);
+  console.log(`Users ${APPLY ? 'updated ' : 'to update'}       : ${totals.usersChanged}`);
+  console.log(`skillMastery keys moved: ${totals.sm} (merged duplicates: ${totals.smMerged})`);
+  console.log(`learningEngine keys    : ${totals.eng} (merged duplicates: ${totals.engMerged})`);
+  if (!APPLY) console.log('\nDry run only — re-run with --apply to write these changes.');
+
+  await mongoose.disconnect();
+  process.exit(0);
+}
+
+main().catch(async (err) => {
+  console.error('backfill failed:', err.message);
+  try { await mongoose.disconnect(); } catch { /* noop */ }
+  process.exit(1);
+});

--- a/scripts/mergeAccounts.js
+++ b/scripts/mergeAccounts.js
@@ -22,6 +22,7 @@ const mongoose = require('mongoose');
 const User = require('../models/user');
 const Conversation = require('../models/conversation');
 const EnrollmentCode = require('../models/enrollmentCode');
+const { canonicalSkillId } = require('../utils/skillCanonicalizer');
 
 // Parse CLI arguments
 const args = process.argv.slice(2);
@@ -172,9 +173,10 @@ async function main() {
       if (source.skillMastery) {
         if (!target.skillMastery) target.skillMastery = new Map();
         for (const [skillId, sourceSkill] of source.skillMastery) {
-          const targetSkill = target.skillMastery.get(skillId);
+          const key = canonicalSkillId(skillId);
+          const targetSkill = target.skillMastery.get(key);
           if (!targetSkill || (sourceSkill.masteryScore || 0) > (targetSkill.masteryScore || 0)) {
-            target.skillMastery.set(skillId, sourceSkill);
+            target.skillMastery.set(key, sourceSkill);
           }
         }
         changes.push(`Merged skill mastery from ${source.email}`);

--- a/tests/unit/skillCanonicalizer.test.js
+++ b/tests/unit/skillCanonicalizer.test.js
@@ -1,0 +1,91 @@
+// tests/unit/skillCanonicalizer.test.js
+// Guards the skillId canonicalization layer that lets the content banks migrate
+// onto unified "Map of Mathmatix" ids without splitting per-skill mastery: a
+// legacy id and its unified id must collapse to ONE node at every mastery
+// read/write boundary. Covers the resolver plus the masteryGuard accessors that
+// route reads/writes through it. Pure — no DB, no env.
+
+const { canonicalSkillId, isUnifiedSkillId } = require('../../utils/skillCanonicalizer');
+const { getSkillMasteryEntry, resolveMasteryKey } = require('../../utils/masteryGuard');
+
+// Stable, high-confidence crosswalk pairs (see seeds/unified-taxonomy/alg1-crosswalk.json).
+const LEGACY = 'solving-multi-step-equations';
+const UNIFIED = 'ALG1.EQV.1';
+const LEGACY2 = 'slope-from-two-points';
+const UNIFIED2 = 'ALG1.PRP.2';
+
+describe('skillCanonicalizer', () => {
+  test('maps a legacy kebab id to its unified id', () => {
+    expect(canonicalSkillId(LEGACY)).toBe(UNIFIED);
+    expect(canonicalSkillId(LEGACY2)).toBe(UNIFIED2);
+  });
+
+  test('passes an already-unified id through unchanged', () => {
+    expect(canonicalSkillId(UNIFIED)).toBe(UNIFIED);
+  });
+
+  test('passes an unknown id and falsy values through unchanged', () => {
+    expect(canonicalSkillId('totally-unknown-skill')).toBe('totally-unknown-skill');
+    expect(canonicalSkillId('')).toBe('');
+    expect(canonicalSkillId(null)).toBe(null);
+    expect(canonicalSkillId(undefined)).toBe(undefined);
+  });
+
+  test('isUnifiedSkillId recognizes real taxonomy ids only', () => {
+    expect(isUnifiedSkillId(UNIFIED)).toBe(true);
+    expect(isUnifiedSkillId(LEGACY)).toBe(false);
+  });
+});
+
+// Helper: build a minimal user with a skillMastery store (Map or plain object).
+const userWith = (store) => ({ skillMastery: store });
+
+describe('getSkillMasteryEntry — canonical read with legacy fallback', () => {
+  for (const kind of ['Map', 'object']) {
+    const make = (entries) => (kind === 'Map' ? new Map(entries) : Object.fromEntries(entries));
+
+    test(`(${kind}) a legacy-id lookup finds a unified-keyed entry`, () => {
+      const user = userWith(make([[UNIFIED, { status: 'mastered' }]]));
+      expect(getSkillMasteryEntry(user, LEGACY)).toEqual({ status: 'mastered' });
+      expect(getSkillMasteryEntry(user, UNIFIED)).toEqual({ status: 'mastered' });
+    });
+
+    test(`(${kind}) a legacy-id lookup still finds a legacy-keyed (historical) entry`, () => {
+      const user = userWith(make([[LEGACY, { status: 'learning' }]]));
+      expect(getSkillMasteryEntry(user, LEGACY)).toEqual({ status: 'learning' });
+    });
+
+    test(`(${kind}) returns null when neither key is present`, () => {
+      const user = userWith(make([]));
+      expect(getSkillMasteryEntry(user, LEGACY)).toBeNull();
+    });
+  }
+
+  test('null-safe on missing user / skillMastery / skillId', () => {
+    expect(getSkillMasteryEntry(null, LEGACY)).toBeNull();
+    expect(getSkillMasteryEntry({}, LEGACY)).toBeNull();
+    expect(getSkillMasteryEntry(userWith(new Map()), null)).toBeNull();
+  });
+});
+
+describe('resolveMasteryKey — duplicate-free read/modify/write key', () => {
+  test('prefers the canonical unified key when an entry lives there', () => {
+    const user = userWith(new Map([[UNIFIED, { status: 'mastered' }]]));
+    expect(resolveMasteryKey(user, LEGACY)).toBe(UNIFIED);
+  });
+
+  test('uses the legacy key when only a historical entry exists there', () => {
+    const user = userWith(new Map([[LEGACY, { status: 'mastered' }]]));
+    expect(resolveMasteryKey(user, LEGACY)).toBe(LEGACY);
+  });
+
+  test('defaults to the canonical key for a brand-new entry', () => {
+    const user = userWith(new Map());
+    expect(resolveMasteryKey(user, LEGACY)).toBe(UNIFIED);
+  });
+
+  test('a canonical entry wins even if a stale legacy entry also exists', () => {
+    const user = userWith(new Map([[LEGACY, { status: 'learning' }], [UNIFIED, { status: 'mastered' }]]));
+    expect(resolveMasteryKey(user, LEGACY)).toBe(UNIFIED);
+  });
+});

--- a/utils/masteryGuard.js
+++ b/utils/masteryGuard.js
@@ -12,6 +12,7 @@
  */
 
 const TutorPlan = require('../models/tutorPlan');
+const { canonicalSkillId } = require('./skillCanonicalizer');
 
 // If a badge has been attempted this many times its requirement without
 // being earned, we consider it stuck and clear it so the student can pick
@@ -19,12 +20,33 @@ const TutorPlan = require('../models/tutorPlan');
 // of room for normal struggle before intervening.
 const STUCK_BADGE_ATTEMPT_MULTIPLIER = 2;
 
+// Central read accessor for a user's per-skill mastery entry. Canonicalizes the
+// requested skillId to its unified id (so a lookup by a legacy kebab id finds the
+// unified-keyed entry that new writes produce), then falls back to the raw id so
+// historical legacy-keyed entries still resolve during the migration — no data
+// backfill required. Every keyed read of skillMastery should go through here.
 function getSkillMasteryEntry(user, skillId) {
   if (!user || !skillId) return null;
   const sm = user.skillMastery;
   if (!sm) return null;
-  if (typeof sm.get === 'function') return sm.get(skillId) || null;
-  return sm[skillId] || null;
+  const read = (k) => (typeof sm.get === 'function' ? sm.get(k) : sm[k]) || null;
+  const canon = canonicalSkillId(skillId);
+  return read(canon) || (canon !== skillId ? read(skillId) : null);
+}
+
+// Resolve the skillMastery KEY to use for a read-modify-write on `skillId`.
+// Prefers the canonical unified id; if no entry exists there but one exists under
+// the raw (legacy) id, returns that so we update the historical entry in place
+// instead of creating a duplicate; otherwise defaults to canonical (new entry).
+function resolveMasteryKey(user, skillId) {
+  if (!skillId) return skillId;
+  const canon = canonicalSkillId(skillId);
+  const sm = user && user.skillMastery;
+  if (!sm) return canon;
+  const present = (k) => (typeof sm.get === 'function' ? sm.get(k) != null : sm[k] != null);
+  if (present(canon)) return canon;
+  if (canon !== skillId && present(skillId)) return skillId;
+  return canon;
 }
 
 /**
@@ -86,6 +108,8 @@ function clearActiveBadge(user, reason) {
 
 module.exports = {
   STUCK_BADGE_ATTEMPT_MULTIPLIER,
+  getSkillMasteryEntry,
+  resolveMasteryKey,
   isSkillMastered,
   isBadgeStuck,
   clearActiveBadge,

--- a/utils/patternBadges.js
+++ b/utils/patternBadges.js
@@ -2,6 +2,18 @@
 // Master Mode: Pattern-Based Badge System
 // Patterns persist K-12, tiers represent abstraction height
 
+const { canonicalSkillId } = require('./skillCanonicalizer');
+
+// Read a mastery entry from a Map|object by canonical (unified) skill id, with a
+// legacy fallback — so tier/milestone checks against pattern-config skillIds keep
+// resolving whether the user's stored keys are unified (new) or legacy (historical).
+function readMasteryEntry(store, skillId) {
+  if (!store || !skillId) return null;
+  const get = (k) => (typeof store.get === 'function' ? store.get(k) : store[k]);
+  const canon = canonicalSkillId(skillId);
+  return get(canon) ?? (canon !== skillId ? get(skillId) : null) ?? null;
+}
+
 /**
  * PATTERN BADGE ARCHITECTURE
  *
@@ -1257,7 +1269,7 @@ function getCurrentTier(patternId, userSkillMastery) {
       // Check if any skillId in this milestone is mastered
       return milestone.skillIds.some(skillId => {
         // Handle both Map and Object types
-        const mastery = userSkillMastery.get?.(skillId) || userSkillMastery[skillId];
+        const mastery = readMasteryEntry(userSkillMastery, skillId);
         return mastery && (mastery.status === 'mastered' || mastery.masteryType === 'inferred');
       });
     }).length;
@@ -1288,7 +1300,7 @@ function getNextMilestone(patternId, currentTier, userSkillMastery) {
   for (const milestone of tier.milestones) {
     const completed = milestone.skillIds.every(skillId => {
       // Handle both Map and Object types
-      const mastery = userSkillMastery?.get?.(skillId) || userSkillMastery?.[skillId];
+      const mastery = readMasteryEntry(userSkillMastery, skillId);
       return mastery && (mastery.status === 'mastered' || mastery.masteryType === 'inferred');
     });
 
@@ -1315,7 +1327,7 @@ function calculatePatternProgress(patternId, currentTier, userSkillMastery) {
   const completedCount = milestones.filter(milestone => {
     return milestone.skillIds.every(skillId => {
       // Handle both Map and Object types
-      const mastery = userSkillMastery?.get?.(skillId) || userSkillMastery?.[skillId];
+      const mastery = readMasteryEntry(userSkillMastery, skillId);
       return mastery && (mastery.status === 'mastered' || mastery.masteryType === 'inferred');
     });
   }).length;

--- a/utils/pipeline/coursePersist.js
+++ b/utils/pipeline/coursePersist.js
@@ -12,6 +12,7 @@
  */
 
 const { calculateOverallProgress } = require('../coursePrompt');
+const { canonicalSkillId } = require('../skillCanonicalizer');
 
 // ── Phase labels for breadcrumb display ──
 const PHASE_LABELS = {
@@ -312,9 +313,11 @@ function processModuleComplete(courseSession) {
  * @param {Object} user - Mongoose user document
  * @param {string} skillId - Skill ID from <SKILL_MASTERED:skillId>
  */
-function processSkillMastery(user, skillId) {
-  if (!skillId) return;
+function processSkillMastery(user, rawSkillId) {
+  if (!rawSkillId) return;
 
+  // canonicalize to the unified skill id so course + chat mastery share one key
+  const skillId = canonicalSkillId(rawSkillId);
   user.skillMastery = user.skillMastery || new Map();
   const existing = user.skillMastery.get(skillId) || {};
   const pillars = existing.pillars || {

--- a/utils/pipeline/index.js
+++ b/utils/pipeline/index.js
@@ -33,6 +33,7 @@ const { assembleEvidence } = require('./evidenceAccumulator');
 
 // New data-driven engines
 const { updateBKT, initializeBKT } = require('../knowledgeTracer');
+const { canonicalSkillId } = require('../skillCanonicalizer');
 const { updateCard, initializeCard, rateAttempt, RATINGS } = require('../fsrsScheduler');
 const { recordAttempt: recordConsistencyAttempt, initializeScore, categorizeDifficulty } = require('../consistencyScorer');
 
@@ -270,26 +271,25 @@ async function runPipeline(message, ctx) {
         : 0,
     };
 
+    // Read per-skill engine state keyed by the canonical (unified) skill id to
+    // match how updateLearningEngines writes it; fall back to the raw id so
+    // historical legacy-keyed state still resolves. Handles Map or plain object.
+    const readEngine = (store, id) => {
+      if (!store || !id) return null;
+      const get = (k) => (typeof store.get === 'function' ? store.get(k) : store[k]);
+      const canon = canonicalSkillId(id);
+      return get(canon) ?? (canon !== id ? get(id) : null) ?? null;
+    };
+    const activeSkillId = ctx.activeSkill ? ctx.activeSkill.skillId : null;
+
     // Get BKT state for active skill (from user's learningEngines data)
-    const bktState = ctx.activeSkill && ctx.user.learningEngines?.bkt
-      ? (ctx.user.learningEngines.bkt.get
-        ? ctx.user.learningEngines.bkt.get(ctx.activeSkill.skillId)
-        : ctx.user.learningEngines.bkt[ctx.activeSkill.skillId])
-      : null;
+    const bktState = readEngine(ctx.user.learningEngines?.bkt, activeSkillId);
 
     // Get FSRS card for active skill
-    const fsrsCard = ctx.activeSkill && ctx.user.learningEngines?.fsrs
-      ? (ctx.user.learningEngines.fsrs.get
-        ? ctx.user.learningEngines.fsrs.get(ctx.activeSkill.skillId)
-        : ctx.user.learningEngines.fsrs[ctx.activeSkill.skillId])
-      : null;
+    const fsrsCard = readEngine(ctx.user.learningEngines?.fsrs, activeSkillId);
 
     // Get consistency state for active skill
-    const consistencyState = ctx.activeSkill && ctx.user.learningEngines?.consistency
-      ? (ctx.user.learningEngines.consistency.get
-        ? ctx.user.learningEngines.consistency.get(ctx.activeSkill.skillId)
-        : ctx.user.learningEngines.consistency[ctx.activeSkill.skillId])
-      : null;
+    const consistencyState = readEngine(ctx.user.learningEngines?.consistency, activeSkillId);
 
     // Get misconception history
     const misconceptionHistory = ctx.user.masteryProgress?.activeBadge?.misconceptionsAddressed || [];
@@ -1658,6 +1658,9 @@ async function runPipeline(message, ctx) {
  * @param {Object} observation - Observation result
  */
 function updateLearningEngines(user, skillId, diagnosis, observation) {
+  // key BKT / FSRS / consistency state on the canonical unified skill id, so a
+  // concept's learning state never splits across a legacy id and its unified id
+  skillId = canonicalSkillId(skillId);
   const isCorrect = diagnosis.isCorrect === true;
   const hintUsed = observation.contextSignals?.some(s => s.type === 'uncertainty') || false;
 

--- a/utils/pipeline/persist.js
+++ b/utils/pipeline/persist.js
@@ -24,6 +24,7 @@ const { canonicalProblemId, contentHash, recordShownProblem } = require('../prob
 const { getNextActions } = require('../nextActionSuggestions');
 const { checkForInterventionAlert } = require('../interventionAlerts');
 const { getReviewSummary } = require('../smartReviewQueue');
+const { canonicalSkillId } = require('../skillCanonicalizer');
 
 /**
  * Persist all state changes from a pipeline run.
@@ -161,7 +162,9 @@ async function persist(params) {
 
   if (extracted.skillStarted) {
     user.skillMastery = user.skillMastery || new Map();
-    user.skillMastery.set(extracted.skillStarted, {
+    // key on the canonical (unified) skill id so learning/mastery state for one
+    // concept never splits across a legacy id and its unified id
+    user.skillMastery.set(canonicalSkillId(extracted.skillStarted), {
       status: 'learning',
       masteryScore: 0.3,
       learningStarted: new Date(),
@@ -584,8 +587,11 @@ async function persist(params) {
  * Update skill mastery from a <SKILL_MASTERED:skillId> tag.
  * Records it as evidence for the 4-pillar system.
  */
-function updateSkillMastery(user, skillId, observation, conversation) {
+function updateSkillMastery(user, rawSkillId, observation, conversation) {
   user.skillMastery = user.skillMastery || new Map();
+  // Canonicalize to the unified skill id for storage/lookup; keep the original
+  // id only for deriving a readable "recent win" label below.
+  const skillId = canonicalSkillId(rawSkillId);
   const existing = user.skillMastery.get(skillId) || {};
 
   const pillars = existing.pillars || {
@@ -647,7 +653,8 @@ function updateSkillMastery(user, skillId, observation, conversation) {
   // Add to recent wins if newly mastered
   if (newStatus === 'mastered' && existing.status !== 'mastered') {
     if (!user.learningProfile.recentWins) user.learningProfile.recentWins = [];
-    const displayName = skillId.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+    // derive the label from the original (kebab) id — nicer than a dotted unified id
+    const displayName = rawSkillId.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
     user.learningProfile.recentWins.unshift({ skill: skillId, description: `Mastered ${displayName}`, date: new Date() });
     user.learningProfile.recentWins = user.learningProfile.recentWins.slice(0, 10);
     user.markModified('learningProfile');
@@ -738,8 +745,8 @@ function updateBadgeProgress(user, wasCorrect) {
   user.xp = (user.xp || 0) + 500; // Badge XP bonus
   user.markModified('badges');
 
-  // Unlock skill on skill map
-  const skillId = badge.skillId;
+  // Unlock skill on skill map (canonical unified id)
+  const skillId = canonicalSkillId(badge.skillId);
   if (!user.skillMastery) user.skillMastery = new Map();
   if (!user.skillMastery.get(skillId) || user.skillMastery.get(skillId).status !== 'mastered') {
     user.skillMastery.set(skillId, {

--- a/utils/sessionPatternDetector.js
+++ b/utils/sessionPatternDetector.js
@@ -13,6 +13,8 @@
  * @module utils/sessionPatternDetector
  */
 
+const { canonicalSkillId } = require('./skillCanonicalizer');
+
 // ── Pattern types ──
 const PATTERN_TYPES = {
   RECURRING_STRUGGLE: 'recurring_struggle',
@@ -331,9 +333,9 @@ function detectRetentionDecay(skillMastery, recent, patterns, notes, planUpdates
       .filter(Boolean);
 
     for (const skillId of incorrectSkills) {
-      const mastery = skillMastery instanceof Map
-        ? skillMastery.get(skillId)
-        : skillMastery?.[skillId];
+      const canonId = canonicalSkillId(skillId);
+      const read = (k) => (skillMastery instanceof Map ? skillMastery.get(k) : skillMastery?.[k]);
+      const mastery = read(canonId) ?? (canonId !== skillId ? read(skillId) : null);
 
       if (mastery && (mastery.status === 'mastered' || mastery.masteryScore >= 70)) {
         decayingSkills.push(skillId);


### PR DESCRIPTION
## What

Activates the unified **Map of Mathmatix** taxonomy for per-skill state — **without re-tagging any content bank**. Every mastery read and write now normalizes its `skillId` to the canonical unified id via `utils/skillCanonicalizer` (merged in #1228), so a legacy kebab id and its unified id collapse to **one node**. That's the payoff of the unified taxonomy (cross-source mastery, one prerequisite graph) with none of the breakage a bank re-tag would cause.

## Why this shape (not a bank flip)

A choke-point audit found:
- The **screener** pulls problems by **exact** `Problem.skillId` match, and its candidate ids come from the catalog + `Problem.distinct('skillId')` + generator templates — all legacy. Flipping the bank's tags would return **zero problems** for those skills unless the catalog and generator moved in lockstep.
- Mastery writes/reads are **scattered** (~8 write sites, ~14 read sites across 7 files), and BKT/FSRS lives in a *separate* keyed map — there is no single choke-point to flip.

Canonicalizing at the mastery boundary sidesteps the screener landmine entirely, and as a bonus fixes the **pre-existing** fragmentation between the screener's grade-map vocabulary and the bank vocabularies.

## Write boundary — new writes land on the unified key
- `utils/pipeline/persist.js` — `updateSkillMastery`, `skillStarted`, `updateBadgeProgress`
- `utils/pipeline/coursePersist.js` — `processSkillMastery`
- `utils/pipeline/index.js` — `updateLearningEngines` (BKT/FSRS/consistency) **and** the paired engine reads
- `routes/{screener,assessment}.js` — placement results
- `routes/{review,mastery,student}.js` — read-modify-write via a new `resolveMasteryKey` (canonical key, legacy fallback, canonical default — duplicate-free)
- `routes/admin.js` + `scripts/mergeAccounts.js` — account-merge collapses legacy+unified duplicates onto one key

## Read boundary — a legacy-id lookup resolves the unified-keyed entry
Canonical-first with a **legacy fallback**, so historical data still resolves and **no backfill is required** for correctness.
- `utils/masteryGuard.js` — `getSkillMasteryEntry` now canonicalizes; exports `resolveMasteryKey`
- `routes/mastery.js` + `utils/patternBadges.js` — milestone/tier checks via a canonicalizing `readMasteryEntry` (caught 3 pattern-badge reads the first audit pass missed)
- `utils/sessionPatternDetector.js` — retention-decay lookup

## Also included
- **`scripts/backfillUnifiedMasteryKeys.js`** — optional one-time migration (dry-run by default; `--apply` to write) that rewrites historical `skillMastery` + `learningEngines` keys legacy→unified and collapses duplicates. Optional because the read fallback keeps things working without it.
- **`tests/unit/skillCanonicalizer.test.js`** — 15 tests: resolver contract, canonical read with legacy fallback (Map + object), and `resolveMasteryKey` duplicate-avoidance.

## Verification
- Full unit suite green: **3844 passed / 238 suites** (was 3829; +15 new).
- Drove the **real** write path with a minimal user: `updateSkillMastery(user, 'solving-multi-step-equations', …)` → entry lands under `ALG1.EQV.1`, no legacy key leaked; `updateBadgeProgress` badge-unlock → `ALG1.PRP.2`.
- `eslint` clean on all touched files (0 errors).

## Scope / follow-ups
- This lands the mechanism (bank-agnostic — driven by `seeds/unified-taxonomy/*-crosswalk.json`) and the **Algebra 1** crosswalk. ACT/Calc activate by adding their reviewed crosswalks — no further code change here.
- Running the backfill against production is an ops step (dry-run first); not required for this PR to be correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTm55BDVTnGaJm3DRVauGZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTm55BDVTnGaJm3DRVauGZ)_