### PR TITLE
fix(courses): show day-one diagnostic when resuming into an active course

### DIFF
--- a/public/js/courseCatalog.js
+++ b/public/js/courseCatalog.js
@@ -251,6 +251,12 @@ class CourseManager {
             if (window.lessonTracker) {
                 window.lessonTracker.rehydrate(match._id);
             }
+
+            // Day-one diagnostic (e.g. ACT-prep practice test): when a student
+            // loads straight into an already-active course, neither the enroll
+            // splash nor an explicit activate fires — so surface the card here
+            // too. Server gates it (returns null once they've taken it).
+            this.maybeShowActiveDiagnostic(match._id);
         } else {
             wrapper.style.display = 'none';
             this.activeCourseSessionId = null;
@@ -1124,6 +1130,22 @@ class CourseManager {
                     font-weight:700; font-size:14px; cursor:pointer;
                 "><i class="fas fa-play" style="margin-right:6px;"></i>${this.escapeHtml(diag.cta)}</button>
             </div>`;
+    }
+
+    // Fetch + show the day-one diagnostic for an already-active course on page
+    // load (checkActiveProgressBar). Non-fatal; the server returns null once the
+    // student has completed the diagnostic, so the card stops appearing.
+    async maybeShowActiveDiagnostic(sessionId) {
+        try {
+            const res = await csrfFetch(`/api/course-sessions/${sessionId}/diagnostic`, {
+                credentials: 'include'
+            });
+            if (!res.ok) return;
+            const data = await res.json();
+            if (data && data.diagnostic) this.showDiagnosticCard(data.diagnostic);
+        } catch {
+            /* non-fatal — diagnostic is a nudge, never blocks the course */
+        }
     }
 
     // Show the diagnostic card on its own (returning students who re-open the

--- a/routes/courseSession.js
+++ b/routes/courseSession.js
@@ -382,6 +382,30 @@ router.post('/:id/activate', async (req, res) => {
 });
 
 /* ============================================================
+   GET /api/course-sessions/:id/diagnostic
+   Day-one diagnostic descriptor for a session (or null). Lets the client
+   surface the practice-ACT / starting-point card when a returning student loads
+   straight into an already-active course — i.e. neither the enroll/resume splash
+   nor an explicit activate fired, so the card would otherwise never appear.
+   ============================================================ */
+router.get('/:id/diagnostic', async (req, res) => {
+  try {
+    const session = await CourseSession.findOne({
+      _id: req.params.id,
+      userId: req.user._id
+    });
+    if (!session) {
+      return res.status(404).json({ success: false, message: 'Course session not found' });
+    }
+    const diagnostic = await buildCourseDiagnostic(req.user, session.courseId);
+    res.json({ success: true, diagnostic });
+  } catch (err) {
+    console.error('[CourseSession] diagnostic lookup failed (non-fatal):', err.message);
+    res.status(500).json({ success: false, diagnostic: null });
+  }
+});
+
+/* ============================================================
    POST /api/course-sessions/deactivate
    Clear active course session (return to general tutoring)
    ============================================================ */


### PR DESCRIPTION
## Bug

A student in the **ACT prep** course never got prompted to take the day-one practice ACT. Root cause: the diagnostic card was only surfaced on two entry paths — the enroll/resume **welcome splash** and an **explicit sidebar `activateCourse`**. When a returning student loads straight into their already-active course (the page just "carries on from where we left off"), the client hits a *third* path — `checkActiveProgressBar` — which rehydrated the progress bar and lesson tracker but **never checked the diagnostic**. So the card never appeared. Anyone who enrolled before the day-one-card feature shipped lands here every time.

Two reported symptoms — "no practice test" and "it carries on from where we left off" — are the **same** root cause.

## Fix

- **`routes/courseSession.js`** — new `GET /:id/diagnostic`: returns the card descriptor for the session's `courseId` via `buildCourseDiagnostic`, or `null` once the student has completed it (same gate as every other entry point; owner-scoped query).
- **`public/js/courseCatalog.js`** — `checkActiveProgressBar` (the reload-into-active-course path) now calls a new `maybeShowActiveDiagnostic()` that fetches the descriptor and shows the card. Non-fatal — a failed fetch never blocks the course.

The gate is unchanged, so once the student takes the practice ACT the card stops appearing everywhere.

## Verification
- `node --check` + `eslint` clean (0 errors) on both files.
- `tests/unit/coursePersist.test.js` green (31).
- **Not** verified against a live deploy from this environment — `public/js/courseCatalog.js` is Vite-bundled, so this needs a build+deploy to confirm on the site. Worth a manual check as an already-enrolled ACT-prep student who has not completed a practice ACT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTm55BDVTnGaJm3DRVauGZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTm55BDVTnGaJm3DRVauGZ)_