### PR TITLE
Ban em dashes and fix spoken-math TTS

### DIFF
--- a/tests/unit/mathTTS.test.js
+++ b/tests/unit/mathTTS.test.js
@@ -1,0 +1,52 @@
+// tests/unit/mathTTS.test.js
+// Locks in the spoken-math preprocessing that keeps a TTS engine from reading
+// "80°" as "circ", "=" as "equal sign", and "-" as a bare pause.
+
+const { cleanTextForTTS, convertLatexToSpeech } = require('../../utils/mathTTS');
+
+describe('cleanTextForTTS — undelimited (bare) math', () => {
+  test('degree symbol (unicode) → "degrees"', () => {
+    expect(cleanTextForTTS('The angle is 80° wide')).toBe('The angle is 80 degrees wide');
+  });
+
+  test('LaTeX degrees leaking outside delimiters → "degrees" (^\\circ, ^{\\circ})', () => {
+    expect(cleanTextForTTS('A right angle is 90^\\circ here')).toBe('A right angle is 90 degrees here');
+    expect(cleanTextForTTS('It is 90^{\\circ} exactly')).toBe('It is 90 degrees exactly');
+  });
+
+  test('"=" is spoken as "equals", not "equal sign"', () => {
+    expect(cleanTextForTTS('So A-B=34 here')).toBe('So A minus B equals 34 here');
+  });
+
+  test('"-" between operands is subtraction, not a pause', () => {
+    expect(cleanTextForTTS('That gives 8 - 3 = 5')).toBe('That gives 8 minus 3 equals 5');
+    expect(cleanTextForTTS('Compute A - B now')).toBe('Compute A minus B now');
+  });
+
+  test('a leading "-" is a negative sign', () => {
+    expect(cleanTextForTTS('The value is -7 today')).toBe('The value is negative 7 today');
+    expect(cleanTextForTTS('x = -5 works')).toBe('x equals negative 5 works');
+  });
+
+  // Regression guard: ordinary hyphenated words must NOT become "minus".
+  test.each([
+    ['Great, well-done on that!', 'Great, well-done on that!'],
+    ['Try the x-ray problem', 'Try the x-ray problem'],
+    ['Send an e-mail later', 'Send an e-mail later'],
+    ['twenty-one apples', 'twenty-one apples'],
+  ])('word hyphen preserved: %s', (input, expected) => {
+    expect(cleanTextForTTS(input)).toBe(expected);
+  });
+});
+
+describe('convertLatexToSpeech — delimited math', () => {
+  test('degrees', () => {
+    expect(convertLatexToSpeech('45^\\circ')).toBe('45 degrees');
+    expect(convertLatexToSpeech('90^{\\circ}')).toBe('90 degrees');
+  });
+
+  test('negative vs subtraction', () => {
+    expect(convertLatexToSpeech('x = -5')).toBe('x equals negative 5');
+    expect(convertLatexToSpeech('3x^2 + 2x - 5')).toBe('3x squared plus 2x minus 5');
+  });
+});

--- a/utils/dashNormalizer.js
+++ b/utils/dashNormalizer.js
@@ -1,0 +1,35 @@
+'use strict';
+
+/**
+ * Replace punctuation EM dashes (—, U+2014) with a comma.
+ *
+ * Why: a tutor writing "That's right — 7" gets misread by a student as
+ * "that's right minus 7". An em dash is a punctuation dash, never a math
+ * glyph, so swapping it for a comma removes the dash-vs-minus ambiguity
+ * without touching any math.
+ *
+ * What we deliberately DO NOT touch:
+ *   • hyphen-minus '-' (U+002D)  — the normal minus/subtraction character
+ *   • en dash       '–' (U+2013) — a minus lookalike used for negatives,
+ *                                   subtraction, and numeric ranges
+ * Rewriting those would corrupt real math: "8 – 3" is subtraction, not
+ * "8, 3", and "–7" is negative seven, not ", 7".
+ *
+ * Even for em dashes we leave one alone when it sits directly between two
+ * numbers (e.g. "8—3" or a "3—5" range), on the off chance it was meant as
+ * an operator. An em dash with a non-number on either side is punctuation
+ * and becomes a comma — which is exactly the reported case ("right — 7").
+ *
+ * @param {string} text
+ * @returns {string} the same value if not a non-empty string
+ */
+function replaceDashes(text) {
+  if (typeof text !== 'string' || !text) return text;
+  return text.replace(/(\d?)\s*—\s*(\d?)/g, (match, before, after) => {
+    // Number on both sides → treat as a range/operator, leave untouched.
+    if (before && after) return match;
+    return `${before}, ${after}`;
+  });
+}
+
+module.exports = { replaceDashes };

--- a/utils/mathTTS.js
+++ b/utils/mathTTS.js
@@ -9,6 +9,8 @@
  * @module utils/mathTTS
  */
 
+const { replaceDashes } = require('./dashNormalizer');
+
 /**
  * Convert LaTeX math notation to natural speech.
  *
@@ -20,6 +22,13 @@
  */
 function convertLatexToSpeech(latex) {
   let speech = latex;
+
+  // Degrees: 45^\circ, 45^{\circ}, 45° → "45 degrees". Must run before the
+  // superscript handling below, otherwise \circ is spoken as "to the power".
+  speech = speech.replace(/\^\s*(?:\{\s*)?\\circ(?:\s*\})?/g, ' degrees');
+  speech = speech.replace(/(\d)\s*\\circ\b/g, '$1 degrees');
+  speech = speech.replace(/°/g, ' degrees');
+  speech = speech.replace(/\\degrees?\b/gi, ' degrees');
 
   // Fractions: \frac{a}{b} → spoken fraction
   speech = speech.replace(/\\frac\{([^}]+)\}\{([^}]+)\}/g, (_, num, den) => {
@@ -96,12 +105,16 @@ function convertLatexToSpeech(latex) {
   speech = speech.replace(/\\rightarrow/g, ' leads to ');
   speech = speech.replace(/\\Rightarrow/g, ' therefore ');
 
+  // Plus/minus in expressions: make them speakable. A "-" that has no
+  // operand before it (start of expression, or after "(", "=", another
+  // operator) is a negative sign; everything else is subtraction. Runs
+  // before "=" is turned into a word, so "= -5" is still seen as negative.
+  speech = speech.replace(/\s*\+\s*/g, ' plus ');
+  speech = speech.replace(/(^|[^\w).\s])\s*-\s*(?=[\d.]|[A-Za-z])/g, '$1negative ');
+  speech = speech.replace(/\s*-\s*/g, ' minus ');
+
   // Equals — but only isolated = signs, not inside words
   speech = speech.replace(/\s*=\s*/g, ' equals ');
-
-  // Plus/minus in expressions: make them speakable
-  speech = speech.replace(/\s*\+\s*/g, ' plus ');
-  speech = speech.replace(/\s*-\s*/g, ' minus ');
 
   // Parentheses
   speech = speech.replace(/\\left\(/g, '(');
@@ -187,6 +200,14 @@ function cleanTextForTTS(text) {
   cleaned = cleaned.replace(/\\\(([^)]+)\\\)/g, (_, latex) => convertLatexToSpeech(latex));
   cleaned = cleaned.replace(/(?<![\\$])\$([^$\n]+?)\$/g, (_, latex) => convertLatexToSpeech(latex));
 
+  // Degrees: 45°, 45^\circ, 45^{\circ}, \degree → "45 degrees". Must run
+  // before the generic LaTeX-command strip below, which would otherwise
+  // delete \circ and leave a stray "^".
+  cleaned = cleaned.replace(/\^\s*(?:\{\s*)?\\?circ(?:\s*\})?/g, ' degrees');
+  cleaned = cleaned.replace(/(\d)\s*\\circ\b/g, '$1 degrees');
+  cleaned = cleaned.replace(/°/g, ' degrees');
+  cleaned = cleaned.replace(/\\degrees?\b/gi, ' degrees');
+
   // Remove any remaining LaTeX commands
   cleaned = cleaned.replace(/\\[a-zA-Z]+/g, '');
 
@@ -194,8 +215,6 @@ function cleanTextForTTS(text) {
   // Function notation: f(x) → "f of x", g(2) → "g of 2", f'(x) → "f prime of x"
   cleaned = cleaned.replace(/\b([a-zA-Z])'\(([^)]+)\)/g, '$1 prime of $2');
   cleaned = cleaned.replace(/\b([a-zA-Z])\(([^)]{1,20})\)/g, '$1 of $2');
-  // Equals sign in math context: "x = 5" → "x equals 5"
-  cleaned = cleaned.replace(/(\w)\s*=\s*(\w)/g, '$1 equals $2');
   // Caret exponents: x^2 → "x squared", y^3 → "y cubed", n^{k+1} → "n to the k+1 power"
   cleaned = cleaned.replace(/\^\{([^}]+)\}/g, ' to the $1 power');
   cleaned = cleaned.replace(/\^2(?=\b|[^0-9]|$)/g, ' squared');
@@ -207,6 +226,23 @@ function cleanTextForTTS(text) {
   cleaned = cleaned.replace(/_(\d)/g, ' sub $1');
   // Remove leftover curly braces
   cleaned = cleaned.replace(/[{}]/g, '');
+
+  // ── Spoken math operators for undelimited notation ──
+  // (Delimited math already went through convertLatexToSpeech above.)
+  // Otherwise a TTS engine reads "=" as "equal sign" and "-" as a bare pause.
+  // Equals — but not <=, >=, !=, ==.
+  cleaned = cleaned.replace(/(?<![<>=!])=(?!=)/g, ' equals ');
+  // Subtraction: only between math operands (digit, ")", or a single-letter
+  // variable), so word hyphens like "well-done" or "x-ray" stay intact.
+  cleaned = cleaned.replace(/(\d|\))\s*-\s*(?=\d|\(|[A-Za-z]\b)/g, '$1 minus ');
+  cleaned = cleaned.replace(/\b([A-Za-z])\s*-\s*(?=\d|\(|[A-Za-z]\b)/g, '$1 minus ');
+  // Whatever "-" is left in front of a number/variable (after "(", "=", an
+  // operator, or at the start) is a negative sign, not a pause.
+  cleaned = cleaned.replace(/(^|[\s(=+*/,:])-\s*(?=[\d.]|[A-Za-z]\b)/g, '$1negative ');
+
+  // Em dash → comma (a natural spoken pause). Leaves en dashes and hyphens
+  // alone so "8 – 3" / "-7" still read as subtraction / a negative.
+  cleaned = replaceDashes(cleaned);
 
   // Strip emoji — TTS engines read them as names ("party popper", "sparkles", etc.)
   cleaned = cleaned.replace(/[\u{1F300}-\u{1F9FF}\u{2600}-\u{27BF}\u{FE00}-\u{FE0F}\u{200D}\u{20E3}\u{E0020}-\u{E007F}]/gu, '');

--- a/utils/pipeline/generate.js
+++ b/utils/pipeline/generate.js
@@ -19,6 +19,7 @@ const { formatVerifiedTwinInstruction } = require('../worksheetGuard');
 const { VISUAL_TOOLS, resolveToolCalls, describeTools } = require('../visualTools');
 const { parseBoardTags } = require('../boardTagParser');
 const { stripInternalTags } = require('../internalTagSanitizer');
+const { replaceDashes } = require('../dashNormalizer');
 const { createBoardTagStreamFilter } = require('../boardTagStreamFilter');
 const { createXpTagStreamFilter } = require('../xpTagStreamFilter');
 const { createVisualTabTagStreamFilter } = require('../visualTabTagStreamFilter');
@@ -529,7 +530,7 @@ async function generate(assembled, options = {}) {
     if (options.stream && options.res) {
       try {
         const safe = stripBoardTagsForStream(text);
-        options.res.write(`data: ${JSON.stringify({ type: 'chunk', content: safe })}\n\n`);
+        options.res.write(`data: ${JSON.stringify({ type: 'chunk', content: replaceDashes(safe) })}\n\n`);
       } catch (e) { /* client disconnected */ }
     }
     return { text, toolCalls: [], resolvedTools: null };
@@ -715,7 +716,7 @@ async function generateStreaming(model, messages, llmOptions, res) {
         const afterXp = afterBoard ? xpFilter.push(afterBoard) : '';
         const safe = afterXp ? visualTabFilter.push(afterXp) : '';
         if (safe) {
-          res.write(`data: ${JSON.stringify({ type: 'chunk', content: safe })}\n\n`);
+          res.write(`data: ${JSON.stringify({ type: 'chunk', content: replaceDashes(safe) })}\n\n`);
         }
       }
 
@@ -751,7 +752,7 @@ async function generateStreaming(model, messages, llmOptions, res) {
       const tabTail = visualTabFilter.flush();
       const tail = tabHead + tabTail;
       if (tail && !clientDisconnected) {
-        res.write(`data: ${JSON.stringify({ type: 'chunk', content: tail })}\n\n`);
+        res.write(`data: ${JSON.stringify({ type: 'chunk', content: replaceDashes(tail) })}\n\n`);
       }
     }
 
@@ -784,7 +785,7 @@ async function generateStreaming(model, messages, llmOptions, res) {
 
       if (narration && !clientDisconnected) {
         const safeNarration = stripBoardTagsForStream(narration);
-        res.write(`data: ${JSON.stringify({ type: 'chunk', content: safeNarration })}\n\n`);
+        res.write(`data: ${JSON.stringify({ type: 'chunk', content: replaceDashes(safeNarration) })}\n\n`);
       }
 
       return {
@@ -808,9 +809,9 @@ async function generateStreaming(model, messages, llmOptions, res) {
     const safeText = stripBoardTagsForStream(text);
     if (fullResponse.length > 0) {
       // Partial content was already sent — tell client to replace it
-      res.write(`data: ${JSON.stringify({ type: 'replacement', content: safeText })}\n\n`);
+      res.write(`data: ${JSON.stringify({ type: 'replacement', content: replaceDashes(safeText) })}\n\n`);
     } else {
-      res.write(`data: ${JSON.stringify({ type: 'chunk', content: safeText })}\n\n`);
+      res.write(`data: ${JSON.stringify({ type: 'chunk', content: replaceDashes(safeText) })}\n\n`);
     }
     return { text, toolCalls: [], resolvedTools: null };
   }
@@ -869,7 +870,7 @@ async function generateStreamingStructured(model, messages, llmOptions, res) {
           const afterXp = xpFilter.push(newChat);
           const safe = afterXp ? visualTabFilter.push(afterXp) : '';
           if (safe) {
-            res.write(`data: ${JSON.stringify({ type: 'chunk', content: safe })}\n\n`);
+            res.write(`data: ${JSON.stringify({ type: 'chunk', content: replaceDashes(safe) })}\n\n`);
           }
         }
       }
@@ -884,7 +885,7 @@ async function generateStreamingStructured(model, messages, llmOptions, res) {
       const tabTail = visualTabFilter.flush();
       const tail = tabHead + tabTail;
       if (tail && !clientDisconnected) {
-        res.write(`data: ${JSON.stringify({ type: 'chunk', content: tail })}\n\n`);
+        res.write(`data: ${JSON.stringify({ type: 'chunk', content: replaceDashes(tail) })}\n\n`);
       }
     }
 
@@ -932,9 +933,9 @@ async function generateStreamingStructured(model, messages, llmOptions, res) {
       const safeText = stripBoardTagsForStream(text);
       if (!clientDisconnected) {
         if (extractedChatSoFar.length > 0) {
-          res.write(`data: ${JSON.stringify({ type: 'replacement', content: safeText })}\n\n`);
+          res.write(`data: ${JSON.stringify({ type: 'replacement', content: replaceDashes(safeText) })}\n\n`);
         } else {
-          res.write(`data: ${JSON.stringify({ type: 'chunk', content: safeText })}\n\n`);
+          res.write(`data: ${JSON.stringify({ type: 'chunk', content: replaceDashes(safeText) })}\n\n`);
         }
       }
       return { text, toolCalls: [], resolvedTools: null };
@@ -942,7 +943,7 @@ async function generateStreamingStructured(model, messages, llmOptions, res) {
       console.error('[Generate] Structured-stream fallback also failed:', fallbackErr.message);
       const text = "I'm having trouble generating a response right now. Could you please rephrase?";
       if (!clientDisconnected) {
-        res.write(`data: ${JSON.stringify({ type: 'chunk', content: text })}\n\n`);
+        res.write(`data: ${JSON.stringify({ type: 'chunk', content: replaceDashes(text) })}\n\n`);
       }
       return { text, toolCalls: [], resolvedTools: null };
     }

--- a/utils/pipeline/verify.js
+++ b/utils/pipeline/verify.js
@@ -15,6 +15,7 @@ const { checkReadingLevel, buildSimplificationPrompt } = require('../readability
 const { enforceVisualTeaching } = require('../visualCommandEnforcer');
 const { parseVisualTeaching } = require('../visualTeachingParser');
 const { processAIResponse } = require('../chatBoardParser');
+const { replaceDashes } = require('../dashNormalizer');
 const { callLLM } = require('../llmGateway');
 const { ACTIONS } = require('./decide');
 const { MESSAGE_TYPES, detectBareProblemDrop } = require('./observe');
@@ -1008,6 +1009,12 @@ async function verify(responseText, context = {}) {
   text = text.replace(/\n\s*([?!.])\s*$/gm, '$1');
   // Collapse runs of 3+ newlines to a double newline
   text = text.replace(/\n{3,}/g, '\n\n');
+
+  // ── 8d. Ban em/en dashes (dash-vs-minus confusion) ──
+  // "That's right — 7" reads to a student as "that's right minus 7". Replace
+  // with a comma across all student-facing prose. Runs after math has been
+  // normalized into LaTeX, where minus is '-', so real math is untouched.
+  text = replaceDashes(text);
 
   // ── 9. Validate non-empty (after all stripping) ──
   if (!text || text.trim() === '') {

--- a/utils/promptCompact.js
+++ b/utils/promptCompact.js
@@ -359,6 +359,7 @@ For confused students, go concrete first: counters, tiles, fraction bars. CPA pr
 - Match student energy: frustrated → direct and brief; excited → match it; tired → chill.
 - Always move forward. Don't re-explain something already confirmed.
 - Max 3 bullet points per message. If you need more, spread across messages.
+- NEVER use em dashes (—) for punctuation. A student reads "that's right — 7" as "minus 7". Use a comma, a period, or the word "and" instead. (A normal minus sign for subtraction or negatives is fine.)
 
 CONVERSATIONAL RHYTHM. The shape of each message should come from what the moment needs. Sometimes you just react. Sometimes you ask one question. Sometimes you explain something and ask a follow-up. Sometimes you just confirm and keep moving.
 

--- a/utils/voiceSession.js
+++ b/utils/voiceSession.js
@@ -10,6 +10,7 @@ const { generateSystemPrompt } = require('./prompt');
 const { callLLM, callLLMStream } = require('./llmGateway');
 const { verify: pipelineVerify } = require('./pipeline');
 const { checkReadingLevel } = require('./readability');
+const { replaceDashes } = require('./dashNormalizer');
 const { ensureBoardCarriesSpokenMath } = require('./voiceBoardGuard');
 const sttStream = require('./sttStream');
 const ttsStream = require('./ttsStream');
@@ -998,6 +999,10 @@ Never speak math notation. Never include system tags. Always valid JSON.`;
         // are caught when the closing ']' arrives.
         text = this._stripVisualDirectives(text);
         if (!text) return;
+        // Em dash reads as a minus in speech ("that's right minus 7"); swap
+        // for a comma pause. En dashes / hyphens (real subtraction and
+        // negatives) are left alone.
+        text = replaceDashes(text);
         turn.spokenAcc += text;
         // Emit a streamed-text event so client transcript renders incrementally
         this._send({


### PR DESCRIPTION
Two tutor-output cleanups, both driven by dash/symbol confusion.

Em dashes: a tutor writing "That's right — 7" reads to a student as "minus 7". Replace em dashes (—) with a comma across every student-facing surface — chat final text (verify), live streamed chunks (generate), on-demand + live-voice TTS, and a prompt rule to prevent them up front. Only em dashes are touched: hyphen-minus (-) and en dash (–) are left alone because those are the glyphs real subtraction and negatives use, and an em dash sitting directly between two numbers is preserved too.

Spoken math (mathTTS): undelimited math the LLM emits outside \(...\) was never converted for speech, so the TTS engine read "80°" as "circ", "=" as "equal sign", and "-" as a bare pause. Added degree handling (°, ^\circ), "=" → "equals", and "-" → "minus"/"negative". Subtraction only fires between real operands (digit, ")", single-letter variable) so ordinary hyphenated words (well-done, x-ray, e-mail, twenty-one) stay intact.

New shared helper utils/dashNormalizer.js is the single source of truth for the em-dash rule. Behavior locked in by tests/unit/mathTTS.test.js.