### PR TITLE
Capitalize the XP ceremony caption (fixes lowercase "caught your own mistake")

### DIFF
--- a/public/js/xpTagHandler.js
+++ b/public/js/xpTagHandler.js
@@ -49,12 +49,21 @@
         } catch (e) { /* silent */ }
     }
 
+    // Sentence-case the caption's first letter. The model emits these reasons
+    // lowercase (e.g. "caught your own mistake"), which reads as sloppy when it
+    // floats up on its own. Only the first character is touched, so acronyms and
+    // proper nouns mid-phrase are left intact.
+    function sentenceCase(s) {
+        s = String(s == null ? '' : s).trim();
+        return s ? s.charAt(0).toUpperCase() + s.slice(1) : s;
+    }
+
     function showCeremonyCaption(text, size) {
         if (!text || typeof document === 'undefined') return;
         try {
             var el = document.createElement('div');
             el.className = 'cr-xp-caption cr-xp-caption--' + (size || 'medium');
-            el.textContent = text;
+            el.textContent = sentenceCase(text);
             el.setAttribute('role', 'status');
             el.setAttribute('aria-live', 'polite');
             document.body.appendChild(el);


### PR DESCRIPTION
## The toast

You spotted it: **"caught your own mistake"** popped up all-lowercase.

**Cause:** the floating XP ceremony caption (`xpTagHandler.js`) prints the model's `<XP … reason="…">` text **verbatim**, and the model writes those reasons lowercase per the prompt examples (`reason="caught your own mistake"`, `reason="caught your own sign error"`, …). So the caption rendered exactly as written.

**Fix:** sentence-case the first character at render time — `"caught your own mistake"` → **"Caught your own mistake"**. Done at display, so it's robust no matter what the model emits, and only the first character is touched (acronyms/proper nouns mid-phrase stay intact).

This is why I couldn't find it earlier by grepping message strings — the text is generated by the LLM at runtime, not a hardcoded `showToast(...)` call.

## Test
- `node --check` passes; `xpTagHandler.js` loads as source (no bundle rebuild needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9zNo7LtFvgW4DMxH8HiEi)_