### PR TITLE
feat(act): priority-ranked study plan from the practice ACT (step 1)

### DIFF
--- a/routes/actTest.js
+++ b/routes/actTest.js
@@ -20,6 +20,7 @@ const router = express.Router();
 const ActTestSession = require('../models/actTestSession');
 const Problem = require('../models/problem');
 const { assembleForm, rawToScaled, getBlueprint } = require('../utils/actTestAssembler');
+const { buildActPlan } = require('../utils/actBootcampPlan');
 
 // skillId → human-readable name, so the report can name EXACT weak skills
 // (e.g. "Quadratic Equations") rather than just the broad category.
@@ -235,6 +236,11 @@ router.post('/complete', async (req, res) => {
       }))
       .sort((a, b) => (b.missed / b.total) - (a.missed / a.total) || b.missed - a.missed);
 
+    // "Great tutor" triage: skip mastered domains, rank the rest by leverage
+    // (weakness x ACT exam-weight), and pick a prerequisite-aware starting module.
+    // This is the plan the course opening + module ordering consume (next step).
+    const plan = buildActPlan(byCategory);
+
     session.status = 'completed';
     session.completedAt = new Date();
     session.rawScore = raw;
@@ -275,6 +281,7 @@ router.post('/complete', async (req, res) => {
         byCategory,
         weakSkills,
         plannedSkills,
+        plan,
         durationMinutes: session.startedAt
           ? Math.round((session.completedAt - session.startedAt) / 60000)
           : null,

--- a/tests/unit/actBootcampPlan.test.js
+++ b/tests/unit/actBootcampPlan.test.js
@@ -1,0 +1,71 @@
+// tests/unit/actBootcampPlan.test.js
+// Guards the "great tutor" triage that turns a practice-ACT result into a study
+// plan: skip mastered domains, rank the rest by leverage (weakness x exam-weight),
+// and pick a prerequisite-aware starting module. Pure — no DB.
+
+const { buildActPlan, CATEGORY_MODULE } = require('../../utils/actBootcampPlan');
+
+describe('buildActPlan — great-tutor triage', () => {
+  test('skips a domain the student already mastered (fast-pass, not a target)', () => {
+    const plan = buildActPlan({
+      'number-quantity': { correct: 5, total: 5 }, // aced -> mastered
+      'algebra': { correct: 3, total: 8 },
+    });
+    expect(plan.summary.masteredCategories).toContain('number-quantity');
+    expect(plan.targets.map(t => t.category)).not.toContain('number-quantity');
+    expect(plan.targets.map(t => t.category)).toContain('algebra');
+  });
+
+  test('ranks by leverage: a higher-weight domain can outrank a weaker-but-lighter one', () => {
+    // algebra: acc .50, weight 8 -> priority 4.0
+    // number-quantity: acc .40, weight 5 -> priority 3.0
+    // Lower accuracy (nq) but algebra still ranks first because it's worth more.
+    const plan = buildActPlan({
+      'algebra': { correct: 4, total: 8 },
+      'number-quantity': { correct: 2, total: 5 },
+    });
+    expect(plan.targets[0].category).toBe('algebra');
+    expect(plan.targets[1].category).toBe('number-quantity');
+  });
+
+  test('respects foundations: starts on the weak prerequisite, not the higher-priority dependent', () => {
+    // functions has higher priority than algebra, but algebra is more foundational
+    // and also weak — a great tutor starts there.
+    const plan = buildActPlan({
+      'algebra': { correct: 5, total: 8 },   // acc .625, weight 8 -> 3.0, foundation 1
+      'functions': { correct: 4, total: 8 }, // acc .50,  weight 8 -> 4.0, foundation 2
+    });
+    expect(plan.targets[0].category).toBe('functions');      // ranked first by leverage
+    expect(plan.startModuleId).toBe(CATEGORY_MODULE.algebra); // but we START on the foundation
+  });
+
+  test('caps the plan to a focused set of targets', () => {
+    const plan = buildActPlan({
+      'algebra': { correct: 1, total: 8 },
+      'functions': { correct: 1, total: 8 },
+      'geometry': { correct: 1, total: 8 },
+      'statistics-probability': { correct: 1, total: 7 },
+      'number-quantity': { correct: 1, total: 5 },
+    }, { maxTargets: 3 });
+    expect(plan.targets).toHaveLength(3);
+  });
+
+  test('maps every target/start to a real pathway module id', () => {
+    const plan = buildActPlan({
+      'geometry': { correct: 2, total: 8 },
+      'statistics-probability': { correct: 3, total: 7 },
+    });
+    for (const t of plan.targets) expect(typeof t.moduleId).toBe('string');
+    expect(plan.startModuleId).toBeTruthy();
+  });
+
+  test('empty / all-mastered / unknown input is handled gracefully', () => {
+    expect(buildActPlan({}).targets).toEqual([]);
+    expect(buildActPlan({}).startModuleId).toBeNull();
+    const allMastered = buildActPlan({ 'algebra': { correct: 8, total: 8 } });
+    expect(allMastered.targets).toEqual([]);
+    expect(allMastered.summary.masteredCategories).toContain('algebra');
+    // an unrecognized category is ignored, never crashes
+    expect(() => buildActPlan({ 'unknown': { correct: 0, total: 3 } })).not.toThrow();
+  });
+});

--- a/utils/actBootcampPlan.js
+++ b/utils/actBootcampPlan.js
@@ -1,0 +1,116 @@
+// utils/actBootcampPlan.js
+//
+// Turns a completed practice-ACT result into a priority-ranked study plan — the
+// "great tutor" triage:
+//   1. SKIP what they've already mastered (don't re-teach a domain they aced).
+//   2. PRIORITIZE by leverage = weakness x exam-weight (a small gap in a heavily
+//      tested domain beats a big gap in a lightly tested one).
+//   3. RESPECT FOUNDATIONS — pick the entry point so we don't start a dependent
+//      domain (e.g. Functions) while its prerequisite (Algebra) is also weak.
+//
+// Reuses the AP Calc bootcamp's proven priorityScore((1-accuracy) * examWeight),
+// so the two bootcamps share one brain. Pure/deterministic — no DB, no LLM.
+
+const { priorityScore } = require('./calcBootcamp');
+const DEFAULT_BLUEPRINT = require('../seeds/act-math-blueprint.json');
+
+// ACT reporting category -> act-prep pathway moduleId (public/resources/act-prep-pathway.json).
+const CATEGORY_MODULE = {
+  'number-quantity': 'number_quantity',
+  'algebra': 'algebra',
+  'functions': 'functions',
+  'geometry': 'geometry',
+  'statistics-probability': 'statistics_probability',
+  'integrating-essential-skills': 'integrating_essential_skills',
+};
+
+// Prerequisite depth among ACT Higher-Math domains (lower = more foundational).
+// Used only as a tie-break for the STARTING module, so foundations are shored up
+// before the domains built on them — a dependent weak domain never jumps ahead
+// of a weak prerequisite as the entry point.
+const FOUNDATION_ORDER = {
+  'number-quantity': 0,
+  'algebra': 1,
+  'integrating-essential-skills': 1,
+  'functions': 2,
+  'geometry': 2,
+  'statistics-probability': 3,
+};
+
+const MASTERED_ACCURACY = 0.85; // aced this domain on the practice test -> skip/fast-pass
+const MAX_TARGETS = 3;           // a focused plan, not a laundry list
+
+/**
+ * @param {Object} byCategory { category: { correct, total } } from the practice ACT
+ * @param {Object} [opts] { blueprint?, masteredAccuracy?, maxTargets? }
+ * @returns {{
+ *   targets: Array,      // weak domains to focus on, highest-leverage first
+ *   mastered: Array,     // domains to fast-pass (already aced)
+ *   startModuleId: ?string,  // where a great tutor would begin
+ *   all: Array,          // every scored domain, annotated
+ *   summary: { focusCategories: string[], masteredCategories: string[] }
+ * }}
+ */
+function buildActPlan(byCategory, opts = {}) {
+  const weights = (opts.blueprint || DEFAULT_BLUEPRINT).categoryWeights || {};
+  const masteredAt = opts.masteredAccuracy != null ? opts.masteredAccuracy : MASTERED_ACCURACY;
+  const maxTargets = opts.maxTargets != null ? opts.maxTargets : MAX_TARGETS;
+
+  const rows = Object.entries(byCategory || {})
+    .filter(([category]) => category && category !== 'unknown')
+    .map(([category, v]) => {
+      const total = v.total || 0;
+      const correct = v.correct || 0;
+      const accuracy = total > 0 ? correct / total : 0;
+      const examWeight = weights[category] || 0;
+      return {
+        category,
+        moduleId: CATEGORY_MODULE[category] || null,
+        correct,
+        total,
+        accuracy,
+        examWeight,
+        mastered: total > 0 && accuracy >= masteredAt,
+        foundation: FOUNDATION_ORDER[category] != null ? FOUNDATION_ORDER[category] : 9,
+        // leverage: how weak x how much the test rewards it
+        priority: priorityScore(accuracy, examWeight || 1),
+      };
+    });
+
+  const weak = rows
+    .filter(r => !r.mastered && r.total > 0)
+    .sort((a, b) => b.priority - a.priority || a.foundation - b.foundation);
+
+  const targets = weak.slice(0, maxTargets).map(r => ({ ...r, kind: 'target' }));
+  const mastered = rows.filter(r => r.mastered).sort((a, b) => b.examWeight - a.examWeight);
+
+  // Entry point: the most FOUNDATIONAL domain among the top targets, so a weak
+  // prerequisite is fixed before a weak domain that depends on it. Falls back to
+  // the single highest-priority target, then to any target with a module.
+  let startModuleId = null;
+  if (targets.length) {
+    const byFoundation = [...targets].sort(
+      (a, b) => a.foundation - b.foundation || b.priority - a.priority,
+    );
+    const start = byFoundation.find(t => t.moduleId) || targets.find(t => t.moduleId);
+    startModuleId = start ? start.moduleId : null;
+  }
+
+  return {
+    targets,
+    mastered,
+    startModuleId,
+    all: rows.sort((a, b) => b.priority - a.priority),
+    summary: {
+      focusCategories: targets.map(t => t.category),
+      masteredCategories: mastered.map(m => m.category),
+    },
+  };
+}
+
+module.exports = {
+  buildActPlan,
+  CATEGORY_MODULE,
+  FOUNDATION_ORDER,
+  MASTERED_ACCURACY,
+};


### PR DESCRIPTION
## Context

The ACT course currently teaches a **fixed module march** (Number & Quantity → Algebra → …) that ignores the practice-ACT diagnostic — so a student who aced Number & Quantity still gets lectured on real numbers. Step 1 of closing that loop: **turn the practice-ACT result into the plan a great tutor would make.**

## What a great tutor does (the spec)

1. **Skip mastered** domains (fast-pass, not re-teach).
2. **Prioritize by leverage** — weakness × ACT exam-weight.
3. **Respect foundations** — start on the most foundational weak domain (Algebra before Functions).

## Changes

- **`utils/actBootcampPlan.js`** — `buildActPlan(byCategory)` → `{ targets, mastered, startModuleId, all, summary }`. Reuses the AP Calc bootcamp's `priorityScore`. Includes ACT-category → pathway-module map + prerequisite ordering. Pure.
- **`routes/actTest.js`** — `/complete` returns the plan in the report (additive).
- **`tests/unit/actBootcampPlan.test.js`** — 6 tests (skip-mastered, leverage, prereq-aware start, cap, mapping, edge).

## Verification
`node --check` + `eslint` clean; new suite 6/6; assembler suite green.

## Next (step 2)
ACT course consumes `startModuleId` — open on the highest-leverage weak domain with a diagnostic recap, fast-pass mastered domains, keep Gradual Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTm55BDVTnGaJm3DRVauGZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTm55BDVTnGaJm3DRVauGZ)_