### PR TITLE
fix(mastery): collapse the duplicate mastery model in the chat path

### DIFF
--- a/scripts/backfillSkillRungs.js
+++ b/scripts/backfillSkillRungs.js
@@ -28,8 +28,6 @@
 //   node scripts/backfillSkillRungs.js --apply --demote-unsupported
 //   node scripts/backfillSkillRungs.js --limit 100            # sample a subset
 
-require('dotenv').config();
-const mongoose = require('mongoose');
 const { GATES } = require('../utils/skillRung');
 
 const APPLY = process.argv.includes('--apply');
@@ -52,8 +50,11 @@ function evidenceSupportsMastery(entry) {
   return contexts >= GATES.PRACTICE_MIN_CONTEXTS;
 }
 
-/** Decide the rung for one legacy entry. Returns null when nothing should change. */
-function plan(entry) {
+/**
+ * Decide the rung for one legacy entry. Returns null when nothing should change.
+ * Exported so the tests exercise THIS function rather than a copy of it.
+ */
+function plan(entry, { demote = DEMOTE } = {}) {
   if (entry.rung) return null;                       // already migrated
 
   const status = entry.status;
@@ -61,7 +62,7 @@ function plan(entry) {
 
   if (status === 'mastered') {
     const supported = evidenceSupportsMastery(entry);
-    if (!supported && DEMOTE) {
+    if (!supported && demote) {
       return { rung: 'learned', provenBy: 'legacy', supported: false, demoted: true };
     }
     return {
@@ -104,6 +105,8 @@ function receipt(entry, decision) {
 }
 
 async function main() {
+  require('dotenv').config();
+  const mongoose = require('mongoose');
   if (!process.env.MONGO_URI) throw new Error('MONGO_URI is not set');
   await mongoose.connect(process.env.MONGO_URI);
   const User = require('../models/user');
@@ -171,7 +174,13 @@ async function main() {
   await mongoose.disconnect();
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+module.exports = { plan, evidenceSupportsMastery, receipt, IN_PROGRESS };
+
+// Only connect to a database when run directly, so the decision logic above can
+// be imported and tested without Mongo.
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/tests/unit/backfillSkillRungs.test.js
+++ b/tests/unit/backfillSkillRungs.test.js
@@ -7,36 +7,9 @@
  */
 
 const { GATES } = require('../../utils/skillRung');
-
-// Mirrors scripts/backfillSkillRungs.js. Kept in step by the tests below.
-const IN_PROGRESS = ['learning', 'practicing', 'needs-review', 're-fragile'];
-
-function evidenceSupportsMastery(entry) {
-  const p = entry.pillars || {};
-  const total = p.accuracy?.total || 0;
-  const correct = p.accuracy?.correct || 0;
-  const hints = p.independence?.hintsUsed || 0;
-  const contexts = p.transfer?.contextsAttempted?.length || 0;
-  if (total < GATES.PRACTICE_MIN_ATTEMPTS) return false;
-  if (correct / total < GATES.PROVE_MIN_ACCURACY) return false;
-  if (hints > GATES.PROVE_MAX_HINTS) return false;
-  return contexts >= GATES.PRACTICE_MIN_CONTEXTS;
-}
-
-function plan(entry, { demote = false } = {}) {
-  if (entry.rung) return null;
-  const wasInferred = entry.masteryType === 'inferred' || entry.masteryType === 'fragile-inferred';
-
-  if (entry.status === 'mastered') {
-    const supported = evidenceSupportsMastery(entry);
-    if (!supported && demote) return { rung: 'learned', provenBy: 'legacy', supported: false, demoted: true };
-    return { rung: 'proved', provenBy: wasInferred ? 'inference' : 'legacy', supported, demoted: false };
-  }
-  if (IN_PROGRESS.includes(entry.status)) {
-    return { rung: 'learned', provenBy: 'legacy', supported: null, demoted: false };
-  }
-  return { rung: 'none', provenBy: null, supported: null, demoted: false };
-}
+// Imported from the script itself — an earlier version of this file re-declared
+// these, so the script could drift and every test would still pass.
+const { plan, evidenceSupportsMastery, IN_PROGRESS } = require('../../scripts/backfillSkillRungs');
 
 const solid = {
   status: 'mastered',

--- a/tests/unit/persistSkillMastery.test.js
+++ b/tests/unit/persistSkillMastery.test.js
@@ -1,0 +1,127 @@
+/**
+ * The chat path's skill-mastery write — utils/pipeline/persist.js.
+ *
+ * This is the main tutoring flow: every turn runs it. It used to be a SECOND,
+ * independent implementation of the mastery model, with its own pillars, its own
+ * scoring formula and its own thresholds — `accuracy >= 0.90 && total >= 3`, so
+ * three demonstrations was mastery. That is what produced "100% mastered" beside
+ * a "Continue" button in production. The fix for that bug went into
+ * masteryEngine first, which serves a DIFFERENT route; this path was untouched
+ * and had no tests at all.
+ */
+
+const { updateSkillMastery } = require('../../utils/pipeline/persist');
+const { currentRung } = require('../../utils/skillRung');
+
+const makeUser = () => ({
+  skillMastery: new Map(),
+  learningProfile: { recentWins: [] },
+  markModified: jest.fn()
+});
+
+const convo = (msgs = []) => ({ messages: msgs });
+const askedForHelp = convo([{ role: 'user', content: "I'm stuck, can I get a hint?" }]);
+
+/** Drive n verified demonstrations, cycling contexts. */
+const demonstrate = (user, skillId, n, { contexts = ['numeric'], conversation = convo() } = {}) => {
+  let last;
+  for (let i = 0; i < n; i += 1) {
+    last = updateSkillMastery(user, skillId, { problemContext: contexts[i % contexts.length] }, conversation);
+  }
+  return last;
+};
+
+describe('the chat path no longer runs its own mastery model', () => {
+  test('three demonstrations is not mastery', () => {
+    // The old bar exactly: accuracy >= 0.90 && total >= 3, with 3 contexts.
+    const user = makeUser();
+    demonstrate(user, 'ALG1.EQV.1', 3, { contexts: ['numeric', 'graphical', 'word-problem'] });
+
+    const entry = user.skillMastery.get('ALG1.EQV.1');
+    expect(currentRung(entry)).not.toBe('proved');
+    expect(entry.status).not.toBe('mastered');
+  });
+
+  test('sustained demonstration across contexts does prove it', () => {
+    const user = makeUser();
+    demonstrate(user, 'ALG1.EQV.1', 8, { contexts: ['numeric', 'graphical', 'word-problem'] });
+
+    const entry = user.skillMastery.get('ALG1.EQV.1');
+    expect(currentRung(entry)).toBe('proved');
+    expect(entry.status).toBe('mastered');
+  });
+
+  test('the crossing is reported to the caller so the cascade can fire', () => {
+    const user = makeUser();
+    const ctx = { contexts: ['numeric', 'graphical', 'word-problem'] };
+    const flags = [];
+    for (let i = 0; i < 9; i += 1) {
+      flags.push(demonstrate(user, 'ALG1.EQV.1', 1, {
+        contexts: [ctx.contexts[i % 3]]
+      }).justProved);
+    }
+    expect(flags.filter(Boolean)).toHaveLength(1);
+  });
+
+  test('a verified demonstration writes a receipt', () => {
+    const user = makeUser();
+    demonstrate(user, 'ALG1.EQV.1', 8, { contexts: ['numeric', 'graphical', 'word-problem'] });
+
+    const entry = user.skillMastery.get('ALG1.EQV.1');
+    const proof = entry.rungHistory.find((h) => h.to === 'proved');
+    expect(proof).toBeDefined();
+    expect(proof.via).toBe('practice');
+  });
+
+  test('repeated identical practice does not prove transfer', () => {
+    const user = makeUser();
+    demonstrate(user, 'ALG1.EQV.1', 12, { contexts: ['numeric'] });
+    expect(currentRung(user.skillMastery.get('ALG1.EQV.1'))).toBe('learned');
+  });
+
+  test('asking for help repeatedly blocks the independence pillar', () => {
+    const user = makeUser();
+    demonstrate(user, 'ALG1.EQV.1', 8, {
+      contexts: ['numeric', 'graphical', 'word-problem'],
+      conversation: askedForHelp
+    });
+    expect(currentRung(user.skillMastery.get('ALG1.EQV.1'))).not.toBe('proved');
+  });
+
+  test('skill ids are canonicalized so one concept is one entry', () => {
+    const user = makeUser();
+    demonstrate(user, 'ALG1.EQV.1', 1);
+    expect([...user.skillMastery.keys()]).toHaveLength(1);
+  });
+});
+
+describe('recent wins', () => {
+  test('a win is recorded once, when the skill is first owned', () => {
+    const user = makeUser();
+    demonstrate(user, 'ALG1.EQV.1', 12, { contexts: ['numeric', 'graphical', 'word-problem'] });
+    expect(user.learningProfile.recentWins).toHaveLength(1);
+  });
+
+  test('no win is claimed before the skill is owned', () => {
+    const user = makeUser();
+    demonstrate(user, 'ALG1.EQV.1', 3, { contexts: ['numeric', 'graphical', 'word-problem'] });
+    expect(user.learningProfile.recentWins).toHaveLength(0);
+  });
+});
+
+describe('existing evidence is never clobbered', () => {
+  test('a prior entry keeps its pillars and history across a new demonstration', () => {
+    const user = makeUser();
+    demonstrate(user, 'ALG1.EQV.1', 8, { contexts: ['numeric', 'graphical', 'word-problem'] });
+    const before = user.skillMastery.get('ALG1.EQV.1');
+    const historyLength = before.rungHistory.length;
+    const attemptsBefore = before.pillars.accuracy.total;
+
+    demonstrate(user, 'ALG1.EQV.1', 1);
+    const after = user.skillMastery.get('ALG1.EQV.1');
+
+    expect(after.rungHistory.length).toBeGreaterThanOrEqual(historyLength);
+    expect(after.pillars.accuracy.total).toBe(attemptsBefore + 1);
+    expect(currentRung(after)).toBe('proved');
+  });
+});

--- a/utils/pipeline/persist.js
+++ b/utils/pipeline/persist.js
@@ -25,6 +25,8 @@ const { getNextActions } = require('../nextActionSuggestions');
 const { checkForInterventionAlert } = require('../interventionAlerts');
 const { getReviewSummary } = require('../smartReviewQueue');
 const { canonicalSkillId } = require('../skillCanonicalizer');
+const { updateSkillMastery: engineUpdateSkillMastery, initializeSkillMastery } = require('../masteryEngine');
+const { advanceRung, currentRung, clearsPrerequisites } = require('../skillRung');
 
 /**
  * Persist all state changes from a pipeline run.
@@ -157,20 +159,45 @@ async function persist(params) {
 
   // ── 3. Skill mastery tracking ──
   if (extracted.skillMastered) {
-    updateSkillMastery(user, extracted.skillMastered, observation, conversation);
+    const { skillId, justProved } = updateSkillMastery(user, extracted.skillMastered, observation, conversation);
+    // Proving a skill clears everything beneath it, so a student never re-grinds
+    // a prerequisite they have just demonstrated they own. Awaited but guarded:
+    // a cascade failure must never cost the student the turn they just earned.
+    if (justProved) {
+      try {
+        await cascadeBeneath(user, skillId);
+      } catch (err) {
+        console.error('[Persist] cascade failed for %s:', skillId, err);
+      }
+    }
   }
 
   if (extracted.skillStarted) {
     user.skillMastery = user.skillMastery || new Map();
     // key on the canonical (unified) skill id so learning/mastery state for one
     // concept never splits across a legacy id and its unified id
-    user.skillMastery.set(canonicalSkillId(extracted.skillStarted), {
-      status: 'learning',
-      masteryScore: 0.3,
-      learningStarted: new Date(),
-      notes: 'Currently learning with AI',
-    });
-    user.markModified('skillMastery');
+    const startedId = canonicalSkillId(extracted.skillStarted);
+    const prior = user.skillMastery.get(startedId);
+    // MERGE, never replace. This used to assign a fresh object, so revisiting a
+    // skill the student had already worked on wiped its pillars, rung and
+    // rungHistory — silently destroying the evidence behind an earned rung.
+    if (!prior) {
+      const entry = initializeSkillMastery(startedId);
+      advanceRung(entry, 'learned', { via: 'lesson' });
+      delete entry.__rungResult;
+      entry.masteryScore = 0.3;
+      entry.notes = 'Currently learning with AI';
+      user.skillMastery.set(startedId, entry);
+      user.markModified('skillMastery');
+    } else if (currentRung(prior) === 'none') {
+      advanceRung(prior, 'learned', { via: 'lesson' });
+      delete prior.__rungResult;
+      prior.status = prior.status === 'ready' || !prior.status ? 'learning' : prior.status;
+      prior.notes = 'Currently learning with AI';
+      user.skillMastery.set(startedId, prior);
+      user.markModified('skillMastery');
+    }
+    // A skill already at learned-or-better needs no downgrade for being revisited.
   }
 
   // ── 4. Learning insight ──
@@ -587,71 +614,85 @@ async function persist(params) {
  * Update skill mastery from a <SKILL_MASTERED:skillId> tag.
  * Records it as evidence for the 4-pillar system.
  */
+/**
+ * Clear every prerequisite beneath a newly-proved skill.
+ *
+ * Loads the unified catalog through the shared cache so the graph is the same
+ * one the closure engine and the board read. Returns the ids cleared, so the
+ * caller can surface the cascade ("Slope unlocked 6 skills") rather than having
+ * it happen invisibly.
+ */
+async function cascadeBeneath(user, skillId) {
+  const { configCache } = require('../cache');
+  const Skill = require('../../models/skill');
+  const { buildGraph, applyProofCascade } = require('../skillClosure');
+
+  const skills = await configCache.getOrSet(
+    'skills:unified',
+    () => Skill.find({ isActive: true, source: 'unified-taxonomy' }).lean(),
+    3600
+  );
+  if (!skills.length) return [];
+
+  const { cleared } = applyProofCascade(buildGraph(skills), user.skillMastery, skillId);
+  if (cleared.length) user.markModified('skillMastery');
+  return cleared;
+}
+
+/**
+ * Record a verified skill demonstration from a chat turn.
+ *
+ * This used to be a second, independent implementation of the whole mastery
+ * model — its own pillars, its own scoring formula (unweighted mean of three,
+ * against masteryEngine's weighted four), and its own thresholds. Its bar was
+ * `accuracy >= 0.90 && total >= 3`, so THREE demonstrations was mastery. That is
+ * the path that produced "100% mastered" beside a "Continue" button in
+ * production, and it is the main tutoring flow — every chat turn runs it.
+ *
+ * It now delegates to masteryEngine.updateSkillMastery, which delegates rung
+ * transitions to utils/skillRung. One model, one set of gates, one receipt.
+ *
+ * ONE-SIDED EVIDENCE — READ THIS BEFORE TRUSTING `accuracy` HERE.
+ * This function is only ever called on `extracted.skillMastered`, i.e. on a
+ * success. Incorrect attempts from chat are never recorded against a skill, so
+ * `pillars.accuracy.percentage` on this path is 1.0 by construction and the
+ * accuracy gate is vacuous. What the ladder actually requires here is therefore
+ * "N verified demonstrations across 3 contexts with few hints" — a real bar, but
+ * not the one the field name implies. Wiring the diagnose stage's incorrect
+ * ANSWER_ATTEMPTs through to the pillars is the fix; until then this comment is
+ * the honest description.
+ */
 function updateSkillMastery(user, rawSkillId, observation, conversation) {
   user.skillMastery = user.skillMastery || new Map();
   // Canonicalize to the unified skill id for storage/lookup; keep the original
   // id only for deriving a readable "recent win" label below.
   const skillId = canonicalSkillId(rawSkillId);
-  const existing = user.skillMastery.get(skillId) || {};
+  const existing = user.skillMastery.get(skillId) || initializeSkillMastery(skillId);
+  const wasOwned = clearsPrerequisites(existing);
 
-  const pillars = existing.pillars || {
-    accuracy: { correct: 0, total: 0, percentage: 0, threshold: 0.90 },
-    independence: { hintsUsed: 0, hintsAvailable: 15, hintThreshold: 3, autoStepUsed: false },
-    transfer: { contextsAttempted: [], contextsRequired: 3, formatVariety: false },
-    retention: { retentionChecks: [], failed: false },
-  };
-
-  // Record correct demonstration
-  pillars.accuracy.correct = (pillars.accuracy.correct || 0) + 1;
-  pillars.accuracy.total = (pillars.accuracy.total || 0) + 1;
-  pillars.accuracy.percentage = pillars.accuracy.total > 0
-    ? pillars.accuracy.correct / pillars.accuracy.total : 0;
-
-  // Independence: check if hints were used recently
+  // Independence proxy: the student asking for help in recent turns. Weaker than
+  // a real hint counter — it reads the student's words, not the tutor's actions.
   const recentMsgs = conversation.messages.slice(-6);
   const usedHint = recentMsgs.some(msg =>
     msg.role === 'user' && /\b(hint|help|stuck|don'?t know|idk|confused)\b/i.test(msg.content)
   );
-  if (usedHint) pillars.independence.hintsUsed = (pillars.independence.hintsUsed || 0) + 1;
 
-  // Transfer: detect context type
-  if (observation?.problemContext && !pillars.transfer.contextsAttempted.includes(observation.problemContext)) {
-    pillars.transfer.contextsAttempted.push(observation.problemContext);
-  }
-
-  // Calculate mastery score
-  const accuracyScore = Math.min(pillars.accuracy.percentage / 0.90, 1.0);
-  const independenceScore = pillars.independence.hintsUsed <= pillars.independence.hintThreshold ? 1.0
-    : Math.max(0, 1.0 - (pillars.independence.hintsUsed - pillars.independence.hintThreshold) * 0.15);
-  const transferScore = Math.min(pillars.transfer.contextsAttempted.length / pillars.transfer.contextsRequired, 1.0);
-  const masteryScore = Math.round(((accuracyScore + independenceScore + transferScore) / 3) * 100);
-
-  // Determine status
-  const meetsAccuracy = pillars.accuracy.percentage >= 0.90 && pillars.accuracy.total >= 3;
-  const meetsIndependence = pillars.independence.hintsUsed <= pillars.independence.hintThreshold;
-  const meetsTransfer = pillars.transfer.contextsAttempted.length >= pillars.transfer.contextsRequired;
-  const allPillarsMet = meetsAccuracy && meetsIndependence && meetsTransfer;
-
-  let newStatus = existing.status || 'practicing';
-  if (allPillarsMet) newStatus = 'mastered';
-  else if (pillars.accuracy.total >= 2) newStatus = 'practicing';
-  else newStatus = 'learning';
-
-  user.skillMastery.set(skillId, {
-    ...existing,
-    status: newStatus,
-    masteryScore,
-    masteryType: 'verified',
-    lastPracticed: new Date(),
-    consecutiveCorrect: (existing.consecutiveCorrect || 0) + 1,
-    totalAttempts: (existing.totalAttempts || 0) + 1,
-    masteredDate: newStatus === 'mastered' ? (existing.masteredDate || new Date()) : existing.masteredDate,
-    pillars,
-    notes: `AI-verified demonstration (${pillars.accuracy.correct}/${pillars.accuracy.total} correct)`,
+  const updated = engineUpdateSkillMastery(existing, {
+    correct: true,
+    hintUsed: usedHint,
+    problemContext: observation?.problemContext,
+    responseTime: observation?.responseTime
   });
 
-  // Add to recent wins if newly mastered
-  if (newStatus === 'mastered' && existing.status !== 'mastered') {
+  const justProved = !!updated.__justProved;
+  delete updated.__justProved;
+  const acc = updated.pillars?.accuracy || {};
+  updated.notes = `AI-verified demonstration (${acc.correct || 0}/${acc.total || 0} correct)`;
+
+  user.skillMastery.set(skillId, updated);
+
+  // Add to recent wins the first time the skill is genuinely owned.
+  if (justProved && !wasOwned) {
     if (!user.learningProfile.recentWins) user.learningProfile.recentWins = [];
     // derive the label from the original (kebab) id — nicer than a dotted unified id
     const displayName = rawSkillId.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
@@ -661,6 +702,7 @@ function updateSkillMastery(user, rawSkillId, observation, conversation) {
   }
 
   user.markModified('skillMastery');
+  return { skillId, justProved };
 }
 
 /**
@@ -748,13 +790,26 @@ function updateBadgeProgress(user, wasCorrect) {
   // Unlock skill on skill map (canonical unified id)
   const skillId = canonicalSkillId(badge.skillId);
   if (!user.skillMastery) user.skillMastery = new Map();
-  if (!user.skillMastery.get(skillId) || user.skillMastery.get(skillId).status !== 'mastered') {
-    user.skillMastery.set(skillId, {
-      status: 'mastered',
-      masteredDate: new Date(),
-      accuracy,
-      attempts: badge.problemsCompleted,
+  const entry = user.skillMastery.get(skillId) || initializeSkillMastery(skillId);
+  if (!clearsPrerequisites(entry)) {
+    // MERGE, never replace. This used to assign a bare object, so earning a badge
+    // destroyed the skill's pillars, rung and rungHistory — wiping the receipts
+    // for work the student had actually done.
+    //
+    // A completed badge is a real, gated demonstration (see badgePhaseController),
+    // so it proves the skill via 'challenge' rather than being asserted.
+    advanceRung(entry, 'proved', {
+      via: 'challenge',
+      evidence: {
+        correct: Math.round(accuracy * (badge.problemsCompleted || 0)),
+        total: badge.problemsCompleted || 0,
+        hintsUsed: entry.pillars?.independence?.hintsUsed || 0,
+        badgeId: badge.badgeId
+      }
     });
+    delete entry.__rungResult;
+    if (clearsPrerequisites(entry)) entry.status = 'mastered';
+    user.skillMastery.set(skillId, entry);
     user.markModified('skillMastery');
   }
 


### PR DESCRIPTION
The previous commit fixed the wrong function.

utils/pipeline/persist.js carried its OWN updateSkillMastery — same name, a completely separate reimplementation of the mastery model, with its own pillars, its own scoring formula (unweighted mean of three, against masteryEngine's weighted four) and its own thresholds. Its bar was:

    accuracy >= 0.90 && total >= 3

Three demonstrations was mastery. And because the function is only ever called on extracted.skillMastered — a success — it increments `correct` and `total` together every time, so accuracy is 1.0 by construction. That is not the UI inventing a label. That is this function computing "100% mastered" on three correct answers, on the main tutoring flow, every chat turn.

The ladder work went into masteryEngine.updateSkillMastery, which serves routes/mastery.js (badge mode). The path that produced the reported bug was untouched and had no tests.

This collapses them: persist now delegates to masteryEngine, which delegates rung transitions to skillRung. One model, one set of gates, one receipt. The cascade fires from the chat path too, so proving a skill mid-conversation clears what sits beneath it.

TWO CLOBBERS FIXED, both of which destroyed evidence:
  - `skillStarted` assigned a fresh object, so revisiting a skill the student had already worked wiped its pillars, rung and rungHistory. Now merges, and only advances a skill that is not yet on the ladder.
  - the badge award assigned a bare {status, masteredDate, accuracy, attempts}, so earning a badge erased the receipts for the work behind it. Now merges and proves via 'challenge', since a completed badge IS a gated demonstration.

HONESTY NOTE LEFT IN THE CODE: incorrect attempts from chat are still never recorded against a skill, so `pillars.accuracy` on this path is 1.0 by construction and the accuracy gate is vacuous. What the ladder actually enforces here is "N verified demonstrations across 3 contexts with few hints" — a real bar, but not the one the field name implies. Wiring diagnose's incorrect ANSWER_ATTEMPTs through to the pillars is the fix; the comment says so rather than leaving it to be discovered.

Also fixes a test that was theater: tests/unit/backfillSkillRungs.test.js re-declared the script's plan() and evidenceSupportsMastery() instead of importing them, under a comment claiming they were kept in step. Nothing kept them in step — the script could drift and all 12 tests would still pass. The script now exports them and only connects to Mongo when run directly.

10 new tests on a path that had none, including the three-demonstration case. Unit suite 3986 pass (246 suites); eslint clean.