### PR TITLE
Resizable work board + minimizable tutor hero on the chat stage

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -91,6 +91,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <link rel="stylesheet" href="/css/coin-fx.css" />
 <!-- Interactive math workspace (chat right slot) -->
   <link rel="stylesheet" href="/css/workspace.css?v=20260711" />
+  <!-- Adjustable panels: resizable work board + minimizable tutor hero -->
+  <link rel="stylesheet" href="/css/adjustable-panels.css?v=20260721" />
   <!-- Voice mode (layout mode of the chat stage) -->
   <link rel="stylesheet" href="/css/voice-mode.css?v=3" />
   <!-- Fresh styling for rendered math (equation cards) -->
@@ -2354,6 +2356,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <script src="/js/avatar-config-data.js"></script>
 <!-- Redesigned chat shell behavior (tutor swap, quick actions, header pills) -->
   <script defer src="/js/chat-redesign.js?v=20260717"></script>
+  <!-- Adjustable panels: resizable work board + minimizable tutor hero -->
+  <script defer src="/js/adjustable-panels.js?v=20260721"></script>
   <!-- Drive the "Live with <tutor>" pill bars from real TTS playback -->
   <script type="module" src="/js/chat-voice-meter.js"></script>
   <script src="/dist/js/chat-js2.dacbff7b.js"></script>

--- a/public/css/adjustable-panels.css
+++ b/public/css/adjustable-panels.css
@@ -1,0 +1,175 @@
+/* ============================================================
+   adjustable-panels.css — resizable work board + minimizable tutor
+
+   Two chat-stage affordances layered on top of chat-redesign.css:
+
+   1. A drag handle sitting in the gap between the chat column and the
+      workspace (work board). Dragging it left grows the board and shrinks
+      chat; right does the reverse. It drives --cr-side-w, so the whole
+      grid reflows. Desktop only (below 1200px the board is a slide-in
+      drawer — see workspace.css — so there's nothing to resize against).
+
+   2. A minimize button on the tutor hero. Minimizing collapses the hero
+      column entirely and drops a small "Show tutor" pill in its place,
+      handing that space to chat + board. Works at every width.
+
+   Both preferences persist in localStorage (see adjustable-panels.js).
+   ============================================================ */
+
+/* The stage becomes the positioning context for the injected handle +
+   restore pill (both absolutely positioned children). */
+body.cr-mode .cr-stage { position: relative; }
+
+/* ----- Work board resize handle ----- */
+/* Anchored to the stage's right content edge, offset inward by the board
+   width so it always lands in the 18px gap between chat and the board —
+   the same calc() pattern the tour button uses (chat-redesign.css:110).
+   No JS needed to keep it aligned as the board resizes or the window
+   changes. */
+.cr-ws-resizer {
+  position: absolute;
+  top: 16px;
+  bottom: 60px;
+  right: calc(var(--cr-side-w) + 4px);
+  width: 12px;
+  z-index: 20;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: col-resize;
+  touch-action: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+/* The visible grip: a short rounded bar that lights up on hover / drag. */
+.cr-ws-resizer::before {
+  content: "";
+  width: 3px;
+  height: 46px;
+  border-radius: 3px;
+  background: var(--cr-border);
+  transition: background 0.15s var(--cr-ease), height 0.15s var(--cr-ease);
+}
+.cr-ws-resizer:hover::before,
+body.cr-resizing .cr-ws-resizer::before {
+  background: var(--cr-accent);
+  height: 74px;
+}
+.cr-ws-resizer:focus-visible { outline: none; }
+.cr-ws-resizer:focus-visible::before {
+  background: var(--cr-accent);
+  height: 74px;
+  box-shadow: 0 0 0 3px rgba(139, 123, 255, 0.30);
+}
+
+/* While dragging: page-wide col-resize cursor, no text selection, and
+   freeze pointer events on the two panels so an iframe/canvas inside them
+   can't swallow the drag. */
+body.cr-resizing { cursor: col-resize; user-select: none; }
+body.cr-resizing #chat-container,
+body.cr-resizing .cr-workspace { pointer-events: none; }
+
+/* The board is a drawer (or hidden) below 1200px / with the board flag off —
+   nothing to drag against, so hide the handle. */
+@media (max-width: 1200px) { .cr-ws-resizer { display: none; } }
+html.mm-board-hidden .cr-ws-resizer { display: none; }
+
+@media (prefers-reduced-motion: reduce) {
+  .cr-ws-resizer::before { transition: none; }
+}
+
+/* ----- Tutor hero: minimize button ----- */
+.cr-hero-min-btn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 6;
+  width: 30px;
+  height: 30px;
+  border: 0;
+  border-radius: 50%;
+  background: rgba(15, 20, 35, 0.55);
+  color: #fff;
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  transition: background 0.15s var(--cr-ease);
+}
+.cr-hero-min-btn:hover { background: rgba(15, 20, 35, 0.85); }
+.cr-hero-min-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(139, 123, 255, 0.45);
+}
+/* Phones already dock the tutor to a compact cam (mobile-tutor-cam.css),
+   so the minimize button would just crowd it — hide it there. A state
+   minimized on desktop still restores fine via the pill below. */
+@media (max-width: 900px) { .cr-hero-min-btn { display: none; } }
+
+/* ----- Minimized state ----- */
+/* Hide the whole hero column and reflow the grid so chat (and the board)
+   reclaim the space. The grid overrides are width-scoped to match the base
+   layout in chat-redesign.css:
+     >1200px : chat | board
+     901-1200: chat only (board is a drawer)
+     <=900   : already a single 1fr column — hiding the hero is enough. */
+body.cr-hero-min .cr-hero-col { display: none !important; }
+
+@media (min-width: 1201px) {
+  body.cr-hero-min .cr-stage {
+    grid-template-columns: minmax(0, 1fr) var(--cr-side-w);
+  }
+  html.mm-board-hidden body.cr-hero-min .cr-stage {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+@media (min-width: 901px) and (max-width: 1200px) {
+  body.cr-hero-min .cr-stage {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+/* ----- "Show tutor" restore pill (shown only while minimized) ----- */
+.cr-hero-restore {
+  position: absolute;
+  top: 16px;
+  left: 18px;
+  z-index: 25;
+  display: none;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 13px 7px 7px;
+  border: 1px solid var(--cr-border);
+  border-radius: 999px;
+  background: var(--cr-bg-panel);
+  color: var(--cr-text);
+  box-shadow: var(--cr-shadow-md);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+  transition: filter 0.15s var(--cr-ease);
+}
+.cr-hero-restore:hover { filter: brightness(1.08); }
+.cr-hero-restore:focus-visible {
+  outline: none;
+  box-shadow: var(--cr-shadow-md), 0 0 0 3px rgba(139, 123, 255, 0.40);
+}
+body.cr-hero-min .cr-hero-restore { display: inline-flex; }
+.cr-hero-restore img {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  object-fit: cover;
+  object-position: center top;
+  flex-shrink: 0;
+}
+.cr-hero-restore .cr-hero-restore-fallback { color: var(--cr-accent); }
+
+@media (max-width: 900px) {
+  .cr-hero-restore { top: 8px; left: 8px; padding: 6px 11px 6px 6px; }
+}

--- a/public/js/adjustable-panels.js
+++ b/public/js/adjustable-panels.js
@@ -1,0 +1,207 @@
+/* ============================================================
+   adjustable-panels.js — resizable work board + minimizable tutor
+
+   Wires the two affordances styled in adjustable-panels.css:
+
+   1. A drag handle in the gap between chat and the work board. Dragging
+      it drives --cr-side-w (clamped so neither chat nor the board can be
+      crushed); the grid in chat-redesign.css reflows off that variable.
+      Arrow keys nudge it; double-click resets to the default width.
+
+   2. A minimize button on the tutor hero that toggles body.cr-hero-min,
+      collapsing the hero column, plus a "Show tutor" pill that restores it.
+
+   Both preferences persist in localStorage. Everything is injected here so
+   chat.html only needs the <link> + <script> includes.
+   ============================================================ */
+(function () {
+  'use strict';
+
+  var DOC = document.documentElement;
+
+  var LS_WIDTH = 'mm_ws_width';   // board width in px (number as string)
+  var LS_HERO = 'mm_hero_min';    // '1' when the tutor hero is minimized
+
+  // Board width bounds. The hard max is also clamped per-frame against the
+  // viewport so chat always keeps at least MIN_CHAT px.
+  var MIN_W = 240;
+  var MAX_W = 960;
+  var DEFAULT_W = 320;   // matches --cr-side-w in design-system.css
+  var MIN_CHAT = 360;
+  var STEP = 24;         // arrow-key nudge
+
+  function readSideVar() {
+    var v = parseInt(getComputedStyle(DOC).getPropertyValue('--cr-side-w'), 10);
+    return isNaN(v) ? DEFAULT_W : v;
+  }
+
+  function heroWidth() {
+    if (document.body.classList.contains('cr-hero-min')) return 0;
+    var v = parseInt(getComputedStyle(DOC).getPropertyValue('--cr-hero-w'), 10);
+    return isNaN(v) ? 320 : v;
+  }
+
+  function clampWidth(px) {
+    var vw = window.innerWidth;
+    // Leave room for the hero column, the chat minimum, and the two 18px
+    // grid gaps; never let the ceiling drop below the floor.
+    var ceiling = Math.min(MAX_W, vw - heroWidth() - MIN_CHAT - 36);
+    ceiling = Math.max(MIN_W, ceiling);
+    return Math.max(MIN_W, Math.min(ceiling, Math.round(px)));
+  }
+
+  function applyWidth(px) {
+    DOC.style.setProperty('--cr-side-w', clampWidth(px) + 'px');
+  }
+
+  function saveWidth() {
+    try { localStorage.setItem(LS_WIDTH, String(readSideVar())); } catch (e) { /* ignore */ }
+  }
+
+  // --- Resize handle -----------------------------------------------------
+
+  function buildResizer(stage) {
+    var resizer = document.createElement('button');
+    resizer.type = 'button';
+    resizer.id = 'cr-ws-resizer';
+    resizer.className = 'cr-ws-resizer';
+    resizer.setAttribute('role', 'separator');
+    resizer.setAttribute('aria-orientation', 'vertical');
+    resizer.setAttribute('aria-label', 'Resize work board — drag or use arrow keys');
+    resizer.title = 'Drag to resize the work board (double-click to reset)';
+    stage.appendChild(resizer);
+
+    var wsRight = 0;
+
+    function onMove(ev) {
+      // Board's right edge is pinned; its width is that edge minus the pointer.
+      applyWidth(wsRight - ev.clientX);
+    }
+
+    function onUp(ev) {
+      try { resizer.releasePointerCapture(ev.pointerId); } catch (e) { /* ignore */ }
+      resizer.removeEventListener('pointermove', onMove);
+      resizer.removeEventListener('pointerup', onUp);
+      resizer.removeEventListener('pointercancel', onUp);
+      document.body.classList.remove('cr-resizing');
+      saveWidth();
+    }
+
+    resizer.addEventListener('pointerdown', function (ev) {
+      if (window.innerWidth <= 1200) return;           // board is a drawer here
+      if (DOC.classList.contains('mm-board-hidden')) return;
+      var ws = document.getElementById('cr-workspace');
+      if (!ws) return;
+      ev.preventDefault();
+      wsRight = ws.getBoundingClientRect().right;
+      try { resizer.setPointerCapture(ev.pointerId); } catch (e) { /* ignore */ }
+      document.body.classList.add('cr-resizing');
+      resizer.addEventListener('pointermove', onMove);
+      resizer.addEventListener('pointerup', onUp);
+      resizer.addEventListener('pointercancel', onUp);
+    });
+
+    // Keyboard: left/right nudge; home resets.
+    resizer.addEventListener('keydown', function (ev) {
+      var cur = readSideVar();
+      if (ev.key === 'ArrowLeft') { applyWidth(cur + STEP); saveWidth(); ev.preventDefault(); }
+      else if (ev.key === 'ArrowRight') { applyWidth(cur - STEP); saveWidth(); ev.preventDefault(); }
+      else if (ev.key === 'Home') { applyWidth(DEFAULT_W); saveWidth(); ev.preventDefault(); }
+    });
+
+    // Double-click resets to the default width.
+    resizer.addEventListener('dblclick', function () { applyWidth(DEFAULT_W); saveWidth(); });
+  }
+
+  // --- Tutor hero minimize ----------------------------------------------
+
+  function setHeroMinimized(min, minBtn) {
+    document.body.classList.toggle('cr-hero-min', min);
+    try { localStorage.setItem(LS_HERO, min ? '1' : '0'); } catch (e) { /* ignore */ }
+    if (minBtn) minBtn.setAttribute('aria-expanded', min ? 'false' : 'true');
+  }
+
+  function buildHeroControls(stage) {
+    var hero = stage.querySelector('.cr-tutor-hero');
+    if (!hero) return;
+
+    // Minimize button on the hero.
+    var minBtn = document.createElement('button');
+    minBtn.type = 'button';
+    minBtn.className = 'cr-hero-min-btn';
+    minBtn.setAttribute('aria-label', 'Minimize tutor');
+    minBtn.setAttribute('aria-expanded', 'true');
+    minBtn.title = 'Minimize tutor';
+    minBtn.innerHTML = '<i class="fas fa-chevron-left" aria-hidden="true"></i>';
+    hero.appendChild(minBtn);
+
+    // "Show tutor" restore pill, placed where the hero column was.
+    var restore = document.createElement('button');
+    restore.type = 'button';
+    restore.className = 'cr-hero-restore';
+    restore.setAttribute('aria-label', 'Show tutor');
+    restore.title = 'Show tutor';
+    restore.innerHTML =
+      '<img alt="" id="cr-hero-restore-avatar" />' +
+      '<i class="fas fa-user cr-hero-restore-fallback" aria-hidden="true" style="display:none;"></i>' +
+      '<span>Show tutor</span>';
+    stage.appendChild(restore);
+
+    // Mirror the current tutor portrait onto the pill so it reads as "bring
+    // the tutor back", falling back to a generic icon if the portrait is blank.
+    function syncAvatar() {
+      var portrait = document.getElementById('cr-tutor-portrait');
+      var img = document.getElementById('cr-hero-restore-avatar');
+      var fallback = restore.querySelector('.cr-hero-restore-fallback');
+      if (!img) return;
+      if (portrait && portrait.getAttribute('src')) {
+        img.src = portrait.getAttribute('src');
+        img.style.display = '';
+        if (fallback) fallback.style.display = 'none';
+      } else {
+        img.style.display = 'none';
+        if (fallback) fallback.style.display = '';
+      }
+    }
+
+    minBtn.addEventListener('click', function () {
+      syncAvatar();
+      setHeroMinimized(true, minBtn);
+    });
+    restore.addEventListener('click', function () {
+      setHeroMinimized(false, minBtn);
+    });
+
+    // Restore the persisted minimized state.
+    var savedHero = null;
+    try { savedHero = localStorage.getItem(LS_HERO); } catch (e) { /* ignore */ }
+    if (savedHero === '1') { syncAvatar(); setHeroMinimized(true, minBtn); }
+  }
+
+  // --- Boot --------------------------------------------------------------
+
+  function init() {
+    var stage = document.querySelector('.cr-stage');
+    if (!stage || !document.body.classList.contains('cr-mode')) return;
+
+    // Restore the persisted board width (clamped to the current viewport).
+    var savedW = null;
+    try { savedW = parseInt(localStorage.getItem(LS_WIDTH), 10); } catch (e) { /* ignore */ }
+    if (savedW) applyWidth(savedW);
+
+    buildResizer(stage);
+    buildHeroControls(stage);
+
+    // Keep the width valid if the window shrinks under a wide board.
+    window.addEventListener('resize', function () {
+      if (window.innerWidth <= 1200) return;
+      applyWidth(readSideVar());
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## What & why

Adds two layout controls to the `cr-mode` chat stage so students can trade space between the chat column and the work board, and hide the tutor avatar when they want more room. Both preferences persist in `localStorage`.

### 1. Resizable work board
A drag handle sits in the gap between the chat column and the work board. Dragging it drives `--cr-side-w`, so the existing CSS grid (`hero | chat | workspace`) reflows off that variable — drag left to grow the board, right to grow chat.

- Width is clamped so neither chat (min 360px) nor the board (min 240px) gets crushed, re-clamped on window resize.
- Keyboard accessible: the handle is focusable (`role="separator"`), arrow keys nudge it, double-click / `Home` resets to the default width.
- Desktop only — below 1200px the board is already a slide-in drawer (see `workspace.css`), so the handle is hidden there.

### 2. Minimizable tutor hero
A minimize button on the tutor hero collapses the entire hero column and drops a **"Show tutor"** pill (mirroring the current tutor's portrait) where it was, handing that space to chat and the board. Works at all widths except phones, where the tutor is already docked to a compact cam.

## Implementation
- New self-contained `public/css/adjustable-panels.css` + `public/js/adjustable-panels.js`, wired into `public/chat.html` via two includes. The JS injects all controls, so no structural HTML changes were needed.
- Grid overrides for the minimized state are width-scoped to match the base responsive breakpoints already in `chat-redesign.css` (>1200: `chat | board`; 901–1200: chat only; ≤900: single column).
- Reuses the existing `--cr-side-w` / `--cr-hero-w` design tokens and the `calc(var(--cr-side-w) + …)` anchoring pattern already used for the tour button, so the handle stays aligned with no per-frame JS.

## Testing
Verified in a headless Chromium harness that mirrors the stage grid:
- Handle drag updates `--cr-side-w` and persists it.
- Minimize toggles `body.cr-hero-min`, hides the hero column, reflows the grid to `chat | board`, shows the restore pill, and persists state.
- Restore reverses cleanly.

Screenshots of the wide-board and minimized states were captured during review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J1yZi13mTFJtdxHMRzAnBo)_