### PR TITLE
Fix chat-stage layout flash from persisted panel prefs on load

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -174,6 +174,38 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <script defer src="/js/i18n.js"></script>
 </head>
 <body class="landing-page-body cr-mode">
+  <!-- No-flash: apply the persisted adjustable-panel prefs (minimized tutor
+       hero + custom work-board width) BEFORE the chat stage paints, so it
+       never renders its default 3-column layout for a frame and then jump to
+       the saved one (the "avatar flashes then the board takes over" bug).
+       adjustable-panels.js re-applies + wires the controls once it loads;
+       this only pre-paints the layout. Runs here (not <head>) because it
+       needs document.body, and still executes before .cr-stage is parsed. -->
+  <script>
+    (function () {
+      // Keep these constants in sync with adjustable-panels.js (MIN_W / MAX_W /
+      // MIN_CHAT and the default --cr-hero-w in design-system.css). The width is
+      // clamped here exactly as the JS clamps it, so the pre-paint value already
+      // equals the value the JS will settle on — no load-time reflow.
+      var MIN_W = 240, MAX_W = 960, MIN_CHAT = 360, HERO_W = 320, GAPS = 36;
+      try {
+        var heroMin = localStorage.getItem('mm_hero_min') === '1';
+        if (heroMin) document.body.classList.add('cr-hero-min');
+
+        // The board width only drives the grid above 1200px (below that the
+        // board is a fixed drawer — see workspace.css — and --cr-side-w is
+        // unused). Applying it narrower just risks a needless reflow, so skip.
+        var w = parseInt(localStorage.getItem('mm_ws_width'), 10);
+        if (w && window.innerWidth > 1200) {
+          var heroW = heroMin ? 0 : HERO_W;
+          var ceil = Math.min(MAX_W, window.innerWidth - heroW - MIN_CHAT - GAPS);
+          ceil = Math.max(MIN_W, ceil);
+          w = Math.max(MIN_W, Math.min(ceil, w));
+          document.documentElement.style.setProperty('--cr-side-w', w + 'px');
+        }
+      } catch (e) { /* localStorage unavailable — fall back to defaults */ }
+    })();
+  </script>
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WDF79L47"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>


### PR DESCRIPTION
## The bug

The adjustable work board + minimizable tutor hero (shipped in #1252) persist their state in `localStorage`, but `adjustable-panels.js` only applied that state at `DOMContentLoaded`. So on every load the stage painted its **default** 3-column layout first, then the deferred JS jumped the board to the saved (often wide) width and/or collapsed the hero.

The result, reported by the user: on load a persisted-wide board makes the chat column paint wide for a frame (the student's message avatar prominent on the right) and then the board expands and **"takes the whole column,"** crushing chat — a jarring reflow. The minimized tutor hero flashed the same way.

Reproduced in a headless Chromium render of the real page with a persisted `mm_ws_width`: the board went `760px → 652px → 644px` over the first frames (chat crushed to 208px mid-reflow) before settling.

## The fix

Apply the persisted prefs in a tiny inline script right after `<body>`, **before `.cr-stage` is parsed**, so the stage paints at its final width/state — no reflow. Mirrors the no-flash patterns already in this file (`mm-board-hidden` in `<head>`, the tutor-poster script).

- The width is clamped with the **same math** `adjustable-panels.js` uses (`MIN_W`/`MAX_W`/`MIN_CHAT`/hero width/gaps), so the pre-paint value equals the value the JS settles on — they never disagree.
- Only applied above 1200px, where `--cr-side-w` actually drives the grid (below that the board is a fixed drawer and the variable is unused).
- `adjustable-panels.js` still re-applies + wires the controls once it loads; this script only pre-paints the layout.

After the fix the same render holds the board steady at `644px` from the first painted frame — no flash.

## Scope
One file, additive: a ~30-line inline script in `public/chat.html`. No changes to `adjustable-panels.js` / `.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J1yZi13mTFJtdxHMRzAnBo)_