### PR TITLE
Fix: give the mobile Living Workspace a clear, non-colliding exit to chat

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -114,7 +114,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
        LivingWorkspace flag is dev|beta|live (?livingWorkspace=dev). When on,
        it lazy-loads the workspace and mirrors the tutor's board output onto
        the new surface beside the old board. Default OFF → zero impact. -->
-  <script defer src="/js/living-workspace/chat-workspace.js?v=20260720a"></script>
+  <script defer src="/js/living-workspace/chat-workspace.js?v=20260720b"></script>
   <!-- Final safety net: strips any inline visual tag no renderer handled -->
   <script defer src="/js/stripVisualTags.js"></script>
   <!-- Non-core libs (lazy-loaded after first interaction) -->

--- a/public/css/living-workspace.css
+++ b/public/css/living-workspace.css
@@ -179,6 +179,39 @@ html[data-theme="dark"] .lws-root {
 .lws-dv-az button:disabled { opacity: .35; cursor: default; background: transparent; }
 .lws-dv-az .az-dn { font-size: 12px; }
 .lws-dv-az .az-up { font-size: 17px; }
+
+/* Back-to-chat pill (mobile only). On phones/tablets the swapped workspace is
+   a full-screen drawer with no other way out — this is the exit. Pinned
+   TOP-LEFT so it never collides with the text-size control (.lws-dv-az,
+   top-right). Hidden on desktop, where the workspace is a persistent column
+   beside the chat and needs no exit. Uses the chat design tokens (not --lws-*,
+   which are scoped to .lws-root) so it stays readable in either theme. */
+.lws-chat-exit { display: none; }
+@media (max-width: 1200px) {
+  .lws-swapped .lws-chat-exit {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    position: absolute;
+    top: calc(env(safe-area-inset-top, 0px) + 10px);
+    left: 12px;
+    z-index: 7;
+    height: 32px;
+    padding: 0 14px 0 10px;
+    border: 1px solid var(--cr-border, rgba(15, 26, 36, 0.14));
+    border-radius: 999px;
+    background: var(--cr-bg-panel, #ffffff);
+    color: var(--cr-text, #0f1a24);
+    font: 700 13px/1 Inter, system-ui, -apple-system, sans-serif;
+    letter-spacing: 0.01em;
+    box-shadow: 0 2px 10px rgba(7, 9, 15, 0.22);
+    cursor: pointer;
+  }
+  .lws-swapped .lws-chat-exit i { font-size: 12px; }
+  /* Reserve headroom so the floating exit / text-size pills don't cover the
+     first line of the derivation once a problem is posed. */
+  .lws-swapped .lws-dv { padding-top: 54px; }
+}
 .lws-dv-az .az-lab { font-size: 10px; opacity: .7; min-width: 34px; letter-spacing: .02em; font-variant-numeric: tabular-nums; }
 
 /* ── equation card ── */

--- a/public/js/living-workspace/chat-workspace.js
+++ b/public/js/living-workspace/chat-workspace.js
@@ -61,7 +61,7 @@
   // public/ with a 7-day cache and no content hashing, so bump this whenever
   // any living-workspace asset changes (and the chat.html <script ?v=> tag to
   // match, so this file itself refreshes). See project_asset_cache_busting.
-  var ASSET_V = '?v=20260718a';
+  var ASSET_V = '?v=20260720b';
   var BASE = '/js/living-workspace/';
   var SCRIPTS = [
     'core/flags.js', 'core/viewport.js', 'core/elementRegistry.js',
@@ -109,33 +109,35 @@
     var region = document.getElementById('cr-workspace');
     if (region) {
       region.classList.add('lws-swapped');
-      // Hide the old tabbed board tools, keep them in the DOM (reversible) —
-      // EXCEPT the drawer's close button. On mobile #cr-workspace is a
-      // full-width slide-in drawer; that X is the only way back to chat (the
-      // tap-to-close backdrop sits hidden behind the full-width drawer and the
-      // FAB is hidden while it's open). Hiding it stranded phone users in the
-      // workspace with no exit. Keep it visible, lift it above the derivation's
-      // sticky problem card / caption (z-index 3 / 4), and make sure it closes
-      // the drawer even if workspace.js hasn't wired it.
+      // Hide the old tabbed board tools, keep them in the DOM (reversible).
       for (var i = 0; i < region.children.length; i++) {
-        var child = region.children[i];
-        if (child.classList && child.classList.contains('cr-ws-close')) {
-          child.style.zIndex = '6';
-          child.addEventListener('click', function () {
-            if (window.MathWorkspace && typeof window.MathWorkspace.close === 'function') {
-              window.MathWorkspace.close();
-            }
-          });
-          continue;
-        }
-        child.setAttribute('data-lws-hidden', '1');
-        child.style.display = 'none';
+        region.children[i].setAttribute('data-lws-hidden', '1');
+        region.children[i].style.display = 'none';
       }
       var mountIn = document.createElement('div');
       mountIn.id = 'lws-chat-mount';
       mountIn.style.cssText = 'position:absolute;inset:0;';
       if (getComputedStyle(region).position === 'static') region.style.position = 'relative';
       region.appendChild(mountIn);
+      // Way back to chat. On mobile the swapped workspace is a FULL-SCREEN
+      // drawer, and the old close X is hidden with the rest of the legacy board
+      // chrome — leaving phone students with no exit. A dedicated, clearly
+      // labeled "‹ Chat" pill fixes that. Deliberately TOP-LEFT: the
+      // derivation's own text-size control (.lws-dv-az) floats top-right, so the
+      // right corner is taken. Appended after the mount (and z-index'd in CSS)
+      // so it sits above the board; shown only on the mobile drawer (CSS), since
+      // on desktop the workspace is a persistent column that needs no exit.
+      var exit = document.createElement('button');
+      exit.type = 'button';
+      exit.className = 'lws-chat-exit';
+      exit.setAttribute('aria-label', 'Close workspace and return to chat');
+      exit.innerHTML = '<i class="fas fa-chevron-left" aria-hidden="true"></i><span>Chat</span>';
+      exit.addEventListener('click', function () {
+        if (window.MathWorkspace && typeof window.MathWorkspace.close === 'function') {
+          window.MathWorkspace.close();
+        }
+      });
+      region.appendChild(exit);
       return mountIn;
     }
 


### PR DESCRIPTION
## Follow-up to #1240

#1240 restored the legacy close **✕** at the drawer's **top-right**. But on a real phone the exit was still invisible: the derivation view renders its **own text-size control** (`.lws-dv-az`, the "A 100% A" pill) pinned at `top:10px; right:12px; z-index:6` — the *same* top-right corner and z-index as the restored ✕. Because the text-size control is later in the DOM (inside the mount, appended after the button), it paints over the ✕, so there was still no usable way back to chat. A user screenshot confirmed this.

``&lt;img width="300" alt="mobile workspace with no visible exit" src="https://github.com/jnappier7/mathmatix-ai/pull/1240" /&gt;``

## Fix

Stop reusing the top-right ✕. Instead inject a dedicated, clearly labeled **"‹ Chat" pill at the drawer's TOP-LEFT**:

- **Top-left** is empty and collision-free (the text-size control owns the top-right), and is the conventional mobile "back" position.
- Wired directly to `window.MathWorkspace.close()`.
- **Mobile/tablet only** (`≤1200px`, matching the drawer breakpoint) via CSS — the desktop workspace is a persistent column that needs no exit, so it's unaffected.
- Reserved a little top padding on the derivation (`.lws-dv`) so the floating exit / text-size pills don't cover the first line once a problem is posed.
- Uses the chat `--cr-*` design tokens (with fallbacks) so it stays readable in both light and dark themes.

The legacy `.cr-ws-close` reuse from #1240 is reverted (all legacy board chrome is hidden again on swap, as before).

## Files
- `public/js/living-workspace/chat-workspace.js` — inject the top-left "‹ Chat" exit on swap; revert the top-right ✕ reuse; bump `ASSET_V`.
- `public/css/living-workspace.css` — `.lws-chat-exit` styles (mobile-only) + derivation top padding.
- `public/chat.html` — cache-buster bump so prod refetches the script.

## Testing
- `node --check` passes on the modified script.
- Verified positioning against `.lws-dv-az` (top-right) and the mobile drawer CSS in `workspace.css`; the new pill sits top-left at `z-index:7`, clear of the text-size control. Recommend a quick phone-width check after deploy: open the Workspace FAB → "‹ Chat" appears top-left → tapping it returns to the chat thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBbs1emwBp5EdHCmhqfNQX

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBbs1emwBp5EdHCmhqfNQX)_