### PR TITLE
Stop over-scaffolding a student who solved it first try

### DIFF
--- a/tests/unit/pipeline.test.js
+++ b/tests/unit/pipeline.test.js
@@ -73,6 +73,19 @@ describe('Pipeline: Observe Stage', () => {
       expect(result.answer).not.toBeNull();
     });
 
+    test('counts recent correct answers into streaks.recentCorrectCount', () => {
+      const result = observe('7', {
+        recentAssistantMessages: [
+          { content: 'nice', problemResult: 'correct' },
+          { content: 'yep', problemResult: 'correct' },
+          { content: 'not quite', problemResult: 'incorrect' },
+          { content: 'chatter with no result' },
+        ],
+      });
+      expect(result.streaks.recentCorrectCount).toBe(2);
+      expect(result.streaks.recentWrongCount).toBe(1);
+    });
+
     test('classifies IDK', () => {
       expect(observe('idk').messageType).toBe(MESSAGE_TYPES.IDK);
       expect(observe("i don't know").messageType).toBe(MESSAGE_TYPES.IDK);
@@ -442,6 +455,42 @@ describe('Pipeline: Decide Stage', () => {
     const obs = makeObs(MESSAGE_TYPES.ANSWER_ATTEMPT, { answer: { value: '7' } });
     const dec = decide(obs, correctDiag, {});
     expect(dec.action).toBe(ACTIONS.CONFIRM_CORRECT);
+  });
+
+  test('bare correct answer → forward-move menu, no over-scaffolding', () => {
+    const obs = makeObs(MESSAGE_TYPES.ANSWER_ATTEMPT, { answer: { value: '7' } });
+    const dec = decide(obs, correctDiag, {});
+    expect(dec.action).toBe(ACTIONS.CONFIRM_CORRECT);
+    expect(dec.directives).toContainEqual(expect.stringContaining('DO NOT OVER-SCAFFOLD'));
+    expect(dec.directives).toContainEqual(expect.stringContaining('TEACH-BACK'));
+  });
+
+  test('correct answer WITH demonstrated reasoning → advance, no over-scaffold menu', () => {
+    const obs = makeObs(MESSAGE_TYPES.ANSWER_ATTEMPT, { answer: { value: '7' } });
+    const dec = decide(obs, { ...correctDiag, demonstratedReasoning: true }, {});
+    expect(dec.action).toBe(ACTIONS.CONFIRM_CORRECT);
+    expect(dec.directives).toContainEqual(expect.stringContaining('DEMONSTRATED UNDERSTANDING'));
+    // The reasoning path advances on its own — don't double up with the bare-answer menu.
+    expect(dec.directives).not.toContainEqual(expect.stringContaining('DO NOT OVER-SCAFFOLD'));
+  });
+
+  test('correct streak with no misses → bias toward advancing / teach-back', () => {
+    const obs = makeObs(MESSAGE_TYPES.ANSWER_ATTEMPT, {
+      answer: { value: '7' },
+      streaks: { idkCount: 0, giveUpCount: 0, recentWrongCount: 0, recentCorrectCount: 3 },
+    });
+    const dec = decide(obs, correctDiag, {});
+    expect(dec.action).toBe(ACTIONS.CONFIRM_CORRECT);
+    expect(dec.directives).toContainEqual(expect.stringContaining('CORRECT STREAK'));
+  });
+
+  test('single correct (no streak) → no CORRECT STREAK directive', () => {
+    const obs = makeObs(MESSAGE_TYPES.ANSWER_ATTEMPT, {
+      answer: { value: '7' },
+      streaks: { idkCount: 0, giveUpCount: 0, recentWrongCount: 0, recentCorrectCount: 0 },
+    });
+    const dec = decide(obs, correctDiag, {});
+    expect(dec.directives).not.toContainEqual(expect.stringContaining('CORRECT STREAK'));
   });
 
   test('incorrect answer → guide_incorrect', () => {

--- a/utils/pipeline/decide.js
+++ b/utils/pipeline/decide.js
@@ -352,11 +352,34 @@ function decideCore(observation, diagnosis, context) {
           'Do NOT walk them through steps they already explained.',
           'Do NOT ask them to re-derive or re-explain what they clearly understand.'
         );
-      } else if (diagnosis.hasExplanation) {
+      } else {
+        // Bare correct answer (with or without a brief explanation), no full
+        // reasoning shown. This is the over-scaffolding trap: the tutor breaks
+        // the SAME just-solved problem into micro-steps ("what did you do
+        // first?", "what's 8+2?") or re-asks a part with doubt-toned language
+        // ("wait, slow down, are you sure?"). A student who solved it cleanly
+        // does not need it disassembled. Affirm, then move FORWARD.
+        if (diagnosis.hasExplanation) {
+          decision.directives.push(
+            'Student provided their answer within an explanation.',
+            'Acknowledge what they said and confirm correctness concisely.'
+          );
+        }
         decision.directives.push(
-          'Student provided their answer within an explanation.',
-          'Acknowledge what they said and confirm correctness concisely.'
+          'DO NOT OVER-SCAFFOLD: they solved it. Do NOT break this same problem into smaller sub-steps, do NOT re-ask a part they already answered, and do NOT cast doubt on a correct answer with "wait", "slow down", "are you sure", or "try it on your fingers".',
+          'After affirming (and the XP that goes with it), pick ONE forward move that fits the moment: (a) ADVANCE to the next, appropriately harder problem; (b) GATHER DATA with one more problem of similar difficulty to confirm the pattern; or (c) TEACH-BACK — e.g. "Let\'s try something on this one. I\'m going to pretend I\'m a student who hasn\'t learned this yet. Can you teach me how you did it?"'
         );
+
+        // On a correct streak with no recent misses, the student is clearly
+        // ready for more — bias away from another same-level problem and toward
+        // leveling up or a teach-back, not more support.
+        const onCorrectStreak =
+          (streaks.recentCorrectCount || 0) >= 2 && (streaks.recentWrongCount || 0) === 0;
+        if (onCorrectStreak) {
+          decision.directives.push(
+            'CORRECT STREAK: multiple right in a row with no misses. Lean toward ADVANCING difficulty or a TEACH-BACK. Do NOT add scaffolding — they are past needing it here.'
+          );
+        }
       }
 
       // Update phase state via evidence-based evaluator

--- a/utils/pipeline/generate.js
+++ b/utils/pipeline/generate.js
@@ -85,7 +85,8 @@ function buildActionPrompt(decision) {
       } else if (diagnosis.hasExplanation) {
         parts.push('The student embedded their answer in an explanation. Acknowledge their reasoning and confirm correctness.');
       } else {
-        parts.push('Confirm their answer naturally — the way a human tutor would when they know the student got it right. Then continue the lesson.');
+        parts.push('Confirm their answer naturally — the way a human tutor would when they know the student got it right.');
+        parts.push('Then move FORWARD — do NOT rebuild this same problem step-by-step or re-ask a part they already got. Pick one: advance to a harder problem, give one more at this level to confirm the pattern, or flip it into a teach-back: "Let me play the student who hasn\'t learned this yet — can you teach me how you did it?"');
       }
       break;
 

--- a/utils/pipeline/observe.js
+++ b/utils/pipeline/observe.js
@@ -557,6 +557,14 @@ function observe(message, context = {}) {
   const recentWrongCount = (context.recentAssistantMessages || [])
     .filter(msg => msg.problemResult === 'incorrect').length;
 
+  // Count recent correct answers — the symmetric "on a roll" signal. Without
+  // this the pipeline could only ever ratchet support UP (on wrong streaks)
+  // and never DOWN, so a fluent student kept getting the same problem broken
+  // into micro-steps (the "over-scaffolding" failure). decide's CONFIRM_CORRECT
+  // branch reads this to advance / gather data / teach-back instead.
+  const recentCorrectCount = (context.recentAssistantMessages || [])
+    .filter(msg => msg.problemResult === 'correct').length;
+
   // ── Classify: check high-confidence intent signals FIRST ──
   //
   // Intent detection (explicit keywords like "help", "skip", "how do I")
@@ -665,6 +673,7 @@ function observe(message, context = {}) {
       idkCount: streaks.idkCount,
       giveUpCount: streaks.giveUpCount,
       recentWrongCount,
+      recentCorrectCount,
     },
     problemContext: detectProblemContext(text),
     isDispute,            // true if the student is challenging something the tutor said

--- a/utils/pipeline/promptSlim.js
+++ b/utils/pipeline/promptSlim.js
@@ -150,6 +150,7 @@ PACE: If student answers fast + correct, speed up (less explanation, more proble
 ENERGY MATCH: Short student messages → short tutor responses. Enthusiastic student → match enthusiasm. Flat/disengaged → offer a change of pace, not more of the same.
 APPROACH TRACKING: After each correct answer, mentally note what worked (visual? concrete? analogy?). Lean into approaches that work. Abandon approaches that don't.
 DIFFICULTY CALIBRATION: If student gets 3+ correct in a row quickly, increase difficulty immediately. If 2+ wrong, decrease immediately. Don't wait for a phase transition — adapt NOW.
+DON'T OVER-SCAFFOLD A SOLVED PROBLEM: When a student answers correctly on the first try, do NOT break that same problem back into micro-steps and do NOT re-ask a part they already got right. Affirm it, then move forward: a harder problem, one more at this level to confirm the pattern, or a teach-back ("I'll pretend I haven't learned this — can you teach me?").
 FEEDBACK INTEGRATION: If the student says "that made sense" or "oh I see" — that representation works. Use it more. If "I still don't get it" or re-asks — that approach failed. Switch immediately.`;
 
 const CONVERSATIONAL_CONTINUITY_RULES = `--- CONVERSATIONAL FLOW ---
@@ -172,6 +173,7 @@ const ACTION_RULES = {
     ANSWER_VERIFICATION_RULES,
     MASTERY_CHECK_RULES,
     CONVERSATIONAL_CONTINUITY_RULES,
+    MICRO_ADAPTATION_RULES,
   ],
   [ACTIONS.GUIDE_INCORRECT]: [
     ANSWER_VERIFICATION_RULES,

--- a/utils/promptCompact.js
+++ b/utils/promptCompact.js
@@ -319,6 +319,7 @@ Use 2+ representations per concept. Students who see a concept in multiple repre
 --- MICRO-ADAPTATION ---
 Adapt WITHIN the conversation, not just between sessions:
 - 3+ correct in a row fast → increase difficulty NOW. 2+ wrong → decrease NOW. Don't wait for phase transitions.
+- Solved it first try? Do NOT rebuild that same problem into micro-steps or re-ask a part they already got. Affirm, then move forward: a harder problem, one more at this level to confirm the pattern, or a teach-back ("I'll pretend I haven't learned this — can you teach me?").
 - Fast + wrong = guessing → slow them down, ask them to show their reasoning. Slow + wrong = overload → break into one micro-step.
 - Track what works: if visual clicked, use more visuals. If concrete worked, stay concrete. Don't go back to an approach that already failed.
 - Energy match: short student messages → short responses. Enthusiastic → match it. Flat → be calm and steady, not artificially peppy.


### PR DESCRIPTION
When a student answered a problem correctly on the first try, the tutor would break that same problem back into micro-steps and re-ask parts they already got — even casting doubt ("wait, slow down, try it on your fingers") on a verified-correct answer. The pipeline had no signal for "on a roll": it could ratchet support UP on wrong streaks but never ease it DOWN.

- observe: add streaks.recentCorrectCount (mirrors recentWrongCount).
- decide (CONFIRM_CORRECT): on a bare correct answer, forbid re-decomposing the solved problem and offer one forward move — advance, gather more data, or teach-back ("I'll pretend I haven't learned this — can you teach me?"). Streak-scaled: bias toward advancing/teach-back after multiple clean wins. The demonstrated-reasoning path is untouched (it already advances).
- generate/promptSlim: carry the teach-back phrasing into the prompt and give CONFIRM_CORRECT the MICRO-ADAPTATION rules it previously lacked.
- promptCompact: parity line for the slim-off fallback path.
- tests: 6 new cases; full pipeline suite green (277 passing).