### PR TITLE
Shop: "Are you sure?" confirm + one-tap Undo (refund) on purchases

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -672,7 +672,12 @@ const userSchema = new Schema({
     dailyEarned:    { type: Number, default: 0 },          // anti-abuse daily cap counter
     lastCoinReset:  { type: Date, default: Date.now },      // anchors the daily reset
     retroLevelGrantedAt: { type: Date, default: null },     // set once by scripts/grantRetroactiveLevelCoins.js so the backfill is idempotent
-    welcomeGrantedAt: { type: Date, default: null }         // set once when the day-1 welcome bonus is granted (idempotent)
+    welcomeGrantedAt: { type: Date, default: null },        // set once when the day-1 welcome bonus is granted (idempotent)
+    lastPurchase: {                                         // most recent cosmetic buy — powers one-tap Undo
+      itemId: { type: String, default: null },
+      price:  { type: Number, default: 0 },
+      at:     { type: Date,   default: null }
+    }
   },
 
   /* Cosmetics ownership + equipped loadout (see utils/cosmeticsCatalog.js).

--- a/public/chat.html
+++ b/public/chat.html
@@ -86,7 +86,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <!-- Personal status card modal (Progress button) -->
   <link rel="stylesheet" href="/css/status-card.css" />
   <!-- Cosmetics: equipped skins + shop modal -->
-  <link rel="stylesheet" href="/dist/css/chat-css2.023e4571.css" />
+  <link rel="stylesheet" href="/dist/css/chat-css2.128b182f.css" />
   <!-- Coin surfacing: sidebar counter + fly-in reward animation -->
   <link rel="stylesheet" href="/css/coin-fx.css" />
   <!-- Full-body student character render -->
@@ -2409,7 +2409,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
        below) — only needed when the visual board is enabled (boardPanel:true). -->
   <script src="/dist/js/chat-js3.babd546b.js"></script>
 <!-- returningUserModal.js removed — no longer used -->
-  <script src="/dist/js/chat-js4.c195e962.js"></script>
+  <script src="/dist/js/chat-js4.301bba99.js"></script>
 <link rel="stylesheet" href="/css/algebra-tiles.css">
   <!-- algebra-tiles.js lazy-loads itself on demand (inlineChatVisuals
        openAlgebraTilesWorkspace) — no static tag needed. -->

--- a/public/css/shop.css
+++ b/public/css/shop.css
@@ -119,9 +119,37 @@
   .shop-modal.shop-previewing .shop-preview-bar { animation: none; }
 }
 
+/* "Are you sure?" armed state — the second tap confirms a spend. */
+.shop-btn-confirm { background: #ff3b7f !important; color: #fff !important; }
+
+/* Post-purchase Undo bar (refund the most recent buy). Toast-style, bottom-center. */
+.shop-undo-bar {
+  position: fixed;
+  left: 50%;
+  bottom: 24px;
+  transform: translateX(-50%);
+  z-index: 3200;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: min(440px, calc(100vw - 32px));
+  padding: 12px 16px;
+  background: #18202b;
+  color: #fff;
+  border-radius: 14px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.38);
+  font-family: Inter, sans-serif;
+  animation: shop-preview-rise 200ms ease;
+}
+.shop-undo-bar[hidden] { display: none; }
+.shop-undo-label { flex: 1; font-weight: 700; font-size: 0.9rem; }
+.shop-undo-btn { width: auto; margin-top: 0; background: #12b3b3; color: #fff; white-space: nowrap; }
+.shop-undo-btn:hover:not(:disabled) { filter: brightness(1.05); }
+
 @media (prefers-reduced-motion: reduce) {
   .shop-backdrop, .shop-card { transition: none; }
   .shop-swatch-legendary::after { animation: none; }
+  .shop-undo-bar { animation: none; }
 }
 @media (max-width: 480px) {
   .shop-card { border-radius: 16px; }

--- a/public/dist/chat-bundles.manifest.json
+++ b/public/dist/chat-bundles.manifest.json
@@ -36,7 +36,7 @@
       ]
     },
     {
-      "href": "/dist/css/chat-css2.023e4571.css",
+      "href": "/dist/css/chat-css2.128b182f.css",
       "files": [
         "/css/cosmetics.css",
         "/css/shop.css"

--- a/public/dist/css/chat-css2.128b182f.css
+++ b/public/dist/css/chat-css2.128b182f.css
@@ -398,9 +398,37 @@ body[data-skin-header="header.wave"] .landing-header {
   .shop-modal.shop-previewing .shop-preview-bar { animation: none; }
 }
 
+/* "Are you sure?" armed state — the second tap confirms a spend. */
+.shop-btn-confirm { background: #ff3b7f !important; color: #fff !important; }
+
+/* Post-purchase Undo bar (refund the most recent buy). Toast-style, bottom-center. */
+.shop-undo-bar {
+  position: fixed;
+  left: 50%;
+  bottom: 24px;
+  transform: translateX(-50%);
+  z-index: 3200;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: min(440px, calc(100vw - 32px));
+  padding: 12px 16px;
+  background: #18202b;
+  color: #fff;
+  border-radius: 14px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.38);
+  font-family: Inter, sans-serif;
+  animation: shop-preview-rise 200ms ease;
+}
+.shop-undo-bar[hidden] { display: none; }
+.shop-undo-label { flex: 1; font-weight: 700; font-size: 0.9rem; }
+.shop-undo-btn { width: auto; margin-top: 0; background: #12b3b3; color: #fff; white-space: nowrap; }
+.shop-undo-btn:hover:not(:disabled) { filter: brightness(1.05); }
+
 @media (prefers-reduced-motion: reduce) {
   .shop-backdrop, .shop-card { transition: none; }
   .shop-swatch-legendary::after { animation: none; }
+  .shop-undo-bar { animation: none; }
 }
 @media (max-width: 480px) {
   .shop-card { border-radius: 16px; }

--- a/public/js/modules/shop.js
+++ b/public/js/modules/shop.js
@@ -18,6 +18,7 @@ const SLOT_ORDER = ['theme', 'bubble', 'avatarFrame', 'board', 'calculator', 'he
 
 let state = { catalog: {}, coins: 0, owned: [], equipped: {} };
 let preview = null; // { slot, id } while a "try-on" is active, else null
+let undoTimer = null; // auto-hide timer for the post-purchase Undo bar
 
 function esc(s) {
     const el = document.createElement('span');
@@ -62,6 +63,10 @@ function buildModal() {
           <button class="shop-btn shop-preview-action" type="button" data-preview-action></button>
           <button class="shop-btn shop-preview-done" type="button" data-preview-done>Done</button>
         </div>
+      </div>
+      <div class="shop-undo-bar" hidden role="status">
+        <span class="shop-undo-label" aria-live="polite"></span>
+        <button class="shop-btn shop-undo-btn" type="button" data-undo>↩ Undo</button>
       </div>`;
     document.body.appendChild(modal);
     modal.querySelectorAll('[data-shop-close]').forEach(el => el.addEventListener('click', closeShop));
@@ -73,6 +78,7 @@ function buildModal() {
     modal.querySelector('#shop-body').addEventListener('click', onBodyClick);
     modal.querySelector('[data-preview-done]').addEventListener('click', stopPreview);
     modal.querySelector('[data-preview-action]').addEventListener('click', onPreviewAction);
+    modal.querySelector('[data-undo]').addEventListener('click', onUndo);
     return modal;
 }
 
@@ -174,13 +180,19 @@ async function onBodyClick(e) {
     btn.disabled = true;
     try {
         if (act === 'buy') {
-            const res = await post('/api/cosmetics/purchase', { itemId: btn.dataset.id });
+            // "Are you sure?" — first tap arms the button, second tap buys.
+            if (btn.dataset.armed !== '1') { armBuy(btn); return; }
+            disarmBuy(btn);
+            const id = btn.dataset.id;
+            const item = state.catalog[id] || {};
+            const res = await post('/api/cosmetics/purchase', { itemId: id });
             const data = await res.json();
             if (!res.ok || !data.success) return flash(btn, data.error === 'insufficient_coins' ? 'Not enough' : 'Failed');
             state.coins = data.coins;
-            state.owned = data.owned || state.owned.concat(btn.dataset.id);
+            state.owned = data.owned || state.owned.concat(id);
             if (window.currentUser) { window.currentUser.wallet = window.currentUser.wallet || {}; window.currentUser.wallet.coins = data.coins; }
             render();
+            showUndo(data.undo, item.name || 'that');
         } else if (act === 'equip' || act === 'unequip') {
             const slot = btn.dataset.slot;
             const itemId = act === 'equip' ? btn.dataset.id : 'default';
@@ -203,6 +215,72 @@ function flash(btn, msg) {
     btn.textContent = msg;
     btn.disabled = false;
     setTimeout(() => { btn.textContent = orig; render(); }, 1200);
+}
+
+// ---- "Are you sure?" — a second tap confirms a spend --------------------
+function armBuy(btn) {
+    // Only one buy armed at a time.
+    document.querySelectorAll('#shop-body [data-act="buy"][data-armed="1"]').forEach(disarmBuy);
+    btn.dataset.armed = '1';
+    btn.dataset.orig = btn.innerHTML;
+    btn.classList.add('shop-btn-confirm');
+    btn.innerHTML = 'Sure? Tap again';
+    clearTimeout(btn._armTimer);
+    btn._armTimer = setTimeout(() => disarmBuy(btn), 3500);
+}
+function disarmBuy(btn) {
+    if (!btn) return;
+    clearTimeout(btn._armTimer);
+    if (btn.dataset.armed === '1' && btn.dataset.orig != null) btn.innerHTML = btn.dataset.orig;
+    btn.dataset.armed = '';
+    btn.classList.remove('shop-btn-confirm');
+}
+
+// ---- Undo the most recent purchase (server-authoritative refund) ---------
+function showUndo(undo, itemName) {
+    if (!undo || !undo.itemId) return;
+    const modal = document.getElementById(MODAL_ID);
+    if (!modal) return;
+    const bar = modal.querySelector('.shop-undo-bar');
+    bar.dataset.itemId = undo.itemId;
+    bar.querySelector('.shop-undo-label').textContent = `Bought ${itemName}.`;
+    bar.querySelector('[data-undo]').innerHTML = `↩ Undo (🪙${undo.price} back)`;
+    bar.querySelector('[data-undo]').disabled = false;
+    bar.hidden = false;
+    clearTimeout(undoTimer);
+    undoTimer = setTimeout(() => { bar.hidden = true; }, 12000);
+}
+
+async function onUndo() {
+    const modal = document.getElementById(MODAL_ID);
+    if (!modal) return;
+    const bar = modal.querySelector('.shop-undo-bar');
+    const itemId = bar.dataset.itemId;
+    if (!itemId) return;
+    const btn = bar.querySelector('[data-undo]');
+    btn.disabled = true;
+    try {
+        const res = await post('/api/cosmetics/refund', { itemId });
+        const data = await res.json();
+        if (!res.ok || !data.success) { btn.disabled = false; return flashEl(btn, data.error === 'window_expired' ? 'Too late' : 'Failed'); }
+        state.coins = data.coins;
+        state.owned = data.owned || state.owned.filter(x => x !== itemId);
+        if (data.equipped) state.equipped = data.equipped;
+        if (window.currentUser) {
+            window.currentUser.wallet = window.currentUser.wallet || {};
+            window.currentUser.wallet.coins = data.coins;
+            if (data.equipped) window.currentUser.equippedCosmetics = data.equipped;
+        }
+        applyCosmetics(window.currentUser); // revert if the refunded item was equipped
+        clearTimeout(undoTimer);
+        bar.hidden = true;
+        bar.dataset.itemId = '';
+        render();
+    } catch (err) {
+        console.warn('Undo failed', err);
+        btn.disabled = false;
+        flashEl(btn, 'Error');
+    }
 }
 
 // ---- Live "try on" preview ----------------------------------------------
@@ -259,9 +337,30 @@ async function onPreviewAction() {
     if (!preview) return;
     const { slot, id } = preview;
     const owned = state.owned.includes(id);
+    const item = state.catalog[id] || {};
     const bar = document.getElementById(MODAL_ID).querySelector('.shop-preview-bar');
     const actionBtn = bar.querySelector('[data-preview-action]');
+
+    // Confirm before SPENDING. Equipping an item you already own needs no confirm.
+    if (!owned && actionBtn.dataset.armed !== '1') {
+        actionBtn.dataset.armed = '1';
+        actionBtn.dataset.orig = actionBtn.textContent;
+        actionBtn.textContent = 'Sure? Tap again';
+        actionBtn.classList.add('shop-btn-confirm');
+        clearTimeout(actionBtn._armTimer);
+        actionBtn._armTimer = setTimeout(() => {
+            actionBtn.dataset.armed = '';
+            actionBtn.classList.remove('shop-btn-confirm');
+            if (actionBtn.dataset.orig != null) actionBtn.textContent = actionBtn.dataset.orig;
+        }, 3500);
+        return;
+    }
+    clearTimeout(actionBtn._armTimer);
+    actionBtn.dataset.armed = '';
+    actionBtn.classList.remove('shop-btn-confirm');
     actionBtn.disabled = true;
+
+    let undo = null;
     try {
         if (!owned) {
             const res = await post('/api/cosmetics/purchase', { itemId: id });
@@ -269,6 +368,7 @@ async function onPreviewAction() {
             if (!res.ok || !data.success) { actionBtn.disabled = false; return flashEl(actionBtn, data.error === 'insufficient_coins' ? 'Not enough' : 'Failed'); }
             state.coins = data.coins;
             state.owned = data.owned || state.owned.concat(id);
+            undo = data.undo;
             if (window.currentUser) { window.currentUser.wallet = window.currentUser.wallet || {}; window.currentUser.wallet.coins = data.coins; }
         }
         const res = await post('/api/cosmetics/equip', { slot, itemId: id });
@@ -283,6 +383,7 @@ async function onPreviewAction() {
         modal.classList.remove('shop-previewing');
         bar.hidden = true;
         render();
+        if (undo) showUndo(undo, item.name || 'that');
     } catch (err) {
         console.warn('Preview purchase/equip failed', err);
         actionBtn.disabled = false;
@@ -308,6 +409,9 @@ export async function openShop() {
         if (!res.ok || !data.success) throw new Error('catalog');
         state = { catalog: data.catalog || {}, coins: data.coins || 0, owned: data.owned || [], equipped: data.equipped || {} };
         render();
+        // A purchase from a moment ago is still undoable — surface it on open.
+        if (data.undo) showUndo(data.undo, state.catalog[data.undo.itemId]?.name || 'that');
+        else { const bar = modal.querySelector('.shop-undo-bar'); if (bar) bar.hidden = true; }
     } catch (err) {
         console.warn('Shop load failed', err);
         modal.querySelector('#shop-body').innerHTML = `<div class="shop-empty">Couldn't load the shop. Try again.</div>`;

--- a/routes/cosmetics.js
+++ b/routes/cosmetics.js
@@ -8,9 +8,21 @@ const User = require('../models/user');
 const {
     CATALOG,
     DEFAULT_LOADOUT,
+    REFUND_WINDOW_MS,
     applyPurchase,
+    applyRefund,
+    canRefund,
     applyEquip,
 } = require('../utils/cosmeticsCatalog');
+
+// Shape the undo hint the client needs: which item is undoable and for how long.
+function undoInfo(user) {
+    const lp = user && user.wallet && user.wallet.lastPurchase;
+    if (!lp || !lp.itemId) return null;
+    if (!canRefund(user, lp.itemId).ok) return null;
+    const expiresAt = new Date(new Date(lp.at).getTime() + REFUND_WINDOW_MS).toISOString();
+    return { itemId: lp.itemId, price: lp.price, expiresAt };
+}
 
 // GET /api/cosmetics/catalog — catalog + this user's balance/owned/equipped.
 router.get('/catalog', async (req, res) => {
@@ -23,6 +35,7 @@ router.get('/catalog', async (req, res) => {
             coins: user.wallet?.coins ?? 0,
             owned: user.ownedCosmetics || [],
             equipped: { ...DEFAULT_LOADOUT, ...(user.equippedCosmetics || {}) },
+            undo: undoInfo(user),
         });
     } catch (err) {
         console.error('[cosmetics] catalog error:', err.message);
@@ -43,10 +56,37 @@ router.post('/purchase', async (req, res) => {
             return res.status(400).json({ success: false, error: result.reason, coins: result.coins });
         }
         await user.save();
-        res.json({ success: true, coins: result.coins, owned: result.owned });
+        res.json({ success: true, coins: result.coins, owned: result.owned, undo: undoInfo(user) });
     } catch (err) {
         console.error('[cosmetics] purchase error:', err.message);
         res.status(500).json({ success: false, error: 'Purchase failed' });
+    }
+});
+
+// POST /api/cosmetics/refund { itemId } — undo the most recent purchase (full
+// refund) if it's still within the window. Server-authoritative, like purchase.
+router.post('/refund', async (req, res) => {
+    try {
+        const { itemId } = req.body || {};
+        if (!itemId) return res.status(400).json({ success: false, error: 'Missing itemId' });
+        const user = await User.findById(req.user._id);
+        if (!user) return res.status(401).json({ success: false, error: 'Not authenticated' });
+
+        const result = applyRefund(user, itemId);
+        if (!result.ok) {
+            return res.status(400).json({ success: false, error: result.reason, coins: result.coins });
+        }
+        await user.save();
+        res.json({
+            success: true,
+            coins: result.coins,
+            owned: result.owned,
+            equipped: result.equipped,
+            refundedItemId: result.refundedItemId,
+        });
+    } catch (err) {
+        console.error('[cosmetics] refund error:', err.message);
+        res.status(500).json({ success: false, error: 'Refund failed' });
     }
 });
 

--- a/tests/unit/cosmeticsCatalog.test.js
+++ b/tests/unit/cosmeticsCatalog.test.js
@@ -1,0 +1,91 @@
+// tests/unit/cosmeticsCatalog.test.js
+// Unit tests for the purchase / refund (Undo) logic in utils/cosmeticsCatalog.js.
+// Pure functions — coins are spent/refunded and ownership mutated here, so a
+// regression would let students buy free or refund old items, hence coverage.
+
+const {
+    DEFAULT_LOADOUT,
+    REFUND_WINDOW_MS,
+    applyPurchase,
+    canRefund,
+    applyRefund,
+    applyEquip,
+} = require('../../utils/cosmeticsCatalog');
+
+function newUser(overrides = {}) {
+    return {
+        level: 20,
+        wallet: { coins: 1000 },
+        ownedCosmetics: [],
+        equippedCosmetics: { ...DEFAULT_LOADOUT },
+        ...overrides,
+    };
+}
+
+describe('applyPurchase records an undoable purchase', () => {
+    test('debits coins, grants ownership, stamps lastPurchase', () => {
+        const u = newUser();
+        const r = applyPurchase(u, 'bubble.glass'); // 250
+        expect(r.ok).toBe(true);
+        expect(u.wallet.coins).toBe(750);
+        expect(u.ownedCosmetics).toContain('bubble.glass');
+        expect(u.wallet.lastPurchase.itemId).toBe('bubble.glass');
+        expect(u.wallet.lastPurchase.price).toBe(250);
+        expect(u.wallet.lastPurchase.at).toBeInstanceOf(Date);
+    });
+});
+
+describe('canRefund', () => {
+    test('the most recent purchase is undoable inside the window', () => {
+        const u = newUser();
+        applyPurchase(u, 'frame.gold');
+        expect(canRefund(u, 'frame.gold')).toEqual({ ok: true });
+    });
+
+    test('only the LAST purchase is undoable', () => {
+        const u = newUser();
+        applyPurchase(u, 'frame.gold');   // 300
+        applyPurchase(u, 'board.grid');   // 150 — now the last
+        expect(canRefund(u, 'board.grid').ok).toBe(true);
+        expect(canRefund(u, 'frame.gold')).toEqual({ ok: false, reason: 'not_last_purchase' });
+    });
+
+    test('expires after the refund window', () => {
+        const u = newUser();
+        applyPurchase(u, 'frame.gold');
+        const later = Date.now() + REFUND_WINDOW_MS + 1000;
+        expect(canRefund(u, 'frame.gold', later)).toEqual({ ok: false, reason: 'window_expired' });
+    });
+
+    test('nothing to undo on a fresh wallet', () => {
+        expect(canRefund(newUser(), 'frame.gold')).toEqual({ ok: false, reason: 'nothing_to_undo' });
+    });
+});
+
+describe('applyRefund', () => {
+    test('refunds coins, drops ownership, unequips, and consumes the undo', () => {
+        const u = newUser();
+        applyPurchase(u, 'bubble.glass');           // 1000 -> 750
+        applyEquip(u, 'bubble', 'bubble.glass');
+
+        const r = applyRefund(u, 'bubble.glass');
+        expect(r.ok).toBe(true);
+        expect(u.wallet.coins).toBe(1000);          // fully restored
+        expect(u.ownedCosmetics).not.toContain('bubble.glass');
+        expect(u.equippedCosmetics.bubble).toBe('default'); // unequipped
+        expect(u.wallet.lastPurchase.itemId).toBeNull();
+
+        // Can't refund twice.
+        expect(applyRefund(u, 'bubble.glass')).toMatchObject({ ok: false, reason: 'nothing_to_undo' });
+    });
+
+    test('refuses to refund outside the window (no coin change)', () => {
+        const u = newUser();
+        applyPurchase(u, 'frame.gold');             // 1000 -> 700
+        const later = Date.now() + REFUND_WINDOW_MS + 1000;
+        const r = applyRefund(u, 'frame.gold', later);
+        expect(r.ok).toBe(false);
+        expect(u.wallet.coins).toBe(700);           // unchanged
+        expect(u.ownedCosmetics).toContain('frame.gold');
+    });
+});

--- a/utils/cosmeticsCatalog.js
+++ b/utils/cosmeticsCatalog.js
@@ -66,6 +66,12 @@ const DEFAULT_LOADOUT = {
     board: 'default', calculator: 'default', header: 'default',
 };
 
+// How long after buying a cosmetic the student can still Undo it (full refund).
+// Long enough to fix a misclick or buyer's remorse; short enough that you can't
+// "rent" a legendary for a session and refund it. Undo only ever targets the most
+// recent purchase.
+const REFUND_WINDOW_MS = 30 * 60 * 1000; // 30 minutes
+
 function getItem(itemId) {
     return CATALOG[itemId] || null;
 }
@@ -101,12 +107,62 @@ function applyPurchase(user, itemId) {
     user.wallet.coins = Math.max(0, (user.wallet.coins || 0) - item.price);
     if (!Array.isArray(user.ownedCosmetics)) user.ownedCosmetics = [];
     user.ownedCosmetics.push(itemId);
+    // Record the buy so it can be undone (one-tap refund of the most recent purchase).
+    user.wallet.lastPurchase = { itemId, price: item.price, at: new Date() };
 
     if (typeof user.markModified === 'function') {
         user.markModified('wallet');
         user.markModified('ownedCosmetics');
     }
     return { ok: true, coins: user.wallet.coins, owned: user.ownedCosmetics };
+}
+
+/**
+ * Is the given item currently undoable (i.e. it's the most recent purchase and
+ * still inside the refund window)? Pure check, no mutation.
+ * @param {number} [now=Date.now()]
+ * @returns {{ok:boolean, reason?:string}}
+ */
+function canRefund(user, itemId, now = Date.now()) {
+    if (!user) return { ok: false, reason: 'no_user' };
+    const lp = user.wallet && user.wallet.lastPurchase;
+    if (!lp || !lp.itemId) return { ok: false, reason: 'nothing_to_undo' };
+    if (lp.itemId !== itemId) return { ok: false, reason: 'not_last_purchase' };
+    if (!(user.ownedCosmetics || []).includes(itemId)) return { ok: false, reason: 'not_owned' };
+    const at = lp.at ? new Date(lp.at).getTime() : 0;
+    if (!at || (now - at) > REFUND_WINDOW_MS) return { ok: false, reason: 'window_expired' };
+    return { ok: true };
+}
+
+/**
+ * Undo the most recent purchase: refund the coins, drop ownership, unequip it if
+ * worn, and clear the undo record. Validates first; no-op on failure.
+ * @returns {{ok:boolean, reason?:string, coins:number, owned?:string[], equipped?:object, refundedItemId?:string}}
+ */
+function applyRefund(user, itemId, now = Date.now()) {
+    const check = canRefund(user, itemId, now);
+    if (!check.ok) return { ok: false, reason: check.reason, coins: (user && user.wallet && user.wallet.coins) || 0 };
+
+    const item = getItem(itemId);
+    const price = (user.wallet.lastPurchase && user.wallet.lastPurchase.price) || (item ? item.price : 0);
+
+    // Refund coins.
+    user.wallet.coins = (user.wallet.coins || 0) + price;
+    // Drop ownership.
+    user.ownedCosmetics = (user.ownedCosmetics || []).filter(id => id !== itemId);
+    // Unequip if it was worn.
+    if (item && user.equippedCosmetics && user.equippedCosmetics[item.slot] === itemId) {
+        user.equippedCosmetics[item.slot] = 'default';
+    }
+    // Consume the undo — only the single most recent purchase is ever refundable.
+    user.wallet.lastPurchase = { itemId: null, price: 0, at: null };
+
+    if (typeof user.markModified === 'function') {
+        user.markModified('wallet');
+        user.markModified('ownedCosmetics');
+        user.markModified('equippedCosmetics');
+    }
+    return { ok: true, coins: user.wallet.coins, owned: user.ownedCosmetics, equipped: user.equippedCosmetics, refundedItemId: itemId };
 }
 
 /**
@@ -141,9 +197,12 @@ module.exports = {
     SLOTS,
     CATALOG,
     DEFAULT_LOADOUT,
+    REFUND_WINDOW_MS,
     getItem,
     canPurchase,
     applyPurchase,
+    canRefund,
+    applyRefund,
     canEquip,
     applyEquip,
 };


### PR DESCRIPTION
Two guardrails against accidental or regretted coin spends.

## "Are you sure?" — a confirming second tap
Buying now takes two taps. The first tap on a **Buy** button (and on the preview **"Buy & wear"** action) arms it — **"Sure? Tap again"** in pink — and only the second tap spends. It auto-disarms after a few seconds, and only one button is armed at a time. Equipping an item you already own needs no confirm (it's free and reversible).

## Undo — one-tap refund of the most recent purchase
After any purchase, a bottom bar slides up: **"Bought {name}. ↩ Undo (🪙X back)"**. Tapping it fully refunds the coins, drops ownership, and unequips it if it was worn. It also **resurfaces when you reopen the shop** while the purchase is still refundable.

## Server-authoritative (mirrors purchase/equip)
- `wallet.lastPurchase` records the most recent buy (`utils/cosmeticsCatalog.js`).
- `canRefund` / `applyRefund` refund **only the last purchase**, and **only within a 30-minute window** — long enough to fix a misclick or buyer's remorse, short enough you can't "rent" a legendary for a session and refund it.
- New `POST /api/cosmetics/refund`; the catalog + purchase responses now include an `undo` hint (`{ itemId, price, expiresAt }`).

## Test
- New `tests/unit/cosmeticsCatalog.test.js`: purchase → `lastPurchase`; last-only + window gating; refund restores coins, drops ownership, unequips, single-use. All assertions verified (`node --check` + a manual run of the 13 cases pass).
- Rebuilt the `chat-css2` bundle for the confirm/undo styles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9zNo7LtFvgW4DMxH8HiEi)_