### PR TITLE
feat(skill-map): the board — strand towers, proximity hook, and both …

### DIFF
--- a/public/css/skill-map.css
+++ b/public/css/skill-map.css
@@ -1,522 +1,250 @@
 /* ================================================================
-   THE MATHEMATICAL UNIVERSE — Constellation Skill Map
+   SKILL MAP — "Your climb"
+   Six strand towers, one band per course level, filling bottom-up.
    ================================================================ */
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
+:root {
+    --sm-bg: #0D131B;
+    --sm-board: #121B25;
+    --sm-panel: #16202B;
+    --sm-line: #22303E;
+    --sm-ink: #E7EEF4;
+    --sm-muted: #8397A9;
+    --sm-faint: #54677A;
+    --sm-locked: #1B2734;
+    --sm-good: #4FC08A;
+    --sm-warn: #F0A93C;
+
+    /* One hue per strand. A pattern is a column, so colour identifies the
+       through-line, not the difficulty. */
+    --qnt: #F0A93C;
+    --prp: #3FBFD4;
+    --eqv: #8E7BE8;
+    --fnc: #4FC08A;
+    --spc: #E8735F;
+    --dta: #D46BA6;
+}
+
+@media (prefers-color-scheme: light) {
+    :root {
+        --sm-bg: #EDF0F4; --sm-board: #F7F9FB; --sm-panel: #FFFFFF;
+        --sm-line: #D8DFE7; --sm-ink: #16202B; --sm-muted: #5A6C7E;
+        --sm-faint: #8397A9; --sm-locked: #DDE3EA;
+        --qnt: #C4801E; --prp: #1E8FA6; --eqv: #6A55C7;
+        --fnc: #2E9268; --spc: #C64F3C; --dta: #AC4681;
+    }
+}
+
 html, body {
-    height: 100%;
-    overflow: hidden;
+    min-height: 100%;
     font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
-    background: #04060c;
-    color: #ccd6e0;
+    background: var(--sm-bg);
+    color: var(--sm-ink);
 }
 
 .skip-to-content {
-    position: absolute; left: -9999px; z-index: 9999;
-    padding: 0.5rem 1rem; background: #0a1628; color: #fff;
+    position: absolute; left: -9999px; top: 0;
+    background: var(--sm-panel); color: var(--sm-ink);
+    padding: 10px 16px; z-index: 100;
 }
-.skip-to-content:focus { left: 10px; top: 10px; }
+.skip-to-content:focus { left: 8px; top: 8px; }
 
-/* ================================================================
-   FULL-VIEWPORT CANVAS
-   ================================================================ */
-
-#graph-container {
-    position: fixed;
-    inset: 0;
-    width: 100vw;
-    height: 100vh;
-    cursor: grab;
-    background: #04060c;
+.wrap {
+    max-width: 1200px; margin: 0 auto;
+    padding: clamp(16px, 3vw, 34px);
+    display: flex; flex-direction: column; gap: 20px;
 }
 
-#graph-container:active { cursor: grabbing; }
-#graph-container svg { display: block; }
-
-/* ================================================================
-   FLOATING UI — minimal, glass
-   ================================================================ */
-
-.info-box {
-    position: fixed;
-    top: 20px;
-    left: 20px;
-    z-index: 100;
-    display: flex;
-    align-items: flex-start;
-    gap: 12px;
-    background: rgba(6, 10, 20, 0.75);
-    backdrop-filter: blur(16px) saturate(120%);
-    border: 1px solid rgba(255, 255, 255, 0.06);
-    border-radius: 10px;
-    padding: 14px 18px;
-    max-width: 320px;
-    opacity: 0;
-    animation: uiFadeIn 1.2s 2.2s ease-out forwards;
+/* ── header ─────────────────────────────────────────────── */
+.top { display: flex; flex-wrap: wrap; align-items: flex-end; justify-content: space-between; gap: 18px; }
+.brandline { display: flex; flex-direction: column; gap: 6px; }
+.eyebrow {
+    font-size: 11px; letter-spacing: .16em; text-transform: uppercase;
+    color: var(--sm-faint);
 }
+.top h1 { font-size: clamp(22px, 3vw, 34px); font-weight: 600; letter-spacing: .01em; }
+.top h1 em { font-style: normal; color: var(--sm-muted); font-weight: 400; }
 
-.info-back {
-    color: rgba(255, 255, 255, 0.4);
-    text-decoration: none;
-    font-size: 1.1rem;
-    line-height: 1;
-    padding: 2px 4px;
-    border-radius: 4px;
-    transition: color 0.2s, background 0.2s;
-}
-.info-back:hover { color: #fff; background: rgba(255,255,255,0.06); }
+.tally { display: flex; gap: 24px; font-variant-numeric: tabular-nums; }
+.tally div { display: flex; flex-direction: column; gap: 2px; }
+.tally b { font-size: 26px; font-weight: 600; line-height: 1; }
+.tally span { font-size: 10px; letter-spacing: .14em; text-transform: uppercase; color: var(--sm-faint); }
 
-.info-title {
-    font-size: 0.65rem;
-    font-weight: 700;
-    letter-spacing: 2.5px;
-    text-transform: uppercase;
-    color: rgba(255, 255, 255, 0.55);
-}
-
-.info-subtitle {
-    font-size: 0.6rem;
-    letter-spacing: 0.5px;
-    color: rgba(255, 255, 255, 0.25);
-    margin-top: 2px;
-}
-
-.info-stats {
-    margin-top: 8px;
-    font-size: 0.8rem;
-    color: rgba(255, 255, 255, 0.4);
-}
-
-.info-stat strong { color: #fff; font-size: 1rem; }
-.info-stat-sep   { margin: 0 4px; opacity: 0.2; }
-
-.nav-float {
-    position: fixed;
-    top: 20px;
-    right: 20px;
-    z-index: 100;
-    display: flex;
-    gap: 5px;
-    opacity: 0;
-    animation: uiFadeIn 1.2s 2.4s ease-out forwards;
-}
-
+.nav-float { display: flex; gap: 8px; }
 .nav-btn {
-    background: rgba(6, 10, 20, 0.75);
-    backdrop-filter: blur(16px);
-    border: 1px solid rgba(255, 255, 255, 0.06);
-    border-radius: 6px;
-    padding: 7px 12px;
-    color: rgba(255, 255, 255, 0.45);
-    font-size: 0.78rem;
-    cursor: pointer;
-    text-decoration: none;
-    transition: all 0.2s;
+    color: var(--sm-ink); text-decoration: none; font-size: 13px;
+    border: 1px solid var(--sm-line); border-radius: 3px; padding: 8px 14px;
 }
-.nav-btn:hover {
-    color: #fff;
-    background: rgba(15, 22, 40, 0.9);
-    border-color: rgba(255, 255, 255, 0.12);
+.nav-btn:hover { border-color: var(--sm-muted); }
+
+/* ── proximity hook ─────────────────────────────────────── */
+.hook {
+    background: var(--sm-panel); border: 1px solid var(--sm-line); border-radius: 4px;
+    padding: 14px 18px; display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
 }
-
-@keyframes uiFadeIn {
-    from { opacity: 0; transform: translateY(-6px); }
-    to   { opacity: 1; transform: translateY(0); }
+.hook .pip {
+    width: 8px; height: 8px; border-radius: 50%; background: var(--sm-warn);
+    animation: pulse 2.2s infinite; flex: none;
 }
-
-/* ================================================================
-   SVG — TIERS (horizontal reference lines)
-   ================================================================ */
-
-.tier-label {
-    fill: rgba(255, 255, 255, 0.07);
-    font-size: 11px;
-    font-weight: 700;
-    letter-spacing: 4px;
-    text-transform: uppercase;
-    pointer-events: none;
+@keyframes pulse {
+    0%   { box-shadow: 0 0 0 0 var(--sm-warn); }
+    70%  { box-shadow: 0 0 0 9px transparent; }
+    100% { box-shadow: 0 0 0 0 transparent; }
 }
+.hook p { flex: 1; min-width: 240px; font-size: 15px; }
 
-.tier-line {
-    stroke: rgba(255, 255, 255, 0.025);
-    stroke-width: 1;
-    stroke-dasharray: 4, 10;
-    pointer-events: none;
+.status { color: var(--sm-muted); font-size: 14px; padding: 8px 0; }
+
+/* ── the board ──────────────────────────────────────────── */
+.board { background: var(--sm-board); border: 1px solid var(--sm-line); border-radius: 6px; overflow-x: auto; }
+.towers { display: grid; min-width: 640px; }
+
+.colhead {
+    padding: 14px 10px 12px; border-bottom: 1px solid var(--sm-line);
+    display: flex; flex-direction: column; gap: 5px;
 }
+.colhead .code { font-size: 10px; letter-spacing: .16em; font-weight: 600; }
+.colhead .nm { font-size: 12px; color: var(--sm-muted); line-height: 1.25; }
+.colhead .bar { height: 2px; background: var(--sm-locked); border-radius: 2px; overflow: hidden; }
+.colhead .bar i { display: block; height: 100%; background: currentColor; transition: width .7s cubic-bezier(.2,.7,.3,1); }
+.spacer { border-bottom: 1px solid var(--sm-line); }
 
-/* ================================================================
-   SVG — NEBULA HULLS (region backgrounds)
-   ================================================================ */
-
-.nebula-hull {
-    pointer-events: none;
-    transition: fill-opacity 0.8s;
+.bandlabel {
+    display: flex; align-items: center; justify-content: flex-end;
+    padding: 0 10px; border-right: 1px solid var(--sm-line);
+    font-size: 10px; letter-spacing: .13em; text-transform: uppercase; color: var(--sm-faint);
+}
+.band {
+    border-top: 1px solid var(--sm-line); padding: 9px 8px;
+    display: flex; flex-wrap: wrap; gap: 4px; align-content: flex-start; min-height: 44px;
 }
 
-/* ================================================================
-   SVG — REGION LABELS
-   ================================================================ */
+/* strand hues drive both the header and every cell in the column */
+.strand-qnt { color: var(--qnt); --hue: var(--qnt); }
+.strand-prp { color: var(--prp); --hue: var(--prp); }
+.strand-eqv { color: var(--eqv); --hue: var(--eqv); }
+.strand-fnc { color: var(--fnc); --hue: var(--fnc); }
+.strand-spc { color: var(--spc); --hue: var(--spc); }
+.strand-dta { color: var(--dta); --hue: var(--dta); }
 
-.region-label {
-    font-size: 12px;
-    font-weight: 700;
-    letter-spacing: 3px;
-    text-transform: uppercase;
-    pointer-events: none;
+/* ── cells: the six board states ────────────────────────── */
+.cell {
+    width: 15px; height: 15px; border-radius: 2.5px; border: none; padding: 0;
+    background: var(--sm-locked); cursor: pointer;
+    transition: background .35s, box-shadow .35s, transform .18s;
+}
+.cell:disabled { cursor: default; }
+.cell:hover:not(:disabled) { transform: scale(1.35); z-index: 3; }
+.cell:focus-visible { outline: 2px solid var(--sm-ink); outline-offset: 2px; }
+
+.cell.s-locked  { background: var(--sm-locked); }
+.cell.s-open    { background: transparent; box-shadow: inset 0 0 0 1.5px color-mix(in srgb, var(--hue) 60%, transparent); }
+.cell.s-learned { background: color-mix(in srgb, var(--hue) 34%, transparent); }
+/* cleared from above — deliberately dimmer than proved: the system granted it,
+   the student did not demonstrate it */
+.cell.s-above   { background: color-mix(in srgb, var(--hue) 62%, transparent); }
+.cell.s-proved  { background: var(--hue); box-shadow: 0 0 7px color-mix(in srgb, var(--hue) 55%, transparent); }
+.cell.s-taught  {
+    background: radial-gradient(circle at 50% 50%, #fff 0 22%, var(--hue) 24% 100%);
+    box-shadow: 0 0 11px color-mix(in srgb, var(--hue) 60%, transparent);
+}
+.cell.target { box-shadow: 0 0 0 2px var(--sm-ink), 0 0 12px var(--hue); }
+
+/* ── legend ─────────────────────────────────────────────── */
+.legend {
+    display: flex; gap: 18px; flex-wrap: wrap;
+    font-size: 10px; letter-spacing: .12em; text-transform: uppercase; color: var(--sm-faint);
+}
+.legend span { display: flex; align-items: center; gap: 7px; }
+.swatch { width: 11px; height: 11px; border-radius: 2px; background: var(--sm-muted); }
+.swatch.s-locked { background: var(--sm-locked); }
+.swatch.s-open { background: transparent; box-shadow: inset 0 0 0 1.5px var(--sm-muted); }
+.swatch.s-learned { background: color-mix(in srgb, var(--sm-muted) 34%, transparent); }
+.swatch.s-above { background: color-mix(in srgb, var(--sm-muted) 62%, transparent); }
+.swatch.s-proved { background: var(--sm-muted); }
+.swatch.s-taught { background: radial-gradient(circle at 50% 50%, var(--sm-bg) 0 24%, var(--sm-muted) 26% 100%); }
+
+/* ── buttons ────────────────────────────────────────────── */
+button.act {
+    font-size: 14px; background: var(--sm-ink); color: var(--sm-bg);
+    border: none; border-radius: 3px; padding: 10px 18px; cursor: pointer;
+}
+button.act:hover { opacity: .85; }
+button.act:disabled { opacity: .5; cursor: default; }
+button.ghost {
+    font-size: 13px; background: transparent; color: var(--sm-ink);
+    border: 1px solid var(--sm-line); border-radius: 3px; padding: 9px 16px; cursor: pointer;
+}
+button.ghost:hover { border-color: var(--sm-muted); }
+button:focus-visible { outline: 2px solid var(--sm-ink); outline-offset: 2px; }
+
+/* ── drawer ─────────────────────────────────────────────── */
+.drawer {
+    position: fixed; inset: auto 0 0 0; background: var(--sm-panel);
+    border-top: 1px solid var(--sm-line); padding: 22px clamp(16px, 4vw, 40px);
+    transform: translateY(101%); transition: transform .4s cubic-bezier(.2,.8,.25,1);
+    z-index: 20; box-shadow: 0 -20px 50px rgba(0,0,0,.35);
+    max-height: 85vh; overflow-y: auto;
+}
+.drawer.open { transform: none; }
+.drawer-inner { max-width: 900px; margin: 0 auto; display: flex; flex-direction: column; gap: 16px; }
+.dhead { display: flex; justify-content: space-between; align-items: flex-start; gap: 20px; flex-wrap: wrap; }
+.dhead h2 { font-size: 22px; font-weight: 600; margin-bottom: 4px; }
+.dhead .meta { font-size: 11px; letter-spacing: .06em; color: var(--sm-faint); }
+.d-state { font-size: 14px; color: var(--sm-muted); }
+
+.proofs { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 12px; }
+.proof {
+    background: var(--sm-board); border: 1px solid var(--sm-line); border-radius: 4px;
+    padding: 15px; text-align: left; cursor: pointer; color: var(--sm-ink);
+    transition: border-color .2s, transform .2s;
+}
+.proof:hover { border-color: var(--sm-muted); transform: translateY(-2px); }
+.proof h3 { font-size: 16px; font-weight: 600; margin-bottom: 5px; }
+.proof p { font-size: 12.5px; color: var(--sm-muted); line-height: 1.45; }
+
+/* ── proof runners ──────────────────────────────────────── */
+.runner {
+    border-top: 1px solid var(--sm-line); padding-top: 16px;
+    display: flex; flex-direction: column; gap: 12px;
+}
+.runner h3 { font-size: 17px; font-weight: 600; }
+.runner-sub { font-size: 13.5px; color: var(--sm-muted); line-height: 1.5; }
+.qs { list-style: decimal; padding-left: 22px; display: flex; flex-direction: column; gap: 14px; }
+.q-prompt { font-size: 15px; margin-bottom: 6px; }
+.q-input, #teach-input {
+    width: 100%; max-width: 420px; background: var(--sm-board); color: var(--sm-ink);
+    border: 1px solid var(--sm-line); border-radius: 3px; padding: 9px 11px;
+    font-size: 15px; font-family: inherit;
+}
+#teach-input { max-width: none; resize: vertical; line-height: 1.5; }
+.q-options { display: flex; flex-direction: column; gap: 6px; }
+.q-option { font-size: 14.5px; cursor: pointer; display: flex; align-items: center; gap: 8px; }
+.runner-actions { display: flex; gap: 10px; flex-wrap: wrap; }
+.runner-result { font-size: 14.5px; line-height: 1.5; }
+.runner-result.good { color: var(--sm-good); }
+.runner-result.miss { color: var(--sm-warn); }
+
+/* ── toast ──────────────────────────────────────────────── */
+.toast {
+    position: fixed; left: 50%; top: 34px; transform: translate(-50%, -24px);
+    opacity: 0; pointer-events: none; background: var(--sm-panel);
+    border: 1px solid var(--sm-line); border-radius: 4px; padding: 14px 24px;
+    z-index: 40; text-align: center; transition: opacity .3s, transform .3s;
+    box-shadow: 0 14px 40px rgba(0,0,0,.4);
+}
+.toast.on { opacity: 1; transform: translate(-50%, 0); }
+.toast .big { font-size: 28px; font-weight: 600; line-height: 1; font-variant-numeric: tabular-nums; }
+.toast .sub { font-size: 10px; letter-spacing: .16em; text-transform: uppercase; color: var(--sm-faint); margin-top: 7px; }
+
+@media (prefers-reduced-motion: reduce) {
+    * { animation: none !important; transition: none !important; }
 }
 
-/* ================================================================
-   SVG — EDGES (constellation lines)
-   ================================================================ */
-
-.edge-group {
-    transition: opacity 0.25s;
-}
-
-.edge-path {
-    fill: none;
-    stroke-width: 1;
-    opacity: 0.35;
-    transition: opacity 0.25s, stroke-width 0.25s;
-}
-
-.edge-path.edge-active {
-    opacity: 1 !important;
-    stroke-width: 2.5;
-}
-
-.edge-label-text {
-    font-size: 7.5px;
-    font-style: italic;
-    fill: rgba(255, 255, 255, 0.18);
-    pointer-events: none;
-    letter-spacing: 0.3px;
-}
-
-/* ================================================================
-   SVG — NODES (stars)
-   ================================================================ */
-
-.skill-node {
-    cursor: pointer;
-}
-
-.skill-node.locked { cursor: default; }
-
-.node-shape {
-    transition: transform 0.2s;
-}
-
-.skill-node:not(.locked):hover .node-shape {
-    transform: scale(1.2);
-}
-
-.node-symbol {
-    font-size: 10px;
-    font-weight: 800;
-    text-anchor: middle;
-    dominant-baseline: central;
-    fill: #fff;
-    pointer-events: none;
-    opacity: 0.9;
-}
-
-.skill-node.locked .node-symbol { opacity: 0.15; }
-
-.node-label {
-    font-size: 9px;
-    fill: rgba(255, 255, 255, 0.45);
-    text-anchor: middle;
-    pointer-events: none;
-    transition: fill 0.2s;
-}
-
-.skill-node:not(.locked):hover .node-label {
-    fill: rgba(255, 255, 255, 0.85);
-}
-
-.skill-node.locked .node-label {
-    fill: rgba(255, 255, 255, 0.08);
-}
-
-/* ================================================================
-   SVG — BACKGROUND STARS
-   ================================================================ */
-
-.bg-star {
-    fill: #fff;
-    pointer-events: none;
-}
-
-.bg-star.twinkle-slow  { animation: twinkle 6s ease-in-out infinite; animation-delay: var(--twinkle-delay, 0s); }
-.bg-star.twinkle-med   { animation: twinkle 4s ease-in-out infinite; animation-delay: var(--twinkle-delay, 0s); }
-.bg-star.twinkle-fast  { animation: twinkle 2.5s ease-in-out infinite; animation-delay: var(--twinkle-delay, 0s); }
-
-@keyframes twinkle {
-    0%, 100% { opacity: 1; }
-    50%      { opacity: 0.25; }
-}
-
-/* ================================================================
-   NODE DETAIL PANEL
-   ================================================================ */
-
-.node-detail {
-    position: fixed;
-    top: 0;
-    right: 0;
-    width: 320px;
-    max-width: 90vw;
-    height: 100vh;
-    z-index: 200;
-    background: rgba(6, 10, 20, 0.92);
-    backdrop-filter: blur(30px) saturate(140%);
-    border-left: 1px solid rgba(255, 255, 255, 0.06);
-    transform: translateX(100%);
-    opacity: 0;
-    transition: transform 0.45s cubic-bezier(0.22, 1, 0.36, 1),
-                opacity 0.35s ease;
-    display: flex;
-    flex-direction: column;
-}
-
-.node-detail:not(.hidden) { transform: translateX(0); opacity: 1; }
-
-.detail-close {
-    position: absolute;
-    top: 14px;
-    right: 14px;
-    background: none;
-    border: none;
-    color: rgba(255, 255, 255, 0.3);
-    font-size: 1.4rem;
-    cursor: pointer;
-    padding: 4px 8px;
-    border-radius: 4px;
-    transition: color 0.2s, background 0.2s;
-}
-.detail-close:hover { color: #fff; background: rgba(255,255,255,0.06); }
-
-.detail-body {
-    padding: 48px 24px 24px;
-    flex: 1;
-    overflow-y: auto;
-}
-
-.detail-body h2 {
-    font-size: 1.2rem;
-    font-weight: 600;
-    color: #fff;
-    margin-bottom: 24px;
-    line-height: 1.3;
-}
-
-.detail-meta {
-    display: flex;
-    flex-direction: column;
-    gap: 14px;
-    margin-bottom: 28px;
-    padding-bottom: 20px;
-    border-bottom: 1px solid rgba(255,255,255,0.05);
-}
-
-.detail-row {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-}
-
-.detail-label {
-    font-size: 0.7rem;
-    text-transform: uppercase;
-    letter-spacing: 1.5px;
-    color: rgba(255, 255, 255, 0.25);
-}
-
-.detail-value {
-    font-size: 0.85rem;
-    color: rgba(255, 255, 255, 0.7);
-}
-
-.detail-status-section {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    margin-bottom: 32px;
-}
-
-.status-badge {
-    font-size: 0.65rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 1px;
-    padding: 3px 8px;
-    border-radius: 3px;
-    white-space: nowrap;
-}
-
-.status-badge.mastered   { background: rgba(0, 230, 118, 0.12); color: #69f0ae; }
-.status-badge.developing { background: rgba(255, 213, 79, 0.12); color: #ffd54f; }
-.status-badge.ready      { background: rgba(79, 195, 247, 0.12); color: #4fc3f7; }
-.status-badge.locked     { background: rgba(255, 255, 255, 0.04); color: rgba(255,255,255,0.2); }
-
-.progress-track {
-    flex: 1;
-    height: 3px;
-    background: rgba(255, 255, 255, 0.04);
-    border-radius: 2px;
-    overflow: hidden;
-}
-
-.progress-fill {
-    height: 100%;
-    background: linear-gradient(90deg, #4fc3f7, #69f0ae);
-    border-radius: 2px;
-    transition: width 0.5s ease;
-}
-
-.progress-text {
-    font-size: 0.75rem;
-    color: rgba(255, 255, 255, 0.35);
-    min-width: 30px;
-    text-align: right;
-}
-
-.practice-btn {
-    width: 100%;
-    padding: 13px;
-    background: linear-gradient(135deg, #4fc3f7 0%, #7c4dff 100%);
-    border: none;
-    border-radius: 8px;
-    color: #fff;
-    font-size: 0.9rem;
-    font-weight: 600;
-    letter-spacing: 0.5px;
-    cursor: pointer;
-    transition: transform 0.15s, box-shadow 0.25s, opacity 0.2s;
-}
-
-.practice-btn:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 8px 24px rgba(79, 195, 247, 0.25);
-}
-
-.practice-btn:disabled {
-    opacity: 0.25;
-    cursor: not-allowed;
-    transform: none;
-    box-shadow: none;
-}
-
-/* ================================================================
-   HELP OVERLAY
-   ================================================================ */
-
-.help-overlay {
-    position: fixed;
-    inset: 0;
-    z-index: 10000;
-    background: rgba(0, 0, 0, 0.65);
-    backdrop-filter: blur(8px);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    animation: fadeIn 0.2s ease-out;
-}
-
-.help-modal {
-    background: rgba(10, 16, 30, 0.97);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    border-radius: 12px;
-    width: 90%;
-    max-width: 360px;
-    padding: 24px;
-}
-
-.help-modal h3 {
-    font-size: 0.85rem;
-    color: rgba(255,255,255,0.6);
-    margin-bottom: 18px;
-    letter-spacing: 2px;
-    text-transform: uppercase;
-}
-
-.help-row {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 7px 0;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.03);
-}
-
-.help-row kbd {
-    background: rgba(255, 255, 255, 0.06);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    border-radius: 3px;
-    padding: 2px 7px;
-    font-family: monospace;
-    font-size: 0.8rem;
-    color: rgba(255, 255, 255, 0.5);
-}
-
-.help-row span { color: rgba(255, 255, 255, 0.35); font-size: 0.8rem; }
-
-@keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
-
-/* ================================================================
-   RESPONSIVE
-   ================================================================ */
-
-@media (max-width: 640px) {
-    /* Stack info and nav vertically */
-    .info-box {
-        top: 10px;
-        left: 10px;
-        right: 10px;
-        max-width: none;
-        padding: 10px 14px;
-        flex-direction: row;
-        align-items: center;
-    }
-    .info-title { font-size: 0.55rem; letter-spacing: 1.5px; }
-    .info-subtitle { display: none; }
-    .info-stats { margin-top: 4px; font-size: 0.75rem; }
-
-    .nav-float {
-        top: auto;
-        bottom: 16px;
-        right: 16px;
-        left: 16px;
-        justify-content: center;
-    }
-    .nav-btn { padding: 10px 16px; font-size: 0.8rem; flex: 1; text-align: center; }
-
-    /* Full-width detail panel, swipe-hint bar at top */
-    .node-detail { width: 100vw; max-width: 100vw; }
-    .detail-body { padding: 44px 20px 20px; }
-    .detail-body h2 { font-size: 1.1rem; }
-    .detail-close { top: 10px; right: 10px; font-size: 1.6rem; padding: 8px 12px; }
-    .practice-btn { padding: 16px; font-size: 1rem; }
-
-    /* Larger labels and touch targets */
-    .node-label { font-size: 8px; }
-    .region-label { font-size: 10px; }
-    .tier-label { font-size: 9px; }
-}
-
-/* Touch-specific: larger tap targets on any touch device */
-@media (pointer: coarse) {
-    .skill-node circle.node-shape,
-    .skill-node path.node-shape {
-        stroke-width: 3;
-    }
-    /* Invisible tap target expander */
-    .node-tap-target {
-        fill: transparent;
-        stroke: none;
-        cursor: pointer;
-    }
-    .nav-btn { min-height: 44px; min-width: 44px; }
-    .detail-close { min-height: 44px; min-width: 44px; }
+@media (max-width: 768px) {
+    .top { flex-direction: column; align-items: flex-start; }
+    .cell { width: 13px; height: 13px; }
+    .colhead .nm { display: none; }
 }

--- a/public/js/skill-map.js
+++ b/public/js/skill-map.js
@@ -1,832 +1,397 @@
 /**
- * THE MATHEMATICAL UNIVERSE — Constellation Skill Map
+ * SKILL MAP — "Your climb".
  *
- * Cinematic entrance, organic force layout, SVG glow filters,
- * starfield background, curved gradient edges, smooth nebula hulls.
+ * Six strand towers, one band per course level, filling bottom-up. A pattern is a
+ * vertical thread you can trace: unit rate sits in the PRP column at MS, slope is
+ * the same column at ALG1, derivative-in-context is the same column at CALC. That
+ * layout IS the "see the patterns" argument — the previous force-directed
+ * constellation scattered exactly the relationship the product is built on.
+ *
+ * Reads GET /api/mastery/map, which is built from the real prerequisite graph the
+ * closure engine reasons over. The old /api/mastery/skill-graph built nodes from a
+ * hardcoded pattern config and edges from a hardcoded prerequisite map, so what a
+ * student saw and what the system would actually unlock could disagree.
+ *
+ * Pure view logic lives in skillMapModel.js and is unit-tested; this file is DOM,
+ * fetch, and the two proof runners.
  */
+(function () {
+  'use strict';
 
-// ============================================================================
-// PALETTE — unique, space-appropriate colors per pattern
-// ============================================================================
+  var M = window.SkillMapModel;
+  var $ = function (id) { return document.getElementById(id); };
 
-const COLORS = {
-    equivalence:  '#4fc3f7',
-    scaling:      '#ce93d8',
-    change:       '#ffb74d',
-    structure:    '#81c784',
-    space:        '#4dd0e1',
-    comparison:   '#ff8a65',
-    uncertainty:  '#f48fb1',
-    accumulation: '#a1887f'
-};
+  var state = { skills: [], byId: {}, nearest: null, current: null, teach: null };
 
-const PATTERN_SYMBOLS = {
-    equivalence:  '=',
-    scaling:      '\u00D7',
-    change:       '\u0394',
-    structure:    '\u03B1',
-    space:        '\u25B3',
-    comparison:   '\u2264',
-    uncertainty:  '\u03C3',
-    accumulation: '\u03A3'
-};
+  // ── data ────────────────────────────────────────────────────────────
+  function withCsrf(options) {
+    return (typeof addCsrfToken === 'function') ? addCsrfToken(options) : options;
+  }
 
-const TIER_NAMES = ['Concrete', 'Symbolic', 'Structural', 'Formal'];
-const TIER_SHAPES = { 1: 'circle', 2: 'diamond', 3: 'star4', 4: 'star6' };
+  function api(url, options) {
+    var opts = Object.assign({ credentials: 'include' }, options || {});
+    return fetch(url, opts).then(function (res) {
+      if (res.status === 401) { window.location.href = '/login.html'; throw new Error('unauthenticated'); }
+      return res.json().then(function (body) {
+        if (!res.ok) throw Object.assign(new Error(body.error || 'Request failed'), { body: body, status: res.status });
+        return body;
+      });
+    });
+  }
 
-function crossPatternLabel(source, target, type) {
-    if (source.pattern === target.pattern) return null;
-    return type === 'enables' ? 'extends to' : 'builds on';
-}
+  function load() {
+    setStatus('Loading your map…');
+    return api('/api/mastery/map').then(function (data) {
+      if (!data.seeded) {
+        // Say so plainly. An empty board reads as "you have done nothing"
+        // rather than "nothing is set up in this environment".
+        setStatus('The skill map has not been set up for this environment yet.');
+        return;
+      }
+      state.skills = data.skills || [];
+      state.byId = {};
+      state.skills.forEach(function (s) { state.byId[s.skillId] = s; });
+      state.nearest = data.nearest || null;
+      setStatus('');
+      render(data);
+    }).catch(function (err) {
+      if (err && err.message === 'unauthenticated') return;
+      setStatus('Could not load your map. Refresh to try again.');
+    });
+  }
 
-// ============================================================================
-// STATE
-// ============================================================================
+  function setStatus(text) {
+    var el = $('status');
+    el.textContent = text || '';
+    el.hidden = !text;
+  }
 
-const state = {
-    graphData: null, svg: null, g: null, zoom: null,
-    edgeGroups: null, nodeGroups: null, selectedNode: null,
-    frontierIds: new Set(), currentZoom: 1.0,
-    highlightedNodeId: null
-};
+  // ── render ──────────────────────────────────────────────────────────
+  function render(data) {
+    var counts = M.summarize(data);
+    $('t-proved').textContent = counts.proved;
+    $('t-taught').textContent = counts.taught;
+    $('t-open').textContent = counts.open;
 
-const $ = id => document.getElementById(id);
-const graphContainer = $('graph-container');
-const isTouchDevice = window.matchMedia('(pointer: coarse)').matches;
-const isMobile = window.innerWidth <= 640;
+    renderTowers();
+    renderHook();
+    $('board').hidden = false;
+    $('legend').hidden = false;
+  }
 
-// ============================================================================
-// INIT
-// ============================================================================
+  function renderTowers() {
+    var towers = $('towers');
+    var levels = M.activeLevels(state.skills);
+    var grid = M.buildGrid(state.skills);
+    var totals = M.strandTotals(state.skills);
 
-document.addEventListener('DOMContentLoaded', async () => {
-    await loadGraphData();
-    initEventListeners();
-});
+    towers.innerHTML = '';
+    towers.style.gridTemplateColumns = '64px repeat(' + M.STRANDS.length + ', 1fr)';
 
-async function loadGraphData() {
-    try {
-        const res = await fetch('/api/mastery/skill-graph', { credentials: 'include' });
-        if (res.status === 401) { window.location.href = '/login.html'; return; }
-        if (!res.ok) throw new Error('Failed to load');
-        const data = await res.json();
-        if (!data.assessmentCompleted) { window.location.href = '/screener.html'; return; }
-        if (!data.nodes || !data.nodes.length) {
-            graphContainer.innerHTML =
-                '<div style="display:flex;align-items:center;justify-content:center;height:100vh;color:#667;text-align:center;padding:2rem">' +
-                '<div><p style="font-size:1.8rem;margin-bottom:12px;opacity:0.4">&#x2728;</p>' +
-                '<p style="font-size:0.95rem;opacity:0.5">No skills discovered yet.</p>' +
-                '<p style="font-size:0.85rem;opacity:0.3;margin-top:6px">Complete the screener to begin.</p></div></div>';
-            return;
-        }
-        state.graphData = data;
-        $('masteredCount').textContent = data.nodes.filter(n => n.state === 'mastered').length;
-        $('totalSkills').textContent = data.nodes.length;
-
-        // Frontier
-        const ready = data.nodes.filter(n => n.state === 'ready');
-        const scored = ready.map(n => ({
-            id: n.id,
-            unlocks: data.edges.filter(e => e.source === n.id).length
-        })).sort((a, b) => b.unlocks - a.unlocks);
-        state.frontierIds = new Set(scored.slice(0, 3).map(s => s.id));
-
-        // Override colors with our richer palette
-        data.nodes.forEach(n => { if (COLORS[n.pattern]) n.color = COLORS[n.pattern]; });
-
-        buildGraph(data);
-    } catch (err) {
-        console.error('Skill map error:', err);
-        graphContainer.innerHTML =
-            '<div style="display:flex;align-items:center;justify-content:center;height:100vh;color:#667">' +
-            '<p>Failed to load. Please refresh.</p></div>';
-    }
-}
-
-// ============================================================================
-// LAYOUT — force-sim: free X, pinned Y by tier
-// ============================================================================
-
-function computeLayout(data, W, H) {
-    const PAD = 120;
-    const gW = W - PAD * 2, gH = H - PAD * 2;
-    const tierY = {};
-    for (let t = 1; t <= 4; t++) tierY[t] = PAD + gH - ((t - 1) / 3) * gH;
-
-    const patterns = data.clusters.map(c => c.id);
-    const pCX = {};
-    patterns.forEach((p, i) => { pCX[p] = PAD + (i + 0.5) / patterns.length * gW; });
-
-    // Seed positions
-    const counts = {};
-    data.nodes.forEach(n => {
-        const k = n.pattern + '-' + n.tier;
-        counts[k] = (counts[k] || 0);
-        n.x = pCX[n.pattern] + (counts[k]++ - 1) * 45;
-        n.y = tierY[n.tier];
+    towers.appendChild(el('div', 'spacer'));
+    M.STRANDS.forEach(function (strand) {
+      var t = totals[strand.key] || { total: 0, owned: 0 };
+      var pct = t.total ? Math.round((t.owned / t.total) * 100) : 0;
+      var head = el('div', 'colhead strand-' + strand.key.toLowerCase());
+      head.innerHTML =
+        '<span class="code">' + strand.key + '</span>' +
+        '<span class="nm">' + escapeHtml(strand.name) + '</span>' +
+        '<span class="bar"><i style="width:' + pct + '%"></i></span>';
+      head.title = strand.name + ' — ' + t.owned + ' of ' + t.total;
+      towers.appendChild(head);
     });
 
-    // Resolve links
-    const byId = new Map(data.nodes.map(n => [n.id, n]));
-    const simLinks = data.edges
-        .map(e => ({ source: byId.get(e.source), target: byId.get(e.target), type: e.type }))
-        .filter(l => l.source && l.target);
+    // Highest level at the top, so the board reads as a climb.
+    levels.slice().reverse().forEach(function (level) {
+      var lab = el('div', 'bandlabel');
+      lab.textContent = level;
+      towers.appendChild(lab);
 
-    // Simulate
-    const sim = d3.forceSimulation(data.nodes)
-        .force('link', d3.forceLink(simLinks).id(d => d.id).distance(90).strength(0.35))
-        .force('charge', d3.forceManyBody().strength(-100))
-        .force('collide', d3.forceCollide(24))
-        .force('cx', d3.forceX(d => pCX[d.pattern]).strength(0.12))
-        .force('ty', d3.forceY(d => tierY[d.tier]).strength(0.95))
-        .alphaDecay(0.04).velocityDecay(0.35).stop();
-
-    for (let i = 0; i < 350; i++) sim.tick();
-
-    // Slight Y breathing room
-    data.nodes.forEach(n => { n.y = tierY[n.tier] + (n.y - tierY[n.tier]) * 0.18; });
-
-    return { tierY, pCX, simLinks };
-}
-
-// ============================================================================
-// BUILD GRAPH
-// ============================================================================
-
-function buildGraph(data) {
-    const W = graphContainer.clientWidth;
-    const H = graphContainer.clientHeight;
-    const { tierY, simLinks } = computeLayout(data, W, H);
-
-    // Zoom
-    state.zoom = d3.zoom().scaleExtent([0.2, 7.0])
-        .on('zoom', e => { state.g.attr('transform', e.transform); state.currentZoom = e.transform.k; });
-
-    state.svg = d3.select('#graph-container').append('svg')
-        .attr('width', W).attr('height', H).call(state.zoom);
-
-    const defs = state.svg.append('defs');
-    buildSVGFilters(defs);
-    buildEdgeGradients(defs, simLinks, data);
-    buildArrowMarkers(defs, data);
-
-    state.g = state.svg.append('g');
-
-    // Layers (back to front)
-    const starLayer   = state.g.append('g').attr('class', 'star-layer');
-    const tierLayer   = state.g.append('g').attr('class', 'tier-layer');
-    const nebulaLayer = state.g.append('g').attr('class', 'nebula-layer');
-    const edgeLayer   = state.g.append('g').attr('class', 'edge-layer');
-    const labelLayer  = state.g.append('g').attr('class', 'region-label-layer');
-    const nodeLayer   = state.g.append('g').attr('class', 'node-layer');
-
-    // 1. Starfield
-    drawStarfield(starLayer, W, H, data.nodes);
-
-    // 2. Tier lines
-    drawTiers(tierLayer, tierY, W);
-
-    // 3. Nebula hulls
-    drawNebulas(nebulaLayer, data);
-
-    // 4. Region labels
-    drawRegionLabels(labelLayer, data);
-
-    // 5. Edges
-    drawEdges(edgeLayer, simLinks, data);
-
-    // 6. Nodes
-    drawNodes(nodeLayer, data);
-
-    // 7. Cinematic entrance
-    cinematicEntrance(data);
-
-    // 8. Fit view after entrance
-    setTimeout(() => fitView(1200), 2600);
-}
-
-// ============================================================================
-// SVG DEFS — glow filters, gradients, markers
-// ============================================================================
-
-function buildSVGFilters(defs) {
-    // Glow filter: mastered (green-white)
-    const glowMastered = defs.append('filter').attr('id', 'glow-mastered')
-        .attr('x', '-80%').attr('y', '-80%').attr('width', '260%').attr('height', '260%');
-    glowMastered.append('feGaussianBlur').attr('in', 'SourceGraphic').attr('stdDeviation', '3').attr('result', 'b1');
-    glowMastered.append('feGaussianBlur').attr('in', 'SourceGraphic').attr('stdDeviation', '8').attr('result', 'b2');
-    const gm = glowMastered.append('feMerge');
-    gm.append('feMergeNode').attr('in', 'b2');
-    gm.append('feMergeNode').attr('in', 'b1');
-    gm.append('feMergeNode').attr('in', 'SourceGraphic');
-
-    // Glow filter: ready (blue)
-    const glowReady = defs.append('filter').attr('id', 'glow-ready')
-        .attr('x', '-60%').attr('y', '-60%').attr('width', '220%').attr('height', '220%');
-    glowReady.append('feGaussianBlur').attr('in', 'SourceGraphic').attr('stdDeviation', '4').attr('result', 'b1');
-    const gr = glowReady.append('feMerge');
-    gr.append('feMergeNode').attr('in', 'b1');
-    gr.append('feMergeNode').attr('in', 'SourceGraphic');
-
-    // Glow filter: frontier (warm beacon)
-    const glowFrontier = defs.append('filter').attr('id', 'glow-frontier')
-        .attr('x', '-100%').attr('y', '-100%').attr('width', '300%').attr('height', '300%');
-    glowFrontier.append('feGaussianBlur').attr('in', 'SourceGraphic').attr('stdDeviation', '4').attr('result', 'b1');
-    glowFrontier.append('feGaussianBlur').attr('in', 'SourceGraphic').attr('stdDeviation', '10').attr('result', 'b2');
-    const gf = glowFrontier.append('feMerge');
-    gf.append('feMergeNode').attr('in', 'b2');
-    gf.append('feMergeNode').attr('in', 'b1');
-    gf.append('feMergeNode').attr('in', 'SourceGraphic');
-
-    // Glow filter: developing (amber)
-    const glowDev = defs.append('filter').attr('id', 'glow-developing')
-        .attr('x', '-60%').attr('y', '-60%').attr('width', '220%').attr('height', '220%');
-    glowDev.append('feGaussianBlur').attr('in', 'SourceGraphic').attr('stdDeviation', '3').attr('result', 'b1');
-    const gd = glowDev.append('feMerge');
-    gd.append('feMergeNode').attr('in', 'b1');
-    gd.append('feMergeNode').attr('in', 'SourceGraphic');
-
-    // Nebula blur filter (reduced on mobile for GPU perf)
-    const nebulaBlur = defs.append('filter').attr('id', 'nebula-blur')
-        .attr('x', '-50%').attr('y', '-50%').attr('width', '200%').attr('height', '200%');
-    nebulaBlur.append('feGaussianBlur').attr('stdDeviation', isMobile ? '15' : '35');
-}
-
-function buildEdgeGradients(defs, simLinks, data) {
-    simLinks.forEach((link, i) => {
-        const sc = COLORS[link.source.pattern] || '#fff';
-        const tc = COLORS[link.target.pattern] || '#fff';
-        const grad = defs.append('linearGradient')
-            .attr('id', 'eg-' + i)
-            .attr('gradientUnits', 'userSpaceOnUse')
-            .attr('x1', link.source.x).attr('y1', link.source.y)
-            .attr('x2', link.target.x).attr('y2', link.target.y);
-        grad.append('stop').attr('offset', '0%').attr('stop-color', sc).attr('stop-opacity', 0.6);
-        grad.append('stop').attr('offset', '100%').attr('stop-color', tc).attr('stop-opacity', 0.6);
-    });
-}
-
-function buildArrowMarkers(defs, data) {
-    // One marker per pattern color
-    const seen = new Set();
-    data.clusters.forEach(c => {
-        const col = COLORS[c.id] || c.color;
-        const key = col.replace('#', '');
-        if (seen.has(key)) return;
-        seen.add(key);
-        defs.append('marker')
-            .attr('id', 'arrow-' + key)
-            .attr('viewBox', '0 -3 6 6')
-            .attr('refX', 18).attr('refY', 0)
-            .attr('markerWidth', 4).attr('markerHeight', 4)
-            .attr('orient', 'auto')
-            .append('path')
-            .attr('d', 'M0,-2.5L6,0L0,2.5')
-            .attr('fill', col)
-            .attr('opacity', 0.5);
-    });
-}
-
-// ============================================================================
-// STARFIELD — procedural background stars
-// ============================================================================
-
-function drawStarfield(layer, W, H, nodes) {
-    // Calculate bounds to cover the full graph area
-    const pad = 300;
-    const xMin = Math.min(0, d3.min(nodes, n => n.x)) - pad;
-    const xMax = Math.max(W, d3.max(nodes, n => n.x)) + pad;
-    const yMin = Math.min(0, d3.min(nodes, n => n.y)) - pad;
-    const yMax = Math.max(H, d3.max(nodes, n => n.y)) + pad;
-    const areaW = xMax - xMin;
-    const areaH = yMax - yMin;
-
-    const maxStars = isMobile ? 400 : 1500;
-    const starCount = Math.min(Math.floor(areaW * areaH / 2500), maxStars);
-    const rng = mulberry32(42); // seeded RNG for consistency
-
-    for (let i = 0; i < starCount; i++) {
-        const x = xMin + rng() * areaW;
-        const y = yMin + rng() * areaH;
-        const r = rng() < 0.92 ? 0.5 + rng() * 0.8 : 1.2 + rng() * 1.5;
-        const baseOp = 0.08 + rng() * 0.3;
-
-        const twinkleClass = rng() < 0.06 ? 'twinkle-fast' :
-                             rng() < 0.15 ? 'twinkle-med' :
-                             rng() < 0.3  ? 'twinkle-slow' : '';
-
-        const star = layer.append('circle')
-            .attr('class', 'bg-star' + (twinkleClass ? ' ' + twinkleClass : ''))
-            .attr('cx', x).attr('cy', y).attr('r', r)
-            .style('opacity', 0)
-            .style('--star-base-opacity', baseOp);
-
-        // Random twinkle phase offset so stars don't pulse in sync
-        if (twinkleClass) {
-            star.style('--twinkle-delay', -(rng() * 6).toFixed(1) + 's');
-        }
-    }
-}
-
-// Seeded PRNG (Mulberry32)
-function mulberry32(seed) {
-    return function () {
-        seed |= 0; seed = seed + 0x6D2B79F5 | 0;
-        let t = Math.imul(seed ^ seed >>> 15, 1 | seed);
-        t = t + Math.imul(t ^ t >>> 7, 61 | t) ^ t;
-        return ((t ^ t >>> 14) >>> 0) / 4294967296;
-    };
-}
-
-// ============================================================================
-// TIER LINES
-// ============================================================================
-
-function drawTiers(layer, tierY, W) {
-    for (let t = 1; t <= 4; t++) {
-        const y = tierY[t];
-        layer.append('line').attr('class', 'tier-line')
-            .attr('x1', 30).attr('x2', W - 30).attr('y1', y).attr('y2', y);
-        layer.append('text').attr('class', 'tier-label')
-            .attr('x', 16).attr('y', y + 4).text(TIER_NAMES[t - 1]);
-    }
-}
-
-// ============================================================================
-// NEBULA HULLS — smooth organic blobs using basis-closed curves
-// ============================================================================
-
-function drawNebulas(layer, data) {
-    const grouped = d3.group(data.nodes, d => d.pattern);
-
-    grouped.forEach((nodes, pid) => {
-        if (nodes.length < 3) return;
-        const cluster = data.clusters.find(c => c.id === pid);
-        if (!cluster) return;
-        const color = COLORS[pid] || cluster.color;
-
-        const points = nodes.map(n => [n.x, n.y]);
-        const hull = d3.polygonHull(points);
-        if (!hull) return;
-
-        // Expand + add midpoints for smoother curves
-        const cx = d3.mean(hull, p => p[0]);
-        const cy = d3.mean(hull, p => p[1]);
-        const expanded = [];
-        for (let i = 0; i < hull.length; i++) {
-            const p = hull[i];
-            const next = hull[(i + 1) % hull.length];
-            // Expand point outward from center
-            expanded.push([
-                cx + (p[0] - cx) * 1.6,
-                cy + (p[1] - cy) * 1.6
-            ]);
-            // Add midpoint (also expanded)
-            const mx = (p[0] + next[0]) / 2;
-            const my = (p[1] + next[1]) / 2;
-            expanded.push([
-                cx + (mx - cx) * 1.5,
-                cy + (my - cy) * 1.5
-            ]);
-        }
-
-        const line = d3.line().curve(d3.curveBasisClosed);
-
-        layer.append('path')
-            .attr('class', 'nebula-hull')
-            .attr('d', line(expanded))
-            .attr('fill', color)
-            .attr('fill-opacity', 0.06)
-            .attr('stroke', color)
-            .attr('stroke-opacity', 0.08)
-            .attr('stroke-width', 1)
-            .attr('filter', 'url(#nebula-blur)')
-            .style('opacity', 0);
-    });
-}
-
-// ============================================================================
-// REGION LABELS
-// ============================================================================
-
-function drawRegionLabels(layer, data) {
-    data.clusters.forEach(cluster => {
-        const nodes = data.nodes.filter(n => n.pattern === cluster.id);
-        if (!nodes.length) return;
-        const color = COLORS[cluster.id] || cluster.color;
-        const cx = d3.mean(nodes, n => n.x);
-        const minY = d3.min(nodes, n => n.y);
-
-        layer.append('text')
-            .attr('class', 'region-label')
-            .attr('x', cx).attr('y', minY - 40)
-            .attr('text-anchor', 'middle')
-            .attr('fill', color)
-            .attr('fill-opacity', 0.2)
-            .style('opacity', 0)
-            .text(cluster.name.toUpperCase());
-    });
-}
-
-// ============================================================================
-// EDGES — curved paths with per-edge gradient
-// ============================================================================
-
-function drawEdges(layer, simLinks, data) {
-    state.edgeGroups = layer.selectAll('.edge-group')
-        .data(simLinks, d => d.source.id + '->' + d.target.id)
-        .join('g')
-        .attr('class', 'edge-group')
-        .style('opacity', 0); // hidden for entrance
-
-    // Curved path with gradient stroke
-    state.edgeGroups.append('path')
-        .attr('class', 'edge-path')
-        .attr('d', d => curvedEdge(d.source, d.target))
-        .attr('stroke', (d, i) => 'url(#eg-' + i + ')')
-        .attr('marker-end', d => {
-            const col = (COLORS[d.source.pattern] || '#fff').replace('#', '');
-            return 'url(#arrow-' + col + ')';
+      M.STRANDS.forEach(function (strand) {
+        var band = el('div', 'band strand-' + strand.key.toLowerCase());
+        (grid.get(level + '|' + strand.key) || []).forEach(function (skill) {
+          band.appendChild(cell(skill));
         });
-
-    // Cross-pattern labels
-    state.edgeGroups.each(function (d) {
-        const label = crossPatternLabel(d.source, d.target, d.type);
-        if (!label) return;
-        const mx = (d.source.x + d.target.x) / 2;
-        const my = (d.source.y + d.target.y) / 2;
-        d3.select(this).append('text')
-            .attr('class', 'edge-label-text')
-            .attr('x', mx).attr('y', my - 4)
-            .attr('text-anchor', 'middle')
-            .text(label);
+        towers.appendChild(band);
+      });
     });
-}
+  }
 
-function curvedEdge(s, t) {
-    const dx = t.x - s.x, dy = t.y - s.y;
-    const dist = Math.sqrt(dx * dx + dy * dy);
-    if (dist < 1) return 'M' + s.x + ',' + s.y + ' L' + t.x + ',' + t.y;
-    const curve = Math.min(dist * 0.15, 35);
-    const nx = -dy / dist * curve;
-    const ny = dx / dist * curve;
-    const mx = (s.x + t.x) / 2 + nx;
-    const my = (s.y + t.y) / 2 + ny;
-    return 'M' + s.x + ',' + s.y + ' Q' + mx + ',' + my + ' ' + t.x + ',' + t.y;
-}
+  function cell(skill) {
+    var b = document.createElement('button');
+    b.type = 'button';
+    b.className = 'cell s-' + skill.state;
+    b.dataset.skillId = skill.skillId;
+    b.title = skill.label + ' — ' + (M.STATE_LABEL[skill.state] || skill.state);
+    b.setAttribute('aria-label', b.title);
+    if (!M.isActionable(skill.state)) b.disabled = true;
+    b.addEventListener('click', function () { openSkill(skill.skillId); });
+    return b;
+  }
 
-// ============================================================================
-// NODES — shape per tier, SVG glow filter, math symbol
-// ============================================================================
+  function renderHook() {
+    var text = M.hookText(state.nearest);
+    var hook = $('hook');
+    if (!text) { hook.hidden = true; return; }
+    $('hook-text').textContent = text;
+    hook.hidden = false;
+    var target = state.nearest.nextSkillId;
+    $('hook-btn').onclick = function () { openSkill(target); };
+    highlightTarget(target);
+  }
 
-function drawNodes(layer, data) {
-    state.nodeGroups = layer.selectAll('.skill-node')
-        .data(data.nodes, d => d.id)
-        .join('g')
-        .attr('class', d => {
-            let c = 'skill-node ' + d.state;
-            if (state.frontierIds.has(d.id)) c += ' frontier';
-            return c;
-        })
-        .attr('transform', d => 'translate(' + d.x + ',' + d.y + ')')
-        .style('opacity', 0) // hidden for entrance
-        .on('click', (ev, d) => {
-            ev.stopPropagation();
-            if (d.state === 'locked') return;
-            // On touch: first tap highlights, second tap opens detail
-            if (isTouchDevice && state.highlightedNodeId !== d.id) {
-                state.highlightedNodeId = d.id;
-                highlightConnected(d);
-                return;
-            }
-            showNodeDetail(d);
-        })
-        .on('mouseover', (ev, d) => { if (!isTouchDevice && d.state !== 'locked') highlightConnected(d); })
-        .on('mouseout', () => { if (!isTouchDevice) unhighlightAll(); });
+  function highlightTarget(skillId) {
+    Array.prototype.forEach.call(document.querySelectorAll('.cell.target'), function (c) {
+      c.classList.remove('target');
+    });
+    var cellEl = document.querySelector('.cell[data-skill-id="' + cssEscape(skillId) + '"]');
+    if (cellEl) cellEl.classList.add('target');
+  }
 
-    // Invisible larger tap target for touch devices
-    if (isTouchDevice) {
-        state.nodeGroups.append('circle')
-            .attr('class', 'node-tap-target')
-            .attr('r', 28); // 44px diameter minimum touch target
+  // ── drawer ──────────────────────────────────────────────────────────
+  function openSkill(skillId) {
+    var skill = state.byId[skillId];
+    if (!skill || !M.isActionable(skill.state)) return;
+    state.current = skill;
+
+    $('d-label').textContent = skill.label;
+    $('d-meta').textContent = [skill.skillId, skill.courseLevel, M.strandName(skill.strand)].join(' · ')
+      + (skill.formalName && skill.formalName !== skill.label ? ' · ' + skill.formalName : '');
+    $('d-state').textContent = stateSentence(skill);
+
+    var proofs = $('d-proofs');
+    proofs.innerHTML = '';
+    M.rungOptions(skill).forEach(function (opt) {
+      var b = document.createElement('button');
+      b.type = 'button';
+      b.className = 'proof';
+      b.innerHTML = '<h3>' + escapeHtml(opt.label) + '</h3><p>' + escapeHtml(opt.hint) + '</p>';
+      b.addEventListener('click', function () { chooseRung(opt.key, skill); });
+      proofs.appendChild(b);
+    });
+
+    hide('runner'); hide('teach');
+    $('drawer').classList.add('open');
+    $('drawer').setAttribute('aria-hidden', 'false');
+  }
+
+  function stateSentence(skill) {
+    switch (skill.state) {
+      case 'taught': return 'You have taught this one. Top of the ladder.';
+      case 'proved': return 'Proved. One rung left.';
+      case 'above': return 'Cleared from above when you proved something higher up. Prove it directly to unlock teaching.';
+      case 'learned': return 'You have worked through this. Prove it when you are ready.';
+      default: return 'Every prerequisite is done — you can start this now.';
     }
+  }
 
-    // Shape with glow filter
-    state.nodeGroups.each(function (d) {
-        const g = d3.select(this);
-        const r = nodeRadius(d);
-        const isFrontier = state.frontierIds.has(d.id);
-        const filter = isFrontier ? 'url(#glow-frontier)' :
-                       d.state === 'mastered' ? 'url(#glow-mastered)' :
-                       d.state === 'developing' ? 'url(#glow-developing)' :
-                       d.state === 'ready' ? 'url(#glow-ready)' : 'none';
-        const fill = d.state === 'mastered' ? '#fff' :
-                     d.state === 'locked' ? 'rgba(255,255,255,0.04)' :
-                     isFrontier ? '#ff8a65' : d.color;
-        const stroke = d.state === 'mastered' ? '#69f0ae' :
-                       d.state === 'locked' ? 'rgba(255,255,255,0.08)' :
-                       isFrontier ? '#ffab91' : d.color;
+  function closeDrawer() {
+    $('drawer').classList.remove('open');
+    $('drawer').setAttribute('aria-hidden', 'true');
+    state.current = null;
+    state.teach = null;
+  }
 
-        const path = shapePath(d.tier, r);
-        const el = path
-            ? g.append('path').attr('class', 'node-shape').attr('d', path)
-            : g.append('circle').attr('class', 'node-shape').attr('r', r);
-
-        el.attr('fill', fill).attr('stroke', stroke).attr('stroke-width', d.state === 'locked' ? 0.5 : 2)
-          .attr('filter', filter);
-    });
-
-    // Symbol
-    state.nodeGroups.append('text')
-        .attr('class', 'node-symbol').attr('y', 1)
-        .text(d => PATTERN_SYMBOLS[d.pattern] || '');
-
-    // Label
-    state.nodeGroups.append('text')
-        .attr('class', 'node-label')
-        .attr('y', d => nodeRadius(d) + 14)
-        .text(d => d.label);
-}
-
-function nodeRadius(d) {
-    let r = 10;
-    if (d.tier >= 3) r = 12;
-    if (d.tier === 4) r = 14;
-    if (d.state === 'mastered') r += 2;
-    if (state.frontierIds.has(d.id)) r += 1;
-    return r;
-}
-
-function shapePath(tier, r) {
-    if (TIER_SHAPES[tier] === 'diamond') {
-        const s = r * 1.2;
-        return 'M0,' + (-s) + ' L' + s + ',0 L0,' + s + ' L' + (-s) + ',0 Z';
+  function chooseRung(key, skill) {
+    if (key === 'learn') {
+      window.location.href = '/chat.html?skill=' + encodeURIComponent(skill.skillId);
+      return;
     }
-    if (TIER_SHAPES[tier] === 'star4') {
-        const o = r * 1.3, n = r * 0.55; let d = '';
-        for (let i = 0; i < 8; i++) {
-            const a = i * Math.PI / 4 - Math.PI / 2;
-            const dist = i % 2 === 0 ? o : n;
-            d += (i ? 'L' : 'M') + (Math.cos(a) * dist).toFixed(1) + ',' + (Math.sin(a) * dist).toFixed(1);
-        }
-        return d + 'Z';
+    if (key === 'challenge') return startChallenge(skill);
+    if (key === 'teach') return startTeachBack(skill);
+  }
+
+  // ── challenge runner ────────────────────────────────────────────────
+  function startChallenge(skill) {
+    hide('teach');
+    var runner = $('runner');
+    $('runner-sub').textContent = 'Loading…';
+    $('runner-qs').innerHTML = '';
+    $('runner-result').hidden = true;
+    runner.hidden = false;
+
+    api('/api/mastery/challenge/' + encodeURIComponent(skill.skillId)).then(function (data) {
+      $('runner-sub').textContent = data.instructions || '';
+      var list = $('runner-qs');
+      list.innerHTML = '';
+      (data.problems || []).forEach(function (p) {
+        var li = document.createElement('li');
+        var prompt = el('div', 'q-prompt');
+        prompt.textContent = p.prompt;
+        li.appendChild(prompt);
+        li.appendChild(answerField(p));
+        list.appendChild(li);
+      });
+    }).catch(function (err) {
+      var body = (err && err.body) || {};
+      // Too few items in the bank, or the skill is already proved — give the
+      // reason instead of a dead form.
+      $('runner-sub').textContent = body.reason || body.error || 'Could not start a challenge for this skill.';
+    });
+  }
+
+  function answerField(problem) {
+    if (Array.isArray(problem.options) && problem.options.length) {
+      var wrap = el('div', 'q-options');
+      problem.options.forEach(function (opt, i) {
+        var id = 'opt-' + problem.problemId + '-' + i;
+        var label = document.createElement('label');
+        label.className = 'q-option';
+        label.htmlFor = id;
+        var radio = document.createElement('input');
+        radio.type = 'radio';
+        radio.id = id;
+        radio.name = 'q-' + problem.problemId;
+        radio.value = opt;
+        radio.dataset.problemId = problem.problemId;
+        label.appendChild(radio);
+        label.appendChild(document.createTextNode(' ' + opt));
+        wrap.appendChild(label);
+      });
+      return wrap;
     }
-    if (TIER_SHAPES[tier] === 'star6') {
-        const o = r * 1.4, n = r * 0.6; let d = '';
-        for (let i = 0; i < 12; i++) {
-            const a = i * Math.PI / 6 - Math.PI / 2;
-            const dist = i % 2 === 0 ? o : n;
-            d += (i ? 'L' : 'M') + (Math.cos(a) * dist).toFixed(1) + ',' + (Math.sin(a) * dist).toFixed(1);
-        }
-        return d + 'Z';
-    }
-    return null;
-}
+    var input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'q-input';
+    input.dataset.problemId = problem.problemId;
+    input.setAttribute('aria-label', 'Your answer');
+    input.placeholder = 'Your answer';
+    return input;
+  }
 
-// ============================================================================
-// CINEMATIC ENTRANCE — staggered reveal
-// ============================================================================
-
-function cinematicEntrance(data) {
-    // Phase 1: Stars fade in (0–800ms, staggered)
-    // Transition to a data attribute, then remove inline opacity so CSS animation takes over
-    state.g.selectAll('.bg-star').each(function () {
-        const star = d3.select(this);
-        const baseOp = parseFloat(star.style('--star-base-opacity')) || 0.2;
-        star.transition()
-            .duration(800)
-            .delay(Math.random() * 600)
-            .style('opacity', baseOp)
-            .on('end', function () {
-                // Remove inline opacity so CSS @keyframes twinkle can take over
-                d3.select(this).style('opacity', null).attr('opacity', baseOp);
-            });
+  function collectSubmissions() {
+    var out = [];
+    Array.prototype.forEach.call(document.querySelectorAll('#runner-qs .q-input'), function (i) {
+      out.push({ problemId: i.dataset.problemId, answer: i.value });
     });
-
-    // Phase 2: Nebulas bloom (400–1200ms)
-    state.g.selectAll('.nebula-hull')
-        .transition()
-        .duration(1000)
-        .delay(400)
-        .ease(d3.easeCubicOut)
-        .style('opacity', 1);
-
-    // Phase 3: Region labels fade in (600–1200ms)
-    state.g.selectAll('.region-label')
-        .transition()
-        .duration(600)
-        .delay(700)
-        .style('opacity', 1);
-
-    // Phase 4: Edges trace in (800–1800ms)
-    state.edgeGroups
-        .transition()
-        .duration(600)
-        .delay((d, i) => 800 + i * 8)
-        .style('opacity', 1);
-
-    // Edge paths: stroke-dash animation (staggered by group index)
-    state.edgeGroups.each(function (d, idx) {
-        const pathEl = d3.select(this).select('.edge-path').node();
-        if (!pathEl) return;
-        const len = pathEl.getTotalLength ? pathEl.getTotalLength() : 200;
-        d3.select(pathEl)
-            .attr('stroke-dasharray', len)
-            .attr('stroke-dashoffset', len)
-            .transition()
-            .duration(700)
-            .delay(900 + idx * 8)
-            .ease(d3.easeLinear)
-            .attr('stroke-dashoffset', 0);
+    Array.prototype.forEach.call(document.querySelectorAll('#runner-qs input[type=radio]:checked'), function (i) {
+      out.push({ problemId: i.dataset.problemId, answer: i.value });
     });
+    return out;
+  }
 
-    // Phase 5: Nodes pop in (1200–2200ms, bottom tier first)
-    state.nodeGroups
-        .transition()
-        .duration(400)
-        .delay(d => 1200 + (4 - d.tier) * 200 + Math.random() * 150)
-        .ease(d3.easeBackOut.overshoot(1.2))
-        .style('opacity', 1)
-        .attrTween('transform', function (d) {
-            const base = 'translate(' + d.x + ',' + d.y + ')';
-            return d3.interpolateString(base + ' scale(0)', base + ' scale(1)');
-        });
-}
+  function submitChallenge() {
+    if (!state.current) return;
+    var submissions = collectSubmissions();
+    if (!submissions.length) return;
+    var btn = $('runner-submit');
+    btn.disabled = true;
 
-// ============================================================================
-// HIGHLIGHT — constellation illumination
-// ============================================================================
+    api('/api/mastery/challenge/' + encodeURIComponent(state.current.skillId), withCsrf({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ submissions: submissions })
+    })).then(function (res) {
+      var out = $('runner-result');
+      out.hidden = false;
+      out.textContent = res.message || '';
+      out.className = 'runner-result ' + (res.passed ? 'good' : 'miss');
+      if (res.passed) {
+        var cleared = (res.clearedFromAbove || []).length;
+        toast(cleared ? '+' + cleared : 'Proved', cleared ? 'cleared from above' : 'rung 2 of 3');
+        setTimeout(function () { closeDrawer(); load(); }, 1400);
+      }
+    }).catch(function () {
+      var out = $('runner-result');
+      out.hidden = false;
+      out.className = 'runner-result miss';
+      out.textContent = 'Could not score that run. Nothing was lost — try again.';
+    }).then(function () { btn.disabled = false; });
+  }
 
-function highlightConnected(node) {
-    const ids = new Set([node.id]);
-    state.edgeGroups.each(d => {
-        if (d.source.id === node.id) ids.add(d.target.id);
-        if (d.target.id === node.id) ids.add(d.source.id);
+  // ── teach-back ──────────────────────────────────────────────────────
+  function startTeachBack(skill) {
+    hide('runner');
+    var panel = $('teach');
+    $('teach-prompt').textContent = 'Loading…';
+    $('teach-input').value = '';
+    $('teach-result').hidden = true;
+    panel.hidden = false;
+
+    api('/api/mastery/teachback/' + encodeURIComponent(skill.skillId)).then(function (data) {
+      state.teach = data;
+      $('teach-prompt').textContent = data.eligible
+        ? data.opener
+        : (data.reason || 'Not eligible to teach this yet.');
+      $('teach-submit').disabled = !data.eligible;
+    }).catch(function () {
+      $('teach-prompt').textContent = 'Could not start a teach-back right now.';
+      $('teach-submit').disabled = true;
     });
+  }
 
-    state.nodeGroups.transition().duration(180)
-        .style('opacity', d => ids.has(d.id) ? 1 : 0.06);
+  function submitTeachBack() {
+    if (!state.current) return;
+    var explanation = $('teach-input').value.trim();
+    if (!explanation) return;
+    var btn = $('teach-submit');
+    btn.disabled = true;
 
-    state.edgeGroups.transition().duration(180)
-        .style('opacity', d =>
-            (d.source.id === node.id || d.target.id === node.id) ? 1 : 0.02);
+    api('/api/mastery/teachback/' + encodeURIComponent(state.current.skillId), withCsrf({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        explanation: explanation,
+        misconception: (state.teach && state.teach.misconception) || undefined
+      })
+    })).then(function (res) {
+      var out = $('teach-result');
+      out.hidden = false;
+      // A scorer outage is neither a pass nor a fail — say exactly that, and
+      // change nothing on the board.
+      if (!res.scored) {
+        out.className = 'runner-result';
+        out.textContent = res.message || 'Could not grade that just now — try again.';
+        return;
+      }
+      out.className = 'runner-result ' + (res.passed ? 'good' : 'miss');
+      out.textContent = (res.message || '') + (res.feedback ? ' ' + res.feedback : '');
+      if (res.passed) {
+        toast('Taught it', 'rung 3 — rarest');
+        setTimeout(function () { closeDrawer(); load(); }, 1600);
+      }
+    }).catch(function () {
+      var out = $('teach-result');
+      out.hidden = false;
+      out.className = 'runner-result';
+      out.textContent = 'Could not grade that just now — try again.';
+    }).then(function () { btn.disabled = false; });
+  }
 
-    state.edgeGroups.select('.edge-path')
-        .classed('edge-active', d => d.source.id === node.id || d.target.id === node.id);
-}
-
-function unhighlightAll() {
-    state.nodeGroups.transition().duration(250).style('opacity', 1);
-    state.edgeGroups.transition().duration(250).style('opacity', 1);
-    state.edgeGroups.select('.edge-path').classed('edge-active', false);
-}
-
-// ============================================================================
-// NODE DETAIL PANEL
-// ============================================================================
-
-function showNodeDetail(node) {
-    state.selectedNode = node;
-    $('nodeDetail').classList.remove('hidden');
-
-    $('detailTitle').textContent = node.label;
-    $('detailPattern').textContent = node.patternName;
-    $('detailTier').textContent = node.tier + ' \u2014 ' + node.tierName;
-    $('detailMilestone').textContent = node.milestoneName;
-
-    const badge = $('detailStatus');
-    badge.textContent = (node.state || '').toUpperCase();
-    badge.className = 'status-badge ' + node.state;
-
-    const pct = Math.round(node.progress || 0);
-    $('detailProgressBar').style.width = pct + '%';
-    $('detailProgressText').textContent = pct + '%';
-
-    $('practiceBtn').disabled = (node.state === 'locked');
-
-    flyTo(node.x, node.y, 2.8);
-}
-
-function hideNodeDetail() {
-    $('nodeDetail').classList.add('hidden');
-    state.selectedNode = null;
-}
-
-// ============================================================================
-// CAMERA
-// ============================================================================
-
-function flyTo(x, y, scale, dur = 650) {
-    if (!state.svg) return;
-    const W = graphContainer.clientWidth, H = graphContainer.clientHeight;
-    state.svg.transition().duration(dur).ease(d3.easeCubicInOut)
-        .call(state.zoom.transform,
-            d3.zoomIdentity.translate(W / 2 - x * scale, H / 2 - y * scale).scale(scale));
-}
-
-function fitView(dur) {
-    if (!state.graphData || !state.svg) return;
-    const ns = state.graphData.nodes;
-    const W = graphContainer.clientWidth, H = graphContainer.clientHeight;
-    const pad = 100;
-    const x0 = d3.min(ns, n => n.x) - pad, x1 = d3.max(ns, n => n.x) + pad;
-    const y0 = d3.min(ns, n => n.y) - pad, y1 = d3.max(ns, n => n.y) + pad;
-    const s = Math.min(W / (x1 - x0), H / (y1 - y0), 2.5);
-    const cx = (x0 + x1) / 2, cy = (y0 + y1) / 2;
-    const t = dur ? state.svg.transition().duration(dur).ease(d3.easeCubicInOut) : state.svg;
-    t.call(state.zoom.transform,
-        d3.zoomIdentity.translate(W / 2 - cx * s, H / 2 - cy * s).scale(s));
-}
-
-function resetView() { hideNodeDetail(); fitView(650); }
-
-// ============================================================================
-// PRACTICE
-// ============================================================================
-
-async function startPractice() {
-    if (!state.selectedNode) return;
-    const node = state.selectedNode;
-    const btn = $('practiceBtn');
-    btn.disabled = true; btn.textContent = 'Loading...';
-    try {
-        const res = await csrfFetch('/api/mastery/start-skill-practice', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            credentials: 'include',
-            body: JSON.stringify({
-                skillId: node.id, pattern: node.pattern,
-                tier: node.tier, milestone: node.milestone || node.milestoneName
-            })
-        });
-        const body = await res.json();
-        if (!res.ok) throw new Error(body.error || 'Failed');
-        window.location.href = body.redirect || '/mastery-chat.html';
-    } catch (err) {
-        console.error('Practice error:', err);
-        alert('Failed to start practice: ' + err.message);
-        btn.disabled = false; btn.textContent = 'Start Practice';
-    }
-}
-
-// ============================================================================
-// EVENTS
-// ============================================================================
-
-function initEventListeners() {
-    $('closeDetail').addEventListener('click', hideNodeDetail);
-    $('practiceBtn').addEventListener('click', startPractice);
-    $('resetZoom').addEventListener('click', resetView);
-    $('showHelp').addEventListener('click', showHelp);
-
-    document.addEventListener('click', e => {
-        const detail = $('nodeDetail');
-        const clickedNode = e.target.closest('.skill-node');
-
-        // Clear touch highlight when tapping background
-        if (!clickedNode && state.highlightedNodeId) {
-            state.highlightedNodeId = null;
-            unhighlightAll();
-        }
-
-        if (!detail.classList.contains('hidden') &&
-            !detail.contains(e.target) && !clickedNode)
-            hideNodeDetail();
+  // ── helpers ─────────────────────────────────────────────────────────
+  function el(tag, cls) { var e = document.createElement(tag); e.className = cls; return e; }
+  function hide(id) { $(id).hidden = true; }
+  function escapeHtml(s) {
+    return String(s == null ? '' : s).replace(/[&<>"']/g, function (c) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
     });
+  }
+  function cssEscape(s) { return String(s).replace(/["\\]/g, '\\$&'); }
 
-    document.addEventListener('keydown', e => {
-        if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
-        if (e.key === 'Escape') hideNodeDetail();
-        if ((e.key === 'r' || e.key === 'R') && !e.ctrlKey && !e.metaKey) resetView();
-        if (e.key === '?') showHelp();
+  var toastTimer = null;
+  function toast(big, sub) {
+    $('toast-big').textContent = big;
+    $('toast-sub').textContent = sub || '';
+    var t = $('toast');
+    t.hidden = false;
+    requestAnimationFrame(function () { t.classList.add('on'); });
+    clearTimeout(toastTimer);
+    toastTimer = setTimeout(function () {
+      t.classList.remove('on');
+      setTimeout(function () { t.hidden = true; }, 300);
+    }, 2200);
+  }
+
+  // ── wire up ─────────────────────────────────────────────────────────
+  document.addEventListener('DOMContentLoaded', function () {
+    $('d-close').addEventListener('click', closeDrawer);
+    $('runner-cancel').addEventListener('click', function () { hide('runner'); });
+    $('teach-cancel').addEventListener('click', function () { hide('teach'); });
+    $('runner-submit').addEventListener('click', submitChallenge);
+    $('teach-submit').addEventListener('click', submitTeachBack);
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') closeDrawer();
     });
-
-    let rt;
-    window.addEventListener('resize', () => {
-        clearTimeout(rt);
-        rt = setTimeout(() => {
-            if (state.svg) {
-                state.svg.attr('width', graphContainer.clientWidth)
-                         .attr('height', graphContainer.clientHeight);
-            }
-        }, 250);
-    });
-}
-
-function showHelp() {
-    const ex = document.getElementById('helpOverlay');
-    if (ex) { ex.remove(); return; }
-    const el = document.createElement('div');
-    el.id = 'helpOverlay'; el.className = 'help-overlay';
-    el.innerHTML =
-        '<div class="help-modal"><h3>Shortcuts</h3>' +
-        '<div class="help-row"><kbd>Esc</kbd><span>Close</span></div>' +
-        '<div class="help-row"><kbd>R</kbd><span>Reset view</span></div>' +
-        '<div class="help-row"><kbd>?</kbd><span>Help</span></div>' +
-        '<div class="help-row"><kbd>Scroll</kbd><span>Zoom</span></div>' +
-        '<div class="help-row"><kbd>Drag</kbd><span>Pan</span></div></div>';
-    document.body.appendChild(el);
-    el.addEventListener('click', e => { if (e.target === el) el.remove(); });
-    const esc = e => { if (e.key === 'Escape') { el.remove(); document.removeEventListener('keydown', esc); } };
-    document.addEventListener('keydown', esc);
-}
+    load();
+  });
+}());

--- a/public/js/skillMapModel.js
+++ b/public/js/skillMapModel.js
@@ -1,0 +1,168 @@
+/**
+ * SKILL MAP — pure view model.
+ *
+ * Everything here is a plain data transform over the /api/mastery/map payload:
+ * no DOM, no fetch. The renderer in skill-map.js does the drawing. Split out so
+ * the parts that decide what a student is TOLD — which rung they can attempt,
+ * how close a band is, what the board calls a skill — are unit-testable rather
+ * than only observable by clicking around production.
+ *
+ * Loads as a browser global and as a CommonJS module (for jest).
+ */
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  else root.SkillMapModel = api;
+}(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  // Ascending abstraction. STAT and CALC are peers in reality — AP Statistics
+  // needs no calculus — so this order is for layout only and carries no claim
+  // that one follows the other.
+  const COURSE_LEVELS = ['ELEM', 'MS', 'ALG1', 'GEO', 'ALG2', 'PREC', 'STAT', 'CALC'];
+
+  const STRANDS = [
+    { key: 'QNT', name: 'Quantity & Operations' },
+    { key: 'PRP', name: 'Proportional Reasoning' },
+    { key: 'EQV', name: 'Equivalence & Structure' },
+    { key: 'FNC', name: 'Functional Dependence' },
+    { key: 'SPC', name: 'Space & Measure' },
+    { key: 'DTA', name: 'Data & Chance' }
+  ];
+
+  // The six board states, weakest to strongest. `above` is a skill cleared by
+  // prerequisite closure rather than demonstrated — deliberately distinct from
+  // `proved` so the board never implies evidence that does not exist.
+  const STATE_ORDER = ['locked', 'open', 'learned', 'above', 'proved', 'taught'];
+
+  const STATE_LABEL = {
+    locked: 'Locked',
+    open: 'Open',
+    learned: 'Learned it',
+    above: 'Cleared from above',
+    proved: 'Proved it',
+    taught: 'Taught it'
+  };
+
+  /** Group skills into a strand x level grid, preserving catalog order. */
+  function buildGrid(skills) {
+    const grid = new Map();
+    (skills || []).forEach(function (s) {
+      if (!s || !s.strand || !s.courseLevel) return;
+      const key = s.courseLevel + '|' + s.strand;
+      if (!grid.has(key)) grid.set(key, []);
+      grid.get(key).push(s);
+    });
+    return grid;
+  }
+
+  /** Levels that actually contain skills, bottom-up. Never render empty bands. */
+  function activeLevels(skills) {
+    const present = new Set((skills || []).map(function (s) { return s && s.courseLevel; }));
+    return COURSE_LEVELS.filter(function (l) { return present.has(l); });
+  }
+
+  /** Per-strand completion, for the thin bar under each column header. */
+  function strandTotals(skills) {
+    const out = {};
+    STRANDS.forEach(function (s) { out[s.key] = { total: 0, owned: 0 }; });
+    (skills || []).forEach(function (s) {
+      if (!s || !out[s.strand]) return;
+      out[s.strand].total += 1;
+      if (isOwned(s.state)) out[s.strand].owned += 1;
+    });
+    return out;
+  }
+
+  /** Proved or better — the states that clear prerequisites above them. */
+  function isOwned(state) {
+    return state === 'proved' || state === 'taught' || state === 'above';
+  }
+
+  /** Can the student do anything with this cell right now? */
+  function isActionable(state) {
+    return state !== 'locked';
+  }
+
+  /**
+   * Which rungs to offer, given the cell's state.
+   *
+   * Mirrors utils/skillRung.canAdvance so the board never offers a rung the
+   * server will refuse. In particular a skill cleared from above must be proved
+   * DIRECTLY before it can be taught — the system granted it, the student did
+   * not demonstrate it, and the top rung requires demonstration.
+   */
+  function rungOptions(skill) {
+    if (!skill) return [];
+    switch (skill.state) {
+      case 'open':
+        return [
+          { key: 'learn', label: 'Learn it', hint: 'Work through it with your tutor.' },
+          { key: 'challenge', label: 'Prove it', hint: 'Five problems, no hints, one shot.' }
+        ];
+      case 'learned':
+        return [
+          { key: 'learn', label: 'Keep working', hint: 'Back to the lesson.' },
+          { key: 'challenge', label: 'Prove it', hint: 'Five problems, no hints, one shot.' }
+        ];
+      case 'above':
+        return [
+          { key: 'challenge', label: 'Prove it directly', hint: 'This one was cleared from above. Prove it to unlock teaching.' }
+        ];
+      case 'proved':
+        return [
+          { key: 'teach', label: 'Teach it back', hint: 'Explain it to a confused student. The top rung.' }
+        ];
+      default:
+        return [];
+    }
+  }
+
+  /**
+   * The proximity line: "2 skills from closing Proportional Reasoning at ALG1."
+   *
+   * Returns null when there is nothing honest to say. A band is only a hook when
+   * something in it can actually be started — dangling "1 away!" at work that is
+   * still locked is a wall dressed as a nudge.
+   */
+  function hookText(nearest) {
+    if (!nearest || !nearest.remaining || !nearest.nextSkillId) return null;
+    const strand = strandName(nearest.strand);
+    const n = nearest.remaining;
+    const skills = n === 1 ? '1 skill' : n + ' skills';
+    const next = nearest.nextLabel ? ' Next up: ' + nearest.nextLabel + '.' : '';
+    return skills + ' from closing ' + strand + ' at ' + nearest.courseLevel + '.' + next;
+  }
+
+  function strandName(key) {
+    const found = STRANDS.filter(function (s) { return s.key === key; })[0];
+    return found ? found.name : key;
+  }
+
+  /** Headline counts. `open` is what they can start right now, which is the ask. */
+  function summarize(payload) {
+    const c = (payload && payload.counts) || {};
+    return {
+      proved: c.proved || 0,
+      taught: c.taught || 0,
+      open: c.open || 0,
+      total: c.total || 0
+    };
+  }
+
+  return {
+    COURSE_LEVELS: COURSE_LEVELS,
+    STRANDS: STRANDS,
+    STATE_ORDER: STATE_ORDER,
+    STATE_LABEL: STATE_LABEL,
+    buildGrid: buildGrid,
+    activeLevels: activeLevels,
+    strandTotals: strandTotals,
+    isOwned: isOwned,
+    isActionable: isActionable,
+    rungOptions: rungOptions,
+    hookText: hookText,
+    strandName: strandName,
+    summarize: summarize
+  };
+}));

--- a/public/skill-map.html
+++ b/public/skill-map.html
@@ -10,74 +10,104 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- End Google Tag Manager -->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Skill Map | MATHMATIX AI</title>
+    <title>Your Climb | MATHMATIX AI</title>
     <link rel="stylesheet" href="/css/skill-map.css">
     <link rel="icon" type="image/png" href="/images/favicon-256x256.png">
-    <script src="https://d3js.org/d3.v7.min.js"></script>
 </head>
 <body>
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WDF79L47"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
-    <a href="#graph-container" class="skip-to-content">Skip to main content</a>
+    <a href="#board" class="skip-to-content">Skip to main content</a>
 
-    <!-- Full-viewport map canvas -->
-    <div id="graph-container"></div>
-
-    <!-- Floating info box (top-left) — minimal stats -->
-    <div id="infoBox" class="info-box">
-        <div class="info-content">
-            <div class="info-title">THE MATHEMATICAL UNIVERSE</div>
-            <div class="info-subtitle">A Skill Map of Patterns & Connections</div>
-            <div class="info-stats">
-                <span class="info-stat"><strong id="masteredCount">0</strong> mastered</span>
-                <span class="info-stat-sep">/</span>
-                <span class="info-stat"><strong id="totalSkills">0</strong> skills</span>
+    <div class="wrap">
+        <header class="top">
+            <div class="brandline">
+                <div class="eyebrow">Map of Mathmatix</div>
+                <h1>Your climb <em>&mdash; learn it, prove it, teach it</em></h1>
             </div>
+            <div class="tally" aria-live="polite">
+                <div><b id="t-proved">0</b><span>proved</span></div>
+                <div><b id="t-taught">0</b><span>taught</span></div>
+                <div><b id="t-open">0</b><span>open now</span></div>
+            </div>
+            <nav class="nav-float">
+                <a href="/chat.html" class="nav-btn">&larr; Chat</a>
+            </nav>
+        </header>
+
+        <!-- Proximity hook: the nearest band the student can actually close -->
+        <div class="hook" id="hook" hidden>
+            <i class="pip" aria-hidden="true"></i>
+            <p id="hook-text"></p>
+            <button class="act" id="hook-btn" type="button">Prove it</button>
+        </div>
+
+        <div id="status" class="status" role="status"></div>
+
+        <main class="board" id="board" hidden>
+            <div class="towers" id="towers"></div>
+        </main>
+
+        <div class="legend" id="legend" hidden>
+            <span><i class="swatch s-locked"></i>Locked</span>
+            <span><i class="swatch s-open"></i>Open</span>
+            <span><i class="swatch s-learned"></i>Learned it</span>
+            <span><i class="swatch s-above"></i>Cleared from above</span>
+            <span><i class="swatch s-proved"></i>Proved it</span>
+            <span><i class="swatch s-taught"></i>Taught it</span>
         </div>
     </div>
 
-    <!-- Floating nav (top-right) -->
-    <div class="nav-float">
-        <a href="/chat.html" class="nav-btn" title="Back to Chat">&larr; Chat</a>
-        <button id="resetZoom" class="nav-btn" title="Reset View (R)">Reset</button>
-        <button id="showHelp" class="nav-btn" title="Keyboard Shortcuts (?)">?</button>
-    </div>
+    <!-- Skill drawer -->
+    <aside class="drawer" id="drawer" aria-hidden="true">
+        <div class="drawer-inner">
+            <div class="dhead">
+                <div>
+                    <h2 id="d-label"></h2>
+                    <div class="meta" id="d-meta"></div>
+                </div>
+                <button class="ghost" id="d-close" type="button" aria-label="Close">Close</button>
+            </div>
+            <p class="d-state" id="d-state"></p>
+            <div class="proofs" id="d-proofs"></div>
 
-    <!-- Node detail panel — slides in from right on click -->
-    <div id="nodeDetail" class="node-detail hidden">
-        <button id="closeDetail" class="detail-close">&times;</button>
-        <div class="detail-body">
-            <h2 id="detailTitle"></h2>
-            <div class="detail-meta">
-                <div class="detail-row">
-                    <span class="detail-label">Pattern</span>
-                    <span id="detailPattern" class="detail-value"></span>
+            <!-- Challenge runner -->
+            <section class="runner" id="runner" hidden>
+                <h3>Prove it</h3>
+                <p class="runner-sub" id="runner-sub"></p>
+                <ol class="qs" id="runner-qs"></ol>
+                <div class="runner-actions">
+                    <button class="act" id="runner-submit" type="button">Submit</button>
+                    <button class="ghost" id="runner-cancel" type="button">Cancel</button>
                 </div>
-                <div class="detail-row">
-                    <span class="detail-label">Tier</span>
-                    <span id="detailTier" class="detail-value"></span>
+                <p class="runner-result" id="runner-result" hidden></p>
+            </section>
+
+            <!-- Teach-back -->
+            <section class="runner" id="teach" hidden>
+                <h3>Teach it back</h3>
+                <p class="runner-sub" id="teach-prompt"></p>
+                <textarea id="teach-input" rows="6" placeholder="Explain it in your own words &mdash; and say WHY it works, not just the steps."></textarea>
+                <div class="runner-actions">
+                    <button class="act" id="teach-submit" type="button">Submit</button>
+                    <button class="ghost" id="teach-cancel" type="button">Cancel</button>
                 </div>
-                <div class="detail-row">
-                    <span class="detail-label">Milestone</span>
-                    <span id="detailMilestone" class="detail-value"></span>
-                </div>
-            </div>
-            <div class="detail-status-section">
-                <span id="detailStatus" class="status-badge"></span>
-                <div class="progress-track">
-                    <div id="detailProgressBar" class="progress-fill"></div>
-                </div>
-                <span id="detailProgressText" class="progress-text">0%</span>
-            </div>
-            <button id="practiceBtn" class="practice-btn">Start Practice</button>
+                <p class="runner-result" id="teach-result" hidden></p>
+            </section>
         </div>
+    </aside>
+
+    <div class="toast" id="toast" hidden>
+        <div class="big" id="toast-big"></div>
+        <div class="sub" id="toast-sub"></div>
     </div>
 
     <script src="js/storage-utils.js"></script>
     <script src="js/csrf.js"></script>
     <script src="js/logout.js"></script>
+    <script src="js/skillMapModel.js"></script>
     <script src="js/skill-map.js"></script>
 </body>
 </html>

--- a/tests/unit/skillMapModel.test.js
+++ b/tests/unit/skillMapModel.test.js
@@ -1,0 +1,133 @@
+/**
+ * Skill map view model.
+ *
+ * These pin what the board TELLS a student — which rung it offers, how close a
+ * band claims to be — because those are the parts that can quietly lie. The
+ * rung options in particular must mirror utils/skillRung.canAdvance, or the
+ * board offers actions the server then refuses.
+ */
+
+const M = require('../../public/js/skillMapModel');
+
+const skill = (over) => Object.assign(
+  { skillId: 'ALG1.PRP.2', label: 'Slope as a rate', strand: 'PRP', courseLevel: 'ALG1', state: 'open' },
+  over
+);
+
+describe('rungOptions mirrors the server-side ladder', () => {
+  test('an open skill can be learned or proved — the test-out path', () => {
+    const keys = M.rungOptions(skill({ state: 'open' })).map((o) => o.key);
+    expect(keys).toEqual(['learn', 'challenge']);
+  });
+
+  test('a learned skill can still be proved', () => {
+    expect(M.rungOptions(skill({ state: 'learned' })).map((o) => o.key)).toContain('challenge');
+  });
+
+  test('a proved skill is offered teaching, and only teaching', () => {
+    expect(M.rungOptions(skill({ state: 'proved' })).map((o) => o.key)).toEqual(['teach']);
+  });
+
+  test('a skill cleared from above must be proved directly before teaching', () => {
+    // skillRung.canAdvance refuses teachback on an inferred rung. The board must
+    // not offer it, or the student gets a 409 for something the UI invited.
+    const keys = M.rungOptions(skill({ state: 'above' })).map((o) => o.key);
+    expect(keys).toEqual(['challenge']);
+    expect(keys).not.toContain('teach');
+  });
+
+  test('a taught skill offers nothing — it is the top rung', () => {
+    expect(M.rungOptions(skill({ state: 'taught' }))).toEqual([]);
+  });
+
+  test('a locked skill offers nothing', () => {
+    expect(M.rungOptions(skill({ state: 'locked' }))).toEqual([]);
+  });
+});
+
+describe('ownership', () => {
+  test('proved, taught and cleared-from-above all count as owned', () => {
+    ['proved', 'taught', 'above'].forEach((s) => expect(M.isOwned(s)).toBe(true));
+  });
+
+  test('learning something is not owning it', () => {
+    ['open', 'learned', 'locked'].forEach((s) => expect(M.isOwned(s)).toBe(false));
+  });
+});
+
+describe('the grid', () => {
+  const skills = [
+    skill({ skillId: 'A', strand: 'PRP', courseLevel: 'ALG1' }),
+    skill({ skillId: 'B', strand: 'PRP', courseLevel: 'ALG1' }),
+    skill({ skillId: 'C', strand: 'QNT', courseLevel: 'MS' })
+  ];
+
+  test('groups by level and strand', () => {
+    const grid = M.buildGrid(skills);
+    expect(grid.get('ALG1|PRP')).toHaveLength(2);
+    expect(grid.get('MS|QNT')).toHaveLength(1);
+  });
+
+  test('only renders levels that actually have skills', () => {
+    expect(M.activeLevels(skills)).toEqual(['MS', 'ALG1']);
+  });
+
+  test('levels come back bottom-up, not in payload order', () => {
+    const jumbled = [skill({ courseLevel: 'CALC' }), skill({ courseLevel: 'ELEM' })];
+    expect(M.activeLevels(jumbled)).toEqual(['ELEM', 'CALC']);
+  });
+
+  test('skills missing a strand or level are skipped, not crashed on', () => {
+    const grid = M.buildGrid([{ skillId: 'X' }, null, skill({})]);
+    expect(grid.size).toBe(1);
+  });
+});
+
+describe('strand totals', () => {
+  test('counts owned against total per strand', () => {
+    const totals = M.strandTotals([
+      skill({ strand: 'PRP', state: 'proved' }),
+      skill({ strand: 'PRP', state: 'open' }),
+      skill({ strand: 'QNT', state: 'taught' })
+    ]);
+    expect(totals.PRP).toEqual({ total: 2, owned: 1 });
+    expect(totals.QNT).toEqual({ total: 1, owned: 1 });
+  });
+
+  test('every strand is present even with no skills', () => {
+    expect(Object.keys(M.strandTotals([]))).toHaveLength(6);
+  });
+});
+
+describe('the proximity hook', () => {
+  test('names the band and what to do next', () => {
+    const text = M.hookText({
+      strand: 'PRP', courseLevel: 'ALG1', remaining: 2,
+      nextSkillId: 'ALG1.PRP.3', nextLabel: 'Direct variation'
+    });
+    expect(text).toBe('2 skills from closing Proportional Reasoning at ALG1. Next up: Direct variation.');
+  });
+
+  test('says "1 skill", not "1 skills"', () => {
+    const text = M.hookText({ strand: 'PRP', courseLevel: 'ALG1', remaining: 1, nextSkillId: 'x' });
+    expect(text).toMatch(/^1 skill from/);
+  });
+
+  test('says nothing when there is no attackable next skill', () => {
+    // Dangling "2 away!" at locked work is a wall dressed as a nudge.
+    expect(M.hookText({ strand: 'PRP', courseLevel: 'ALG1', remaining: 2, nextSkillId: null })).toBeNull();
+    expect(M.hookText(null)).toBeNull();
+  });
+});
+
+describe('summarize', () => {
+  test('reads the counts the endpoint returns', () => {
+    expect(M.summarize({ counts: { proved: 12, taught: 3, open: 7, total: 348 } }))
+      .toEqual({ proved: 12, taught: 3, open: 7, total: 348 });
+  });
+
+  test('degrades to zeros rather than NaN on a malformed payload', () => {
+    expect(M.summarize({})).toEqual({ proved: 0, taught: 0, open: 0, total: 0 });
+    expect(M.summarize(null)).toEqual({ proved: 0, taught: 0, open: 0, total: 0 });
+  });
+});


### PR DESCRIPTION
…proof runners

Replaces the D3 force-directed "Mathematical Universe" with six strand towers, one band per course level, filling bottom-up.

WHY TOWERS. A pattern is a vertical thread you can trace: unit rate sits in the PRP column at MS, slope is the same column at ALG1, derivative-in-context is the same column at CALC. That layout IS the "see the patterns" argument. A force layout scattered precisely the relationship the product is built on, and an ALEKS pie would do the same.

WHY IT IS NOW HONEST. It reads GET /api/mastery/map, built from the real prerequisite graph the closure engine reasons over. The previous /api/mastery/skill-graph built nodes from the hardcoded pattern-badge config and edges from the hardcoded prerequisiteMapper — so what a student saw and what the system would actually unlock could disagree.

Six states, and the distinction that matters is visible: `proved` (demonstrated) renders solid, `above` (cleared by prerequisite closure) renders dimmer. The system granted the second one; the student did not demonstrate it, and the board should not imply evidence that does not exist. `taught` gets a white core.

The proximity hook reads the nearest closable band — "2 skills from closing Proportional Reasoning at ALG1. Next up: Direct variation." — and highlights the target cell. It stays hidden when there is no attackable next skill, because dangling "2 away!" at locked work is a wall dressed as a nudge.

Both proof runners are wired to the endpoints built earlier: a challenge (five problems, answers submitted for SERVER-side grading, cascade count surfaced on a pass) and a teach-back (the confused-student opener, explanation, rubric result). A teach-back scorer outage is rendered as neither pass nor fail, matching the server's fail-safe.

The rung options offered by the board mirror utils/skillRung.canAdvance — in particular a skill cleared from above is offered "Prove it directly", never "Teach it back", so the UI cannot invite an action the server will 409.

Pure view logic lives in public/js/skillMapModel.js so it is testable rather than only observable by clicking around production: 19 unit tests over rung options, grid/level assembly, strand totals and the hook copy.

Verified by rendering the real 337-skill catalog through jsdom: 337 cells, 6 columns, 8 level bands, correct hook text and tally, locked cells disabled, and a proved skill opening a drawer that offers only "Teach it back".

Unit suite 4100 pass (255 suites); eslint clean.