### PR TITLE
fix(grading): a sentence period silently truncated the problem and it…

### DIFF
--- a/tests/unit/mathSolverSentencePeriod.test.js
+++ b/tests/unit/mathSolverSentencePeriod.test.js
@@ -1,0 +1,89 @@
+/**
+ * Regression tests for expressions written at the END OF A SENTENCE, and for
+ * the LaTeX spellings of ×, ÷ and ·.
+ *
+ * THE BUG (from a real session): the tutor posed "24 − 6 ÷ 2 + 3." in chat, but
+ * the workspace's PROBLEM card read "24 − 6 ÷ 2." The board does not receive the
+ * tutor's own text — boardSynthesizer.detectPosedProblem re-derives the problem
+ * from the prose via parseCleanProblem → isolateNumericExpression, whose
+ * trailing guard `(?![\w.^])` was meant to keep a decimal point inside its
+ * number but also rejected a sentence-ending period. The match backtracked off
+ * the last term and returned the truncated "24 - 6 / 2".
+ *
+ * The visible card was the least of it: the same parse produced
+ * correctAnswer = 21, which is pinned and graded against. A student answering
+ * the correct 24 would have been marked wrong — the same failure mode as the
+ * "16/4 ⋅ 2" regression next door.
+ *
+ * A parallel defect: the engine normalizes the Unicode glyphs (÷ × ⋅) but never
+ * the LaTeX commands, so "3 \times 4 + 2" parsed as "4 + 2" = 6. Wrong answers,
+ * not parse failures.
+ *
+ * THE FIX:
+ *   - Only treat "." as part of a number when a digit follows it.
+ *   - Strip a sentence-final period before the pure-numeric chain parse, so it
+ *     cannot ride along inside `expression` and onto the board card.
+ *   - Normalize \div, \times, \cdot and \ast alongside their Unicode glyphs.
+ */
+const { parseCleanProblem, detectMathProblem } = require('../../utils/mathSolver');
+
+describe('expressions at the end of a sentence — the "24 − 6 ÷ 2 + 3." regression', () => {
+  // Every phrasing here truncated to "24 - 6 / 2" (answer 21) before the fix.
+  const phrasings = [
+    'Try this: 24 − 6 ÷ 2 + 3.',
+    'Solve 24 − 6 ÷ 2 + 3.',
+    'Here is one: 24 − 6 ÷ 2 + 3.',
+    'Next up: 24 − 6 ÷ 2 + 3. Ready?',
+    'Let us try 24 − 6 ÷ 2 + 3. Remember PEMDAS.',
+  ];
+
+  it.each(phrasings)('keeps the whole expression in %j', (text) => {
+    const r = parseCleanProblem(text);
+    expect(r.problem.expression.replace(/\s/g, '')).toBe('24-6/2+3');
+    expect(Number(r.solution.answer)).toBe(24);
+  });
+
+  it('a question mark never regressed, and still works', () => {
+    const r = parseCleanProblem('What is 24 − 6 ÷ 2 + 3?');
+    expect(Number(r.solution.answer)).toBe(24);
+  });
+
+  it('does not carry the sentence period into the expression (it reaches the board verbatim)', () => {
+    const r = parseCleanProblem('24 − 6 ÷ 2 + 3.');
+    expect(r.problem.expression).not.toMatch(/\.$/);
+    expect(Number(r.solution.answer)).toBe(24);
+  });
+
+  it('still keeps decimal points inside their numbers', () => {
+    const r = parseCleanProblem('Compute 3.5 + 1.5 today.');
+    expect(Number(r.solution.answer)).toBe(5);
+  });
+
+  it('drops only the final term-eating period, not a trailing exponent term', () => {
+    const r = parseCleanProblem('Evaluate 2^3 + 1.');
+    expect(Number(r.solution.answer)).toBe(9);
+  });
+});
+
+describe('LaTeX operator spellings grade like their Unicode glyphs', () => {
+  const cases = [
+    ['24 - 6 \\div 2 + 3', 24],
+    ['3 \\times 4 + 2', 14],
+    ['6 \\cdot 2 - 1', 11],
+  ];
+
+  it.each(cases)('%s = %i', (text, expected) => {
+    const r = parseCleanProblem(text);
+    expect(Number(r.solution.answer)).toBe(expected);
+  });
+
+  it('agrees with the Unicode form it mirrors', () => {
+    expect(parseCleanProblem('3 \\times 4 + 2').solution.answer)
+      .toBe(parseCleanProblem('3 × 4 + 2').solution.answer);
+  });
+
+  it('leaves a word merely starting with an operator name alone', () => {
+    // \divide must not normalize as \div + "ide"
+    expect(detectMathProblem('\\divide')).toBeNull();
+  });
+});

--- a/utils/mathSolver.js
+++ b/utils/mathSolver.js
@@ -34,7 +34,13 @@ const { evalExpression, expressionValue } = require('./rationalEvaluator');
  */
 function isolateNumericExpression(text) {
     if (!text) return null;
-    const rx = /(?<![\w.^])-?\d[\d\s.+\-*/^()]*\d(?![\w.^])/g;
+    // The trailing guard must reject a DECIMAL point ("3.5" mid-number) without
+    // rejecting a SENTENCE period. `(?![\w.^])` did both: on "24 - 6 / 2 + 3."
+    // it failed at "3", backtracked to the previous digit, and returned the
+    // truncated "24 - 6 / 2" — which then became the board's PROBLEM card and,
+    // worse, the answer the grader checked against (21 instead of 24). Only a
+    // period followed by a digit is part of the number.
+    const rx = /(?<![\w.^])-?\d[\d\s.+\-*/^()]*\d(?!\.?\d|[\w^])/g;
     let m;
     while ((m = rx.exec(text)) !== null) {
         const expr = m[0].trim();
@@ -569,7 +575,11 @@ function detectMathProblem(message) {
     // floating drift). Placed AFTER the two-operand and fraction-pair patterns so those
     // keep their dedicated types; fires only when the expression has parentheses OR
     // 2+ operators, so simple two-operand arithmetic is left alone.
-    const chainForm = message.replace(/\s+/g, ''); // operators already ASCII-normalized above
+    // Drop a sentence-final period before parsing: "24 - 6 / 2 + 3." is the
+    // expression plus punctuation, and carrying the "." into `expression` puts
+    // it on the board's PROBLEM card verbatim. A decimal point always has a
+    // digit after it, so this can only ever remove punctuation.
+    const chainForm = message.replace(/\s+/g, '').replace(/\.+$/, ''); // operators already ASCII-normalized above
     const isPureNumericExpr = /^[\d.+\-*/^()]+$/.test(chainForm) && /[+\-*/^]/.test(chainForm);
     const hasParens = /[()]/.test(chainForm);
     const hasTwoPlusOps = /^-?\d+\.?\d*(?:[+\-*/^]\d+\.?\d*){2,}$/.test(chainForm);

--- a/utils/mathUnicodeNormalizer.js
+++ b/utils/mathUnicodeNormalizer.js
@@ -128,6 +128,19 @@ const UNICODE_REGEX = new RegExp('[' + Object.keys(ALL_CHARS).join('') + ']', 'g
 // "(1/2)" in place of "½".
 const OPERATOR_REGEX = new RegExp('[' + Object.keys(OPERATOR_MAP).join('') + ']', 'g');
 
+// The LaTeX spellings of the same operators. The tutor and MathLive both emit
+// these, and the regex-based engine's character classes can't see them: it
+// stopped at the backslash, so "3 \times 4 + 2" parsed as "4 + 2" and graded
+// as 6 — a confidently WRONG answer rather than a failure to parse. \b keeps
+// "\divide" and friends from matching a prefix.
+const LATEX_OPERATOR_MAP = {
+  '\\div': '/',
+  '\\times': '*',
+  '\\cdot': '*',
+  '\\ast': '*',
+};
+const LATEX_OPERATOR_REGEX = /\\(?:div|times|cdot|ast)\b/g;
+
 /**
  * Normalize ONLY Unicode math operators and signs to ASCII (minus, ×, ÷, dots,
  * comparison operators, √, and their fullwidth/variant forms). Leaves
@@ -142,7 +155,9 @@ const OPERATOR_REGEX = new RegExp('[' + Object.keys(OPERATOR_MAP).join('') + ']'
  */
 function normalizeMathOperators(str) {
   if (!str || typeof str !== 'string') return str || '';
-  return str.replace(OPERATOR_REGEX, ch => OPERATOR_MAP[ch] || ch);
+  return str
+    .replace(OPERATOR_REGEX, ch => OPERATOR_MAP[ch] || ch)
+    .replace(LATEX_OPERATOR_REGEX, cmd => LATEX_OPERATOR_MAP[cmd] || cmd);
 }
 
 /**


### PR DESCRIPTION
…s answer

A student was told 24 was wrong on "24 - 6 ÷ 2 + 3". Production logged:

    [Pipeline] Diagnose: incorrect (answer: -3, correct: 18)

Three separate defects in the same parse, all producing confidently WRONG answers rather than a failure to parse:

1. isolateNumericExpression's trailing guard `(?![\w.^])` was meant to keep a decimal point inside its number, but it also rejected a SENTENCE period. On "24 - 6 ÷ 2 + 3." the match backtracked off the last term and returned "24 - 6 / 2" — which became the board's PROBLEM card AND correctAnswer 21. Now only a period followed by a digit counts as part of the number.

2. The pure-numeric chain branch carried a sentence-final period into `expression`, so it reached the board card verbatim ("24 - 6 ÷ 2.").

3. normalizeMathOperators handled the Unicode glyphs (÷ × ⋅) but never the LaTeX spellings, so the character classes stopped at the backslash:
     "24 - 6 \div 2 + 3" -> "24 - 6"  = 18   (should be 24)
     "3 \times 4 + 2"    -> "4 + 2"   = 6    (should be 14)
   That is where the logged 18 came from.

Same failure mode as the "16/4 ⋅ 2" regression: a mis-parse pins a wrong correctAnswer, and the tutor then argues with a student who is right.