### PR TITLE
fix(voice): auto-continue on legacy path when streaming STT is rate-limited (Deepgram 429)

### DIFF
--- a/public/js/voice-controller.js
+++ b/public/js/voice-controller.js
@@ -242,7 +242,7 @@ class VoiceController {
                 console.warn('[Voice] stream disconnected — falling back to legacy path');
                 this.useStreamingPipeline = false;
                 this.streamClient = null;
-                this.updateUI('idle');
+                this._resumeOnLegacyAfterFallback();
                 break;
 
             case 'error':
@@ -257,10 +257,32 @@ class VoiceController {
                         try { this.streamClient.disconnect(); } catch (_) {}
                         this.streamClient = null;
                     }
-                    if (this.isListening || this.isAISpeaking) this.updateUI('idle');
+                    this._resumeOnLegacyAfterFallback();
                 }
                 break;
         }
+    }
+
+    // Streaming just died (e.g. Deepgram 429 rate-limit, or a worklet load
+    // failure). If the student was mid-session — actively listening, or in the
+    // full voice-mode call — seamlessly re-open the mic on the LEGACY path
+    // instead of dropping to "Click to start voice" and making them tap to
+    // continue. Legacy STT is a different provider (Whisper), so it keeps
+    // working while Deepgram is rate-limited. If they weren't engaged (or the
+    // tutor is mid-utterance), just settle to idle. No loop risk: the legacy
+    // path never emits these stream events, and a legacy failure lands on idle.
+    _resumeOnLegacyAfterFallback() {
+        const inVoiceMode = typeof document !== 'undefined' &&
+            document.body && document.body.classList.contains('cr-voice');
+        const wasEngaged = this.isListening || inVoiceMode;
+        this.isListening = false; // clear the dead streaming session's flag
+        if (this.isAISpeaking || !wasEngaged) {
+            this.updateUI('idle');
+            return;
+        }
+        Promise.resolve()
+            .then(() => this.startListening())   // useStreamingPipeline is now false → legacy
+            .catch(() => this.updateUI('idle'));
     }
 
     /**


### PR DESCRIPTION
## Root cause (confirmed from prod logs)

The browser console during a voice session:

```
[Voice] stream error: Streaming STT unavailable: Unexpected server response: 429
[Voice] disabling streaming pipeline, falling back
[Voice] stream disconnected — falling back to legacy path
```

**Deepgram is returning HTTP 429** on the streaming STT websocket (rate/quota/concurrency limit — key and `nova-2` model are both valid). So streaming voice is unavailable for everyone, on every device, and the client falls back to the legacy Whisper path. That's why "tap between stages" showed up on desktop as well as mobile. **The underlying fix is on the Deepgram account** (credits / concurrency / plan); this PR is graceful degradation so voice stays usable while that's sorted.

## What this changes

Previously, when streaming died mid-session the client dropped to **"Click to start voice"** and the student had to tap to re-engage the legacy path each time. Now, if the student was engaged (actively listening, or in the full voice-mode call) and the tutor isn't mid-utterance, it **seamlessly re-opens the mic on the legacy path**. Combined with the already-merged hands-free change (#1245), the legacy loop then continues on its own — no tap.

- Applies to both the `disconnected` and `Streaming STT unavailable` / `worklet_load_failed` fallback branches.
- Settles to idle (old behavior) only if the tutor is speaking or the student wasn't engaged.
- No loop risk: the legacy path emits no stream events, and a legacy failure lands on idle.

## Files
- `public/js/voice-controller.js` — new `_resumeOnLegacyAfterFallback()` helper; both fallback branches call it instead of `updateUI('idle')`.

## Verified from the same logs
The hands-free legacy loop is already working post-fallback (`🔄 [Voice] Auto-restarting listening (hands-free mode)`), so this removes the single remaining tap at the moment streaming 429s.

## Separate issues spotted in the same logs (not in this PR)
- **Anthropic 400 on image context:** `[Generate] Streaming failed, falling back: 400 … Input tag 'image_url' … does not match any of the expected tags` — the generate stage sends OpenAI-style `image_url` content blocks to `claude-sonnet-5`, which rejects them (Anthropic expects `image` w/ `source`). Worth its own fix; flagging it.
- **Transient 502s** on `/api/chat`, `/api/upload/classify`, etc. coincided with a deploy/instance restart in the server logs — expected during redeploy, not a standing bug.

## Testing
- `node --check` passes.
- Client-only state/flow change, scoped to the streaming-fallback branches. Best verified live once deployed (or once Deepgram 429s clear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBbs1emwBp5EdHCmhqfNQX

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBbs1emwBp5EdHCmhqfNQX)_