### PR TITLE
feat(act): tutor launches the real practice ACT instead of improvising

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -3035,6 +3035,13 @@ document.addEventListener("DOMContentLoaded", () => {
                 }
             }
 
+            // Launch the real practice-ACT runner when the course tutor signalled
+            // it (student confirmed). Opens the timed, auto-scored test that feeds
+            // the bootcamp plan — instead of the tutor improvising questions.
+            if (data.launchPracticeAct && window.openActTest) {
+                setTimeout(() => window.openActTest(), 400); // let the tutor's confirming reply render first
+            }
+
             // Render interactive graph tool if AI requested one
             if (data.graphTool && window.GraphTool) {
                 const messageElements = document.querySelectorAll('.message.ai');

--- a/routes/courseChat.js
+++ b/routes/courseChat.js
@@ -319,6 +319,8 @@ router.post('/', async (req, res) => {
                     : null,
                 // Interactive tools
                 graphTool: graphToolConfig,
+                // Launch the real practice-ACT runner when the tutor signalled it
+                launchPracticeAct: courseResult.launchPracticeAct || false,
                 // Course-specific fields
                 courseContext: courseResult.courseContext,
                 courseProgress: courseProgressUpdate,

--- a/tests/unit/actPracticeLaunch.test.js
+++ b/tests/unit/actPracticeLaunch.test.js
@@ -1,0 +1,31 @@
+// tests/unit/actPracticeLaunch.test.js
+// Guards that the ACT course tutor is instructed to launch the REAL practice-ACT
+// runner (via the <LAUNCH_PRACTICE_ACT> control tag) instead of improvising its
+// own quiz — and that this guidance is scoped to the ACT course only.
+
+const { buildCourseSystemPrompt } = require('../../utils/coursePrompt');
+
+const prompt = (courseId) => buildCourseSystemPrompt({
+  userProfile: { firstName: 'Kandy' },
+  tutorProfile: { name: 'Mr. Nappier' },
+  pathway: { track: courseId, modules: [] },
+  scaffoldData: { scaffold: [] },
+  currentModule: { title: 'Number & Quantity' },
+  courseSession: { courseId, courseName: courseId, modules: [] },
+});
+
+describe('practice-ACT launch guidance', () => {
+  test('the ACT course prompt tells the tutor to launch the real test, not improvise', () => {
+    const p = prompt('act-prep');
+    expect(p).toContain('<LAUNCH_PRACTICE_ACT>');
+    expect(p).toMatch(/NEVER IMPROVISE|DO NOT write your own quiz/i);
+    // must require an explicit confirmation before firing the tag
+    expect(p).toMatch(/confirm/i);
+  });
+
+  test('non-ACT courses do NOT get the launch guidance', () => {
+    for (const id of ['algebra-1', 'ap-calculus-ab', 'geometry']) {
+      expect(prompt(id)).not.toContain('<LAUNCH_PRACTICE_ACT>');
+    }
+  });
+});

--- a/utils/coursePrompt.js
+++ b/utils/coursePrompt.js
@@ -101,6 +101,30 @@ function buildCourseSystemPrompt({ userProfile, tutorProfile, courseSession, pat
   const preferredLanguage = userProfile.preferredLanguage || 'en';
   const iepAccommodations = userProfile.iepPlan?.accommodations ? formatIEP(userProfile.iepPlan) : '';
 
+  // ACT-prep only: route "I want a practice test" to the REAL runner, never an
+  // improvised quiz (which scores nothing and targets nothing). The tutor offers
+  // it, then emits <LAUNCH_PRACTICE_ACT> once the student confirms.
+  const practiceActGuidance = courseSession.courseId === 'act-prep' ? `
+
+====================================================================
+PRACTICE ACT — USE THE REAL TOOL, NEVER IMPROVISE ONE
+====================================================================
+This course has a real, full-length, auto-scored practice ACT Math test built
+in. It is the ONLY thing that produces a real diagnostic and targets this
+student's bootcamp. When the student asks to take a practice ACT / practice test
+/ diagnostic (or you decide it's time):
+- DO NOT write your own quiz or "short practice set." That produces no score and
+  targets nothing.
+- Briefly set expectations in YOUR voice: it's a full timed ACT Math section
+  (~45 questions) and you'll use the results to focus their sessions. Ask if they
+  want to start it now (a quick informal warm-up with you is fine if they're not
+  ready for the full thing).
+- ONLY once the student confirms they want to start the real test, emit the
+  control tag <LAUNCH_PRACTICE_ACT> on its own line. It is hidden from the student
+  and opens the test. Never describe the tag, and never emit it without an
+  explicit confirmation or just because the ACT was mentioned in passing.
+====================================================================` : '';
+
   return `You are ${tutorName}, an AI math instructor leading a structured, self-paced course.
 ${tutorPersonality ? `Personality: ${tutorPersonality}` : ''}
 
@@ -549,7 +573,7 @@ TEACHER RESOURCE REFERENCE: "${resourceContext.displayName}"
 ====================================================================
 The student is referencing a teacher-assigned resource called "${resourceContext.displayName}" but its content is not loaded.
 Acknowledge it by name, ask which specific problem they are on, then guide them through it once they share it.
-` : ''}`;
+` : ''}` + practiceActGuidance;
 }
 
 /**

--- a/utils/pipeline/courseAdapter.js
+++ b/utils/pipeline/courseAdapter.js
@@ -167,6 +167,17 @@ async function postProcessCourseResult(pipelineResult, courseContext, conversati
     delete graphToolConfig._source;
   }
 
+  // ── Practice-ACT launch detection ──
+  // The ACT tutor emits <LAUNCH_PRACTICE_ACT> (only after the student confirms)
+  // to open the REAL timed test — instead of improvising its own quiz, which
+  // produces no ActTestSession and feeds none of the bootcamp targeting. Strip
+  // the tag and signal the client to launch the runner.
+  let launchPracticeAct = false;
+  if (/<LAUNCH_PRACTICE_ACT\s*>/i.test(pipelineResult.text || '')) {
+    launchPracticeAct = true;
+    pipelineResult.text = pipelineResult.text.replace(/<LAUNCH_PRACTICE_ACT\s*>/gi, '').trim();
+  }
+
   // ── Step evaluation and scaffold advancement ──
   const currentScaffoldIdx = courseSession.currentScaffoldIndex || 0;
   const currentScaffoldStep = (moduleData?.scaffold || [])[currentScaffoldIdx];
@@ -250,6 +261,7 @@ async function postProcessCourseResult(pipelineResult, courseContext, conversati
     ...pipelineResult,
     courseProgressUpdate,
     graphToolConfig,
+    launchPracticeAct,
     progressUpdate,
     courseContext: {
       courseId: courseSession.courseId,


### PR DESCRIPTION
## The bug (from a live transcript)

A student asked "i wanna take a practice act" — and the tutor **improvised its own 5–6 question quiz** (`|6−15|`…) instead of launching the platform's real 45-item auto-scored ACT runner. That improvised quiz produces **no `ActTestSession`**, so it feeds **none** of the step-1/step-2 bootcamp targeting. The tutor had the right instinct ("a diagnostic before the full thing") but no way to reach the actual tool.

## Fix — option 2: offer, then launch on confirm

Give the course tutor a launch affordance, mirroring the existing `<GRAPH_TOOL>` / `isCheckpoint` server→client patterns:

- **`utils/coursePrompt.js`** — ACT-scoped guidance (courseId `act-prep` only): when the student wants a practice test, **do not improvise**; set expectations (full timed ~45-question section), and **only once the student confirms**, emit the control tag `<LAUNCH_PRACTICE_ACT>`.
- **`utils/pipeline/courseAdapter.js`** — strip the tag from the reply and return `launchPracticeAct`.
- **`routes/courseChat.js`** — thread `launchPracticeAct` into the student response payload.
- **`public/js/script.js`** — on `launchPracticeAct`, call `window.openActTest()` (the real auto-scored runner that feeds `buildActPlan` → the course retargeting from #1237).

This preserves the tutor's good judgment (it offers, doesn't force a 60-min test on a tired kid) while routing to the **real** tool instead of a fake one — closing the loop so the practice ACT actually drives the bootcamp.

## Changes
- `tests/unit/actPracticeLaunch.test.js` — guidance present for `act-prep`, absent for other courses; requires an explicit confirmation before the tag fires.

## Verification
- `node --check` + `eslint` clean; `buildCourseSystemPrompt` emits the guidance for `act-prep` only (verified).
- New suite green; **full unit suite 3868 pass**.
- Live behavior needs a deploy (prompt + client bundle). Manual check once live: in the ACT course, say "I want to take a practice ACT" → tutor confirms → on "yes" the real test opens (no improvised quiz).

## Note
This is the last piece of the ACT day-one loop: **real test → plan (#1236) → course retargets + recaps (#1237) → and now the tutor can actually launch the real test (this PR).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTm55BDVTnGaJm3DRVauGZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTm55BDVTnGaJm3DRVauGZ)_