### PR TITLE
fix(mastery): 'placement' could not prove a skill — both credit paths…

### DIFF
--- a/tests/integration/coursePreAssessmentRoute.test.js
+++ b/tests/integration/coursePreAssessmentRoute.test.js
@@ -1,0 +1,222 @@
+/**
+ * The course pre-assessment endpoints, against a real database.
+ *
+ * The unit tests cover the blueprint math; what they cannot cover is the chain
+ * this feature actually is: serve items with no answers -> grade server-side ->
+ * prove credited skills at rung 2 -> cascade prerequisites -> move the course's
+ * start module -> stop offering the card. Each link of that chain has failed
+ * once already this session when only unit-tested, so this drives the real
+ * routes against a real mongod.
+ *
+ * Uses a real pathway file (6th-grade-math) rather than a fixture, so the test
+ * also breaks if the pathway format drifts out from under the endpoint.
+ */
+
+const express = require('express');
+const supertest = require('supertest');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const User = require('../../models/user');
+const Skill = require('../../models/skill');
+const Problem = require('../../models/problem');
+const CourseSession = require('../../models/courseSession');
+const { getSkillMasteryEntry } = require('../../utils/masteryGuard');
+const { courseSkills } = require('../../utils/coursePreAssessment');
+
+const COURSE_ID = '6th-grade-math';
+const pathway = require('../../public/resources/6th-grade-math-pathway.json');
+
+let mem;
+let app;
+let currentUserId;
+let sessionId;
+let servedSkillIds;   // the skills the GET blueprint chose to test
+
+beforeAll(async () => {
+  mem = await MongoMemoryServer.create();
+  await mongoose.connect(mem.getUri());
+
+  // Give every course skill a couple of gradable items so the blueprint can
+  // cover the whole pathway.
+  const skills = courseSkills(pathway);
+  const docs = [];
+  skills.forEach((s, i) => {
+    for (let n = 0; n < 2; n += 1) {
+      docs.push({
+        problemId: `cpa-${i}-${n}`,
+        skillId: s.skillId,
+        prompt: `Compute ${i} + ${n}`,
+        answer: { type: 'exact', value: String(i + n) },
+        difficulty: 2
+      });
+    }
+  });
+  await Problem.insertMany(docs);
+
+  // A minimal unified catalog so the cascade has a graph. Real ids, one edge.
+  await Skill.insertMany([
+    {
+      skillId: 'MS.QNT.1', displayName: 'Decimal ops', studentLabel: 'Decimal arithmetic',
+      description: 'd', category: 'number-system', strand: 'QNT', courseLevel: 'MS',
+      prerequisites: [], crossPrereqs: [], source: 'unified-taxonomy'
+    }
+  ]);
+
+  const router = require('../../routes/courseSession');
+  app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.user = { _id: currentUserId };
+    req.isAuthenticated = () => true;
+    next();
+  });
+  app.use('/api/course-sessions', router);
+}, 60000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  if (mem) await mem.stop();
+});
+
+beforeEach(async () => {
+  const u = await User.create({
+    username: `cpa${Date.now()}`, email: `cpa${Date.now()}@e.com`,
+    firstName: 'C', lastName: 'P'
+  });
+  currentUserId = u._id;
+  const s = await CourseSession.create({
+    userId: u._id, courseId: COURSE_ID, status: 'active',
+    pathwayId: '6th-grade-math-pathway', courseName: '6th Grade Math',
+    currentModuleId: pathway.modules[0].moduleId
+  });
+  sessionId = String(s._id);
+});
+
+afterEach(async () => {
+  await User.deleteMany({});
+  await CourseSession.deleteMany({});
+});
+
+const fetchPre = () => supertest(app).get(`/api/course-sessions/${sessionId}/preassessment`);
+
+const answersFor = async (problems, wrongFor = new Set()) => {
+  const out = [];
+  for (const p of problems) {
+    const doc = await Problem.findById(p.problemId).lean();
+    out.push({
+      problemId: p.problemId,
+      answer: wrongFor.has(doc.skillId) ? 'definitely wrong' : String(doc.answer.value)
+    });
+  }
+  return out;
+};
+
+describe('GET /:id/preassessment', () => {
+  test('serves items for the course without leaking answers', async () => {
+    const res = await fetchPre();
+    expect(res.status).toBe(200);
+    expect(res.body.problems.length).toBeGreaterThan(0);
+    expect(JSON.stringify(res.body)).not.toMatch(/"answer"\s*:/);
+    expect(res.body.coverage).toBeGreaterThan(0);
+    servedSkillIds = [...new Set(res.body.problems.map((p) => p.skillId))];
+  });
+
+  test('is honest about partial coverage', async () => {
+    const res = await fetchPre();
+    // The pathway has more skills than a 20-item cap can cover at 2 per skill,
+    // so coverage must be reported as < 1, not implied as complete.
+    expect(res.body.skillsAssessed).toBeLessThanOrEqual(10);
+    expect(res.body.coverage).toBeLessThan(1);
+    expect(res.body.totalCourseSkills).toBe(courseSkills(pathway).length);
+  });
+});
+
+describe('POST /:id/preassessment', () => {
+  test('a clean run credits skills, moves the start, and stops the card', async () => {
+    const served = (await fetchPre()).body.problems;
+    const submissions = await answersFor(served);
+
+    const res = await supertest(app)
+      .post(`/api/course-sessions/${sessionId}/preassessment`)
+      .send({ submissions });
+
+    expect(res.status).toBe(200);
+    expect(res.body.credited.length).toBeGreaterThan(0);
+
+    // Credited skills are really proved on the user document.
+    const user = await User.findById(currentUserId);
+    const first = getSkillMasteryEntry(user, res.body.credited[0]);
+    expect(first.rung).toBe('proved');
+    expect(first.provenBy).toBe('placement');
+
+    // The session records completion, so buildCourseDiagnostic stops offering it.
+    const session = await CourseSession.findById(sessionId);
+    expect(session.preAssessmentCompletedAt).toBeTruthy();
+    expect(session.preAssessment.credited).toEqual(res.body.credited);
+  });
+
+  test('missing a skill starts the course at that module, not past it', async () => {
+    const served = (await fetchPre()).body.problems;
+    // Fail everything from the FIRST tested skill; ace the rest.
+    const firstSkill = served[0].skillId;
+    const submissions = await answersFor(served, new Set([firstSkill]));
+
+    const res = await supertest(app)
+      .post(`/api/course-sessions/${sessionId}/preassessment`)
+      .send({ submissions });
+
+    expect(res.body.notCredited).toContain(firstSkill);
+    expect(res.body.start).toBeTruthy();
+    // The first module containing the missed skill is where the course starts.
+    const skillModule = courseSkills(pathway).find((s) => s.skillId === firstSkill).moduleId;
+    expect(res.body.start.moduleId).toBe(skillModule);
+
+    const session = await CourseSession.findById(sessionId);
+    expect(session.currentModuleId).toBe(skillModule);
+  });
+
+  test('a wrong-answer run credits nothing and moves nothing', async () => {
+    const served = (await fetchPre()).body.problems;
+    const submissions = served.map((p) => ({ problemId: p.problemId, answer: 'nope' }));
+
+    const res = await supertest(app)
+      .post(`/api/course-sessions/${sessionId}/preassessment`)
+      .send({ submissions });
+
+    expect(res.body.credited).toEqual([]);
+    // Failing the pre-assessment is free: nothing on the user changed.
+    const user = await User.findById(currentUserId);
+    expect(user.skillMastery.size).toBe(0);
+    // And the course starts at the first module with a gap — the beginning.
+    expect(res.body.start.moduleId).toBe(pathway.modules[0].moduleId);
+  });
+
+  test('client-claimed correctness is ignored', async () => {
+    const served = (await fetchPre()).body.problems;
+    const lying = served.map((p) => ({
+      problemId: p.problemId, answer: 'wrong', correct: true, isCorrect: true
+    }));
+
+    const res = await supertest(app)
+      .post(`/api/course-sessions/${sessionId}/preassessment`)
+      .send({ submissions: lying });
+
+    expect(res.body.credited).toEqual([]);
+  });
+
+  test('another user\'s session id is not accessible', async () => {
+    const stranger = await User.create({
+      username: `x${Date.now()}`, email: `x${Date.now()}@e.com`, firstName: 'X', lastName: 'X'
+    });
+    const strangerSession = await CourseSession.create({
+      userId: stranger._id, courseId: COURSE_ID, status: 'active',
+      pathwayId: '6th-grade-math-pathway', courseName: '6th Grade Math'
+    });
+
+    const res = await supertest(app)
+      .post(`/api/course-sessions/${strangerSession._id}/preassessment`)
+      .send({ submissions: [{ problemId: 'p', answer: 'x' }] });
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/unit/skillRung.test.js
+++ b/tests/unit/skillRung.test.js
@@ -248,3 +248,39 @@ describe('clearsPrerequisites', () => {
     expect(clearsPrerequisites(e)).toBe(false);
   });
 });
+
+describe('placement — screener, course pre-assessment, baseline test', () => {
+  test('a placement result proves the skill', () => {
+    // REGRESSION: 'placement' was missing from the allowed via-list, so
+    // advanceRung silently refused and both the ACT baseline credit and the
+    // course pre-assessment credit wrote nothing at all. Unit tests covered the
+    // scoring math; only an integration test caught that the write was a no-op.
+    const e = advanceRung({}, 'proved', { via: 'placement' });
+    expect(e.__rungResult.changed).toBe(true);
+    expect(currentRung(e)).toBe('proved');
+    expect(e.provenBy).toBe('placement');
+  });
+
+  test('placement is a demonstration, not an inference', () => {
+    // The student answered the items. Unlike a cascade-cleared skill, this one
+    // carries real evidence — so it must NOT be flagged inferred.
+    const e = advanceRung({}, 'proved', { via: 'placement' });
+    expect(isInferred(e)).toBe(false);
+    expect(e.masteryType).toBe('verified');
+  });
+
+  test('a placement-proved skill can still be taught', () => {
+    const e = advanceRung({}, 'proved', { via: 'placement' });
+    const t = advanceRung(e, 'taught', { via: 'teachback', evidence: { rubricScore: 4 } });
+    expect(t.__rungResult.changed).toBe(true);
+    expect(currentRung(t)).toBe('taught');
+  });
+
+  test('placement needs no per-item evidence — the assessment already adjudicated', () => {
+    expect(evidenceSupports('proved', 'placement', {}).ok).toBe(true);
+  });
+
+  test('placement still cannot skip straight to taught', () => {
+    expect(canAdvance({}, 'taught', 'placement').ok).toBe(false);
+  });
+});

--- a/utils/skillRung.js
+++ b/utils/skillRung.js
@@ -99,7 +99,10 @@ function canAdvance(entry, to, via) {
   }
 
   if (to === 'proved') {
-    if (!['challenge', 'fluency', 'practice', 'inference'].includes(via)) {
+    // 'placement' = a screener, a course pre-assessment, or a baseline practice
+    // test. Unlike 'inference' it IS a demonstration — the student answered the
+    // items — so a placement-proved skill can go on to be taught.
+    if (!['challenge', 'fluency', 'practice', 'placement', 'inference'].includes(via)) {
       return { ok: false, reason: `cannot prove a skill via ${via}` };
     }
     return { ok: true };
@@ -122,7 +125,11 @@ function canAdvance(entry, to, via) {
  * "you may attempt this" and "you did not clear the bar" as different things.
  */
 function evidenceSupports(to, via, evidence = {}) {
-  if (to === 'learned' || via === 'inference') return { ok: true };
+  // 'placement' arrives pre-adjudicated: the assessment already applied its own
+  // credit rule (a clean run on that skill's items — see
+  // utils/coursePreAssessment.CREDIT_ACCURACY) before calling here, so there is
+  // no per-item evidence left to re-check.
+  if (to === 'learned' || via === 'inference' || via === 'placement') return { ok: true };
 
   if (to === 'proved' && via === 'challenge') {
     const { correct = 0, total = 0, hintsUsed = 0 } = evidence;


### PR DESCRIPTION
… were no-ops

The integration test I wrote for the pre-assessment endpoints immediately failed on the one assertion that mattered: the response said skills were credited, but nothing was on the user document.

Cause: skillRung.canAdvance allows 'proved' via challenge / fluency / practice / inference. 'placement' was never added. So advanceRung refused every call, returned changed:false, and the callers — which correctly check `changed` before writing — wrote nothing.

That means BOTH features shipped this session were no-ops in their core action:
  - the ACT baseline credit (8009bb55)
  - the course pre-assessment credit (b68706c7) Each returned a cheerful "you already own N of these" while persisting nothing. The screener/assessment paths were unaffected: they assign the rung as an object literal rather than going through advanceRung, which is also why this never surfaced there.

Unit tests could not catch it. They covered the blueprint math and the scoring rule — the parts I wrote — not the write, which is where the two subsystems meet. This is the third time this session the same shape of bug has appeared: field or enum drift between a caller and the module it calls, invisible until something drove the real path end to end.

Fix: 'placement' can prove a skill, and needs no per-item evidence at this layer because the assessment already adjudicated it (a clean run on that skill's items, utils/coursePreAssessment.CREDIT_ACCURACY). Unlike 'inference' it IS a demonstration — the student answered — so it stays masteryType 'verified' and a placement-proved skill can go on to be taught. It still cannot skip to 'taught'.

7 integration tests over the real routes and a real mongod: items served without answers, honest partial coverage, credited skills actually proved at rung 2, recommendedStart moving currentModuleId to the first module with a gap, a wrong-answer run costing nothing, client-claimed correctness ignored, and another user's session id returning 404. Plus 5 unit tests pinning the placement rung.

Full run 285 suites, 4407 pass.