### PR TITLE
fix(voice): preserve the user gesture so iOS streaming voice doesn't stall per-stage

### DIFF
--- a/public/js/voice-mode.js
+++ b/public/js/voice-mode.js
@@ -91,8 +91,15 @@
     paintButton();
     paintComposerEntry();
 
-    // Kick off the voice engine. The click that called enter() is a
-    // user gesture, so getUserMedia inside startListening() is allowed.
+    // Kick off the voice engine. enter() runs inside the tap handler, so this
+    // MUST call startListening() synchronously — not from a Promise.resolve()
+    // microtask. On iOS Safari the user-activation that lets us create/resume
+    // the AudioContext and open the mic is only valid within the gesture task;
+    // deferring even one microtask forfeits it, so the AudioContext is born
+    // suspended and the tutor's audio stays silent until the student taps
+    // again to "resume" it — which is exactly the tap-per-stage bug on iPhone.
+    // startListening() is async, but its synchronous prefix (new AudioContext,
+    // getUserMedia) fires in-gesture when called directly; only await the tail.
     var vc = window.voiceController;
     if (vc) {
       // Voice mode is a hands-free, call-style conversation — NOT push-to-talk.
@@ -105,9 +112,12 @@
       // and ignores this flag.)
       vc.handsFreeMode = true;
       if (!vc.isListening && typeof vc.startListening === 'function') {
-        Promise.resolve()
-          .then(function () { return vc.startListening(); })
-          .catch(function () { /* mic denied or unavailable — mode still usable */ });
+        try {
+          var p = vc.startListening();
+          if (p && typeof p.catch === 'function') {
+            p.catch(function () { /* mic denied or unavailable — mode still usable */ });
+          }
+        } catch (_) { /* engine not ready — mode still usable */ }
       }
     }
   }

--- a/public/js/voice-stream-client.js
+++ b/public/js/voice-stream-client.js
@@ -170,6 +170,17 @@
                 this.audioCtx = new (window.AudioContext || window.webkitAudioContext)({
                     latencyHint: 'interactive',
                 });
+                // Unlock IMMEDIATELY, before the async worklet fetch below. iOS
+                // Safari only honors resume() inside the user gesture that
+                // reached here (the orb tap / voice-mode entry). The worklet
+                // addModule() is a network load that ends the gesture window, so
+                // resuming AFTER it leaves the context suspended — AI audio then
+                // stays silent until the student taps again, which reads as
+                // "tap to advance". Kick resume() off synchronously now; the
+                // statechange handler and _playPcmS16 cover any later re-suspend.
+                if (this.audioCtx.state === 'suspended') {
+                    this.audioCtx.resume().catch(() => { /* gesture lost — retried on next tap */ });
+                }
                 this.outGain = this.audioCtx.createGain();
                 this.outGain.gain.value = 1.0;
                 // outGain → analyser → destination, mirroring modules/audio.js,


### PR DESCRIPTION
## Context

You confirmed: **premium account, iPhone**. A premium user is on the continuous **streaming** voice path — which should never need a tap between turns — yet it still stalled per stage (listening / processing / talking) on iOS. That points at iOS Safari's user-activation rules for audio, not the legacy path.

## Root cause (two gesture leaks)

iOS Safari only lets you create/resume an `AudioContext` and open the mic **inside the user-gesture task** that started them. Two places gave that gesture away:

1. **`public/js/voice-mode.js` — `enter()`** kicked off the engine from a `Promise.resolve().then(...)` microtask. The comment even said "the click is a user gesture," but deferring it forfeits that gesture on iOS, so the `AudioContext` was born **suspended**. → Call `startListening()` **synchronously** from the tap; its synchronous prefix (`new AudioContext`, `getUserMedia`) now runs in-gesture.

2. **`public/js/voice-stream-client.js` — `_ensureAudio()`** called `resume()` **after** `await audioWorklet.addModule(...)`. That worklet fetch is a network load that ends the gesture window, so the resume no-op'd and the context stayed suspended — AI audio silent until the next tap "unstuck" it. → `resume()` **immediately after creating the context**, before the worklet fetch. The existing `statechange` handler and `_playPcmS16` still cover any later re-suspend.

Together, the streaming path stays continuous on iOS instead of needing a tap to unstick each stage.

## Scope / safety
- Desktop and Android don't gate audio on the gesture this way, so behavior there is unchanged.
- No API changes; both are ordering/timing fixes.
- Builds on the already-merged hands-free change (#1245) and the legacy-path note there.

## Not in this PR
If, after this, streaming still falls back to legacy on your iPhone for any reason (e.g. AudioWorklet load failure), the legacy path's `new Audio(url).play()` TTS-autoplay tap would remain — that's the separate Web-Audio-playback fix I flagged earlier. This PR targets the streaming path you're actually on as a premium user.

## Testing
- `node --check` passes on both files.
- Timing/ordering change to the audio-unlock path; needs on-device iPhone verification after deploy: enter voice mode, speak, and confirm the tutor responds and the loop continues **without** tapping between stages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBbs1emwBp5EdHCmhqfNQX

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBbs1emwBp5EdHCmhqfNQX)_