### PR TITLE
Make coins easier to earn + a 100-coin day-1 welcome bonus

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -501,6 +501,34 @@ function registerUserRoutes(app) {
         await User.updateOne({ _id: req.user._id }, { $set: updates });
       }
 
+      // One-time welcome coins so students begin with a spendable balance on
+      // day 1 (enough to grab a cosmetic and feel the earn→spend loop). Granted
+      // once, gated by wallet.welcomeGrantedAt; bypasses the daily earn cap since
+      // it's a starter gift, not earned currency.
+      const isStudent = Array.isArray(userObj.roles) && userObj.roles.length
+        ? userObj.roles.includes('student')
+        : userObj.role === 'student';
+      if (isStudent && !(userObj.wallet && userObj.wallet.welcomeGrantedAt)) {
+        const grant = (BRAND_CONFIG.coinRewards && BRAND_CONFIG.coinRewards.welcomeBonus) || 100;
+        const now = new Date();
+        // Atomic + idempotent: the `welcomeGrantedAt: null` filter matches both an
+        // unset and a null field, so only ONE concurrent /user call can win.
+        const result = await User.updateOne(
+          { _id: req.user._id, 'wallet.welcomeGrantedAt': null },
+          {
+            $inc: { 'wallet.coins': grant, 'wallet.lifetimeEarned': grant },
+            $set: { 'wallet.welcomeGrantedAt': now },
+          }
+        );
+        if (result.modifiedCount === 1) {
+          // Reflect it in this response so the balance shows immediately.
+          userObj.wallet = userObj.wallet || { coins: 0, lifetimeEarned: 0, dailyEarned: 0 };
+          userObj.wallet.coins = (userObj.wallet.coins || 0) + grant;
+          userObj.wallet.lifetimeEarned = (userObj.wallet.lifetimeEarned || 0) + grant;
+          userObj.wallet.welcomeGrantedAt = now;
+        }
+      }
+
       const level = userObj.level || 1;
       const xpStart = BRAND_CONFIG.cumulativeXpForLevel(level);
       userObj.xpForCurrentLevel = Math.max(0, (userObj.xp || 0) - xpStart);

--- a/models/user.js
+++ b/models/user.js
@@ -671,7 +671,8 @@ const userSchema = new Schema({
     lifetimeEarned: { type: Number, default: 0 },          // analytics; never spent down
     dailyEarned:    { type: Number, default: 0 },          // anti-abuse daily cap counter
     lastCoinReset:  { type: Date, default: Date.now },      // anchors the daily reset
-    retroLevelGrantedAt: { type: Date, default: null }      // set once by scripts/grantRetroactiveLevelCoins.js so the backfill is idempotent
+    retroLevelGrantedAt: { type: Date, default: null },     // set once by scripts/grantRetroactiveLevelCoins.js so the backfill is idempotent
+    welcomeGrantedAt: { type: Date, default: null }         // set once when the day-1 welcome bonus is granted (idempotent)
   },
 
   /* Cosmetics ownership + equipped loadout (see utils/cosmeticsCatalog.js).

--- a/utils/brand.js
+++ b/utils/brand.js
@@ -174,9 +174,10 @@ const BRAND_CONFIG = {
     // enforces the daily cap. See docs/COSMETICS_SHOP_DESIGN.md.
     coinRewards: {
         dailyCap: 500,            // max coins earnable per UTC day (anti-abuse)
-        levelUp: 20,              // per level gained
-        questComplete: 15,        // per daily quest completed
-        challengeComplete: 75,    // per weekly challenge completed (wiring TBD)
+        welcomeBonus: 100,        // one-time starter grant so students begin with a spendable balance (day 1)
+        levelUp: 30,              // per level gained
+        questComplete: 25,        // per daily quest completed
+        challengeComplete: 100,   // per weekly challenge completed
         masteryBadge: 100         // per mastery badge earned (wiring TBD)
     },
 


### PR DESCRIPTION
## Why

Lower the friction on the coin economy so the shop feels reachable early — students should be able to buy *something* soon after starting.

## Changes

**Day-1 welcome bonus (100 coins)**
- New students start with a spendable balance — enough to grab a cosmetic and feel the earn→spend loop immediately.
- Granted once, idempotently, from `GET /user` via an **atomic conditional update** (`wallet.welcomeGrantedAt: null` matches both unset and null, so two concurrent `/user` calls can't double-grant). Added the `wallet.welcomeGrantedAt` schema flag.
- Bypasses the daily earn cap since it's a starter gift, not earned currency. Students only.

**Higher earn rates** (`utils/brand.js` → `coinRewards`)
- Level-up: **20 → 30** per level
- Daily quest: **15 → 25** each
- Weekly challenge: **75 → 100** each
- Award sites (`xpEngine`, `dailyQuests`, `weeklyChallenges`) read these from `BRAND.coinRewards`, so the change flows through with **no call-site edits**. Daily cap (500) unchanged.

## Heads-up (one deliberate behavior choice)

The welcome bonus grants **existing** students their one-time 100 on next load too — a deliberate one-time top-up for everyone. If you'd rather restrict it to brand-new signups only, I can move the grant to account creation instead; say the word.

## Test
- `node --check` passes on all three files.
- No existing tests assert coin amounts (grepped), so the rate bumps don't break anything.
- Grant verified atomic/idempotent by construction (conditional filter + `modifiedCount` check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9zNo7LtFvgW4DMxH8HiEi)_