### PR TITLE
feat(act): course opens on the practice-ACT plan (step 2)

### DIFF
--- a/models/courseSession.js
+++ b/models/courseSession.js
@@ -60,6 +60,12 @@ const courseSessionSchema = new Schema({
   // Checkpoint state (transient — cleared when checkpoint completes)
   checkpointState: { type: Object, default: null },
 
+  // Diagnostic plan from a completed practice test (e.g. the ACT bootcamp).
+  // Shape: { focusCategories: [], masteredCategories: [], startModuleId, takenAt }.
+  // Used to open the course on the highest-leverage weak module and to recap the
+  // result in the greeting. Set at practice-test completion; null otherwise.
+  diagnosticPlan: { type: Schema.Types.Mixed, default: null },
+
   // Overall progress
   overallProgress: { type: Number, default: 0, min: 0, max: 100 },
 

--- a/routes/actTest.js
+++ b/routes/actTest.js
@@ -20,7 +20,8 @@ const router = express.Router();
 const ActTestSession = require('../models/actTestSession');
 const Problem = require('../models/problem');
 const { assembleForm, rawToScaled, getBlueprint } = require('../utils/actTestAssembler');
-const { buildActPlan } = require('../utils/actBootcampPlan');
+const { buildActPlan, planStartModule, planSummary } = require('../utils/actBootcampPlan');
+const CourseSession = require('../models/courseSession');
 
 // skillId → human-readable name, so the report can name EXACT weak skills
 // (e.g. "Quadratic Equations") rather than just the broad category.
@@ -246,6 +247,22 @@ router.post('/complete', async (req, res) => {
     session.rawScore = raw;
     session.scaledScore = scaled ? scaled.scaled : null;
     await session.save();
+
+    // ── Retarget the ACT course from the pretest ──
+    // If the student is enrolled in the ACT course and hasn't started a module
+    // yet, open it on the highest-leverage weak domain (prereq-aware) and stash
+    // the plan so the greeting can recap it. Additive and non-fatal.
+    try {
+      const cs = await CourseSession.findOne({ userId: req.user._id, courseId: 'act-prep', status: 'active' });
+      if (cs) {
+        const jumpTo = planStartModule(cs, plan);
+        if (jumpTo) cs.currentModuleId = jumpTo;
+        cs.diagnosticPlan = planSummary(plan, session.completedAt);
+        await cs.save();
+      }
+    } catch (retargetErr) {
+      console.error('[actTest] course retarget error (non-fatal):', retargetErr.message);
+    }
 
     // ── Personalize from the pretest ──
     // Seed the exact weak skills into the student's tutor plan (worst first), so

--- a/tests/unit/actBootcampPlan.test.js
+++ b/tests/unit/actBootcampPlan.test.js
@@ -3,7 +3,7 @@
 // plan: skip mastered domains, rank the rest by leverage (weakness x exam-weight),
 // and pick a prerequisite-aware starting module. Pure — no DB.
 
-const { buildActPlan, CATEGORY_MODULE } = require('../../utils/actBootcampPlan');
+const { buildActPlan, planStartModule, planSummary, CATEGORY_MODULE } = require('../../utils/actBootcampPlan');
 
 describe('buildActPlan — great-tutor triage', () => {
   test('skips a domain the student already mastered (fast-pass, not a target)', () => {
@@ -67,5 +67,42 @@ describe('buildActPlan — great-tutor triage', () => {
     expect(allMastered.summary.masteredCategories).toContain('algebra');
     // an unrecognized category is ignored, never crashes
     expect(() => buildActPlan({ 'unknown': { correct: 0, total: 3 } })).not.toThrow();
+  });
+});
+
+describe('planStartModule — retarget only at course start', () => {
+  const plan = { startModuleId: 'geometry' };
+  const modules = (statuses) => statuses.map((s, i) => ({ moduleId: ['number_quantity', 'algebra', 'geometry'][i], status: s }));
+
+  test('retargets a fresh course (no progress, no module begun)', () => {
+    const cs = { currentModuleId: 'number_quantity', overallProgress: 0, modules: modules(['available', 'locked', 'locked']) };
+    expect(planStartModule(cs, plan)).toBe('geometry');
+  });
+
+  test('does NOT retarget once a module is in progress', () => {
+    const cs = { currentModuleId: 'number_quantity', overallProgress: 0, modules: modules(['in_progress', 'locked', 'locked']) };
+    expect(planStartModule(cs, plan)).toBeNull();
+  });
+
+  test('does NOT retarget once there is progress', () => {
+    const cs = { currentModuleId: 'number_quantity', overallProgress: 12, modules: modules(['completed', 'available', 'locked']) };
+    expect(planStartModule(cs, plan)).toBeNull();
+  });
+
+  test('no-op when already on the target module, or target missing', () => {
+    const onTarget = { currentModuleId: 'geometry', overallProgress: 0, modules: modules(['available', 'locked', 'available']) };
+    expect(planStartModule(onTarget, plan)).toBeNull();
+    const noSuch = { currentModuleId: 'number_quantity', overallProgress: 0, modules: modules(['available', 'locked', 'locked']) };
+    expect(planStartModule(noSuch, { startModuleId: 'not_a_module' })).toBeNull();
+    expect(planStartModule(onTarget, { startModuleId: null })).toBeNull();
+  });
+
+  test('planSummary is a compact stashable descriptor', () => {
+    const p = buildActPlan({ 'algebra': { correct: 3, total: 8 }, 'number-quantity': { correct: 5, total: 5 } });
+    const s = planSummary(p, null);
+    expect(s.focusCategories).toContain('algebra');
+    expect(s.masteredCategories).toContain('number-quantity');
+    expect(s).toHaveProperty('startModuleId');
+    expect(s).toHaveProperty('takenAt');
   });
 });

--- a/utils/actBootcampPlan.js
+++ b/utils/actBootcampPlan.js
@@ -37,6 +37,16 @@ const FOUNDATION_ORDER = {
   'statistics-probability': 3,
 };
 
+// Human-readable domain labels for the greeting recap.
+const CATEGORY_LABEL = {
+  'number-quantity': 'Number & Quantity',
+  'algebra': 'Algebra',
+  'functions': 'Functions',
+  'geometry': 'Geometry',
+  'statistics-probability': 'Statistics & Probability',
+  'integrating-essential-skills': 'Essential Skills',
+};
+
 const MASTERED_ACCURACY = 0.85; // aced this domain on the practice test -> skip/fast-pass
 const MAX_TARGETS = 3;           // a focused plan, not a laundry list
 
@@ -108,9 +118,41 @@ function buildActPlan(byCategory, opts = {}) {
   };
 }
 
+/**
+ * Should a course session be retargeted to open on the plan's starting module?
+ * Only at the very START of the course — never yank a student who has begun a
+ * module. Returns the moduleId to jump to, or null (no change).
+ *
+ * @param {Object} courseSession Mongoose CourseSession (modules[], currentModuleId, overallProgress)
+ * @param {Object} plan buildActPlan() output
+ */
+function planStartModule(courseSession, plan) {
+  if (!courseSession || !plan || !plan.startModuleId) return null;
+  const mods = courseSession.modules || [];
+  const untouched = (courseSession.overallProgress || 0) === 0
+    && mods.every(m => m.status !== 'in_progress' && m.status !== 'completed');
+  if (!untouched) return null;
+  if (!mods.some(m => m.moduleId === plan.startModuleId)) return null; // must be a real module
+  if (plan.startModuleId === courseSession.currentModuleId) return null; // already there
+  return plan.startModuleId;
+}
+
+/** Compact plan summary to stash on the course session for the greeting recap. */
+function planSummary(plan, takenAt) {
+  return {
+    focusCategories: (plan.summary?.focusCategories || []),
+    masteredCategories: (plan.summary?.masteredCategories || []),
+    startModuleId: plan.startModuleId || null,
+    takenAt: takenAt || null,
+  };
+}
+
 module.exports = {
   buildActPlan,
+  planStartModule,
+  planSummary,
   CATEGORY_MODULE,
+  CATEGORY_LABEL,
   FOUNDATION_ORDER,
   MASTERED_ACCURACY,
 };

--- a/utils/coursePrompt.js
+++ b/utils/coursePrompt.js
@@ -7,6 +7,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { CATEGORY_LABEL } = require('./actBootcampPlan');
 
 /**
  * Build the complete course-mode system prompt.
@@ -778,6 +779,19 @@ Keep it SHORT. DO NOT ask what they want to work on. Resume the lesson.`;
     if (currentPhase.type === 'explanation' && currentPhase.text) {
       instruction += `\nTeach this concept: ${currentPhase.text.substring(0, 500)}`;
     }
+  }
+
+  // Diagnostic recap: if a practice test set a plan on this session, have the
+  // tutor open by acknowledging the results and framing the focus — so the
+  // course visibly reflects the student's real gaps instead of a generic march.
+  const dp = courseSession.diagnosticPlan;
+  if (dp && ((dp.focusCategories && dp.focusCategories.length) || (dp.masteredCategories && dp.masteredCategories.length))) {
+    const list = (arr) => (arr || []).map(c => CATEGORY_LABEL[c] || c).join(', ');
+    const strong = (dp.masteredCategories || []).length
+      ? `They were already strong on ${list(dp.masteredCategories)} — move fast / spot-check there. ` : '';
+    const focus = (dp.focusCategories || []).length
+      ? `Focus this bootcamp on their weak areas: ${list(dp.focusCategories)}. ` : '';
+    instruction += `\n\nPRACTICE-ACT RESULTS — the student took a full practice ACT. Open your greeting by briefly recapping it IN YOUR VOICE (1-2 sentences): ${strong}${focus}Frame today's module ("${moduleTitle}") as the highest-priority place to start based on their results, then continue. Do NOT dump the full breakdown or list every score.`;
   }
 
   instruction += `\n\nREMINDER: All math MUST use LaTeX: \\\\( x + 3 \\\\) for inline, \\\\[ x^2 \\\\] for display. Never write bare math.`;


### PR DESCRIPTION
## Context

Step 1 (#1236) built the plan; the course still ignored it. This is the visible payoff: the ACT course now **acts on** the practice-ACT diagnostic instead of teaching a generic Number & Quantity march (the behavior in the screenshot).

## What a great tutor does — now wired end to end

At practice-ACT completion, if the student is enrolled in the ACT course **and hasn't started a module yet**:
- **Retarget** the course to the plan's highest-leverage weak module (prerequisite-aware — Algebra before Functions).
- **Stash** a compact plan summary on the session.

The course greeting then **opens by recapping the results** in the tutor's voice — "you were strong on X — we'll move fast there; we'll focus on Y, Z" — and frames today's module as the highest-priority starting point. So a student who aced Number & Quantity no longer gets lectured on real numbers.

## Changes

- **`models/courseSession.js`** — `diagnosticPlan` (Mixed): `{ focusCategories, masteredCategories, startModuleId, takenAt }`.
- **`utils/actBootcampPlan.js`** — `planStartModule()` (retargets **only** at true course start — every guard verified so it never yanks a student mid-module) + `planSummary()`; `CATEGORY_LABEL` for readable recaps.
- **`routes/actTest.js`** — `/complete` retargets the ACT course and stashes the plan (guarded, non-fatal try/catch).
- **`utils/coursePrompt.js`** — `buildCourseGreetingInstruction` recaps `diagnosticPlan` when present.
- **`tests/unit/actBootcampPlan.test.js`** — +5 tests: retarget only at start, no-yank once in-progress/has-progress, no-op when already on target / target missing, summary shape.

## Verification
- `node --check` + `eslint` clean; `coursePrompt` loads with the new require (no cycle).
- New suite 11/11; `coursePersist` green; **full unit suite 3866 pass**.
- Live behavior needs a deploy to confirm (client + prompt path); worth a manual check: enroll in ACT prep → take the practice ACT → the course should open on your weakest domain with a recap.

## Safety
The retarget is tightly gated (`overallProgress === 0` **and** no module `in_progress`/`completed`) and non-fatal — a returning student mid-course is never moved, and any failure just leaves the normal flow untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTm55BDVTnGaJm3DRVauGZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTm55BDVTnGaJm3DRVauGZ)_