### PR TITLE
fix(voice): make mobile voice mode hands-free instead of tap-per-turn

### DIFF
--- a/public/js/voice-mode.js
+++ b/public/js/voice-mode.js
@@ -94,10 +94,21 @@
     // Kick off the voice engine. The click that called enter() is a
     // user gesture, so getUserMedia inside startListening() is allowed.
     var vc = window.voiceController;
-    if (vc && !vc.isListening && typeof vc.startListening === 'function') {
-      Promise.resolve()
-        .then(function () { return vc.startListening(); })
-        .catch(function () { /* mic denied or unavailable — mode still usable */ });
+    if (vc) {
+      // Voice mode is a hands-free, call-style conversation — NOT push-to-talk.
+      // Turning on the controller's hands-free flag makes the legacy path
+      // auto-restart listening after the tutor finishes speaking, instead of
+      // stranding the student on "idle" until they tap the orb again between
+      // every turn. VAD already auto-sends on silence in all modes, so with
+      // this the legacy loop runs listen → send → speak → listen unattended.
+      // (No effect on the premium streaming path, which is already continuous
+      // and ignores this flag.)
+      vc.handsFreeMode = true;
+      if (!vc.isListening && typeof vc.startListening === 'function') {
+        Promise.resolve()
+          .then(function () { return vc.startListening(); })
+          .catch(function () { /* mic denied or unavailable — mode still usable */ });
+      }
     }
   }
 
@@ -109,6 +120,9 @@
 
     var vc = window.voiceController;
     if (vc) {
+      // Leaving the call — hand the controller back to push-to-talk so the
+      // standalone orb (outside voice mode) doesn't keep auto-restarting the mic.
+      vc.handsFreeMode = false;
       try { if (typeof vc.stopListening === 'function') vc.stopListening(); } catch (e) { /* noop */ }
       try { if (typeof vc.stopSpeaking === 'function') vc.stopSpeaking(); } catch (e) { /* noop */ }
     }


### PR DESCRIPTION
## Problem

On mobile, voice tutor requires a tap to advance between stages (listening → processing → talking).

## Diagnosis

There are two voice paths:
- **Streaming** (premium): mic stays open, server VAD drives turns — already continuous, no taps.
- **Legacy** (free tier, or streaming fallback): `voice-controller.js`, driven by client-side VAD.

On the legacy path, the taps come from two places:

1. **After the tutor finishes speaking → back to listening.** Auto-restart of the mic is gated on `handsFreeMode`, which defaults to `false` (push-to-talk). So the turn ends on "idle" and the student must tap the orb to speak again — a tap **every turn**. (VAD auto-send on silence already works in all modes, so listening→processing was *not* the tap.)
2. **On iOS specifically, processing → talking.** The legacy path plays TTS via `new Audio(url).play()` *after* an async fetch, which Safari blocks without a fresh user gesture. *(Not fixed in this PR — see below.)*

## This PR (fix #1)

Entering voice mode is a call-style, hands-free conversation, so turn on `handsFreeMode` when entering voice mode and hand it back to push-to-talk on exit. The legacy loop then runs **listen → send → speak → listen** unattended.

- Scoped to voice mode only — the standalone bottom-right orb outside voice mode stays push-to-talk (spacebar/tap), unchanged.
- **No effect on the premium streaming path**, which ignores this flag and is already continuous.
- Fully removes the tap-per-turn on **Android** legacy (permissive autoplay); on **iOS** legacy it removes the restart-listening tap but the TTS-autoplay tap (#2) remains.

## Not in this PR (fix #2 — needs your input)

The iOS TTS autoplay block. The robust fix is to play legacy TTS through the **already-gesture-unlocked Web Audio context** (`fetch` + `decodeAudioData` + `BufferSource`) instead of a fresh `HTMLAudioElement` — the streaming path already does exactly this and plays fine on iOS. It's an interruption-sensitive change to a flow I can't exercise on a real device from here, so I'd rather land it deliberately.

**To target it correctly, two quick questions:**
- Is the account you tested on **premium** (streaming) or **free** (legacy)? If premium and it's still tappy on mobile, streaming is falling back and that's worth a separate look.
- **iPhone (iOS Safari / any iOS browser)** or **Android**? iOS is where the autoplay fix matters.

## Files
- `public/js/voice-mode.js` — enable `handsFreeMode` on voice-mode enter; reset on exit.

## Testing
- `node --check public/js/voice-mode.js` passes.
- DOM/state-flag change only; scoped so the streaming path and the standalone orb are unaffected. Best verified live on a mobile legacy-path session after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBbs1emwBp5EdHCmhqfNQX

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBbs1emwBp5EdHCmhqfNQX)_