### PR TITLE
ci: move checkout/setup-node to the node24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
         node-version: [20]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -38,10 +38,10 @@ jobs:
     # never lower them to make a red build green.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: 'npm'
@@ -57,10 +57,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: 'npm'
@@ -74,10 +74,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Use Node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: 'npm'


### PR DESCRIPTION
GitHub is retiring the node20 runtime that actions declaring `runs: node20` execute on, and is currently force-running them on node24. Every CI run prints:

  Warning: Node.js 20 is deprecated. The following actions target Node.js 20
  but are being forced to run on Node.js 24: actions/checkout@v4,
  actions/setup-node@v4.

It's only a warning while the forcing lasts; it becomes a hard failure when that ends. v5 of both actions declares `runs: node24`, so the bump is the whole fix — no inputs changed, all four jobs.

Deliberately v5 and not v7 (the current latest): setup-node@v7 migrated to ESM and dropped the dummy NODE_AUTH_TOKEN export. Those are real breaking changes to absorb for what is a runtime-only warning, and v5 already clears it.

This is about the runtime the *action code* runs on, not the Node the app is tested under. `node-version: 20` is untouched in all four jobs — it matches engines >=20.14 and the node:20-slim base image, and testing on a runtime prod doesn't use would be a regression, not an upgrade.