### PR TITLE
Fix: restore mobile exit from Living Workspace back to chat

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -114,7 +114,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
        LivingWorkspace flag is dev|beta|live (?livingWorkspace=dev). When on,
        it lazy-loads the workspace and mirrors the tutor's board output onto
        the new surface beside the old board. Default OFF → zero impact. -->
-  <script defer src="/js/living-workspace/chat-workspace.js?v=20260718a"></script>
+  <script defer src="/js/living-workspace/chat-workspace.js?v=20260720a"></script>
   <!-- Final safety net: strips any inline visual tag no renderer handled -->
   <script defer src="/js/stripVisualTags.js"></script>
   <!-- Non-core libs (lazy-loaded after first interaction) -->

--- a/public/js/living-workspace/chat-workspace.js
+++ b/public/js/living-workspace/chat-workspace.js
@@ -109,10 +109,27 @@
     var region = document.getElementById('cr-workspace');
     if (region) {
       region.classList.add('lws-swapped');
-      // Hide the old tabbed board tools, keep them in the DOM (reversible).
+      // Hide the old tabbed board tools, keep them in the DOM (reversible) —
+      // EXCEPT the drawer's close button. On mobile #cr-workspace is a
+      // full-width slide-in drawer; that X is the only way back to chat (the
+      // tap-to-close backdrop sits hidden behind the full-width drawer and the
+      // FAB is hidden while it's open). Hiding it stranded phone users in the
+      // workspace with no exit. Keep it visible, lift it above the derivation's
+      // sticky problem card / caption (z-index 3 / 4), and make sure it closes
+      // the drawer even if workspace.js hasn't wired it.
       for (var i = 0; i < region.children.length; i++) {
-        region.children[i].setAttribute('data-lws-hidden', '1');
-        region.children[i].style.display = 'none';
+        var child = region.children[i];
+        if (child.classList && child.classList.contains('cr-ws-close')) {
+          child.style.zIndex = '6';
+          child.addEventListener('click', function () {
+            if (window.MathWorkspace && typeof window.MathWorkspace.close === 'function') {
+              window.MathWorkspace.close();
+            }
+          });
+          continue;
+        }
+        child.setAttribute('data-lws-hidden', '1');
+        child.style.display = 'none';
       }
       var mountIn = document.createElement('div');
       mountIn.id = 'lws-chat-mount';


### PR DESCRIPTION
## Problem

On mobile there was no intuitive way to get out of the workspace and return to chat.

`chat.html` runs with `livingWorkspace: 'live'`, so `chat-workspace.js`'s `buildPanel()` swaps the Living Workspace into `#cr-workspace`. To do that it hid **every** child of that region (`data-lws-hidden` + `display:none`) — including `.cr-ws-close`, the drawer's close **X**.

On phones `#cr-workspace` is a **full-width (100vw) slide-in drawer**:
- the tap-to-close backdrop sits *behind* the drawer, fully covered;
- the "Workspace" FAB is hidden while the drawer is open;
- and now the close X was hidden too.

Result: once a student opened the workspace on mobile, there was no visible affordance to close it and get back to the chat thread.

## Fix

In `buildPanel()`, when the Living Workspace swaps in, keep the `.cr-ws-close` button visible instead of hiding it alongside the legacy board tools (it's drawer chrome, not legacy board content). Specifically:

- **Skip** the close button in the hide loop.
- **Lift** it above the derivation view's sticky problem card / caption (`z-index: 6` > their `3` / `4`) so it's never painted over.
- **Wire** it to `window.MathWorkspace.close()` directly, so the exit works regardless of `workspace.js` init order.

The button already has the correct responsive behavior in `workspace.css` (`display:none` on desktop where the workspace is a persistent side panel, `display:block` ≤1200px where it's a drawer), so desktop is unaffected and only the mobile/tablet drawer regains its exit.

Also bumped the `chat-workspace.js` cache-buster (`?v=20260718a` → `?v=20260720a`) in `chat.html` so prod (7-day static cache) refetches the updated script.

## Files
- `public/js/living-workspace/chat-workspace.js` — preserve + elevate + wire the close button on swap.
- `public/chat.html` — cache-buster bump.

## Testing
- `node --check` passes on the modified script.
- Behavior is DOM/CSS-only; verified by tracing the swap path and the mobile drawer CSS (`workspace.css` drawer / backdrop / FAB rules). Manual check on a phone-width viewport recommended: open the Workspace FAB → the ✕ appears top-right → tapping it closes the drawer back to chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBbs1emwBp5EdHCmhqfNQX

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBbs1emwBp5EdHCmhqfNQX)_