### PR TITLE
fix(mobile): voice mode = workspace center stage; thread bleed + STT …

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -163,7 +163,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <!-- Companion HOME screen (phones only; flag-gated OFF by default) -->
   <link rel="stylesheet" href="/css/mobile-companion-home.css" />
   <!-- Docked tutor cam + typing pill (phones only; AFTER poster + light re-skin) -->
-  <link rel="stylesheet" href="/css/mobile-tutor-cam.css?v=20260717" />
+  <link rel="stylesheet" href="/css/mobile-tutor-cam.css?v=20260718" />
   <script defer src="/js/i18n-translations.js"></script>
   <script defer src="/js/i18n.js"></script>
 </head>
@@ -2352,7 +2352,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- Voice as a layout mode of the chat stage -->
   <script src="/js/voice-mode.js?v=3"></script>
   <!-- Voice-mode captions: karaoke subtitles + student STT echo + replay/history -->
-  <script defer src="/js/voice-subtitles.js?v=20260716"></script>
+  <script defer src="/js/voice-subtitles.js?v=20260718"></script>
   <!-- Whiteboard stack lazy-loaded via loadBoardTools() (see boardPanel block
        below) — only needed when the visual board is enabled (boardPanel:true). -->
   <script src="/dist/js/chat-js3.babd546b.js"></script>

--- a/public/css/mobile-tutor-cam.css
+++ b/public/css/mobile-tutor-cam.css
@@ -22,6 +22,36 @@
     /* One knob for the cam height; the thread's top padding tracks it. */
     --mm-cam-h: clamp(150px, 24dvh, 208px);
     --mm-cam-top: calc(env(safe-area-inset-top, 0px) + 58px);
+    /* Visible cam height — the pill state shrinks it (see section 3);
+       the header backdrop band tracks this, not --mm-cam-h. */
+    --mm-cam-vis-h: var(--mm-cam-h);
+  }
+
+  /* ---- 0. Opaque header band ----------------------------------------- */
+  /* The thread scroll container spans the full viewport (only padded to
+     clear the cam), so a scrolled conversation rides up through the
+     topbar band and the cam's side gutters. This band paints the app
+     background from the viewport top to just under the cam.
+     Stacking: main.sidebar-layout is a z1 stacking context that caps the
+     whole stage — the band must live INSIDE it or it covers the cam.
+     .cr-stage::before paints before the (later-DOM) hero at the same z3,
+     so: chat z2 < band < cam. Out-of-flow, so the grid ignores it. */
+  body.cr-mode .cr-stage::before {
+    content: '';
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: calc(var(--mm-cam-top) + var(--mm-cam-vis-h) + 26px);
+    background: linear-gradient(180deg,
+        var(--mlt-bg, #F5F3FB) calc(100% - 16px),
+        rgba(var(--mlt-scrim-rgb, 245, 243, 251), 0) 100%);
+    z-index: 3;
+    pointer-events: none;
+    transition: height 260ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  @media (prefers-reduced-motion: reduce) {
+    body.cr-mode .cr-stage::before { transition: none; }
   }
 
   /* ---- 1. Poster → docked cam card ---------------------------------- */
@@ -93,6 +123,7 @@
   }
 
   /* ---- 3. Pill state (typing) ---------------------------------------- */
+  body.cr-mode.mm-tutor-pill { --mm-cam-vis-h: 46px; }
   body.cr-mode.mm-tutor-pill .cr-tutor-hero {
     height: 46px !important;
     border-radius: 999px !important;
@@ -152,6 +183,73 @@
     height: 130% !important;
     transform: translate(-50%, -50%) scale(calc(0.85 + var(--voice-amp, 0) * 0.4)) !important;
   }
+
+  /* ---- 5. Voice mode: the WORKSPACE is the stage ---------------------- */
+  /* Voice on a phone = cam stays the docked card (presence + captions),
+     the math workspace fills the center, mic dock owns the bottom.
+     "Voice explains, board shows" — the board gets the room. */
+
+  /* Chat records but doesn't render; the workspace replaces it. */
+  body.cr-mode.cr-voice #chat-container { display: none !important; }
+
+  /* Drawer chrome retires — the workspace isn't a drawer here. */
+  body.cr-mode.cr-voice .cr-ws-fab,
+  body.cr-mode.cr-voice .cr-ws-backdrop { display: none !important; }
+
+  /* Workspace: out of the drawer, pinned between cam and mic dock.
+     Overrides workspace.css's mobile drawer (translateX(105%), z900 —
+     which would bury the mic orb at z6). */
+  body.cr-mode.cr-voice #cr-workspace {
+    position: fixed !important;
+    top: calc(var(--mm-cam-top) + var(--mm-cam-h) + 10px) !important;
+    left: 12px !important;
+    right: 12px !important;
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 122px) !important;
+    width: auto !important;
+    height: auto !important;
+    transform: none !important;
+    transition: none !important;
+    border-radius: 18px !important;
+    border: 1px solid var(--mlt-line, rgba(35, 39, 65, 0.10)) !important;
+    background: var(--mlt-surface, #FFFFFF) !important;
+    box-shadow: var(--mlt-card-shadow, 0 6px 22px rgba(60, 50, 120, 0.13)) !important;
+    overflow: hidden !important;
+    z-index: 4 !important;
+  }
+
+  /* Captions: a lower-third inside the cam card (the desktop stage lays
+     them out under the cam; on a phone they'd overflow the fixed,
+     overflow-hidden card — pin them over the video instead). */
+  body.cr-mode.cr-voice #mm-voice-captions {
+    position: absolute !important;
+    left: 8px !important;
+    right: 8px !important;
+    bottom: 8px !important;
+    top: auto !important;
+    margin: 0 !important;
+    gap: 6px !important;
+    z-index: 4 !important;
+  }
+  body.cr-mode.cr-voice .mm-vc-tutor {
+    font-size: 13.5px;
+    padding: 7px 11px;
+    max-height: calc(1.45em * 2 + 14px);   /* 2-line window on a phone */
+  }
+  body.cr-mode.cr-voice .mm-vc-student {
+    font-size: 11.5px;
+    padding: 5px 11px;
+    max-width: 100%;
+  }
+  /* Replay/History are desktop-stage affordances; the phone keeps the
+     surface minimal (History's chat drawer isn't staged here). */
+  body.cr-mode.cr-voice .mm-vc-actions { display: none !important; }
+
+  /* State chip does the live-status job; the badge would double it. */
+  body.cr-mode.cr-voice .cr-live-badge { display: none !important; }
+
+  /* Orb status caption: poster-era mint on dark; unreadable on the
+     light theme. */
+  body.cr-mode.cr-voice #voice-status { color: var(--mlt-ink-dim, #6C7386) !important; }
 
   @media (prefers-reduced-motion: reduce) {
     body.cr-mode .cr-tutor-hero,

--- a/public/js/voice-subtitles.js
+++ b/public/js/voice-subtitles.js
@@ -149,13 +149,32 @@
   }
 
   // --- Student echo --------------------------------------------------------
-  function showStudent(text, interim) {
+  // Low-confidence partials are how a mishear becomes a jump-scare: Deepgram
+  // guessing at mumble/background noise has rendered genuinely disturbing
+  // text on a kid's screen. Below this, the pill holds its last text (or an
+  // ellipsis) instead of echoing the guess. Display-only — the server still
+  // receives the full transcript.
+  const ECHO_MIN_CONFIDENCE = 0.55;
+  // Displayed-echo mask for violent/self-harm mishears. Deliberately tiny:
+  // masking hides the mishear from the student (the echo pill's whole job),
+  // so only words that should never render in a kids' product qualify.
+  const ECHO_MASK_RE = /\b(die|dies|died|dying|dead|death|kill|kills|killed|killing|suicide|gun|guns|knife|stab)\b/i;
+
+  function showStudent(text, interim, confidence) {
     if (!els.student || !els.studentText) return;
+    if (interim && typeof confidence === 'number' && confidence < ECHO_MIN_CONFIDENCE) {
+      if (els.student.hidden || !els.studentText.textContent) {
+        els.student.hidden = false;
+        els.student.classList.add('is-interim');
+        els.studentText.textContent = '…';
+      }
+      return;
+    }
     const t = sanitize(text);
     if (!t) return;
     els.student.hidden = false;
     els.student.classList.toggle('is-interim', !!interim);
-    els.studentText.textContent = t;
+    els.studentText.textContent = ECHO_MASK_RE.test(t) ? '…' : t;
   }
 
   function hideStudent() {
@@ -211,11 +230,11 @@
         break;
 
       case 'transcript_partial':
-        showStudent(ev.text, true);
+        showStudent(ev.text, true, ev.confidence);
         break;
 
       case 'transcript_final':
-        showStudent(ev.text, false);
+        showStudent(ev.text, false, ev.confidence);
         break;
 
       case 'turn_start':

--- a/utils/voiceSession.js
+++ b/utils/voiceSession.js
@@ -305,7 +305,7 @@ class VoiceSession {
         // Don't null this.stt — sendFrame will see isOpen()===false and lazy-reopen
     }
 
-    _onPartial(text) {
+    _onPartial(text, confidence) {
         this._lastPartialAt = Date.now();
         // If AI is currently speaking, partial transcripts on student channel
         // are how the server confirms a barge-in even if the client missed it.
@@ -313,17 +313,23 @@ class VoiceSession {
         if (this.currentTurn && this.currentTurn.status === 'speaking' && text.length > 2) {
             this._abortCurrentTurn('user_barge_in_server_detected');
         }
-        this._send({ type: 'transcript_partial', text });
+        // Confidence rides along so the client can decline to display
+        // low-confidence guesses (Whisper fallback sends none — omit).
+        const msg = { type: 'transcript_partial', text };
+        if (typeof confidence === 'number') msg.confidence = confidence;
+        this._send(msg);
     }
 
     _accumulatedFinal = '';
-    _onFinal(text) {
+    _onFinal(text, confidence) {
         // Concatenate "is_final" segments — Deepgram emits multiple finals
         // per utterance (one per phrase). We commit on UtteranceEnd.
         this._accumulatedFinal = this._accumulatedFinal
             ? `${this._accumulatedFinal} ${text}`
             : text;
-        this._send({ type: 'transcript_final_segment', text });
+        const msg = { type: 'transcript_final_segment', text };
+        if (typeof confidence === 'number') msg.confidence = confidence;
+        this._send(msg);
     }
 
     _onUtteranceEnd() {


### PR DESCRIPTION
…echo hygiene

Three fixes for the broken phone experience (real-device screenshots):

1. Thread bleed: a scrolled conversation rode up through the transparent topbar band and the cam's side gutters (the scroll container spans the viewport; padding-top only clears the cam). New fixed backdrop band (.cr-stage::before — must live inside main.sidebar-layout's z1 stacking context or it covers the cam) paints the app bg from the viewport top to the cam's bottom edge, tracking the pill state via --mm-cam-vis-h.

2. Voice on mobile: the desktop subtitle-stage DOM mounts at every width but its layout was desktop-only, piling captions/echo/Replay/History on top of the chat, cam, and legacy voice dock. New <=768px voice stage: chat hides, the Living Workspace is pinned center stage between cam and mic dock (out of the drawer, z-index under the dock), captions become a lower-third inside the cam card, Replay/History/live-badge/FAB retire. "Voice explains, board shows" — the board gets the room.

3. STT echo hygiene: Deepgram confidence now rides transcript_partial/ final_segment over the WS (was computed then dropped in voiceSession), and the echo pill declines to display low-confidence guesses or violent-mishear words (display-only; the server transcript is untouched).

Verified in a real logged-in phone-size session (390x844): band math in both cam and pill states, voice enter/exit round-trip, KaTeX math rendering on the center-stage workspace, and all four echo-gate cases. Full suite 4068 green, eslint 0 errors. ?v= bumped on both touched public assets.