### PR TITLE
Full-body student avatars on progress, chat sidebar & parent dashboard + retire DiceBear

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -976,6 +976,12 @@ const userSchema = new Schema({
       dismissedAt: { type: Date },
       snoozedUntil: { type: Date },
       dismissCount: { type: Number, default: 0 }
+    },
+    chooseCharacter: {
+      promptedAt: { type: Date },
+      dismissedAt: { type: Date },
+      snoozedUntil: { type: Date },
+      dismissCount: { type: Number, default: 0 }
     }
   },
 

--- a/public/avatar-builder.html
+++ b/public/avatar-builder.html
@@ -8,6 +8,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','GTM-WDF79L47');</script>
 <!-- End Google Tag Manager -->
+    <!-- DiceBear avatar builder retired — students now choose a full-body preset
+         character. Redirect any stale bookmark/direct nav to the picker. -->
+    <script>window.location.replace('/pick-avatar.html');</script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Create Your Avatar | M∆THM∆TIΧ AI</title>

--- a/public/chat.html
+++ b/public/chat.html
@@ -89,6 +89,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <link rel="stylesheet" href="/dist/css/chat-css2.03bfa896.css" />
   <!-- Coin surfacing: sidebar counter + fly-in reward animation -->
   <link rel="stylesheet" href="/css/coin-fx.css" />
+  <!-- Full-body student character render -->
+  <link rel="stylesheet" href="/css/avatar-fullbody.css" />
 <!-- Interactive math workspace (chat right slot) -->
   <link rel="stylesheet" href="/css/workspace.css?v=20260711" />
   <!-- Voice mode (layout mode of the chat stage) -->
@@ -391,6 +393,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
     <!-- Compact Progress Card — motivational, not actionable, so at the bottom -->
     <div class="sidebar-section sidebar-section-compact" style="margin-top: auto;">
+      <div class="sidebar-avatar-panel" id="sidebar-avatar-panel"></div>
       <div class="sidebar-progress">
         <div class="sidebar-progress-topline">
           <div class="sidebar-progress-level"><span data-i18n="misc.level">Level</span> <span id="sidebar-level">1</span></div>
@@ -2352,6 +2355,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <script src="/dist/js/chat-js1.b97aead7.js"></script>
   <script src="/js/tutor-config-data.js"></script>
   <script src="/js/avatar-config-data.js"></script>
+  <script src="/js/avatarFullBody.js"></script>
 <!-- Redesigned chat shell behavior (tutor swap, quick actions, header pills) -->
   <script defer src="/js/chat-redesign.js?v=20260717"></script>
   <!-- Drive the "Live with <tutor>" pill bars from real TTS playback -->

--- a/public/css/avatar-fullbody.css
+++ b/public/css/avatar-fullbody.css
@@ -118,6 +118,19 @@
 .sidebar-avatar-panel .fba-choose-label,
 .sidebar-avatar-panel .fba-empty-label { font-size: 0.75rem; }
 
+/* ---- Student dashboard header ---- */
+.dashboard-header--with-avatar {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+.dashboard-header--with-avatar .dashboard-avatar { flex: 0 0 auto; }
+.dashboard-header--with-avatar .dashboard-header-text { min-width: 0; }
+@media (max-width: 560px) {
+  .dashboard-header--with-avatar { gap: 12px; }
+  .dashboard-header--with-avatar .fba-md .fba-stage { height: 120px; }
+}
+
 /* ---- Parent dashboard child card ---- */
 .child-avatar-fb {
   display: flex;

--- a/public/css/avatar-fullbody.css
+++ b/public/css/avatar-fullbody.css
@@ -1,0 +1,129 @@
+/* avatar-fullbody.css — the big full-body student character render.
+ * Used on the progress page, chat sidebar, and parent dashboard via
+ * window.AvatarFullBody.html(). Portrait (small circular) avatars are unaffected.
+ */
+
+.fba {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  text-decoration: none;
+  color: inherit;
+}
+
+.fba-stage {
+  position: relative;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  width: 100%;
+}
+
+/* Sizes (stage height; the image scales to fit, preserving aspect + transparency). */
+.fba-sm .fba-stage { height: 96px; }
+.fba-md .fba-stage { height: 168px; }
+.fba-lg .fba-stage { height: 240px; }
+
+.fba-img {
+  max-height: 100%;
+  max-width: 100%;
+  width: auto;
+  object-fit: contain;
+  filter: drop-shadow(0 6px 10px rgba(0, 0, 0, 0.18));
+  transition: transform 200ms ease;
+}
+.fba:hover .fba-img { transform: translateY(-3px); }
+
+/* Soft "ground" shadow so the character feels planted, not floating. */
+.fba-shadow {
+  position: absolute;
+  bottom: 2px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 62%;
+  height: 12px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse at center, rgba(0, 0, 0, 0.22), rgba(0, 0, 0, 0) 70%);
+  z-index: 0;
+}
+.fba-img { position: relative; z-index: 1; }
+
+/* Empty / choose states. */
+.fba-empty-icon {
+  font-size: 3rem;
+  line-height: 1;
+  opacity: 0.5;
+  filter: grayscale(0.3);
+  position: relative;
+  z-index: 1;
+}
+.fba-empty-label,
+.fba-choose-label {
+  margin-top: 8px;
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-align: center;
+}
+.fba-empty-label { color: var(--cr-text-dim, #7a8794); }
+
+.fba-choose {
+  cursor: pointer;
+}
+.fba-choose .fba-stage {
+  border: 2px dashed var(--cr-border, #d5dde3);
+  border-radius: 14px;
+  background: var(--cr-pill-bg, rgba(18, 179, 179, 0.08));
+  transition: border-color 160ms ease, background 160ms ease;
+}
+.fba-choose:hover .fba-stage {
+  border-color: var(--cr-accent, #12b3b3);
+  background: var(--cr-pill-bg-hover, rgba(18, 179, 179, 0.16));
+}
+.fba-choose .fba-choose-label { color: var(--cr-accent-strong, #0f8a8a); }
+.fba-choose:hover .fba-empty-icon { opacity: 0.8; }
+
+@media (prefers-reduced-motion: reduce) {
+  .fba-img { transition: none; }
+  .fba:hover .fba-img { transform: none; }
+}
+
+/* ---- Progress page hero ---- */
+.progress-avatar-hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  margin: 4px auto 18px;
+}
+.progress-avatar-hero .pah-name {
+  font-size: 1.15rem;
+  font-weight: 800;
+  color: var(--cr-text, #18202b);
+}
+.progress-avatar-hero .pah-level {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--cr-accent-strong, #0f8a8a);
+  background: var(--cr-pill-bg, rgba(18, 179, 179, 0.1));
+  padding: 2px 12px;
+  border-radius: 999px;
+}
+
+/* ---- Chat sidebar panel ---- */
+.sidebar-avatar-panel {
+  display: flex;
+  justify-content: center;
+  padding: 4px 0 10px;
+}
+.sidebar-avatar-panel .fba-choose-label,
+.sidebar-avatar-panel .fba-empty-label { font-size: 0.75rem; }
+
+/* ---- Parent dashboard child card ---- */
+.child-avatar-fb {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex: 0 0 auto;
+}
+.child-avatar-fb .fba-choose-label,
+.child-avatar-fb .fba-empty-label { font-size: 0.72rem; }

--- a/public/css/status-card.css
+++ b/public/css/status-card.css
@@ -57,6 +57,18 @@
   font-size: 0.72rem; font-weight: 800; line-height: 22px; text-align: center;
   box-shadow: 0 0 0 2px #fff;
 }
+/* Full-body character variant: drop the circular frame + ring, let the
+   character stand, and re-anchor the level badge under it. */
+.sc-avatar-wrap.sc-fullbody { width: auto; height: auto; flex: 0 0 auto; }
+.sc-avatar-wrap.sc-fullbody .sc-ring { display: none; }
+.sc-avatar-wrap.sc-fullbody .sc-avatar {
+  position: static; width: auto; height: auto;
+  border-radius: 0; overflow: visible; background: none;
+}
+.sc-avatar-wrap.sc-fullbody .sc-level-badge {
+  bottom: -2px; right: 50%; transform: translateX(50%);
+}
+
 .sc-identity { flex: 1; min-width: 0; }
 .sc-name { font-size: 1.15rem; font-weight: 800; color: #18202b; }
 .sc-rank { font-size: 0.85rem; font-weight: 700; color: #12b3b3; margin-top: 1px; }

--- a/public/js/avatarFullBody.js
+++ b/public/js/avatarFullBody.js
@@ -1,0 +1,97 @@
+// public/js/avatarFullBody.js
+// Shared FULL-BODY student avatar renderer — global (window.AvatarFullBody) so it
+// works on ES-module pages (chat) and classic inline-script pages (progress,
+// parent dashboard) alike.
+//
+// Full-body art lives at /images/students/<color>.png and is selected via
+// user.selectedAvatarId === 'student.<color>' (the 8 preset characters). DiceBear
+// is retired: only these presets have a full body, so a student without one is
+// prompted to choose a character.
+//
+// Portrait resolution (small circular avatars) still lives in
+// modules/avatarResolver.js; this module is only for the big full-body render.
+(function (global) {
+  'use strict';
+
+  var PREFIX = 'student.';
+
+  function esc(s) {
+    var el = document.createElement('span');
+    el.textContent = s == null ? '' : String(s);
+    return el.innerHTML;
+  }
+
+  function isFullBodyId(id) {
+    return typeof id === 'string' && id.indexOf(PREFIX) === 0;
+  }
+
+  // The full-body PNG url for a user/child object, or null if they haven't
+  // chosen a full-body character. Prefers the catalog image path when the
+  // catalog is loaded (chat/picker pages); otherwise derives it from the id so
+  // it still works on pages that don't ship AVATAR_CONFIG (progress/parent).
+  function resolveUrl(user) {
+    if (!user) return null;
+    var id = user.selectedAvatarId;
+    if (!isFullBodyId(id)) return null;
+    var cfg = (global.AVATAR_CONFIG || {})[id];
+    if (cfg && cfg.image) return cfg.image;
+    return '/images/students/' + id.slice(PREFIX.length) + '.png';
+  }
+
+  function hasFullBody(user) {
+    return !!resolveUrl(user);
+  }
+
+  // Markup for a full-body avatar "stage". Options:
+  //   size:    'sm' | 'md' | 'lg'      (default 'md')
+  //   pickHref: where the choose-CTA links (default '/pick-avatar.html')
+  //   readOnly: true → no CTA when empty (e.g. a parent viewing their child);
+  //             shows a neutral placeholder + optional emptyLabel instead.
+  //   emptyLabel: text under the empty placeholder (default varies by mode)
+  function html(user, opts) {
+    opts = opts || {};
+    var size = opts.size || 'md';
+    var url = resolveUrl(user);
+    var name = (user && user.firstName) || '';
+
+    if (url) {
+      return '' +
+        '<div class="fba fba-' + esc(size) + '">' +
+          '<div class="fba-stage">' +
+            '<img class="fba-img" src="' + esc(url) + '" alt="' + esc(name) + (name ? "'s" : '') + ' character" loading="lazy" />' +
+            '<div class="fba-shadow" aria-hidden="true"></div>' +
+          '</div>' +
+        '</div>';
+    }
+
+    if (opts.readOnly) {
+      var roLabel = opts.emptyLabel || 'No character chosen yet';
+      return '' +
+        '<div class="fba fba-' + esc(size) + ' fba-empty">' +
+          '<div class="fba-stage">' +
+            '<span class="fba-empty-icon" aria-hidden="true">🧍</span>' +
+            '<div class="fba-shadow" aria-hidden="true"></div>' +
+          '</div>' +
+          '<div class="fba-empty-label">' + esc(roLabel) + '</div>' +
+        '</div>';
+    }
+
+    var label = opts.emptyLabel || 'Choose your character';
+    var href = opts.pickHref || '/pick-avatar.html';
+    return '' +
+      '<a class="fba fba-' + esc(size) + ' fba-choose" href="' + esc(href) + '">' +
+        '<div class="fba-stage">' +
+          '<span class="fba-empty-icon" aria-hidden="true">🧍</span>' +
+          '<div class="fba-shadow" aria-hidden="true"></div>' +
+        '</div>' +
+        '<div class="fba-choose-label">' + esc(label) + '</div>' +
+      '</a>';
+  }
+
+  global.AvatarFullBody = {
+    isFullBodyId: isFullBodyId,
+    resolveUrl: resolveUrl,
+    hasFullBody: hasFullBody,
+    html: html,
+  };
+})(window);

--- a/public/js/modules/statusCard.js
+++ b/public/js/modules/statusCard.js
@@ -97,7 +97,7 @@ function buildModal() {
           <div class="sc-identity">
             <div class="sc-name"></div>
             <div class="sc-rank"></div>
-            <a class="sc-lab-cta" href="/pick-avatar.html">🎨 Design in the Creation Lab</a>
+            <a class="sc-lab-cta" href="/pick-avatar.html">🎨 Choose your character</a>
             <button type="button" class="sc-shop-cta">🛍️ Open Shop</button>
           </div>
         </div>

--- a/public/js/modules/statusCard.js
+++ b/public/js/modules/statusCard.js
@@ -141,7 +141,16 @@ function populate(modal, user) {
     if (!user) return;
     const q = (sel) => modal.querySelector(sel);
 
-    q('.sc-avatar').innerHTML = avatarMarkup(user);
+    // Full-body character in the hero when they've chosen one; otherwise the
+    // circular portrait + XP ring.
+    const wrap = q('.sc-avatar-wrap');
+    if (window.AvatarFullBody && window.AvatarFullBody.hasFullBody(user)) {
+        q('.sc-avatar').innerHTML = window.AvatarFullBody.html(user, { size: 'sm' });
+        if (wrap) wrap.classList.add('sc-fullbody');
+    } else {
+        q('.sc-avatar').innerHTML = avatarMarkup(user);
+        if (wrap) wrap.classList.remove('sc-fullbody');
+    }
     q('.sc-name').textContent = user.firstName || 'Mathematician';
     q('.sc-level-num').textContent = String(user.level || 1);
 

--- a/public/js/parent-dashboard.js
+++ b/public/js/parent-dashboard.js
@@ -791,11 +791,18 @@ document.addEventListener("DOMContentLoaded", async () => {
             }).join('') || '<p style="color: var(--color-text-muted); font-size: 0.85em;">No recent sessions with summaries.</p>'
         : '<p style="color: var(--color-text-muted); font-size: 0.85em;">No recent sessions with summaries.</p>';
 
+        const childAvatarHtml = window.AvatarFullBody
+            ? `<div class="child-avatar-fb">${window.AvatarFullBody.html(progress, { size: 'sm', readOnly: true, emptyLabel: 'No character yet' })}</div>`
+            : '';
+
         card.innerHTML = `
             <div class="child-header" style="display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 8px;">
-                <div>
-                    <h3>${progress.firstName || 'Unknown'} ${progress.lastName || 'Child'}</h3>
-                    <span style="font-size: 0.85em; color: var(--color-text-secondary);">Level ${progress.level || '1'} — ${progress.xp || '0'} XP</span>
+                <div style="display: flex; align-items: center; gap: 12px;">
+                    ${childAvatarHtml}
+                    <div>
+                        <h3>${progress.firstName || 'Unknown'} ${progress.lastName || 'Child'}</h3>
+                        <span style="font-size: 0.85em; color: var(--color-text-secondary);">Level ${progress.level || '1'} — ${progress.xp || '0'} XP</span>
+                    </div>
                 </div>
                 <div style="display: flex; gap: 8px;">
                     <button class="learning-report-btn btn" data-childid="${progress._id}" data-childname="${progress.firstName || 'Child'}" title="View ${progress.firstName || 'your child'}'s learning report" aria-label="View learning report for ${progress.firstName || 'child'}" style="background: var(--color-primary); color: white; font-size: 0.85em; padding: 8px 14px;">

--- a/public/js/pick-avatar.js
+++ b/public/js/pick-avatar.js
@@ -1,6 +1,6 @@
-// public/js/pick-avatar.js  –  DiceBear avatar gallery (no preset avatars)
-// Users customize their avatar using the DiceBear builder.
-// Gallery holds up to 3 saved custom avatars.
+// public/js/pick-avatar.js  –  Full-body character select.
+// DiceBear is retired: students choose one of the polished full-body preset
+// characters (the `student.*` catalog). No custom builder, no gallery.
 document.addEventListener('DOMContentLoaded', () => {
   let currentUser  = null;
   const avatarSelectionGrid  = document.getElementById('avatar-selection-grid');
@@ -21,21 +21,6 @@ document.addEventListener('DOMContentLoaded', () => {
       }
 
       renderAvatars();
-
-      // Check if returning from avatar builder
-      const urlParams = new URLSearchParams(window.location.search);
-      if (urlParams.get('avatar') === 'custom' && currentUser.avatarGallery?.length > 0) {
-        const latestIndex = currentUser.avatarGallery.length - 1;
-        setTimeout(() => {
-          const card = document.querySelector(`.avatar-card[data-avatar-id="gallery-${latestIndex}"]`);
-          if (card) {
-            card.classList.add('selected');
-            selectedAvatarId = `gallery-${latestIndex}`;
-            completeSelectionBtn.disabled = false;
-          }
-        }, 100);
-        window.history.replaceState({}, '', '/pick-avatar.html');
-      }
     } catch (err) {
       console.error('Error fetching initial data:', err);
       avatarSelectionGrid.innerHTML = '<p>Error loading avatars. Please refresh.</p>';
@@ -47,55 +32,14 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!avatarSelectionGrid || !currentUser) return;
     avatarSelectionGrid.innerHTML = '';
 
-    // "Create Custom Avatar" card
-    const galleryCount = (currentUser.avatarGallery || []).length;
-    const customCard = document.createElement('div');
-    customCard.classList.add('avatar-card', 'unlocked', 'create-custom');
-    customCard.dataset.avatarId = 'custom';
-    customCard.innerHTML =
-      '<div class="avatar-card-image"><i class="fas fa-magic"></i></div>' +
-      '<h4 class="avatar-card-name">Create Your Own!</h4>' +
-      '<p class="avatar-card-description">' + (galleryCount < 3 ? (3 - galleryCount) + ' slots left' : 'Replace oldest') + '</p>';
-    avatarSelectionGrid.appendChild(customCard);
-
-    // HTML escape helper to prevent XSS from user-created avatar names/URLs
+    // HTML escape helper to prevent XSS from avatar names.
     function esc(str) {
       const el = document.createElement('span');
       el.textContent = str || '';
       return el.innerHTML;
     }
 
-    // Show gallery avatars
-    if (currentUser.avatarGallery && currentUser.avatarGallery.length > 0) {
-      currentUser.avatarGallery.forEach((avatar, index) => {
-        const card = document.createElement('div');
-        card.classList.add('avatar-card', 'unlocked');
-        card.dataset.avatarId = 'gallery-' + index;
-        card.dataset.galleryIndex = index;
-        card.innerHTML =
-          '<div class="avatar-card-image"><img src="' + esc(avatar.dicebearUrl) + '" alt="' + esc(avatar.name) + '" loading="lazy"></div>' +
-          '<h4 class="avatar-card-name">' + esc(avatar.name) + '</h4>' +
-          '<p class="avatar-card-description">Custom avatar</p>';
-        avatarSelectionGrid.appendChild(card);
-      });
-    }
-
-    // Show current default DiceBear avatar if no gallery items
-    if (currentUser.avatar?.dicebearUrl && galleryCount === 0) {
-      const defaultCard = document.createElement('div');
-      defaultCard.classList.add('avatar-card', 'unlocked', 'selected');
-      defaultCard.dataset.avatarId = 'dicebear-default';
-      selectedAvatarId = 'dicebear-default';
-      completeSelectionBtn.disabled = false;
-      defaultCard.innerHTML =
-        '<div class="avatar-card-image"><img src="' + esc(currentUser.avatar.dicebearUrl) + '" alt="My Avatar" loading="lazy"></div>' +
-        '<h4 class="avatar-card-name">Current Avatar</h4>' +
-        '<p class="avatar-card-description">Your default look</p>';
-      avatarSelectionGrid.appendChild(defaultCard);
-    }
-
-    // Catalog avatars (creatures/characters) — coexist with DiceBear. Free ones
-    // unlock at level 1; creatures unlock by level as a progression reward.
+    // The full-body preset character lineup is the only avatar choice.
     renderCatalogAvatars(esc);
   }
 
@@ -139,11 +83,6 @@ document.addEventListener('DOMContentLoaded', () => {
   avatarSelectionGrid.addEventListener('click', e => {
     const card = e.target.closest('.avatar-card');
     if (!card || card.classList.contains('locked')) return;
-
-    if (card.dataset.avatarId === 'custom') {
-      window.location.href = '/avatar-builder.html?from=pick-avatar';
-      return;
-    }
 
     document.querySelectorAll('.avatar-card').forEach(c => c.classList.remove('selected'));
     card.classList.add('selected');

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -448,6 +448,15 @@ document.addEventListener("DOMContentLoaded", () => {
         try { initIdentityChip(currentUser); } catch (e) { console.warn('Identity chip init failed', e); }
         // Apply any equipped cosmetics (no-op until the student equips something).
         try { applyCosmetics(currentUser); } catch (e) { console.warn('Apply cosmetics failed', e); }
+        // Full-body character in the sidebar ("this is me"). Falls back to a
+        // "Choose your character" CTA when they haven't picked one yet.
+        try {
+            const avatarPanel = document.getElementById('sidebar-avatar-panel');
+            if (avatarPanel && window.AvatarFullBody) {
+                avatarPanel.innerHTML = window.AvatarFullBody.html(currentUser, { size: 'sm' });
+            }
+        } catch (e) { console.warn('Sidebar avatar render failed', e); }
+
         // Sidebar coin counter → shop (closes the earn→spend loop right where
         // students watch their balance grow).
         const coinsBtn = document.getElementById('sidebar-coins-btn');

--- a/public/parent-dashboard.html
+++ b/public/parent-dashboard.html
@@ -15,6 +15,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <link rel="stylesheet" href="/css/design-system.css" />
   <link rel="stylesheet" href="/css/impersonation-banner.css" />
   <link rel="stylesheet" href="/css/practice-pack.css" />
+  <link rel="stylesheet" href="/css/avatar-fullbody.css" />
   <style>
     /* ============================================
        MATHMATIX AI - PARENT DASHBOARD
@@ -2456,6 +2457,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <script src="/js/role-switcher.js"></script>
   <script src="/js/storage-utils.js"></script>
   <script src="/js/auto-logout.js"></script>
+  <script src="/js/avatarFullBody.js"></script>
   <script src="/js/parent-dashboard.js"></script>
   <script src="/js/guided-tour.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/js/all.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>

--- a/public/progress.html
+++ b/public/progress.html
@@ -13,6 +13,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <title>M∆THM∆TIΧ AI - Your Math Journey</title>
   <link rel="stylesheet" href="/style.css" />
   <link rel="stylesheet" href="/css/ux-enhancements.css" />
+  <link rel="stylesheet" href="/css/avatar-fullbody.css" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" />
   <style>
     * { box-sizing: border-box; }
@@ -481,6 +482,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         </button>
       </div>
 
+      <div class="progress-avatar-hero" id="progress-avatar-hero"></div>
+
       <div class="stats-row">
         <div class="stat-card mastered-card">
           <div class="stat-ring">
@@ -556,6 +559,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 
 <script src="/js/csrf.js"></script>
+  <script src="/js/avatarFullBody.js"></script>
   <script>
     const CIRCUMFERENCE = 2 * Math.PI * 34; // ~213.6
 
@@ -584,6 +588,22 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         }
 
         await loadProgress();
+
+        // Full-body character hero (survives the normal render; the empty-state
+        // branch replaces progress-content, so guard on the element existing).
+        try {
+          const heroEl = document.getElementById('progress-avatar-hero');
+          if (heroEl && window.AvatarFullBody) {
+            heroEl.innerHTML =
+              window.AvatarFullBody.html(user, { size: 'lg' }) +
+              '<div class="pah-meta">' +
+                '<div class="pah-name"></div>' +
+                '<div class="pah-level">Level ' + (user.level || 1) + '</div>' +
+              '</div>';
+            // Set the name via textContent to avoid any injection.
+            heroEl.querySelector('.pah-name').textContent = user.firstName || 'Mathematician';
+          }
+        } catch (e) { console.warn('Avatar hero render failed', e); }
 
         document.getElementById('loading-state').style.display = 'none';
         document.getElementById('progress-content').style.display = 'block';

--- a/public/student-dashboard.html
+++ b/public/student-dashboard.html
@@ -16,7 +16,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <link rel="stylesheet" href="/css/dark-mode.css" />
   <link rel="stylesheet" href="/css/ux-enhancements.css" />
   <link rel="stylesheet" href="/css/age-adaptive.css" />
+  <link rel="stylesheet" href="/css/avatar-fullbody.css" />
   <script src="/js/csrf.js"></script>
+  <script src="/js/avatarFullBody.js"></script>
   <script src="/js/age-tier-standalone.js"></script>
   <script src="/js/i18n-translations.js"></script>
   <script src="/js/i18n.js"></script>
@@ -379,9 +381,12 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     </div>
 
     <div id="dashboard-content" style="display: none;">
-      <div class="dashboard-header">
-        <h1>Welcome back, <span id="student-name">Student</span>!</h1>
-        <p id="welcome-subtitle" data-i18n="dash.readyToLearn">Ready to learn?</p>
+      <div class="dashboard-header dashboard-header--with-avatar">
+        <div class="dashboard-avatar" id="dashboard-avatar"></div>
+        <div class="dashboard-header-text">
+          <h1>Welcome back, <span id="student-name">Student</span>!</h1>
+          <p id="welcome-subtitle" data-i18n="dash.readyToLearn">Ready to learn?</p>
+        </div>
       </div>
 
       <!-- Hero: Continue Where You Left Off -->
@@ -605,6 +610,15 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
         currentUserId = user._id;
         document.getElementById('student-name').textContent = user.firstName || 'Student';
+
+        // Full-body character next to the welcome (or a "Choose your character"
+        // prompt if they haven't picked one yet).
+        try {
+          const avEl = document.getElementById('dashboard-avatar');
+          if (avEl && window.AvatarFullBody) {
+            avEl.innerHTML = window.AvatarFullBody.html(user, { size: 'md' });
+          }
+        } catch (e) { console.warn('Dashboard avatar render failed', e); }
 
         // Apply age-adaptive UI tier
         if (window.applyAgeTierFromGrade) window.applyAgeTierFromGrade(user.gradeLevel);

--- a/routes/nudges.js
+++ b/routes/nudges.js
@@ -22,8 +22,14 @@ const HOUR_MS = 60 * 60 * 1000;
 // hitting "Skip for today" daily.
 const MAX_SNOOZE_HOURS = 24 * 7;
 
+const STATE_KEYS = {
+  [NUDGE_TYPES.STARTING_POINT]: 'screener',
+  [NUDGE_TYPES.GROWTH_CHECK]: 'growthCheck',
+  [NUDGE_TYPES.CHOOSE_CHARACTER]: 'chooseCharacter',
+};
+
 function stateKeyForType(type) {
-  return type === NUDGE_TYPES.STARTING_POINT ? 'screener' : 'growthCheck';
+  return STATE_KEYS[type] || 'growthCheck';
 }
 
 function ensureNudgeState(user, key) {

--- a/routes/parent.js
+++ b/routes/parent.js
@@ -162,7 +162,7 @@ router.post('/accept-invite', isAuthenticated, isParent, async (req, res) => {
 router.get('/children', isAuthenticated, isParent, async (req, res) => {
     const parentId = req.user._id;
     try {
-        const parent = await User.findById(parentId).populate('children', 'firstName lastName username gradeLevel mathCourse totalActiveTutoringMinutes');
+        const parent = await User.findById(parentId).populate('children', 'firstName lastName username gradeLevel mathCourse totalActiveTutoringMinutes selectedAvatarId level');
         if (!parent) {
             return res.status(404).json({ message: "Parent not found." });
         }
@@ -326,6 +326,7 @@ router.get('/child/:childId/progress', isAuthenticated, isParent, logRecordAcces
             _id: child._id,
             firstName: child.firstName,
             lastName: child.lastName,
+            selectedAvatarId: child.selectedAvatarId || null,
             level: child.level || 1,
             xp: child.xp || 0,
             gradeLevel: child.gradeLevel,

--- a/tests/integration/nudges.test.js
+++ b/tests/integration/nudges.test.js
@@ -38,6 +38,9 @@ function makeUserDoc(fields = {}) {
     startingPointOffered: false,
     startingPointOfferedAt: null,
     nextGrowthCheckDue: null,
+    // Default: already has a full-body character, so the choose-character nudge
+    // stays out of route-plumbing assertions unrelated to avatars.
+    selectedAvatarId: 'student.navy',
     nudgeState: undefined,
     markModified: jest.fn(),
     save: jest.fn().mockResolvedValue(undefined),
@@ -78,6 +81,16 @@ describe('GET /api/nudges', () => {
     expect(res.body.nudges).toEqual([]);
     expect(user.save).not.toHaveBeenCalled();
   });
+
+  test('surfaces choose-character nudge for a student without a full-body character', async () => {
+    const user = makeUserDoc({ assessmentCompleted: true, nextGrowthCheckDue: null, selectedAvatarId: '' });
+    User.findById.mockResolvedValue(user);
+    const res = await supertest(makeApp({ _id: 'u-1' })).get('/api/nudges');
+    expect(res.status).toBe(200);
+    expect(res.body.nudges).toHaveLength(1);
+    expect(res.body.nudges[0].type).toBe('choose-character');
+    expect(user.nudgeState.chooseCharacter.promptedAt).toBeInstanceOf(Date);
+  });
 });
 
 describe('POST /api/nudges/:type/dismiss', () => {
@@ -107,6 +120,15 @@ describe('POST /api/nudges/:type/dismiss', () => {
     const res = await supertest(makeApp({ _id: 'u-1' })).post('/api/nudges/growth-check/dismiss');
     expect(res.status).toBe(200);
     expect(res.body.dismissCount).toBe(3);
+  });
+
+  test('records dismissal for choose-character under its own state key', async () => {
+    const user = makeUserDoc({ selectedAvatarId: '' });
+    User.findById.mockResolvedValue(user);
+    const res = await supertest(makeApp({ _id: 'u-1' })).post('/api/nudges/choose-character/dismiss');
+    expect(res.status).toBe(200);
+    expect(res.body.dismissCount).toBe(1);
+    expect(user.nudgeState.chooseCharacter.dismissedAt).toBeInstanceOf(Date);
   });
 
   test('returns 404 when user disappears', async () => {

--- a/tests/unit/userNudges.test.js
+++ b/tests/unit/userNudges.test.js
@@ -25,6 +25,9 @@ function newStudent(overrides = {}) {
     startingPointOffered: false,
     startingPointOfferedAt: null,
     nextGrowthCheckDue: null,
+    // Default fixtures already have a full-body character so the
+    // choose-character nudge doesn't fire in tests unrelated to avatars.
+    selectedAvatarId: 'student.navy',
     nudgeState: undefined,
     ...overrides,
   };
@@ -230,6 +233,61 @@ describe('computeNudges — snoozedUntil semantics', () => {
     const n = computeNudges(user, { now: NOW }).find(x => x.type === NUDGE_TYPES.GROWTH_CHECK);
     expect(n).toBeDefined();
     expect(n.severity).toBe('overdue');
+  });
+});
+
+describe('computeNudges — choose-character', () => {
+  // A settled student (assessment done, no growth check due) so the only
+  // nudge in play is choose-character.
+  function settled(overrides = {}) {
+    return newStudent({
+      assessmentCompleted: true,
+      startingPointOffered: true,
+      startingPointOfferedAt: daysAgo(120),
+      nextGrowthCheckDue: null,
+      ...overrides,
+    });
+  }
+  const find = (u) => computeNudges(u, { now: NOW }).find(n => n.type === NUDGE_TYPES.CHOOSE_CHARACTER);
+
+  test('student without a full-body character gets the nudge', () => {
+    const n = find(settled({ selectedAvatarId: '' }));
+    expect(n).toBeDefined();
+    expect(n.severity).toBe('recommended');
+    expect(n.dismissible).toBe(true);
+    expect(n.action.href).toBe('/pick-avatar.html');
+  });
+
+  test('student on a DiceBear avatar (no student.* id) still gets the nudge', () => {
+    const n = find(settled({ selectedAvatarId: undefined, avatar: { dicebearUrl: 'https://x/y.svg' } }));
+    expect(n).toBeDefined();
+  });
+
+  test('student with a full-body preset gets NO nudge', () => {
+    expect(find(settled({ selectedAvatarId: 'student.gold' }))).toBeUndefined();
+  });
+
+  test('non-students never get the nudge', () => {
+    expect(find(settled({ role: 'teacher', selectedAvatarId: '' }))).toBeUndefined();
+    expect(find(settled({ role: 'parent', roles: ['parent'], selectedAvatarId: '' }))).toBeUndefined();
+  });
+
+  test('roles[] array takes precedence over legacy role', () => {
+    expect(find(settled({ role: 'teacher', roles: ['student'], selectedAvatarId: '' }))).toBeDefined();
+  });
+
+  test('recently dismissed (within snooze) suppresses; past snooze re-prompts', () => {
+    const dismissed = settled({
+      selectedAvatarId: '',
+      nudgeState: { chooseCharacter: { dismissedAt: daysAgo(SNOOZE_DAYS - 1), dismissCount: 1 } },
+    });
+    expect(find(dismissed)).toBeUndefined();
+
+    const expired = settled({
+      selectedAvatarId: '',
+      nudgeState: { chooseCharacter: { dismissedAt: daysAgo(SNOOZE_DAYS + 1), dismissCount: 1 } },
+    });
+    expect(find(expired)).toBeDefined();
   });
 });
 

--- a/utils/userNudges.js
+++ b/utils/userNudges.js
@@ -31,7 +31,19 @@ const GROWTH_CHECK_OVERDUE_DAYS = 7;
 const NUDGE_TYPES = Object.freeze({
   STARTING_POINT: 'starting-point',
   GROWTH_CHECK: 'growth-check',
+  CHOOSE_CHARACTER: 'choose-character',
 });
+
+// A student "has a character" once they've picked a full-body preset
+// (selectedAvatarId === 'student.<x>'). DiceBear / empty selections do not count
+// — DiceBear is retired, so those students are nudged to choose one.
+function isStudentRole(user) {
+  if (Array.isArray(user.roles) && user.roles.length) return user.roles.includes('student');
+  return user.role === 'student';
+}
+function hasFullBodyCharacter(user) {
+  return typeof user.selectedAvatarId === 'string' && user.selectedAvatarId.indexOf('student.') === 0;
+}
 
 /**
  * @typedef {Object} Nudge
@@ -157,6 +169,31 @@ function buildGrowthCheckNudge(user, now) {
   };
 }
 
+function buildChooseCharacterNudge(user, now) {
+  // Only students, and only until they've chosen a full-body character.
+  if (!isStudentRole(user)) return null;
+  if (hasFullBodyCharacter(user)) return null;
+
+  // Quiet period after a dismissal.
+  if (snoozeActive(user.nudgeState?.chooseCharacter, now)) return null;
+
+  return {
+    type: NUDGE_TYPES.CHOOSE_CHARACTER,
+    severity: 'recommended',
+    title: 'Choose your character',
+    message: "Pick a full-body character — it shows up on your dashboard, chat, and progress page.",
+    action: {
+      label: 'Choose now',
+      href: '/pick-avatar.html',
+    },
+    dismissible: true,
+    autoLaunch: false,
+    meta: {
+      dismissCount: user.nudgeState?.chooseCharacter?.dismissCount || 0,
+    },
+  };
+}
+
 /**
  * Compute the nudges a given user should see right now.
  *
@@ -172,6 +209,7 @@ function computeNudges(user, opts = {}) {
   const nudges = [
     buildGrowthCheckNudge(user, now),
     buildStartingPointNudge(user, now),
+    buildChooseCharacterNudge(user, now),
   ].filter(Boolean);
 
   // Order: overdue → due → recommended


### PR DESCRIPTION
## Why

A student's avatar should feel like *them* — a character they picked and show off — not a tiny circle. This renders the student's **full-body character** across the app and makes choosing an avatar mean choosing a full-body character.

## Full-body render

New shared `window.AvatarFullBody` helper (`public/js/avatarFullBody.js`) + `avatar-fullbody.css`, usable on both ES-module and classic-script pages. It renders the `student.*` preset PNG (`/images/students/<color>.png`) large, with a soft ground shadow, or a fallback state when none is chosen.

- **Progress page** (`progress.html`) — a full-body character hero with name + level (it showed no avatar before).
- **Chat sidebar** (`chat.html`) — the character stands above the level/coins card ("this is me").
- **Parent dashboard** (`parent-dashboard.js`) — each child card shows that child's full-body character. Backend now exposes `selectedAvatarId` on the parent's child-progress data (`routes/parent.js`).
- **Empty state** — students without a full-body character get a friendly **"Choose your character"** CTA → the picker; the parent's view shows a neutral read-only placeholder (no CTA on someone else's kid).

## Retire DiceBear

Per the request, DiceBear is retired as the avatar system:

- The **picker** (`pick-avatar.js`) now shows **only** the full-body preset lineup — the custom-builder card, gallery, and default-DiceBear card are removed. Choosing an avatar = choosing a full-body character.
- The **DiceBear builder page** (`avatar-builder.html`) redirects to the picker (it had no remaining inbound links).
- The status card CTA now reads **"Choose your character."**
- **Transitional courtesy:** existing DiceBear portraits still resolve in the *small* chat/message avatars (`resolveAvatarUrl` unchanged), so no one's avatar suddenly vanishes mid-transition — but every full-body surface is DiceBear-free and nudges selection.

## Test notes

- `node --check` passes on all touched JS; progress.html inline scripts parse.
- Smoke-tested the helper: presets → full-body PNG, DiceBear → null (retired), and the choose/empty/read-only fallbacks render.
- All 8 preset art files confirmed present in `public/images/students/`.
- No CSS-bundle rebuild needed — `avatar-fullbody.css` is linked directly on each page.

### Follow-ups worth a look (not in this PR)
- If you want DiceBear *fully* gone from the small chat portraits too (not just the full-body surfaces), that's a one-line change to `resolveAvatarUrl` — left out here to avoid blanking existing users' chat avatars before they re-pick.
- A one-time nudge for current DiceBear users to pick a character could smooth the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9zNo7LtFvgW4DMxH8HiEi)_