### PR TITLE
fix(anthropic): convert OpenAI image_url blocks to Claude image source

### DIFF
--- a/tests/unit/anthropicClient.test.js
+++ b/tests/unit/anthropicClient.test.js
@@ -36,6 +36,80 @@ describe('anthropicClient.splitSystemAndMessages', () => {
   });
 });
 
+describe('anthropicClient.toAnthropicContent', () => {
+  test('passes plain string content through unchanged', () => {
+    expect(a.toAnthropicContent('hello')).toBe('hello');
+  });
+
+  test('keeps text blocks and converts a base64 image_url to a Claude image', () => {
+    const out = a.toAnthropicContent([
+      { type: 'text', text: 'look at this' },
+      { type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA', detail: 'high' } },
+    ]);
+    expect(out).toEqual([
+      { type: 'text', text: 'look at this' },
+      { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'AAAA' } },
+    ]);
+  });
+
+  test('normalizes image/jpg to image/jpeg', () => {
+    const out = a.toAnthropicContent([
+      { type: 'image_url', image_url: { url: 'data:image/jpg;base64,ZZ' } },
+    ]);
+    expect(out).toEqual([{ type: 'image', source: { type: 'base64', media_type: 'image/jpeg', data: 'ZZ' } }]);
+  });
+
+  test('converts an http(s) image_url to a Claude url source', () => {
+    const out = a.toAnthropicContent([
+      { type: 'image_url', image_url: { url: 'https://cdn.example.com/w.png' } },
+    ]);
+    expect(out).toEqual([{ type: 'image', source: { type: 'url', url: 'https://cdn.example.com/w.png' } }]);
+  });
+
+  test('drops an unsupported image type but keeps the text', () => {
+    const out = a.toAnthropicContent([
+      { type: 'text', text: 'my work' },
+      { type: 'image_url', image_url: { url: 'data:image/heic;base64,QQ' } },
+    ]);
+    expect(out).toEqual([{ type: 'text', text: 'my work' }]);
+  });
+
+  test('falls back to a space when every block is unconvertible', () => {
+    const out = a.toAnthropicContent([
+      { type: 'image_url', image_url: { url: 'data:image/svg+xml;base64,QQ' } },
+    ]);
+    expect(out).toBe(' ');
+  });
+
+  test('leaves an already Claude-shaped image block intact', () => {
+    const block = { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'BB' } };
+    expect(a.toAnthropicContent([block])).toEqual([block]);
+  });
+});
+
+describe('anthropicClient.splitSystemAndMessages (vision)', () => {
+  test('converts an image_url block inside a user turn to Claude shape', () => {
+    const { messages } = a.splitSystemAndMessages([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'grade this' },
+          { type: 'image_url', image_url: { url: 'data:image/jpeg;base64,II', detail: 'high' } },
+        ],
+      },
+    ]);
+    expect(messages).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'grade this' },
+          { type: 'image', source: { type: 'base64', media_type: 'image/jpeg', data: 'II' } },
+        ],
+      },
+    ]);
+  });
+});
+
 describe('anthropicClient.sanitizeSchema', () => {
   test('strips unsupported constraint keywords recursively', () => {
     const clean = a.sanitizeSchema({

--- a/utils/anthropicClient.js
+++ b/utils/anthropicClient.js
@@ -59,6 +59,60 @@ function isClaudeModel(model) {
   return typeof model === 'string' && model.toLowerCase().startsWith('claude');
 }
 
+// ── Content translation (vision) ────────────────────────────────────
+// OpenAI vision blocks are {type:'image_url', image_url:{url}}; Claude wants
+// {type:'image', source:{...}}. Passing an image_url block straight through
+// 400s the whole call ("Input tag 'image_url' ... does not match any of the
+// expected tags"), which is what broke tutor turns that carry an uploaded
+// image. Convert here; text blocks and plain strings pass through untouched.
+const CLAUDE_IMAGE_MEDIA_TYPES = new Set([
+  'image/jpeg', 'image/png', 'image/gif', 'image/webp',
+]);
+
+// Turn an OpenAI image_url `url` into a Claude image `source`, or null if it
+// can't be represented (non-base64 data URL, or a media type Claude vision
+// doesn't accept — e.g. HEIC/SVG). Callers drop unconvertible images rather
+// than fail the request.
+function imageUrlToClaudeSource(url) {
+  if (typeof url !== 'string' || !url) return null;
+  const dataMatch = /^data:([^;,]+)?(;base64)?,([\s\S]*)$/i.exec(url);
+  if (dataMatch) {
+    if (!dataMatch[2]) return null; // Claude needs base64 for inline data: images
+    let mediaType = (dataMatch[1] || '').toLowerCase();
+    if (mediaType === 'image/jpg') mediaType = 'image/jpeg';
+    if (!CLAUDE_IMAGE_MEDIA_TYPES.has(mediaType)) return null;
+    const data = dataMatch[3] || '';
+    if (!data) return null;
+    return { type: 'base64', media_type: mediaType, data };
+  }
+  if (/^https?:\/\//i.test(url)) {
+    return { type: 'url', url };
+  }
+  return null;
+}
+
+// Normalize a message's `content` (string | OpenAI block[]) to what Claude's
+// Messages API accepts. Strings pass through; arrays are mapped block-by-block.
+function toAnthropicContent(content) {
+  if (typeof content === 'string' || !Array.isArray(content)) return content;
+  const out = [];
+  for (const block of content) {
+    if (!block || typeof block !== 'object') continue;
+    if (block.type === 'text' && typeof block.text === 'string') {
+      out.push({ type: 'text', text: block.text });
+    } else if (block.type === 'image_url') {
+      const source = imageUrlToClaudeSource(block.image_url && block.image_url.url);
+      if (source) out.push({ type: 'image', source }); // else drop, don't 400 the call
+    } else if (block.type === 'image' && block.source) {
+      out.push(block); // already Claude-shaped
+    }
+    // unknown block types are dropped
+  }
+  // Claude rejects an empty content array — fall back to a single space so a
+  // turn that was nothing but an unconvertible image still keeps the slot.
+  return out.length ? out : ' ';
+}
+
 // ── Message translation ─────────────────────────────────────────────
 // OpenAI carries the system prompt as a role:"system" message in the array.
 // Claude takes it as a top-level `system` string. Pull all system messages
@@ -74,7 +128,7 @@ function splitSystemAndMessages(messages) {
       continue;
     }
     const role = m.role === 'assistant' ? 'assistant' : 'user';
-    const content = typeof m.content === 'string' ? m.content : m.content;
+    const content = toAnthropicContent(m.content);
     const last = convo[convo.length - 1];
     if (last && last.role === role && typeof last.content === 'string' && typeof content === 'string') {
       last.content += `\n\n${content}`;
@@ -248,6 +302,7 @@ module.exports = {
   callLLMStream,
   // exposed for unit tests
   splitSystemAndMessages,
+  toAnthropicContent,
   sanitizeSchema,
   toClaudeOutputConfig,
   mapStopReason,


### PR DESCRIPTION
## Problem (from prod logs)

Tutor turns that carry an uploaded image were 400-ing against `claude-sonnet-5`:

```
[Generate] Streaming failed, falling back: 400 {"type":"error","error":{"type":"invalid_request_error",
"message":"messages.66.content.1: Input tag 'image_url' found using 'type' does not match any of the
expected tags: … 'image' …"}}
```

The Anthropic adapter (`utils/anthropicClient.js`) passed message `content` through untouched (`splitSystemAndMessages`), but OpenAI vision blocks — `{type:'image_url', image_url:{url}}` — aren't a shape Claude accepts; it wants `{type:'image', source:{...}}`. So **every image-bearing turn failed the streaming call *and* the non-streaming fallback**, and vision context silently dropped on the Claude path.

## Fix

New `toAnthropicContent()`, wired into `splitSystemAndMessages`:

- **Strings** and `{type:'text'}` blocks pass through unchanged.
- **`image_url` → Claude `image`**:
  - inline `data:` URL → `{type:'image', source:{type:'base64', media_type, data}}` (media type lower-cased, `image/jpg` → `image/jpeg`),
  - `http(s)` URL → `{type:'image', source:{type:'url', url}}`.
- **Unrepresentable images** (HEIC/SVG, non-base64 data) are **dropped** rather than 400-ing the whole request; a turn left with nothing falls back to a single space so the message slot survives.
- Already-Claude `{type:'image', source}` blocks pass through.

The OpenAI-only `detail:'high'` hint is dropped (Claude has no equivalent).

## Files
- `utils/anthropicClient.js` — `toAnthropicContent()` + `imageUrlToClaudeSource()`; wired into `splitSystemAndMessages`; exported for tests.
- `tests/unit/anthropicClient.test.js` — 8 new cases (base64, jpg→jpeg, http url, unsupported-type drop, all-dropped→space, passthrough, and an end-to-end `splitSystemAndMessages` vision case).

## Testing
- `node --check` passes on both files.
- Validated the converter's logic against all cases via direct Node assertions (jest deps aren't installed in my sandbox; the committed jest cases run in CI).

## Note
This confirms Claude **is** wired in at runtime now (the tutor generate stage calls `claude-sonnet-5`), which contradicts the "OpenAI-only / Claude not wired in" note in `CLAUDE.md` §2/§7 — worth updating that doc separately so the next reader isn't misled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBbs1emwBp5EdHCmhqfNQX

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBbs1emwBp5EdHCmhqfNQX)_