### PR TITLE
chore(auth): stop flooding prod logs with per-request session logs

### DIFF
--- a/auth/passport-config.js
+++ b/auth/passport-config.js
@@ -7,6 +7,7 @@ const LocalStrategy       = require("passport-local").Strategy;
 const User                = require("../models/user");
 const bcrypt              = require("bcryptjs");
 const { generateUniqueStudentLinkCode } = require("../routes/student");
+const logger              = require("../utils/logger");
 
 /**
  * Generate a unique username from a display name
@@ -38,16 +39,19 @@ async function generateUniqueUsername(displayName, providerId) {
 
 /* --------------------------  SESSION HANDLING  -------------------------- */
 passport.serializeUser((user, done) => {
-  console.log("LOG: serializeUser called. User ID:", user.id);
+  // debug-level: these fire on every authenticated request (many per page load
+  // via parallel asset/API calls). Winston suppresses debug in production, so
+  // this no longer floods prod logs while staying available in dev.
+  logger.debug(`serializeUser called. User ID: ${user.id}`);
   done(null, user.id);
 });
 
 passport.deserializeUser(async (id, done) => {
-  console.log("LOG: deserializeUser called. User ID:", id);
+  logger.debug(`deserializeUser called. User ID: ${id}`);
   try {
     const user = await User.findById(id);
     if (user) {
-      console.log("LOG: deserializeUser found user:", user.username, "Role:", user.role);
+      logger.debug(`deserializeUser found user: ${user.username} Role: ${user.role}`);
     } else {
       console.warn("WARN: deserializeUser could not find user for ID:", id);
     }


### PR DESCRIPTION
## Context

Production logs (shared from Render) are dominated by session-handling debug lines:

```
LOG: deserializeUser called. User ID: 6a55255c...
LOG: deserializeUser found user: kandycane Role: student
LOG: deserializeUser called. User ID: 6a55255c...
LOG: deserializeUser found user: kandycane Role: student
... (dozens per page load)
```

`passport.serializeUser` / `deserializeUser` each ran a bare `console.log` on **every authenticated request**. Because a single page navigation fires many parallel asset/API requests, each one deserializes the session user and logs twice — so a single page load produces 10–20+ of these lines. They bypass the Winston logger entirely and also ship to Better Stack (Logtail), adding cost and drowning out signal.

## Change

Route the three hot-path session lines through the existing Winston logger at **`debug`** level:

- `serializeUser called`
- `deserializeUser called`
- `deserializeUser found user`

`utils/logger.js` sets the logger level to `info` in production (`debug` only in development), so these are **fully suppressed in prod** — no console output and nothing shipped to Logtail — while staying visible locally for debugging.

Left untouched (they're rare / genuinely useful, not per-request spam):
- the `deserializeUser` **warn** (user not found) and **error** branches,
- `LocalStrategy authenticated user` (once per login),
- `User … successfully logged in` (once per login),
- `Calling OpenAI model` (once per turn).

No change to authentication behavior — only logging.

## Not addressed here
The raw `undefined` lines in the same logs could **not** be traced to any plain `console.log(<var>)` in the app code (routes/utils/services/config/server are clean); their source is likely a dependency or an interpolation path and warrants a separate look. Flagged for a follow-up rather than guessed at.

## Files
- `auth/passport-config.js` — import the logger; convert the three per-request `console.log` session lines to `logger.debug`.

## Testing
- `node --check auth/passport-config.js` passes.
- Confirmed no circular require (`utils/logger.js` doesn't depend on auth/passport).
- Winston prod level is `info`, so `logger.debug` is suppressed in production and emitted in development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBbs1emwBp5EdHCmhqfNQX

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBbs1emwBp5EdHCmhqfNQX)_