### PR TITLE
Migrate Cartesia TTS from sonic-2 to sonic-3.5

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,8 +60,8 @@ ANTHROPIC_API_KEY=sk-ant-api03-your_legacy_key_here
 # --- VOICE / TEXT-TO-SPEECH (Cartesia) ---
 # Get from: https://play.cartesia.ai/
 CARTESIA_API_KEY=your_cartesia_key
-# Model: 'sonic-2' (default, most capable) or 'sonic-3'
-CARTESIA_MODEL=sonic-2
+# Model: 'sonic-3.5' (default, latest) — 'sonic-2' is being sunset (Oct 20, 2026)
+CARTESIA_MODEL=sonic-3.5
 
 # --- STREAMING SPEECH-TO-TEXT (Deepgram) ---
 # Required for the live voice tutor (/voice-tutor.html). The HTTP fallback

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ Live at https://www.mathmatix.ai (Render, Oregon). ~70 shipped features (see
 | DB | MongoDB + Mongoose 8 (`connect-mongo` session store) |
 | **LLM (runtime)** | **OpenAI only** — `gpt-4o-mini` (chat/teaching), `gpt-4o` (vision grading). See §7. |
 | Voice STT | Deepgram (`nova-2`/`nova-3`), Whisper-1 fallback |
-| Voice TTS | Cartesia (`sonic-2`), streaming over WebSocket |
+| Voice TTS | Cartesia (`sonic-3.5`), streaming over WebSocket |
 | Math OCR | Mathpix (`/v3/text`, `/v3/pdf`) |
 | Math render | KaTeX + MathLive (client); JSXGraph for interactive diagrams |
 | Auth | Passport (local, Google, Microsoft, Clever SSO) |

--- a/utils/ttsProvider.js
+++ b/utils/ttsProvider.js
@@ -10,7 +10,7 @@ const TTS_PROVIDER = 'cartesia';
 // --- Cartesia config ---
 const CARTESIA_API_KEY = process.env.CARTESIA_API_KEY;
 const CARTESIA_API_VERSION = '2025-04-16';
-const CARTESIA_MODEL = process.env.CARTESIA_MODEL || 'sonic-2';
+const CARTESIA_MODEL = process.env.CARTESIA_MODEL || 'sonic-3.5';
 const CARTESIA_BASE_URL = 'https://api.cartesia.ai';
 
 /**

--- a/utils/ttsStream.js
+++ b/utils/ttsStream.js
@@ -1,5 +1,5 @@
 // utils/ttsStream.js
-// Cartesia Sonic-2 streaming TTS over WebSocket.
+// Cartesia Sonic-3.5 streaming TTS over WebSocket.
 // Send text as it streams from the LLM; receive PCM audio chunks
 // the moment they're synthesized. First-chunk latency ~75ms.
 
@@ -9,7 +9,7 @@ const logger = require('./logger').child({ module: 'ttsStream' });
 
 const CARTESIA_API_KEY = process.env.CARTESIA_API_KEY;
 const CARTESIA_VERSION = '2025-04-16';
-const CARTESIA_MODEL = process.env.CARTESIA_MODEL || 'sonic-2';
+const CARTESIA_MODEL = process.env.CARTESIA_MODEL || 'sonic-3.5';
 const CARTESIA_WS_URL = `wss://api.cartesia.ai/tts/websocket?api_key=${encodeURIComponent(CARTESIA_API_KEY || '')}&cartesia_version=${CARTESIA_VERSION}`;
 
 // Output format: raw PCM s16 mono 22050Hz.

--- a/utils/voiceMetrics.js
+++ b/utils/voiceMetrics.js
@@ -15,7 +15,7 @@ const COST = {
     sttPerMinute: 0.0043,           // Deepgram Nova-3 streaming
     llmInputPer1KTokens: 0.00015,   // gpt-4o-mini input
     llmOutputPer1KTokens: 0.0006,   // gpt-4o-mini output
-    ttsPerCharacter: 0.000020,      // Cartesia Sonic-2 streaming (~$0.020/min ≈ $0.0000133/char @ 150wpm)
+    ttsPerCharacter: 0.000020,      // Cartesia Sonic-3.5 streaming (~$0.020/min ≈ $0.0000133/char @ 150wpm)
 };
 
 function newTurn(sessionId, userId, tutorId) {


### PR DESCRIPTION
## Summary

Cartesia is sunsetting `sonic-2` on **October 20, 2026** — TTS requests to that model will start returning errors after that date. This PR switches the default Cartesia model to `sonic-3.5`, their latest model (improved pacing, prosody, and naturalness).

## Changes

- `utils/ttsStream.js` — default `CARTESIA_MODEL` fallback `sonic-2` → `sonic-3.5` (WebSocket streaming path); updated header comment.
- `utils/ttsProvider.js` — same default fallback change (provider abstraction / HTTP path).
- `.env.example` — `CARTESIA_MODEL=sonic-3.5` and refreshed comment noting the sonic-2 sunset.
- `utils/voiceMetrics.js` — cost-comment reference updated (per-char rate unchanged).
- `CLAUDE.md` — stack table now lists `sonic-3.5`.

All `model_id` request fields already reference the `CARTESIA_MODEL` constant, so no hardcoded model strings needed changing.

## Note / follow-up

The default in code is now `sonic-3.5`, but if the production environment (Render) sets `CARTESIA_MODEL=sonic-2` explicitly, that env var will override the code default. The Render env var should be updated to `sonic-3.5` (or unset to inherit the new default) for the migration to take full effect in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMS7zvK5ZgrZNpL4XAbYkw)_