### PR TITLE
fix(visuals): number lines never rendered — the token regex truncated…

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -2385,6 +2385,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
   <!-- Load CSRF and storage utilities FIRST -->
   <script src="/js/csrf.js"></script>
+  <!-- Visual token grammar (window.VisualTokenParser) — before inlineChatVisuals -->
+  <script src="/js/visualTokenParser.js"></script>
   <script src="/js/analytics.js" data-ga="G-EMX73QXF5H" data-fbp=""></script>
   <script src="/dist/js/chat-js0.95d0ddca.js"></script>
 <!-- LaTeX delimiter scanner (sets window.MathDelimiters) — must load before script.js -->

--- a/public/js/inlineChatVisuals.js
+++ b/public/js/inlineChatVisuals.js
@@ -138,41 +138,53 @@ class InlineChatVisuals {
         let html = message;
         let hasVisuals = false;
 
+        // Token params can nest ONE level of brackets — points=[-2,0,3],
+        // jumps=[(0,3),(3,7)]. The grammar (which fixes the truncation bug that
+        // made every number line with points render nothing) lives in
+        // visualTokenParser.js so it is testable in node with no DOM. Fall back to
+        // a local builder if that script did not load, so a missing dependency
+        // degrades to the previous behaviour rather than throwing.
+        const VTP = (typeof window !== 'undefined' && window.VisualTokenParser) || null;
+        const P = VTP ? VTP.PARAM : '(?:[^\\[\\]]|\\[[^\\]]*\\])';
+        const tok = VTP
+            ? (name) => VTP.tokenRegex(name)
+            : (name) => new RegExp('\\[' + name + ':(' + P + '+)\\]', 'g');
+
         // Process each visual type
         const visualTypes = [
-            { regex: /\[\s*FUNCTION_GRAPH\s*:\s*([^\]]+)\]/g, handler: this.createFunctionGraph.bind(this) },
-            { regex: /\[NUMBER_LINE:([^\]]+)\]/g, handler: this.createNumberLine.bind(this) },
-            { regex: /\[FRACTION:([^\]]+)\]/g, handler: this.createFraction.bind(this) },
-            { regex: /\[PIE_CHART:([^\]]+)\]/g, handler: this.createPieChart.bind(this) },
-            { regex: /\[BAR_CHART:([^\]]+)\]/g, handler: this.createBarChart.bind(this) },
-            { regex: /\[POINTS:([^\]]+)\]/g, handler: this.createPointsPlot.bind(this) },
-            { regex: /\[SLIDER_GRAPH:([^\]]+)\]/g, handler: this.createSliderGraph.bind(this) },
-            { regex: /\[UNIT_CIRCLE:?([^\]]*)\]/g, handler: this.createUnitCircle.bind(this) },
-            { regex: /\[AREA_MODEL:([^\]]+)\]/g, handler: this.createAreaModel.bind(this) },
-            { regex: /\[COMPARISON:([^\]]+)\]/g, handler: this.createComparison.bind(this) },
+            { regex: VTP ? VTP.tokenRegex('FUNCTION_GRAPH', { pad: true }) : new RegExp('\\[\\s*FUNCTION_GRAPH\\s*:\\s*(' + P + '+)\\]', 'g'), handler: this.createFunctionGraph.bind(this) },
+            { regex: tok('NUMBER_LINE'), handler: this.createNumberLine.bind(this) },
+            { regex: tok('FRACTION'), handler: this.createFraction.bind(this) },
+            { regex: tok('PIE_CHART'), handler: this.createPieChart.bind(this) },
+            { regex: tok('BAR_CHART'), handler: this.createBarChart.bind(this) },
+            { regex: tok('POINTS'), handler: this.createPointsPlot.bind(this) },
+            { regex: tok('SLIDER_GRAPH'), handler: this.createSliderGraph.bind(this) },
+            { regex: VTP ? VTP.tokenRegex('UNIT_CIRCLE', { star: true, optionalColon: true }) : new RegExp('\\[UNIT_CIRCLE:?(' + P + '*)\\]', 'g'), handler: this.createUnitCircle.bind(this) },
+            { regex: tok('AREA_MODEL'), handler: this.createAreaModel.bind(this) },
+            { regex: tok('COMPARISON'), handler: this.createComparison.bind(this) },
             // New enhanced visualizations
-            { regex: /\[PYTHAGOREAN:([^\]]+)\]/g, handler: this.createPythagorean.bind(this) },
-            { regex: /\[ANGLE:([^\]]+)\]/g, handler: this.createAngle.bind(this) },
-            { regex: /\[REGULAR_POLYGON:([^\]]+)\]/g, handler: this.createRegularPolygon.bind(this) },
-            { regex: /\[SLOPE:([^\]]+)\]/g, handler: this.createSlope.bind(this) },
-            { regex: /\[PERCENT_BAR:([^\]]+)\]/g, handler: this.createPercentBar.bind(this) },
-            { regex: /\[PLACE_VALUE:([^\]]+)\]/g, handler: this.createPlaceValue.bind(this) },
-            { regex: /\[RIGHT_TRIANGLE:([^\]]+)\]/g, handler: this.createRightTriangle.bind(this) },
-            { regex: /\[INEQUALITY:([^\]]+)\]/g, handler: this.createInequality.bind(this) },
+            { regex: tok('PYTHAGOREAN'), handler: this.createPythagorean.bind(this) },
+            { regex: tok('ANGLE'), handler: this.createAngle.bind(this) },
+            { regex: tok('REGULAR_POLYGON'), handler: this.createRegularPolygon.bind(this) },
+            { regex: tok('SLOPE'), handler: this.createSlope.bind(this) },
+            { regex: tok('PERCENT_BAR'), handler: this.createPercentBar.bind(this) },
+            { regex: tok('PLACE_VALUE'), handler: this.createPlaceValue.bind(this) },
+            { regex: tok('RIGHT_TRIANGLE'), handler: this.createRightTriangle.bind(this) },
+            { regex: tok('INEQUALITY'), handler: this.createInequality.bind(this) },
             // Algebra tiles inline preview + launcher
-            { regex: /\[ALGEBRA_TILES:([^\]]+)\]/g, handler: this.createAlgebraTilesInline.bind(this) },
+            { regex: tok('ALGEBRA_TILES'), handler: this.createAlgebraTilesInline.bind(this) },
             // Integer counters (pos/neg with zero-pair cancellation)
-            { regex: /\[COUNTERS:([^\]]+)\]/g, handler: this.createCounters.bind(this) },
+            { regex: tok('COUNTERS'), handler: this.createCounters.bind(this) },
             // Multi-representation linked views
-            { regex: /\[MULTI_REP:([^\]]+)\]/g, handler: this.createMultiRepresentation.bind(this) },
+            { regex: tok('MULTI_REP'), handler: this.createMultiRepresentation.bind(this) },
             // Calculus: Derivative overlay (f(x) + f'(x) with interactive tangent)
-            { regex: /\[DERIVATIVE_GRAPH:([^\]]+)\]/g, handler: this.createDerivativeGraph.bind(this) },
+            { regex: tok('DERIVATIVE_GRAPH'), handler: this.createDerivativeGraph.bind(this) },
             // Rational function graph (HA, VA, holes auto-detected)
-            { regex: /\[RATIONAL_GRAPH:([^\]]+)\]/g, handler: this.createRationalGraph.bind(this) },
+            { regex: tok('RATIONAL_GRAPH'), handler: this.createRationalGraph.bind(this) },
             // Physics: Position/Velocity/Acceleration overlay
-            { regex: /\[VELOCITY_GRAPH:([^\]]+)\]/g, handler: this.createVelocityGraph.bind(this) },
+            { regex: tok('VELOCITY_GRAPH'), handler: this.createVelocityGraph.bind(this) },
             // Circle geometry: chords, secants, tangents, inscribed/central angles
-            { regex: /\[CIRCLE_DIAGRAM:([^\]]+)\]/g, handler: this.createCircleDiagram.bind(this) }
+            { regex: tok('CIRCLE_DIAGRAM'), handler: this.createCircleDiagram.bind(this) }
         ];
 
         for (const { regex, handler } of visualTypes) {

--- a/public/js/visualTokenParser.js
+++ b/public/js/visualTokenParser.js
@@ -1,0 +1,51 @@
+/**
+ * VISUAL TOKEN PARSER — the bracket grammar for inline visual commands.
+ *
+ * Extracted from inlineChatVisuals.js so the parsing rule that decides whether a
+ * [NUMBER_LINE:...] token is captured whole is testable in node, with no DOM.
+ *
+ * THE BUG THIS FIXES: a token's params can nest ONE level of brackets —
+ * "points=[-2,0,3]", "jumps=[(0,3),(3,7)]". The old param pattern was [^\]]+,
+ * which stops at the FIRST inner "]", so it captured a truncated "points=[-2,0,3"
+ * and left ",highlight=3]" as literal text. Every number line / plot WITH points
+ * rendered nothing usable, and the tutor — seeing no visual appear — narrated
+ * "let me draw that" turn after turn.
+ *
+ * The grammar here matches a run of non-bracket chars OR a complete "[...]"
+ * group. It is a strict superset of the old behaviour: a token with no nested
+ * brackets matches exactly as before.
+ *
+ * Loads as a browser global (window.VisualTokenParser) and a CommonJS module.
+ */
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  else root.VisualTokenParser = api;
+}(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  // One param char: a non-bracket, or a whole "[...]" group (one level of nesting).
+  const PARAM = '(?:[^\\[\\]]|\\[[^\\]]*\\])';
+
+  /**
+   * A global regex that captures the FULL params of a [NAME:...] token, nested
+   * brackets included.
+   *
+   * @param {string} name    the token name, e.g. "NUMBER_LINE"
+   * @param {object} [opts]
+   * @param {boolean} [opts.star]        allow empty params (UNIT_CIRCLE)
+   * @param {boolean} [opts.optionalColon] allow "[NAME]" as well as "[NAME:...]"
+   * @param {boolean} [opts.pad]         tolerate whitespace around name/colon (FUNCTION_GRAPH)
+   */
+  function tokenRegex(name, opts) {
+    const o = opts || {};
+    const quant = o.star ? '*' : '+';
+    const colon = o.optionalColon ? ':?' : ':';
+    const body = o.pad
+      ? '\\[\\s*' + name + '\\s*' + colon + '\\s*(' + PARAM + quant + ')\\]'
+      : '\\[' + name + colon + '(' + PARAM + quant + ')\\]';
+    return new RegExp(body, 'g');
+  }
+
+  return { PARAM: PARAM, tokenRegex: tokenRegex };
+}));

--- a/tests/unit/visualTokenParser.test.js
+++ b/tests/unit/visualTokenParser.test.js
@@ -1,0 +1,91 @@
+/**
+ * Visual token bracket grammar.
+ *
+ * This is the exact rule inlineChatVisuals.js uses to pull [NUMBER_LINE:...] and
+ * friends out of a tutor message. It lived inline as [^\]]+, which truncated at
+ * the first nested "]" — so the documented, canonical form
+ *   [NUMBER_LINE:min=-5,max=5,points=[-2,0,3],highlight=3]
+ * captured only "...points=[-2,0,3" and spilled ",highlight=3]" as literal text.
+ * Every number line with points therefore rendered nothing, and the tutor,
+ * seeing no visual, narrated "let me draw that" over and over.
+ */
+
+const { tokenRegex, PARAM } = require('../../public/js/visualTokenParser');
+
+// Returns the full matched token, or null.
+const matchFull = (re, s) => {
+  re.lastIndex = 0;
+  const m = re.exec(s);
+  return m ? m[0] : null;
+};
+
+describe('nested-bracket tokens are captured whole', () => {
+  const re = tokenRegex('NUMBER_LINE');
+
+  test('the VisualEnforcer injection form', () => {
+    const t = '[NUMBER_LINE:min=-10,max=10,points=[4],highlight=4]';
+    expect(matchFull(re, t)).toBe(t);
+  });
+
+  test('the documented multi-point form', () => {
+    const t = '[NUMBER_LINE:min=-5,max=5,points=[-2,0,3],highlight=3,label="L"]';
+    expect(matchFull(re, t)).toBe(t);
+  });
+
+  test('the jumps form — brackets around parens', () => {
+    const t = '[NUMBER_LINE:min=0,max=10,jumps=[(0,3,"+3"),(3,7,"+4")],label="Adding"]';
+    expect(matchFull(re, t)).toBe(t);
+  });
+
+  test('the fraction form', () => {
+    const t = '[NUMBER_LINE:min=0,max=2,denominator=4,points=[1/4,3/4,5/4]]';
+    expect(matchFull(re, t)).toBe(t);
+  });
+});
+
+describe('the simple cases behave exactly as before', () => {
+  test('a token with no nested brackets', () => {
+    const t = '[NUMBER_LINE:min=-5,max=5]';
+    expect(matchFull(tokenRegex('NUMBER_LINE'), t)).toBe(t);
+  });
+
+  test('captures only the token, not trailing prose with a lone bracket', () => {
+    // The pattern must not run away past the closing "]".
+    const re = tokenRegex('NUMBER_LINE');
+    const s = '[NUMBER_LINE:min=0,max=5] then text with a lone ] bracket';
+    expect(matchFull(re, s)).toBe('[NUMBER_LINE:min=0,max=5]');
+  });
+
+  test('leaves surrounding text intact when used for replace', () => {
+    const re = tokenRegex('NUMBER_LINE');
+    const out = 'before [NUMBER_LINE:min=-1,max=1,points=[0]] after'.replace(re, 'X');
+    expect(out).toBe('before X after');
+  });
+});
+
+describe('token variants', () => {
+  test('star allows empty params (UNIT_CIRCLE)', () => {
+    const re = tokenRegex('UNIT_CIRCLE', { star: true, optionalColon: true });
+    expect(matchFull(re, '[UNIT_CIRCLE]')).toBe('[UNIT_CIRCLE]');
+    expect(matchFull(re, '[UNIT_CIRCLE:angle=45]')).toBe('[UNIT_CIRCLE:angle=45]');
+  });
+
+  test('pad tolerates whitespace around the name (FUNCTION_GRAPH)', () => {
+    const re = tokenRegex('FUNCTION_GRAPH', { pad: true });
+    const t = '[ FUNCTION_GRAPH : fn=x^2,points=[1,2] ]';
+    expect(matchFull(re, t)).toBe(t);
+  });
+
+  test('the plus variant requires at least one param char', () => {
+    const re = tokenRegex('NUMBER_LINE');
+    expect(matchFull(re, '[NUMBER_LINE:]')).toBeNull();
+  });
+});
+
+describe('the grammar piece is exported for reuse', () => {
+  test('PARAM matches a nested group and a plain char', () => {
+    expect(new RegExp('^' + PARAM + '$').test('a')).toBe(true);
+    expect(new RegExp('^' + PARAM + '$').test('[1,2,3]')).toBe(true);
+    expect(new RegExp('^' + PARAM + '$').test(']')).toBe(false);
+  });
+});


### PR DESCRIPTION
… on nested brackets

The reported bug: the tutor promises a number line ("let me draw that"), server logs show [VisualEnforcer] auto-injecting NUMBER_LINE, and nothing appears. Four times in one session, per the screenshot.

Cause is in the frontend token parser, not the tutor. A visual token's params nest one level of brackets by design — the DOCUMENTED format is [NUMBER_LINE:min=-5,max=5,points=[-2,0,3],highlight=3]. The param pattern was [^\]]+, which stops at the FIRST inner "]", so it captured a truncated "min=-5,max=5,points=[-2,0,3" and left ",highlight=3]" as literal text. The handler then got malformed params, and any number line WITH points — which is nearly all of them, and exactly what VisualEnforcer injects ([NUMBER_LINE:min=-10,max=10,points=[4],highlight=4]) — rendered nothing usable. All 27 visual tokens shared the pattern, so POINTS, FUNCTION_GRAPH points=, and NUMBER_LINE jumps= were all affected.

Fix: match a run of non-bracket chars OR a complete "[...]" group. Strict superset of the old behaviour — a token with no nested brackets matches exactly as before, and the pattern still stops at the token's own closing "]" (a lone "]" later in the message is not swallowed; there is a test for that).

The grammar is extracted to public/js/visualTokenParser.js (UMD: window global + CommonJS) so it is testable in node with no DOM — inlineChatVisuals.js is a 3000-line browser class that can't be required. inlineChatVisuals uses the shared parser with a fallback to an identical inline pattern if the script did not load, so a missing dependency degrades to the fix rather than throwing. chat.html loads the parser before the bundles.

11 unit tests over the real grammar: the VisualEnforcer injection form, the documented multi-point / jumps / fraction forms, the non-nested case unchanged, no runaway past a lone bracket, and the UNIT_CIRCLE (empty params) / FUNCTION_GRAPH (whitespace) variants.

Out of scope, flagged: tests/unit/assertionInvariant.test.js fails (5 tests) on a clean checkout without any of these changes — a pre-existing break, not caused here.

visualTokenParser + skillRung suites green (83 tests).