### PR TITLE
feat: freemium conversion instrumentation + card-required trial + parent-reach

### DIFF
--- a/middleware/usageGate.js
+++ b/middleware/usageGate.js
@@ -14,6 +14,7 @@
 
 const User = require('../models/user');
 const SchoolLicense = require('../models/schoolLicense');
+const { recordConversionEvent } = require('../utils/conversionEvents');
 
 const BILLING_ENABLED = process.env.BILLING_ENABLED === 'true';
 // NOTE: constant/field names keep the "weekly" prefix for backward compatibility
@@ -169,6 +170,19 @@ async function usageGate(req, res, next) {
     const upgradeLine = inCourse
       ? `Upgrade to Mathmatix+ to keep going in your course without waiting, or ask your teacher about a school license!`
       : `Upgrade to Unlimited for non-stop tutoring, or ask your teacher about a school license!`;
+
+    // Funnel telemetry — the free wall is the primary conversion moment. Throttle
+    // to once/hour per session so a user retrying a blocked action doesn't inflate
+    // counts; distinct-user totals come from userId at analysis time.
+    const nowMs = Date.now();
+    const lastEvt = (req.session && req.session.__quotaEvtAt) || 0;
+    if (nowMs - lastEvt > 60 * 60 * 1000) {
+      if (req.session) req.session.__quotaEvtAt = nowMs;
+      recordConversionEvent('free_quota_exhausted', {
+        userId: user._id,
+        context: { inCourse, daysUntilReset, tier: user.subscriptionTier || 'free' },
+      });
+    }
 
     return res.status(402).json({
       message: `You've used your 30 free minutes this month. Your minutes reset in ${daysUntilReset} day${daysUntilReset !== 1 ? 's' : ''}. ${upgradeLine}`,

--- a/models/conversionEvent.js
+++ b/models/conversionEvent.js
@@ -1,0 +1,39 @@
+// models/conversionEvent.js — Funnel / conversion telemetry
+//
+// Lightweight, append-only event log for the freemium funnel. The two events
+// that matter first are the "walls" a user hits:
+//   - trial_exhausted     : an anonymous landing-page trial reached its turn cap
+//   - free_quota_exhausted : a signed-in free student hit the 30-min/month 402
+//
+// Rows are written fire-and-forget (never block a request) and are ALSO emitted
+// to Winston -> Better Stack, so the data is queryable from Mongo AND visible in
+// log dashboards immediately. Deliberately minimal PII: we keep an optional
+// userId (for signed-in events) and an anonymized session id (for trial events)
+// so distinct users can be de-duped in analysis without storing names/IPs.
+
+const mongoose = require('mongoose');
+
+const CONVERSION_EVENTS = [
+  'trial_exhausted',       // anonymous trial reached MAX_TURNS
+  'free_quota_exhausted',  // signed-in free student hit the 30-min/month cap (402)
+];
+
+const conversionEventSchema = new mongoose.Schema({
+  event: { type: String, required: true, enum: CONVERSION_EVENTS, index: true },
+  // Present for authenticated events; absent for anonymous trial events.
+  userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null, index: true },
+  // Anonymized session identifier for anonymous events (never an IP or name).
+  sessionKey: { type: String, default: null },
+  // Free-form, non-PII context (e.g. { tier, inCourse, tutorId, daysUntilReset }).
+  context: { type: mongoose.Schema.Types.Mixed, default: {} },
+  createdAt: { type: Date, default: Date.now, index: true },
+});
+
+// Primary analysis access pattern: "events of type X over a time window."
+conversionEventSchema.index({ event: 1, createdAt: -1 });
+
+const ConversionEvent = mongoose.models.ConversionEvent
+  || mongoose.model('ConversionEvent', conversionEventSchema);
+
+module.exports = ConversionEvent;
+module.exports.CONVERSION_EVENTS = CONVERSION_EVENTS;

--- a/models/user.js
+++ b/models/user.js
@@ -687,6 +687,11 @@ const userSchema = new Schema({
   // Subscription cancellation tracking
   cancellationReason: { type: String, default: null },
   cancellationDate: { type: Date, default: null },
+  // Card-required Mathmatix+ free trial (Stripe-managed). During a trial the
+  // subscriptionTier is set to 'unlimited' (so all access gates pass); a future
+  // trialEndsAt is what distinguishes "trialing" from "paid unlimited".
+  trialEndsAt: { type: Date, default: null },       // future = actively trialing
+  hasUsedTrial: { type: Boolean, default: false },  // one trial per user — blocks re-trialing
 
   /* Affiliate / Referral tracking */
   referredByAffiliateId: { type: Schema.Types.ObjectId, ref: 'Affiliate', default: null },  // Which affiliate referred this user

--- a/models/user.js
+++ b/models/user.js
@@ -692,6 +692,9 @@ const userSchema = new Schema({
   // trialEndsAt is what distinguishes "trialing" from "paid unlimited".
   trialEndsAt: { type: Date, default: null },       // future = actively trialing
   hasUsedTrial: { type: Boolean, default: false },  // one trial per user — blocks re-trialing
+  // Throttle for "ask a parent to unlock" requests (student → linked parent),
+  // so a kid hitting the wall repeatedly can't spam their parent.
+  lastParentUpgradeRequestAt: { type: Date, default: null },
 
   /* Affiliate / Referral tracking */
   referredByAffiliateId: { type: Schema.Types.ObjectId, ref: 'Affiliate', default: null },  // Which affiliate referred this user

--- a/public/js/modules/billing.js
+++ b/public/js/modules/billing.js
@@ -204,6 +204,11 @@ export async function showUpgradePrompt(errorData) {
     const trialAvailable = !!(window._billingStatus && window._billingStatus.trialAvailable);
     const trialDays = (window._billingStatus && window._billingStatus.trialDays) || 7;
 
+    // Students usually can't pay themselves — surface an "ask a parent" path so the
+    // offer reaches the person who holds the card.
+    const cu = window.currentUser || {};
+    const isStudentUser = cu.role === 'student' || (Array.isArray(cu.roles) && cu.roles.includes('student'));
+
     const title = trialAvailable
         ? `Try Mathmatix+ free for ${trialDays} days`
         : promo
@@ -260,6 +265,14 @@ export async function showUpgradePrompt(errorData) {
                 ? '<button id="upgrade-dismiss" style="background:transparent;color:#666;border:none;padding:10px;cursor:pointer;font-size:13px;width:100%;margin-top:6px;">Maybe later</button>'
                 : ''
             }
+            ${isStudentUser ? `
+            <div style="border-top:1px solid #333;margin:16px 0 12px;"></div>
+            <button id="ask-parent-btn" style="background:transparent;color:#00d4ff;border:1px solid #00d4ff;padding:11px 20px;border-radius:10px;font-size:14px;font-weight:600;cursor:pointer;width:100%;">🙋 Ask a parent to unlock this</button>
+            <div id="ask-parent-status" style="color:#8fd; font-size:12px;margin-top:8px;display:none;"></div>
+            <div id="parent-email-form" style="display:none;margin-top:10px;">
+                <input id="parent-email-input" type="email" placeholder="parent@email.com" style="width:100%;box-sizing:border-box;padding:10px;border-radius:8px;border:1px solid #444;background:#12121f;color:#fff;font-size:14px;" />
+                <button id="parent-email-send" style="background:#0d9488;color:#fff;border:none;padding:10px 20px;border-radius:8px;font-size:14px;font-weight:600;cursor:pointer;width:100%;margin-top:8px;">Send my parent an invite</button>
+            </div>` : ''}
         </div>`;
     document.body.appendChild(modal);
 
@@ -268,10 +281,89 @@ export async function showUpgradePrompt(errorData) {
     if (dismissBtn) {
         dismissBtn.addEventListener('click', () => modal.remove());
     }
+    if (isStudentUser) wireAskParent();
     // Only allow clicking outside to dismiss if it's not a usage limit block
     if (!isLimitReached) {
         modal.addEventListener('click', (e) => { if (e.target === modal) modal.remove(); });
     }
+}
+
+/**
+ * Wire the "Ask a parent to unlock" flow inside the upgrade modal (students only).
+ * Linked parent → notify them (server emails + notifies). No linked parent →
+ * collect a parent email → send an invite. Gets the offer to the person with the card.
+ */
+function wireAskParent() {
+    const btn = document.getElementById('ask-parent-btn');
+    const statusEl = document.getElementById('ask-parent-status');
+    const form = document.getElementById('parent-email-form');
+    if (!btn) return;
+
+    const showStatus = (msg, ok = true) => {
+        if (!statusEl) return;
+        statusEl.textContent = msg;
+        statusEl.style.color = ok ? '#8fd' : '#ffb3b3';
+        statusEl.style.display = '';
+    };
+    const resetBtn = () => { btn.disabled = false; btn.textContent = '🙋 Ask a parent to unlock this'; };
+
+    btn.addEventListener('click', async () => {
+        btn.disabled = true;
+        btn.textContent = 'Asking…';
+        try {
+            const res = await csrfFetch('/api/student/request-parent-upgrade', {
+                method: 'POST', headers: { 'Content-Type': 'application/json' },
+                body: '{}', credentials: 'include'
+            });
+            const data = await res.json();
+            if (data && data.linked === false) {
+                // No parent linked yet — collect an email to invite one.
+                btn.style.display = 'none';
+                if (form) form.style.display = '';
+                showStatus("Add your parent's email and we'll send them the invite.");
+            } else if (data && data.success) {
+                btn.style.display = 'none';
+                showStatus(data.message || 'We let your parent know!');
+            } else {
+                resetBtn();
+                showStatus((data && data.message) || 'Could not reach your parent right now.', false);
+            }
+        } catch (e) {
+            resetBtn();
+            showStatus('Something went wrong. Please try again.', false);
+        }
+    });
+
+    const sendBtn = document.getElementById('parent-email-send');
+    if (sendBtn) sendBtn.addEventListener('click', async () => {
+        const input = document.getElementById('parent-email-input');
+        const email = ((input && input.value) || '').trim();
+        if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+            showStatus('Please enter a valid email address.', false);
+            return;
+        }
+        sendBtn.disabled = true;
+        sendBtn.textContent = 'Sending…';
+        try {
+            const res = await csrfFetch('/api/student/invite-parent', {
+                method: 'POST', headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ parentEmail: email }), credentials: 'include'
+            });
+            const data = await res.json();
+            if (data && data.success) {
+                if (form) form.style.display = 'none';
+                showStatus(data.message || `Invite sent to ${email}.`);
+            } else {
+                sendBtn.disabled = false;
+                sendBtn.textContent = 'Send my parent an invite';
+                showStatus((data && data.message) || 'Could not send the invite.', false);
+            }
+        } catch (e) {
+            sendBtn.disabled = false;
+            sendBtn.textContent = 'Send my parent an invite';
+            showStatus('Something went wrong. Please try again.', false);
+        }
+    });
 }
 
 /**

--- a/public/js/modules/billing.js
+++ b/public/js/modules/billing.js
@@ -39,6 +39,9 @@ export async function checkBillingStatus() {
             if (manageLink) manageLink.style.display = '';
         }
 
+        // Trial countdown banner for users currently in a Mathmatix+ trial
+        updateTrialBanner(data);
+
         // Show time indicator for students on free/pack tiers only.
         // Teachers, parents, and admins have unlimited access (Infinity) — skip indicator for them.
         if (data.tier !== 'unlimited' && data.usage && data.usage.secondsRemaining !== null && isFinite(data.usage.secondsRemaining)) {
@@ -55,6 +58,33 @@ export async function checkBillingStatus() {
         console.error('[Billing] Status check failed:', e.message);
         return null;
     }
+}
+
+/**
+ * Show a small, non-blocking banner while a Mathmatix+ trial is active, counting
+ * down the days left. Reassures rather than nags — the point is transparency so
+ * the eventual charge is never a surprise. Removed automatically once the trial
+ * converts (isTrialing false).
+ */
+export function updateTrialBanner(data) {
+    const existing = document.getElementById('trial-banner');
+    if (!data || !data.isTrialing) {
+        if (existing) existing.remove();
+        return;
+    }
+    const days = data.trialDaysRemaining || 1;
+    const dayWord = days === 1 ? 'day' : 'days';
+    let banner = existing;
+    if (!banner) {
+        banner = document.createElement('div');
+        banner.id = 'trial-banner';
+        banner.style.cssText = 'position:fixed;top:0;left:0;right:0;background:linear-gradient(135deg,#00d4ff,#7b2ff7);color:#fff;padding:7px 14px;font-size:13px;text-align:center;z-index:1800;box-shadow:0 2px 8px rgba(0,0,0,0.25);';
+        document.body.appendChild(banner);
+    }
+    banner.innerHTML = `✨ Mathmatix+ trial: <strong>${days} ${dayWord} left</strong> of full access. `
+        + '<span id="trial-banner-manage" role="button" style="text-decoration:underline;cursor:pointer;">Manage subscription</span>';
+    const manage = banner.querySelector('#trial-banner-manage');
+    if (manage) manage.addEventListener('click', () => showManageSubscription());
 }
 
 /**
@@ -168,10 +198,22 @@ export async function showUpgradePrompt(errorData) {
 
     const isFeatureBlock = errorData.premiumFeatureBlocked;
     const isLimitReached = errorData.usageLimitReached;
-    const title = promo
+
+    // Card-required free trial: offered to students who haven't trialed yet.
+    // At the 30-min wall this is the primary CTA \u2014 highest-intent moment.
+    const trialAvailable = !!(window._billingStatus && window._billingStatus.trialAvailable);
+    const trialDays = (window._billingStatus && window._billingStatus.trialDays) || 7;
+
+    const title = trialAvailable
+        ? `Try Mathmatix+ free for ${trialDays} days`
+        : promo
         ? 'Pi Day Special \u2014 $3.14 Off!'
         : 'Get Mathmatix+';
-    const subtitle = isFeatureBlock
+    const subtitle = trialAvailable
+        ? (isLimitReached
+            ? `Out of free minutes? Unlock everything free for ${trialDays} days. Card required \u2014 no charge until then, cancel anytime.`
+            : `Full access to everything, free for ${trialDays} days. Card required \u2014 then $9.95/mo, cancel anytime.`)
+        : isFeatureBlock
         ? `${errorData.feature} requires Mathmatix+.`
         : isLimitReached
         ? "You've used your free minutes this month. Upgrade for unlimited tutoring."
@@ -179,7 +221,10 @@ export async function showUpgradePrompt(errorData) {
 
     // Price display
     let priceHtml;
-    if (promo && promo.prices.unlimited) {
+    if (trialAvailable) {
+        priceHtml = `<div style="font-size:34px;font-weight:bold;color:#00d4ff;margin:4px 0;">Free<span style="font-size:16px;color:#aaa;font-weight:normal"> for ${trialDays} days</span></div>
+                     <div style="color:#888;font-size:13px;">then $9.95/mo &mdash; cancel anytime before then and pay nothing</div>`;
+    } else if (promo && promo.prices.unlimited) {
         const promoPrice = (promo.prices.unlimited.promo / 100).toFixed(2);
         priceHtml = `<div style="font-size:16px;color:#888;text-decoration:line-through;">$9.95/mo</div>
                      <div style="font-size:36px;font-weight:bold;color:#00d4ff;margin:4px 0;">$${promoPrice}<span style="font-size:16px;color:#aaa;font-weight:normal">/mo</span></div>
@@ -204,15 +249,21 @@ export async function showUpgradePrompt(errorData) {
                 <li>\u2713 Show My Work grading</li>
                 <li>\u2713 All features unlocked</li>
             </ul>
-            <button id="upgrade-go" style="background:linear-gradient(135deg,#00d4ff,#7b2ff7);color:#fff;border:none;padding:14px 32px;border-radius:10px;font-size:16px;font-weight:700;cursor:pointer;width:100%;">Get Mathmatix+</button>
-            ${isLimitReached
+            <button id="upgrade-go" style="background:linear-gradient(135deg,#00d4ff,#7b2ff7);color:#fff;border:none;padding:14px 32px;border-radius:10px;font-size:16px;font-weight:700;cursor:pointer;width:100%;">${trialAvailable ? `Start my ${trialDays}-day free trial` : 'Get Mathmatix+'}</button>
+            ${trialAvailable
+                ? `<div style="color:#888;font-size:12px;margin-top:12px;">We'll email you before your trial ends so you're never surprised. Cancel anytime — no charge until day ${trialDays}.</div>`
+                : isLimitReached
                 ? '<div style="color:#666;font-size:12px;margin-top:12px;">Your free minutes reset monthly. Upgrade for uninterrupted learning.</div>'
                 : '<button id="upgrade-dismiss" style="background:transparent;color:#666;border:none;padding:10px;cursor:pointer;font-size:13px;width:100%;margin-top:10px;">Keep free plan (30 min/week)</button>'
+            }
+            ${trialAvailable && !isLimitReached
+                ? '<button id="upgrade-dismiss" style="background:transparent;color:#666;border:none;padding:10px;cursor:pointer;font-size:13px;width:100%;margin-top:6px;">Maybe later</button>'
+                : ''
             }
         </div>`;
     document.body.appendChild(modal);
 
-    document.getElementById('upgrade-go').addEventListener('click', () => initiateUpgrade('unlimited'));
+    document.getElementById('upgrade-go').addEventListener('click', () => initiateUpgrade('unlimited', { trial: trialAvailable }));
     const dismissBtn = document.getElementById('upgrade-dismiss');
     if (dismissBtn) {
         dismissBtn.addEventListener('click', () => modal.remove());
@@ -226,12 +277,14 @@ export async function showUpgradePrompt(errorData) {
 /**
  * Redirect to Stripe checkout for a pack upgrade
  */
-export async function initiateUpgrade(pack) {
+export async function initiateUpgrade(pack, opts = {}) {
     try {
+        const body = { pack };
+        if (opts.trial) body.trial = true;
         const res = await csrfFetch('/api/billing/create-checkout-session', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ pack }),
+            body: JSON.stringify(body),
             credentials: 'include'
         });
         if (!res.ok) throw new Error('Failed to create checkout session');

--- a/public/js/parent-dashboard.js
+++ b/public/js/parent-dashboard.js
@@ -5,6 +5,57 @@
 document.addEventListener("DOMContentLoaded", async () => {
 
     // ============================================
+    // UPGRADE / TRIAL PROMPT
+    // Deep-linked from the "your child hit their free limit" email
+    // (parent-dashboard.html?upgrade=1). Gives the parent — the card holder —
+    // a one-click way to start the child's 7-day Mathmatix+ trial.
+    // ============================================
+    (function initParentUpgradePrompt() {
+        const params = new URLSearchParams(window.location.search);
+
+        async function startTrial(btn) {
+            if (btn) { btn.disabled = true; btn.textContent = 'Starting…'; }
+            try {
+                const res = await csrfFetch('/api/billing/create-checkout-session', {
+                    method: 'POST', headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ pack: 'unlimited', trial: true }), credentials: 'include'
+                });
+                const data = await res.json();
+                if (data && data.url) { window.location.href = data.url; return; }
+                throw new Error((data && data.message) || 'checkout failed');
+            } catch (e) {
+                if (typeof showToast === 'function') showToast('Could not start checkout. Please try again.', 'error');
+                if (btn) { btn.disabled = false; btn.textContent = 'Start 7-day free trial'; }
+            }
+        }
+
+        function openUpgrade() {
+            if (document.getElementById('parent-upgrade-modal')) return;
+            const modal = document.createElement('div');
+            modal.id = 'parent-upgrade-modal';
+            modal.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,0.6);display:flex;align-items:center;justify-content:center;z-index:10000;';
+            modal.innerHTML = `
+                <div style="background:#fff;border-radius:16px;padding:32px;max-width:420px;width:92%;text-align:center;box-shadow:0 20px 60px rgba(0,0,0,0.3);">
+                    <h2 style="margin:0 0 8px;color:#0d9488;">Unlock unlimited tutoring</h2>
+                    <p style="color:#555;margin:0 0 16px;line-height:1.5;">Give your child unlimited 24/7 AI tutoring, voice sessions, and homework help. Free for 7 days, then $9.95/month. Cancel anytime.</p>
+                    <button id="parent-start-trial" style="background:#0d9488;color:#fff;border:none;padding:14px 28px;border-radius:10px;font-size:16px;font-weight:700;cursor:pointer;width:100%;">Start 7-day free trial</button>
+                    <button id="parent-upgrade-close" style="background:transparent;color:#888;border:none;padding:10px;cursor:pointer;font-size:13px;width:100%;margin-top:8px;">Maybe later</button>
+                    <div style="color:#999;font-size:12px;margin-top:10px;">Card required. We'll remind you before the trial ends — no surprise charges.</div>
+                </div>`;
+            document.body.appendChild(modal);
+            document.getElementById('parent-start-trial').addEventListener('click', (e) => startTrial(e.currentTarget));
+            const close = () => modal.remove();
+            document.getElementById('parent-upgrade-close').addEventListener('click', close);
+            modal.addEventListener('click', (e) => { if (e.target === modal) close(); });
+        }
+
+        // Auto-open when the parent arrives from the email deep link.
+        if (params.get('upgrade') === '1') openUpgrade();
+        // Expose a hook so any "Upgrade" button on the page can reuse it.
+        window.openParentUpgrade = openUpgrade;
+    })();
+
+    // ============================================
     // TOAST NOTIFICATION SYSTEM
     // ============================================
 

--- a/routes/billing.js
+++ b/routes/billing.js
@@ -24,13 +24,14 @@ const User = require('../models/user');
 const Affiliate = require('../models/affiliate');
 const WebhookEvent = require('../models/webhookEvent');
 const { isAuthenticated } = require('../middleware/auth');
-const { sendCancellationConfirmation } = require('../utils/emailService');
+const { sendCancellationConfirmation, sendTrialEndingReminder } = require('../utils/emailService');
 const logger = require('../utils/logger').child({ route: 'billing' });
 
 // ---- Configuration ----
 const BILLING_ENABLED = process.env.BILLING_ENABLED === 'true';
 const FREE_WEEKLY_SECONDS = 30 * 60; // 30 free AI minutes per reset period (now monthly) for all students
 const FREE_QUOTA_RESET_DAYS = 30;    // free-AI-minute quota window — keep in sync with middleware/usageGate.js
+const TRIAL_DAYS = 7;                // card-required Mathmatix+ free-trial length
 
 // Active plan — Mathmatix+ is the only paid tier for new purchases
 const PACKS = {
@@ -105,7 +106,7 @@ if (BILLING_ENABLED && process.env.STRIPE_SECRET_KEY) {
 router.post('/create-checkout-session', isAuthenticated, async (req, res) => {
   if (!stripe) return res.status(503).json({ message: 'Billing is not configured' });
   try {
-    const { pack, couponCode } = req.body;
+    const { pack, couponCode, trial } = req.body;
     if (pack !== 'unlimited') {
       return res.status(400).json({ message: 'Only the Unlimited plan is available for new purchases.' });
     }
@@ -117,6 +118,11 @@ router.post('/create-checkout-session', isAuthenticated, async (req, res) => {
     if (user.subscriptionTier === 'unlimited') {
       return res.status(400).json({ message: 'Already subscribed to Unlimited' });
     }
+
+    // Card-required free trial: honor the trial request only if this user has
+    // never trialed before (one trial per user). A repeat requester just checks
+    // out as a normal paid subscription.
+    const wantsTrial = trial === true && !user.hasUsedTrial;
 
     // Create or reuse Stripe customer
     let customerId = user.stripeCustomerId;
@@ -180,15 +186,28 @@ router.post('/create-checkout-session', isAuthenticated, async (req, res) => {
       metadata.affiliateId = affiliateId;
       metadata.affiliateCoupon = affiliateCoupon;
     }
+    if (wantsTrial) metadata.trial = 'true';
 
-    const session = await stripe.checkout.sessions.create({
+    const sessionParams = {
       customer: customerId,
       mode: packConfig.mode,
       line_items: [lineItem],
       success_url: `${baseUrl}/chat.html?upgraded=true`,
       cancel_url: `${baseUrl}/chat.html`,
       metadata
-    });
+    };
+
+    // Card-required trial: collect the card now, don't charge for TRIAL_DAYS,
+    // then auto-convert to the paid plan unless the user cancels. Stripe manages
+    // the trial→bill transition and (per dashboard setting) the trial-ending
+    // reminder email; we also send our own via the trial_will_end webhook.
+    if (wantsTrial) {
+      sessionParams.subscription_data = { trial_period_days: TRIAL_DAYS };
+      // Force card capture during the trial (default would let a trial skip it).
+      sessionParams.payment_method_collection = 'always';
+    }
+
+    const session = await stripe.checkout.sessions.create(sessionParams);
 
     res.json({ url: session.url });
   } catch (error) {
@@ -246,10 +265,30 @@ router.post('/webhook', async (req, res) => {
         user.subscriptionStartDate = new Date();
 
         if (packConfig.mode === 'subscription') {
-          // Unlimited monthly
+          // Unlimited monthly (may be starting in a trial)
           user.subscriptionTier = 'unlimited';
           user.stripeSubscriptionId = session.subscription;
-          logger.info('User subscribed to Unlimited', { userId: user._id.toString() });
+
+          // If this checkout started a free trial, record the trial window and
+          // burn the one-trial-per-user flag. We retrieve the subscription so the
+          // trial_end comes from Stripe (source of truth), not our own clock.
+          if (session.metadata?.trial === 'true' && session.subscription) {
+            try {
+              const sub = await stripe.subscriptions.retrieve(session.subscription);
+              if (sub.status === 'trialing' && sub.trial_end) {
+                user.trialEndsAt = new Date(sub.trial_end * 1000);
+              }
+            } catch (subErr) {
+              logger.warn('Could not retrieve subscription for trial info', { error: subErr.message });
+            }
+            user.hasUsedTrial = true;
+            logger.info('User started Mathmatix+ trial', {
+              userId: user._id.toString(),
+              trialEndsAt: user.trialEndsAt?.toISOString()
+            });
+          } else {
+            logger.info('User subscribed to Unlimited', { userId: user._id.toString() });
+          }
 
           // Attribute conversion to affiliate if coupon was used
           const affId = session.metadata?.affiliateId;
@@ -322,6 +361,7 @@ router.post('/webhook', async (req, res) => {
         user.subscriptionTier = 'free';
         user.stripeSubscriptionId = null;
         user.subscriptionEndDate = new Date();
+        user.trialEndsAt = null; // trial cancelled before converting, or paid sub ended
         await user.save();
 
         logger.info('User cancelled Unlimited — downgraded to Free', { userId: user._id.toString() });
@@ -338,14 +378,42 @@ router.post('/webhook', async (req, res) => {
         }
         if (!user) break;
 
-        if (subscription.status === 'active') {
+        if (subscription.status === 'trialing') {
+          // Trial in progress — full access, keep the trial window in sync.
           user.subscriptionTier = 'unlimited';
           user.stripeSubscriptionId = subscription.id;
+          user.hasUsedTrial = true;
+          if (subscription.trial_end) user.trialEndsAt = new Date(subscription.trial_end * 1000);
+        } else if (subscription.status === 'active') {
+          // Active (incl. a trial that just converted) — clear the trial marker.
+          user.subscriptionTier = 'unlimited';
+          user.stripeSubscriptionId = subscription.id;
+          user.trialEndsAt = null;
         } else if (['past_due', 'unpaid', 'canceled'].includes(subscription.status)) {
           user.subscriptionTier = 'free';
           user.subscriptionEndDate = new Date();
+          user.trialEndsAt = null;
         }
         await user.save();
+        break;
+      }
+
+      case 'customer.subscription.trial_will_end': {
+        // Fires ~3 days before a trial converts. Send our own branded reminder so
+        // the parent knows a charge is coming and how to cancel — this is what
+        // keeps the trial brand-safe and chargeback-light.
+        const subscription = event.data.object;
+        let user = await User.findOne({ stripeSubscriptionId: subscription.id });
+        if (!user) user = await User.findOne({ stripeCustomerId: subscription.customer });
+        if (!user) break;
+
+        const trialEnd = subscription.trial_end ? new Date(subscription.trial_end * 1000) : user.trialEndsAt;
+        try {
+          await sendTrialEndingReminder(user, trialEnd);
+          logger.info('Trial-ending reminder sent', { userId: user._id.toString() });
+        } catch (mailErr) {
+          logger.error('Trial-ending reminder failed', { userId: user._id.toString(), error: mailErr.message });
+        }
         break;
       }
 
@@ -641,13 +709,20 @@ router.get('/status', isAuthenticated, async (req, res) => {
     const tier = user.subscriptionTier || 'free';
     const now = new Date();
 
-    // Unlimited users
+    // Unlimited users (paid OR in a card-required trial)
     if (tier === 'unlimited') {
+      const isTrialing = !!(user.trialEndsAt && user.trialEndsAt > now);
+      const trialDaysRemaining = isTrialing
+        ? Math.max(1, Math.ceil((user.trialEndsAt - now) / (1000 * 60 * 60 * 24)))
+        : 0;
       return res.json({
         success: true,
         billingEnabled: true,
         tier: 'unlimited',
         hasAccess: true,
+        isTrialing,
+        trialEndsAt: isTrialing ? user.trialEndsAt : null,
+        trialDaysRemaining,
         usage: { secondsRemaining: Infinity, limitReached: false },
         subscription: {
           startDate: user.subscriptionStartDate,
@@ -751,6 +826,11 @@ router.get('/status', isAuthenticated, async (req, res) => {
       tier: 'free',
       hasAccess: !limitReached,
       hasSeenPricing: user.hasSeenPricing || false,
+      // Whether this free student can still start a card-required Mathmatix+ trial
+      // (one per user). Frontend uses this to show "Start 7-day free trial" vs a
+      // plain upgrade CTA — especially at the 30-min wall.
+      trialAvailable: !user.hasUsedTrial,
+      trialDays: TRIAL_DAYS,
       usage: {
         secondsRemaining: freeRemaining,
         minutesRemaining: Math.floor(freeRemaining / 60),

--- a/routes/student.js
+++ b/routes/student.js
@@ -208,6 +208,82 @@ router.post('/invite-parent', isAuthenticated, isStudent, async (req, res) => {
     }
 });
 
+// POST /api/student/request-parent-upgrade
+// Student hits the paywall and asks a linked parent to unlock Mathmatix+.
+//   - Linked parent(s): notify each (in-app notification + trial-framed email).
+//   - No linked parent: return linked:false so the client can prompt for a
+//     parent email, which flows into POST /invite-parent.
+router.post('/request-parent-upgrade', isAuthenticated, isStudent, async (req, res) => {
+    try {
+        const student = await User.findById(req.user._id);
+        if (!student) {
+            return res.status(404).json({ success: false, message: 'Student not found.' });
+        }
+
+        const parentIds = student.parentIds || [];
+        if (parentIds.length === 0) {
+            return res.json({ success: true, linked: false, message: 'No parent is linked yet.' });
+        }
+
+        // Throttle — at most one nudge per 12 hours so a kid re-hitting the wall
+        // can't spam their parent's inbox.
+        const THROTTLE_MS = 12 * 60 * 60 * 1000;
+        const last = student.lastParentUpgradeRequestAt ? new Date(student.lastParentUpgradeRequestAt).getTime() : 0;
+        if (Date.now() - last < THROTTLE_MS) {
+            return res.json({ success: true, linked: true, alreadySent: true, message: "We already let your parent know — hang tight!" });
+        }
+
+        const parents = await User.find({ _id: { $in: parentIds } })
+            .select('email firstName subscriptionTier').lean();
+
+        const baseUrl = process.env.BASE_URL || 'http://localhost:3000';
+        const actionUrl = `${baseUrl}/parent-dashboard.html?upgrade=1&child=${student._id}`;
+        const Notification = require('../models/notification');
+        const { sendParentUpgradeRequest } = require('../utils/emailService');
+
+        let notified = 0;
+        for (const parent of parents) {
+            // Skip parents who already have unlimited — the child is already covered.
+            if (parent.subscriptionTier === 'unlimited') continue;
+            try {
+                await Notification.create({
+                    recipientId: parent._id,
+                    recipientRole: 'parent',
+                    subjectUserId: student._id,
+                    type: 'help_request',
+                    data: {
+                        kind: 'upgrade_request',
+                        childId: student._id.toString(),
+                        childName: student.firstName,
+                        title: `${student.firstName} wants to keep learning`,
+                        message: `${student.firstName} hit their free tutoring limit and asked you to unlock Mathmatix+.`,
+                        actionUrl
+                    }
+                });
+            } catch (nErr) {
+                console.error('Failed to create parent upgrade notification:', nErr.message);
+            }
+            if (parent.email) {
+                try { await sendParentUpgradeRequest(parent.email, student.firstName, actionUrl); }
+                catch (mErr) { console.error('Failed to email parent upgrade request:', mErr.message); }
+            }
+            notified++;
+        }
+
+        student.lastParentUpgradeRequestAt = new Date();
+        await student.save();
+
+        if (notified === 0) {
+            // Every linked parent already has unlimited → child should already have access.
+            return res.json({ success: true, linked: true, alreadyCovered: true, message: "Good news — you're already covered by a parent's plan. Try reloading!" });
+        }
+        return res.json({ success: true, linked: true, notified, message: "We let your parent know! They'll get an email to unlock unlimited tutoring." });
+    } catch (error) {
+        console.error('ERROR: request-parent-upgrade failed:', error);
+        res.status(500).json({ success: false, message: 'Could not reach your parent right now.' });
+    }
+});
+
 // GET /api/student/progress
 // Returns student's learning progress (mastered, learning, ready skills)
 router.get('/progress', isAuthenticated, isStudent, async (req, res) => {

--- a/routes/trialChat.js
+++ b/routes/trialChat.js
@@ -18,6 +18,7 @@ const { generateSystemPrompt } = require('../utils/prompt');
 const { runPipeline } = require('../utils/pipeline');
 const { callLLM } = require('../utils/llmGateway');
 const { samplePoints } = require('../utils/trialGraphPoints');
+const { recordConversionEvent } = require('../utils/conversionEvents');
 
 const MAX_TURNS = 4; // 1 greeting + 3 student messages
 const MAX_MESSAGE_LENGTH = 500;
@@ -405,6 +406,16 @@ CRITICAL FOR THIS RESPONSE: You MUST end your response with a question or a next
     // Increment server-side turn count AFTER successful response
     bumpTrialTurns(req);
     const newTurnCount = serverTurns + 1;
+
+    // Funnel telemetry — fire once when the anonymous trial first hits its cap.
+    // sessionID is an opaque, anonymized key (never an IP or name).
+    if (newTurnCount >= MAX_TURNS && req.session && !req.session.__trialExhaustedLogged) {
+      req.session.__trialExhaustedLogged = true;
+      recordConversionEvent('trial_exhausted', {
+        sessionKey: req.sessionID,
+        context: { tutorId, turns: newTurnCount },
+      });
+    }
 
     res.json({
       reply,

--- a/tests/integration/billingWebhook.test.js
+++ b/tests/integration/billingWebhook.test.js
@@ -10,6 +10,7 @@ process.env.STRIPE_WEBHOOK_SECRET = 'whsec_test_mock';
 
 global.__stripeWebhookConstruct = jest.fn();
 global.__stripeBillingPortal = jest.fn();
+global.__stripeSubRetrieve = jest.fn();
 
 jest.mock('stripe', () => () => ({
   webhooks: {
@@ -20,7 +21,7 @@ jest.mock('stripe', () => () => ({
   },
   checkout: { sessions: { create: jest.fn() } },
   customers:   { create: jest.fn(), retrieve: jest.fn() },
-  subscriptions: { update: jest.fn(), cancel: jest.fn(), retrieve: jest.fn() },
+  subscriptions: { update: jest.fn(), cancel: jest.fn(), retrieve: (...a) => global.__stripeSubRetrieve(...a) },
   prices:      { list: jest.fn() }
 }));
 
@@ -38,13 +39,15 @@ jest.mock('../../models/webhookEvent', () => ({
 }));
 
 jest.mock('../../utils/emailService', () => ({
-  sendCancellationConfirmation: jest.fn()
+  sendCancellationConfirmation: jest.fn(),
+  sendTrialEndingReminder: jest.fn().mockResolvedValue({ success: true })
 }));
 
 const express = require('express');
 const supertest = require('supertest');
 const User = require('../../models/user');
 const WebhookEvent = require('../../models/webhookEvent');
+const emailService = require('../../utils/emailService');
 const router = require('../../routes/billing');
 
 const constructEvent = global.__stripeWebhookConstruct;
@@ -66,6 +69,8 @@ beforeEach(() => {
   WebhookEvent.create.mockResolvedValue({});
   User.findById.mockReset();
   User.findOne.mockReset();
+  global.__stripeSubRetrieve.mockReset();
+  emailService.sendTrialEndingReminder.mockClear();
 });
 
 describe('POST /api/billing/webhook — signature verification', () => {
@@ -181,6 +186,117 @@ describe('checkout.session.completed', () => {
     expect(user.subscriptionTier).toBe('pack_60');
     expect(user.packSecondsRemaining).toBe(60 * 60);
     expect(user.packExpiresAt).toBeInstanceOf(Date);
+  });
+});
+
+describe('checkout.session.completed — free trial', () => {
+  test('starting a trial records trialEndsAt and burns hasUsedTrial', async () => {
+    constructEvent.mockReturnValue({
+      id: 'evt_trial', type: 'checkout.session.completed',
+      data: { object: {
+        id: 'cs_t', customer: 'cus_1', subscription: 'sub_t',
+        metadata: { userId: 'u1', pack: 'unlimited', trial: 'true' }
+      } }
+    });
+    const trialEndUnix = Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60;
+    global.__stripeSubRetrieve.mockResolvedValue({ status: 'trialing', trial_end: trialEndUnix });
+    const user = { _id: 'u1', firstName: 'Sam', lastName: 'L', save: jest.fn().mockResolvedValue() };
+    User.findById.mockResolvedValue(user);
+
+    const r = await supertest(makeApp())
+      .post('/api/billing/webhook').set('stripe-signature', 's').send({});
+
+    expect(r.status).toBe(200);
+    expect(user.subscriptionTier).toBe('unlimited');
+    expect(user.stripeSubscriptionId).toBe('sub_t');
+    expect(user.hasUsedTrial).toBe(true);
+    expect(user.trialEndsAt).toBeInstanceOf(Date);
+    expect(user.trialEndsAt.getTime()).toBe(trialEndUnix * 1000);
+  });
+
+  test('non-trial subscription does not retrieve the subscription or set trial fields', async () => {
+    constructEvent.mockReturnValue({
+      id: 'evt_notrial', type: 'checkout.session.completed',
+      data: { object: {
+        id: 'cs_n', customer: 'cus_1', subscription: 'sub_n',
+        metadata: { userId: 'u1', pack: 'unlimited' }
+      } }
+    });
+    const user = { _id: 'u1', firstName: 'A', lastName: 'B', save: jest.fn().mockResolvedValue() };
+    User.findById.mockResolvedValue(user);
+
+    await supertest(makeApp())
+      .post('/api/billing/webhook').set('stripe-signature', 's').send({});
+
+    expect(global.__stripeSubRetrieve).not.toHaveBeenCalled();
+    expect(user.hasUsedTrial).toBeUndefined();
+  });
+});
+
+describe('customer.subscription.updated — trialing', () => {
+  test('status=trialing grants unlimited and syncs trialEndsAt', async () => {
+    const trialEndUnix = Math.floor(Date.now() / 1000) + 5 * 24 * 60 * 60;
+    constructEvent.mockReturnValue({
+      id: 'evt_ut', type: 'customer.subscription.updated',
+      data: { object: { id: 'sub_1', customer: 'cus_1', status: 'trialing', trial_end: trialEndUnix } }
+    });
+    const user = { save: jest.fn().mockResolvedValue() };
+    User.findOne.mockResolvedValueOnce(user);
+
+    await supertest(makeApp())
+      .post('/api/billing/webhook').set('stripe-signature', 's').send({});
+
+    expect(user.subscriptionTier).toBe('unlimited');
+    expect(user.hasUsedTrial).toBe(true);
+    expect(user.trialEndsAt.getTime()).toBe(trialEndUnix * 1000);
+  });
+
+  test('status=active clears the trial marker (trial converted)', async () => {
+    constructEvent.mockReturnValue({
+      id: 'evt_ua', type: 'customer.subscription.updated',
+      data: { object: { id: 'sub_1', customer: 'cus_1', status: 'active' } }
+    });
+    const user = { trialEndsAt: new Date(), save: jest.fn().mockResolvedValue() };
+    User.findOne.mockResolvedValueOnce(user);
+
+    await supertest(makeApp())
+      .post('/api/billing/webhook').set('stripe-signature', 's').send({});
+
+    expect(user.subscriptionTier).toBe('unlimited');
+    expect(user.trialEndsAt).toBeNull();
+  });
+});
+
+describe('customer.subscription.trial_will_end', () => {
+  test('sends the trial-ending reminder email', async () => {
+    const trialEndUnix = Math.floor(Date.now() / 1000) + 3 * 24 * 60 * 60;
+    constructEvent.mockReturnValue({
+      id: 'evt_twe', type: 'customer.subscription.trial_will_end',
+      data: { object: { id: 'sub_1', customer: 'cus_1', trial_end: trialEndUnix } }
+    });
+    const user = { _id: 'u1', email: 'p@x.com', firstName: 'Pat' };
+    User.findOne.mockResolvedValueOnce(user);
+
+    const r = await supertest(makeApp())
+      .post('/api/billing/webhook').set('stripe-signature', 's').send({});
+
+    expect(r.status).toBe(200);
+    expect(emailService.sendTrialEndingReminder).toHaveBeenCalledTimes(1);
+    expect(emailService.sendTrialEndingReminder.mock.calls[0][0]).toBe(user);
+  });
+
+  test('no-op when the user cannot be found', async () => {
+    constructEvent.mockReturnValue({
+      id: 'evt_twe2', type: 'customer.subscription.trial_will_end',
+      data: { object: { id: 'sub_x', customer: 'cus_x' } }
+    });
+    User.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+
+    const r = await supertest(makeApp())
+      .post('/api/billing/webhook').set('stripe-signature', 's').send({});
+
+    expect(r.status).toBe(200);
+    expect(emailService.sendTrialEndingReminder).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/integration/studentRequestParentUpgrade.test.js
+++ b/tests/integration/studentRequestParentUpgrade.test.js
@@ -1,0 +1,110 @@
+// tests/integration/studentRequestParentUpgrade.test.js
+// Integration test for POST /api/student/request-parent-upgrade — the "ask a
+// parent to unlock Mathmatix+" path that gets the trial offer to the card holder.
+// Models + email are mocked; no MongoDB.
+
+jest.mock('../../middleware/auth', () => ({
+  isAuthenticated: (req, _res, next) => next(),
+  isStudent: (req, _res, next) => next(),
+}));
+
+jest.mock('../../models/user', () => ({ findById: jest.fn(), find: jest.fn() }));
+jest.mock('../../models/conversation', () => ({}));
+jest.mock('../../models/gradingResult', () => ({}));
+jest.mock('../../models/studentUpload', () => ({}));
+jest.mock('../../models/notification', () => ({ create: jest.fn().mockResolvedValue({}) }));
+jest.mock('../../utils/emailService', () => ({
+  sendParentUpgradeRequest: jest.fn().mockResolvedValue({ success: true }),
+}));
+
+const express = require('express');
+const supertest = require('supertest');
+const User = require('../../models/user');
+const Notification = require('../../models/notification');
+const emailService = require('../../utils/emailService');
+const studentRoutes = require('../../routes/student');
+
+const STUDENT_ID = '507f1f77bcf86cd799439011';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.user = { _id: STUDENT_ID, roles: ['student'] };
+    req.isAuthenticated = () => true;
+    next();
+  });
+  app.use('/api/student', studentRoutes.router);
+  return app;
+}
+
+// findById resolves to a mutable student doc with a save() spy.
+function stubStudent(overrides = {}) {
+  const student = {
+    _id: STUDENT_ID, firstName: 'Kid', parentIds: [],
+    lastParentUpgradeRequestAt: null,
+    save: jest.fn().mockResolvedValue(),
+    ...overrides,
+  };
+  User.findById.mockResolvedValue(student);
+  return student;
+}
+
+function stubParents(parents) {
+  User.find.mockReturnValue({ select: () => ({ lean: () => Promise.resolve(parents) }) });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Notification.create.mockResolvedValue({});
+  emailService.sendParentUpgradeRequest.mockResolvedValue({ success: true });
+});
+
+describe('POST /api/student/request-parent-upgrade', () => {
+  test('notifies a linked (non-subscribed) parent by email + notification', async () => {
+    const student = stubStudent({ parentIds: ['p1'] });
+    stubParents([{ _id: 'p1', email: 'mom@x.com', firstName: 'Mom', subscriptionTier: 'free' }]);
+
+    const r = await supertest(buildApp()).post('/api/student/request-parent-upgrade').send({});
+
+    expect(r.status).toBe(200);
+    expect(r.body).toMatchObject({ success: true, linked: true, notified: 1 });
+    expect(Notification.create).toHaveBeenCalledTimes(1);
+    expect(emailService.sendParentUpgradeRequest).toHaveBeenCalledTimes(1);
+    expect(emailService.sendParentUpgradeRequest.mock.calls[0][1]).toBe('Kid'); // childName
+    expect(student.lastParentUpgradeRequestAt).toBeInstanceOf(Date);
+    expect(student.save).toHaveBeenCalled();
+  });
+
+  test('returns linked:false when no parent is linked (client then invites)', async () => {
+    stubStudent({ parentIds: [] });
+
+    const r = await supertest(buildApp()).post('/api/student/request-parent-upgrade').send({});
+
+    expect(r.status).toBe(200);
+    expect(r.body.linked).toBe(false);
+    expect(emailService.sendParentUpgradeRequest).not.toHaveBeenCalled();
+  });
+
+  test('throttles repeat requests within 12h', async () => {
+    stubStudent({ parentIds: ['p1'], lastParentUpgradeRequestAt: new Date() });
+
+    const r = await supertest(buildApp()).post('/api/student/request-parent-upgrade').send({});
+
+    expect(r.status).toBe(200);
+    expect(r.body).toMatchObject({ linked: true, alreadySent: true });
+    expect(emailService.sendParentUpgradeRequest).not.toHaveBeenCalled();
+  });
+
+  test('reports already-covered when every linked parent is unlimited', async () => {
+    stubStudent({ parentIds: ['p1'] });
+    stubParents([{ _id: 'p1', email: 'mom@x.com', firstName: 'Mom', subscriptionTier: 'unlimited' }]);
+
+    const r = await supertest(buildApp()).post('/api/student/request-parent-upgrade').send({});
+
+    expect(r.status).toBe(200);
+    expect(r.body).toMatchObject({ linked: true, alreadyCovered: true });
+    expect(emailService.sendParentUpgradeRequest).not.toHaveBeenCalled();
+    expect(Notification.create).not.toHaveBeenCalled();
+  });
+});

--- a/utils/conversionEvents.js
+++ b/utils/conversionEvents.js
@@ -1,0 +1,41 @@
+// utils/conversionEvents.js — record freemium-funnel events
+//
+// Single entry point for logging conversion "wall" events. Two design rules:
+//   1. NEVER block or fail the request it's called from — always fire-and-forget
+//      and swallow errors (telemetry must not break tutoring or billing).
+//   2. Write to BOTH Mongo (queryable rows) and Winston (Better Stack dashboards)
+//      so the data is usable immediately without extra tooling.
+
+const ConversionEvent = require('../models/conversionEvent');
+const logger = require('./logger').child({ module: 'conversion' });
+
+/**
+ * Record a conversion-funnel event. Fire-and-forget: returns immediately and
+ * persists in the background; callers should NOT await this in a hot path.
+ *
+ * @param {string} event      One of ConversionEvent.CONVERSION_EVENTS.
+ * @param {object} [opts]
+ * @param {string|object} [opts.userId]     Mongo user id for authenticated events.
+ * @param {string} [opts.sessionKey]        Anonymized session id for anonymous events.
+ * @param {object} [opts.context]           Non-PII context payload.
+ */
+function recordConversionEvent(event, opts = {}) {
+  const { userId = null, sessionKey = null, context = {} } = opts;
+
+  // Structured log line first — cheap, synchronous, always lands even if the DB
+  // write is slow or fails.
+  logger.info(`[conversion] ${event}`, {
+    conversionEvent: event,
+    userId: userId ? String(userId) : undefined,
+    sessionKey: sessionKey || undefined,
+    ...context,
+  });
+
+  // Durable row — background, best-effort.
+  ConversionEvent.create({ event, userId, sessionKey, context })
+    .catch((err) => {
+      logger.warn(`[conversion] failed to persist ${event}: ${err.message}`);
+    });
+}
+
+module.exports = { recordConversionEvent };

--- a/utils/emailService.js
+++ b/utils/emailService.js
@@ -363,6 +363,54 @@ async function sendTrialEndingReminder(user, trialEndsAt) {
   }
 }
 
+/**
+ * "Your child hit their free limit" → parent upgrade nudge. Sent when a student
+ * with a linked parent asks the parent to unlock unlimited (via the wall CTA).
+ * Frames it around a free trial so the parent's first action is low-risk.
+ * @param {String} parentEmail
+ * @param {String} childName
+ * @param {String} actionUrl - deep link into the parent dashboard / upgrade
+ */
+async function sendParentUpgradeRequest(parentEmail, childName, actionUrl) {
+  const transport = initializeTransporter();
+  if (!transport) {
+    console.warn('Email not configured - skipping parent upgrade request');
+    return { success: false, error: 'Email not configured' };
+  }
+  if (!parentEmail) return { success: false, error: 'No parent email' };
+
+  try {
+    const emailConfig = getEmailConfig();
+    const safeName = childName || 'Your child';
+    const html = `
+      <div style="font-family:-apple-system,Segoe UI,Roboto,Arial,sans-serif;max-width:560px;margin:0 auto;color:#1a1a1a;">
+        <h2 style="color:#0d9488;">${safeName} wants to keep learning on Mathmatix</h2>
+        <p>${safeName} used up their free tutoring time this month and asked you to unlock more.</p>
+        <p>You can start a <strong>7-day free trial of Mathmatix+</strong> — unlimited 24/7 AI tutoring, voice sessions, homework help, and your parent dashboard. It's free for the first week, then $9.95/month, and you can cancel anytime.</p>
+        <p style="text-align:center;margin:28px 0;">
+          <a href="${actionUrl}" style="background:#0d9488;color:#fff;padding:12px 28px;border-radius:8px;text-decoration:none;font-weight:600;display:inline-block;">Start ${safeName}'s free trial</a>
+        </p>
+        <p style="font-size:0.85rem;color:#666;">If the button doesn't work, copy and paste this link into your browser:<br><a href="${actionUrl}">${actionUrl}</a></p>
+        <p style="font-size:0.8rem;color:#999;">You're receiving this because ${safeName} requested it from their Mathmatix account. No charge is made unless you start the trial.</p>
+      </div>`;
+
+    const mailOptions = {
+      from: getFromAddress(),
+      replyTo: emailConfig.replyTo,
+      to: parentEmail,
+      subject: `${safeName} asked you to unlock more Mathmatix tutoring`,
+      html
+    };
+
+    const info = await transport.sendMail(mailOptions);
+    console.log(`✅ Parent upgrade request sent to ${parentEmail}:`, info.messageId);
+    return { success: true, messageId: info.messageId };
+  } catch (error) {
+    console.error('❌ Error sending parent upgrade request:', error);
+    return { success: false, error: error.message };
+  }
+}
+
 async function sendPasswordResetEmail(email, resetToken) {
   const transport = initializeTransporter();
   if (!transport) {
@@ -1785,6 +1833,7 @@ module.exports = {
   sendWaitlistConfirmation,
   sendCancellationConfirmation,
   sendTrialEndingReminder,
+  sendParentUpgradeRequest,
   initializeTransporter,
   getEmailConfig
 };

--- a/utils/emailService.js
+++ b/utils/emailService.js
@@ -307,6 +307,62 @@ async function sendTeenConsentRequest(parentEmail, studentName, consentToken, st
  * @param {String} email - User's email address
  * @param {String} resetToken - Password reset token
  */
+/**
+ * Reminder that a Mathmatix+ free trial is about to end and the card will be
+ * charged. Sent from the Stripe `customer.subscription.trial_will_end` webhook
+ * (~3 days out). Clear, honest, easy-to-cancel — the anti-dark-pattern email.
+ * @param {Object} user       - User doc (needs email, firstName)
+ * @param {Date}   trialEndsAt - When the trial converts to a paid charge
+ */
+async function sendTrialEndingReminder(user, trialEndsAt) {
+  const transport = initializeTransporter();
+  if (!transport) {
+    console.warn('Email not configured - skipping trial-ending reminder');
+    return { success: false, error: 'Email not configured' };
+  }
+  const to = user && user.email;
+  if (!to) return { success: false, error: 'No email on user' };
+
+  try {
+    const baseUrl = process.env.BASE_URL || 'http://localhost:3000';
+    const manageUrl = `${baseUrl}/chat.html`;
+    const emailConfig = getEmailConfig();
+    const name = user.firstName || 'there';
+    const endStr = trialEndsAt
+      ? new Date(trialEndsAt).toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })
+      : 'in a few days';
+
+    const html = `
+      <div style="font-family:-apple-system,Segoe UI,Roboto,Arial,sans-serif;max-width:520px;margin:0 auto;color:#1a1a2e;">
+        <h2 style="margin:0 0 12px;">Your Mathmatix+ free trial ends ${endStr}</h2>
+        <p>Hi ${name},</p>
+        <p>Just a heads-up: your 7-day Mathmatix+ free trial ends on <strong>${endStr}</strong>.
+           When it does, your subscription continues at <strong>$9.95/month</strong> unless you cancel first.</p>
+        <p>If Mathmatix+ is helping, you don't need to do anything — your access just keeps going.</p>
+        <p>If you'd rather not continue, you can cancel any time before then, no questions asked:</p>
+        <p style="text-align:center;margin:24px 0;">
+          <a href="${manageUrl}" style="background:#0d9488;color:#fff;padding:12px 28px;border-radius:8px;text-decoration:none;font-weight:600;display:inline-block;">Manage my subscription</a>
+        </p>
+        <p style="color:#666;font-size:13px;">Cancelling keeps you on the free plan (30 minutes of AI tutoring a month) — you won't lose your account or progress.</p>
+      </div>`;
+
+    const mailOptions = {
+      from: getFromAddress(),
+      replyTo: emailConfig.replyTo,
+      to,
+      subject: `Your Mathmatix+ trial ends ${endStr} — you'll be charged $9.95/mo`,
+      html
+    };
+
+    const info = await transport.sendMail(mailOptions);
+    console.log(`✅ Trial-ending reminder sent to ${to}:`, info.messageId);
+    return { success: true, messageId: info.messageId };
+  } catch (error) {
+    console.error('❌ Error sending trial-ending reminder:', error);
+    return { success: false, error: error.message };
+  }
+}
+
 async function sendPasswordResetEmail(email, resetToken) {
   const transport = initializeTransporter();
   if (!transport) {
@@ -1728,6 +1784,7 @@ module.exports = {
   sendWelcomeEmail,
   sendWaitlistConfirmation,
   sendCancellationConfirmation,
+  sendTrialEndingReminder,
   initializeTransporter,
   getEmailConfig
 };


### PR DESCRIPTION
## What & why

Closes the freemium-funnel gaps now that billing is live in prod: we couldn't **measure** conversion, there was no **trial** to soften the 30-min wall, and the wall is hit by the student while the card belongs to the **parent**. Three commits:

1. **Conversion instrumentation** — telemetry for the funnel "walls".
2. **Card-required Mathmatix+ free trial (v1)** — 7-day trial offered contextually at the wall.
3. **Parent-reach** — routes the trial offer to the payer.

Free tier stays **no-card**. The card is required only to start a trial.

## 1. Conversion instrumentation
- `models/conversionEvent.js`, `utils/conversionEvents.js` — durable, fire-and-forget events → Mongo + Winston/Better Stack.
- `free_quota_exhausted` at the 30-min `402` (usageGate, throttled) and `trial_exhausted` when the anonymous trial caps (trialChat).

## 2. Card-required free trial
- `models/user.js` — `trialEndsAt` + `hasUsedTrial` (one trial per user).
- `routes/billing.js` — `create-checkout-session` accepts `{ trial: true }` → `trial_period_days` + forced card capture; webhook records/updates/clears the trial and handles `trial_will_end` → reminder email; `GET /status` exposes trial state + `trialAvailable`.
- `utils/emailService.js` — `sendTrialEndingReminder`.
- `public/js/modules/billing.js` — trial-first upgrade modal, trial flag through checkout, countdown banner.
- Trial access reuses `subscriptionTier='unlimited'`, so `usageGate` is unchanged.

## 3. Parent-reach ("ask a parent to unlock")
- Upgrade modal (students): **"🙋 Ask a parent to unlock this"** →
  - Linked parent → `POST /api/student/request-parent-upgrade` notifies each parent (in-app + trial-framed email), throttled once/12h.
  - No linked parent → reveals a parent-email field reusing `POST /api/student/invite-parent`.
- Parent side: the email deep-links to `parent-dashboard.html?upgrade=1`, which now **auto-opens a "Start 7-day free trial" prompt** running the same card-required checkout (parent pays → child gets access via existing `parentIds`/`parentSubscription`).
- `models/user.js` — `lastParentUpgradeRequestAt` (anti-spam); `utils/emailService.js` — `sendParentUpgradeRequest`.

## Design notes
- **Contextual-only** for v1 (offered at the wall, not signup) — highest-intent moment, keeps signup frictionless. Up-front-at-signup is a deliberate later experiment once conversion data justifies it.
- **Card + reminder**, not silent auto-bill — keeps the conversion lift while staying compliant (FTC/state negative-option rules) and brand-safe for a parent/school audience.

## Requires (Stripe Dashboard — not in this diff)
- Enable **"Send trial-ending notifications"** (belt-and-suspenders with our own email).
- Confirm the **Customer Portal** allows self-serve cancellation.

## Testing
- `billingWebhook.test.js` extended: trial checkout, `trialing` status, `trial_will_end` reminder, non-trial path.
- New `studentRequestParentUpgrade.test.js`: linked-parent notify, unlinked, 12h throttle, already-covered.
- `node --check` passes on all changed files (backend + ES-module frontend). Full suite in CI.

## Follow-ups (not in this PR)
- Persistent "link a parent" affordance in student settings (this PR covers it at the wall).
- Up-front-at-signup trial experiment, pending conversion data.
- Isolated dev database (unrelated to this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnQmCziCoM17VG2VqTwrPs