### PR TITLE
Respect a fluent student: durable back-off + no trivial-sub-step interrogation

### DIFF
--- a/tests/unit/pipeline.test.js
+++ b/tests/unit/pipeline.test.js
@@ -563,6 +563,72 @@ describe('Pipeline: Decide Stage', () => {
 });
 
 // ============================================================================
+// BACK-OFF MODE (student asserts competence / rejects scaffolding)
+// ============================================================================
+
+describe('Pipeline: back-off mode', () => {
+  const correctDiag = { type: 'correct', isCorrect: true, answer: '7', correctAnswer: '7', misconception: null };
+  const makeObs = (type, overrides = {}) => ({
+    messageType: type,
+    answer: null,
+    contextSignals: [],
+    streaks: { idkCount: 0, giveUpCount: 0, recentWrongCount: 0, recentCorrectCount: 0 },
+    ...overrides,
+  });
+
+  describe('observe — signal detection', () => {
+    test('flags the transcript competence assertions', () => {
+      const hits = [
+        'I know the steps. this is too easy for me',
+        "I don't NEED HELP! I know this stuff already. Can we MOVE ON",
+        'WHY ARE YOU ASKING ME ABOUT 9+3! Do you think I am a 2nd grader?',
+        'I can do those too!',
+      ];
+      for (const m of hits) expect(observe(m).assertsCompetence).toBe(true);
+    });
+
+    test('does NOT flag genuine help requests or "I know this is hard"', () => {
+      expect(observe('I know this is hard').assertsCompetence).toBe(false);
+      expect(observe('I need help with this').assertsCompetence).toBe(false);
+      expect(observe('can you help me').assertsCompetence).toBe(false);
+    });
+
+    test('"I don\'t need help" is NOT misclassified as HELP_REQUEST', () => {
+      expect(observe("I don't need help, I know this stuff").messageType).not.toBe(MESSAGE_TYPES.HELP_REQUEST);
+    });
+
+    test('backOffMode persists across the recent user window', () => {
+      const o = observe('32', { recentUserMessages: [{ content: 'this is too easy for me' }, { content: 'ok' }] });
+      expect(o.backOffMode).toBe(true);
+      expect(o.messageType).toBe(MESSAGE_TYPES.ANSWER_ATTEMPT); // still an answer, but back-off is live
+    });
+  });
+
+  describe('decide — behavior under back-off', () => {
+    test('correct answer → confirm, minimal scaffold, BACK OFF directive', () => {
+      const obs = makeObs(MESSAGE_TYPES.ANSWER_ATTEMPT, { answer: { value: '7' }, backOffMode: true });
+      const dec = decide(obs, correctDiag, {});
+      expect(dec.action).toBe(ACTIONS.CONFIRM_CORRECT);
+      expect(dec.scaffoldLevel).toBeLessThanOrEqual(2);
+      expect(dec.directives).toContainEqual(expect.stringContaining('BACK OFF'));
+      expect(dec.directives).toContainEqual(expect.stringContaining('do NOT re-check trivial sub-steps'));
+    });
+
+    test('a comprehension check is downgraded to presenting a harder problem', () => {
+      const obs = makeObs(MESSAGE_TYPES.SKIP_REQUEST, { backOffMode: true });
+      const dec = decide(obs, { type: 'no_answer' }, { phaseState: { currentPhase: 'we-do' } });
+      expect(dec.action).toBe(ACTIONS.PRESENT_PROBLEM);
+    });
+
+    test('no back-off signal → no BACK OFF directive (guard is inert by default)', () => {
+      const obs = makeObs(MESSAGE_TYPES.ANSWER_ATTEMPT, { answer: { value: '7' } });
+      const dec = decide(obs, correctDiag, {});
+      expect(dec.directives).not.toContainEqual(expect.stringContaining('BACK OFF'));
+    });
+  });
+});
+
+// ============================================================================
 // GENERATE STAGE (prompt assembly only, no LLM calls)
 // ============================================================================
 

--- a/tests/unit/pipeline.test.js
+++ b/tests/unit/pipeline.test.js
@@ -449,7 +449,25 @@ describe('Pipeline: Decide Stage', () => {
 
   const correctDiag = { type: 'correct', isCorrect: true, answer: '7', correctAnswer: '7', misconception: null };
   const incorrectDiag = { type: 'incorrect', isCorrect: false, answer: '5', correctAnswer: '7', misconception: null };
+  const unverifiableDiag = { type: 'unverifiable', isCorrect: null, answer: '26', correctAnswer: null, misconception: null };
   const noDiag = { type: 'no_answer' };
+
+  test('unverifiable answer → verify silently, do NOT interrogate trivial sub-steps', () => {
+    const obs = makeObs(MESSAGE_TYPES.ANSWER_ATTEMPT, { answer: { value: '26' } });
+    const dec = decide(obs, unverifiableDiag, {});
+    expect(dec.action).toBe(ACTIONS.CONTINUE_CONVERSATION);
+    expect(dec.directives).toContainEqual(expect.stringContaining('NEVER ask the student to re-compute trivial sub-steps'));
+    expect(dec.directives).toContainEqual(expect.stringContaining('brief confirmation, not an interrogation'));
+  });
+
+  test('unverifiable + correct streak → keep advancing, no probing', () => {
+    const obs = makeObs(MESSAGE_TYPES.ANSWER_ATTEMPT, {
+      answer: { value: '26' },
+      streaks: { idkCount: 0, giveUpCount: 0, recentWrongCount: 0, recentCorrectCount: 3 },
+    });
+    const dec = decide(obs, unverifiableDiag, {});
+    expect(dec.directives).toContainEqual(expect.stringContaining('CORRECT STREAK'));
+  });
 
   test('correct answer → confirm_correct', () => {
     const obs = makeObs(MESSAGE_TYPES.ANSWER_ATTEMPT, { answer: { value: '7' } });

--- a/utils/pipeline/decide.js
+++ b/utils/pipeline/decide.js
@@ -96,6 +96,11 @@ function decide(observation, diagnosis, context = {}) {
     applyEvidenceModifiers(decision, context.evidence);
   }
 
+  // Back-off runs AFTER evidence on purpose: an explicit student directive
+  // ("I know this", "too easy", "stop asking") outranks any inferred signal,
+  // including a BKT "possible guessing" nudge that would re-inject probing.
+  applyBackOffModifiers(decision, observation);
+
   return decision;
 }
 
@@ -928,6 +933,39 @@ function applyInstructionalMode(decision, context) {
     default:
       return null;
   }
+}
+
+/**
+ * Apply durable back-off modifiers when the student has asserted competence /
+ * rejected scaffolding ("I know this", "too easy", "I don't need help", "stop
+ * asking", "why are you asking me?").
+ *
+ * This is the fix for the documented "won't take the hint" spiral: the tutor
+ * would say "I hear you!" and then interrogate the very next correct answer,
+ * driving the student to "Christ!!!". Acknowledging feedback once is not
+ * honoring it — the behavior has to change and STAY changed. observe.backOffMode
+ * persists the signal across the recent window so this applies for the rest of
+ * the session (fading only if the student later goes quiet or actually struggles).
+ *
+ * Runs LAST in decide() so it overrides any inferred nudge (mood, BKT guessing)
+ * that would re-inject probing.
+ */
+function applyBackOffModifiers(decision, observation) {
+  if (!observation || !observation.backOffMode) return;
+
+  decision.scaffoldLevel = Math.min(decision.scaffoldLevel, 2);
+
+  // Never run a comprehension check on a student who's telling us to back off.
+  if (decision.action === ACTIONS.CHECK_UNDERSTANDING) {
+    decision.action = ACTIONS.PRESENT_PROBLEM;
+  }
+
+  decision.directives.push(
+    'BACK OFF (student asserted competence): they have explicitly told you they know this / it is too easy / to stop asking. Honor it for the rest of the session unless they actually struggle.',
+    'Do NOT ask them to explain, justify, or walk through a CORRECT answer, and do NOT re-check trivial sub-steps (e.g. "how did you get 9+3?"). Confirm briefly and move on.',
+    'Raise the difficulty to something that respects their level.',
+    'You may acknowledge their point ONCE, briefly and without defensiveness, then just teach at the harder level. Never re-run the probing they just pushed back on.'
+  );
 }
 
 /**

--- a/utils/pipeline/decide.js
+++ b/utils/pipeline/decide.js
@@ -477,15 +477,29 @@ function decideCore(observation, diagnosis, context) {
         }
       }
     } else {
-      // Unverifiable — pipeline couldn't parse the problem to verify.
-      // The LLM must compute the answer itself before responding.
+      // Unverifiable — pipeline couldn't parse the problem to verify (garbled
+      // LaTeX, a nested/complex expression, a fraction-bar problem). The LLM
+      // must compute the answer itself before responding. The failure to guard
+      // against here is the tutor treating "I couldn't auto-verify" as license
+      // to interrogate the student's trivial sub-steps ("how did you get 9+3?")
+      // on a perfectly correct answer — the documented spiral into "WHY ARE YOU
+      // ASKING ME ABOUT 9+3! Do you think I am a 2nd grader?".
       decision.action = ACTIONS.CONTINUE_CONVERSATION;
       decision.directives.push(
-        'ANSWER VERIFICATION REQUIRED: Our math engine could not verify this answer automatically.',
-        'You must compute the correct answer yourself BEFORE responding — work it out, then respond accordingly.',
-        'If correct: confirm naturally. If wrong: guide with Socratic method without revealing the answer.',
+        'ANSWER VERIFICATION REQUIRED: Our math engine could not auto-verify this answer (the problem was hard to parse). Work the whole thing out YOURSELF before responding.',
+        'If you determine it is correct: confirm briefly and move on. Do NOT ask the student to explain, justify, or re-derive a correct answer.',
+        'NEVER ask the student to re-compute trivial sub-steps that are obviously below their level (single-digit sums, basic times-tables like 3×2 or 9+3, dividing small numbers). Check those silently yourself.',
+        'Only ask about a specific step if YOU found a genuine error in it — name that step. Absent a found error, a correct answer gets a brief confirmation, not an interrogation.',
         'When genuinely uncertain, say "Let me think about that..." and work through it. Do not default to implying the student is wrong.'
       );
+
+      // A student on a clean correct streak has earned the benefit of the doubt:
+      // keep it moving instead of probing an answer you merely couldn't auto-check.
+      if ((streaks.recentCorrectCount || 0) >= 2 && (streaks.recentWrongCount || 0) === 0) {
+        decision.directives.push(
+          'CORRECT STREAK: this student has been right repeatedly with no misses. Verify silently and keep advancing — do not slow them down to justify an answer you just could not auto-check.'
+        );
+      }
     }
     return decision;
   }

--- a/utils/pipeline/observe.js
+++ b/utils/pipeline/observe.js
@@ -114,6 +114,15 @@ const PATTERNS = {
   // against a mistaken tutor changed nothing about what happened next, and the
   // tutor restated its claim with mounting concreteness.
   dispute: /\b(you(?:'?re|\s+are)\s+(?:wrong|mistaken|incorrect|not\s+listening)|that'?s\s+(?:not\s+(?:correct|right|true)|wrong|incorrect)|that\s+is\s+not\s+(?:correct|right|true)|no\s+it'?s\s+not|i\s+disagree|i\s+already\s+(?:said|told\s+you)|that'?s\s+not\s+what\s+i\s+(?:said|meant)|you\s+made\s+a\s+mistake|check\s+it\s+again|look\s+again|it\s+is\s+(?:too|so))\b/i,
+
+  // The student is asserting competence / rejecting scaffolding: "I know this",
+  // "too easy", "I don't need help", "stop asking", "why are you asking me",
+  // "do you think I'm a 2nd grader". High precision on purpose — a false hit
+  // suppresses scaffolding, so bare "I know" and "I can do this" are excluded;
+  // only unambiguous "back off" phrasings match. Drives a DURABLE back-off mode
+  // (see observe(): once asserted, the tutor stops probing correct answers and
+  // raises difficulty for the rest of the session).
+  competenceAssertion: /\b(too\s+easy|this\s+is\s+(?:so\s+|way\s+)?easy|i\s+(?:already\s+)?know\s+(?:this\s+stuff|the\s+steps|how\s+to|it\s+already|this\s+already)|i\s+know\s+this\s+already|i\s+(?:don'?t|do\s+not)\s+need\s+(?:the\s+)?help|stop\s+(?:asking|explaining|quizzing)|quit\s+asking|i\s+got\s+this|i\s+can\s+do\s+(?:these|those|them|this\s+too)|(?:2nd|second)\s+grader|why\s+are\s+you\s+(?:asking|quizzing)\s+me)\b/i,
 };
 
 /**
@@ -589,6 +598,13 @@ function observe(message, context = {}) {
   // decide whether correctness gets re-examined.
   const isDispute = PATTERNS.dispute.test(lower);
 
+  // Competence assertion / scaffolding rejection — computed as a SIGNAL (like
+  // isDispute) because it co-occurs with answers, skips, and frustration. It
+  // also GUARDS the help-request branch below: "I don't NEED HELP" contains
+  // "help" and was misclassified as HELP_REQUEST, so the tutor handed a hint to
+  // a student demanding the opposite.
+  const assertsCompetence = PATTERNS.competenceAssertion.test(lower);
+
   if (PATTERNS.giveUp.test(lower)) {
     messageType = MESSAGE_TYPES.GIVE_UP;
   } else if (PATTERNS.idk.test(lower) && text.length < 50) {
@@ -598,7 +614,7 @@ function observe(message, context = {}) {
   } else if (PATTERNS.frustration.test(lower)) {
     messageType = MESSAGE_TYPES.FRUSTRATION;
     confidence = 0.8;
-  } else if (PATTERNS.helpRequest.test(lower)) {
+  } else if (PATTERNS.helpRequest.test(lower) && !assertsCompetence) {
     messageType = MESSAGE_TYPES.HELP_REQUEST;
   } else if (PATTERNS.offTask.test(lower)) {
     messageType = MESSAGE_TYPES.OFF_TASK;
@@ -663,6 +679,16 @@ function observe(message, context = {}) {
     text, messageType, !!answer, context.recentAssistantMessages
   );
 
+  // ── Durable back-off mode ──
+  // Once a student asserts competence / rejects scaffolding, the tutor must not
+  // revert to probing on the very next turn (the documented "I hear you!" then
+  // re-interrogate failure that drove a student to "Christ!!!"). Re-derive the
+  // mode each turn from the recent user window so it persists as long as the
+  // signal is live, and fades naturally if they later go quiet or struggle.
+  const backOffMode = assertsCompetence ||
+    (context.recentUserMessages || [])
+      .some(m => PATTERNS.competenceAssertion.test((m.content || '').toLowerCase()));
+
   return {
     messageType,
     confidence,
@@ -677,6 +703,8 @@ function observe(message, context = {}) {
     },
     problemContext: detectProblemContext(text),
     isDispute,            // true if the student is challenging something the tutor said
+    assertsCompetence,    // true if THIS message asserts competence / rejects scaffolding
+    backOffMode,          // durable: student has signaled "I know this" recently — stop probing, raise difficulty
     isWorksheetFollowUp,  // true if student is asking for multiple worksheet problems
     isBareProblemDrop,    // true if student handed over a new problem with no attempt
     hasRecentUpload,      // forwarded for decide stage


### PR DESCRIPTION
Two related fixes for the transcript where a fluent student was interrogated on correct answers until they hit "Christ!!!" and "what in the entire hell".

## 1. Durable back-off when a student asserts competence
The tutor would say "I hear you!" to "I know this / too easy / I don't need help / MOVE ON" and then interrogate the very next correct answer. Acknowledging feedback once isn't honoring it — the behavior has to change and stay changed.

- `observe.js`: high-precision `competenceAssertion` signal (excludes ambiguous "I know this is hard" / "I can do this") and a **durable `backOffMode`** re-derived each turn from the recent user window. Also fixes **"I don't NEED HELP" being classified as `HELP_REQUEST`** (it contains "help"), which handed a hint to a student demanding the opposite.
- `decide.js`: `applyBackOffModifiers` runs **last** (an explicit student directive outranks inferred mood/BKT nudges) — caps scaffold, downgrades a comprehension check to a harder problem, and forbids probing a correct answer or re-checking trivial sub-steps.

## 2. No trivial-sub-step interrogation on unverifiable-correct answers
When the solver can't parse the problem (garbled LaTeX, fraction bars), verification returns `unverifiable`, the answer never reaches `CONFIRM_CORRECT`, and the correct-answer guards are bypassed — so the tutor freely asked "how did you get 9+3?" on a perfect answer.

- `decide.js`: the unverifiable branch now says compute it yourself, confirm briefly if correct, **never** ask the student to justify a correct answer or re-compute obviously-below-level arithmetic; only probe a step where an actual error was found. On a clean correct streak, verify silently and keep advancing.

## Testing
New tests for signal precision, the help-request guard, the durable window, back-off decide behavior, and the unverifiable-correct branch. **Full unit suite green (8,481 passing), 0 lint errors.**

## Relationship to prior fixes
Complements the merged over-scaffolding (#1270) and doubt-on-correct guard (#1275): those protect *verified*-correct turns; this adds the durable "won't take the hint" adaptation and covers the *unverifiable*-correct case those can't reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)