### PR TITLE
feat(chat): add a "My Progress" profile card to the workspace rail

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -93,6 +93,9 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <link rel="stylesheet" href="/css/avatar-fullbody.css" />
 <!-- Interactive math workspace (chat right slot) -->
   <link rel="stylesheet" href="/css/workspace.css?v=20260723" />
+  <!-- Enriched right-rail player card (stats band + expand-up progress panel).
+       Loads AFTER workspace.css/avatar-fullbody.css so .psc-* rules win. -->
+  <link rel="stylesheet" href="/css/player-stats-card.css?v=20260723c" />
   <!-- Adjustable panels: resizable work board + minimizable tutor hero -->
   <link rel="stylesheet" href="/css/adjustable-panels.css?v=20260721" />
   <!-- Voice mode (layout mode of the chat stage) -->
@@ -2469,7 +2472,10 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     })();
   </script>
   <script src="/dist/js/chat-js8.2b53a001.js"></script>
-<script src="/js/script.js?v=20260723a" type="module"></script>
+<!-- Player stats card: window-global, loaded before script.js which calls
+     window.PlayerStatsCard.init(currentUser) once the user doc is fetched. -->
+<script defer src="/js/modules/playerStatsCard.js?v=20260723c"></script>
+<script src="/js/script.js?v=20260723b" type="module"></script>
   <script src="/js/guidedPath.js" type="module"></script>
   <script src="/dist/js/chat-js9.bc0be9a3.js"></script>
   <!-- Companion HOME screen (phones only; flag-gated OFF by default) -->

--- a/public/css/player-stats-card.css
+++ b/public/css/player-stats-card.css
@@ -1,0 +1,217 @@
+/* ============================================================
+   player-stats-card.css — full profile card for the chat right rail,
+   built to match the profile mockup: a gradient Level/XP hero with a
+   trophy, colored stat tiles, "Skills Recently Mastered" and
+   "What's Next?" rows, and a CTA banner.
+
+   Rendered as a full, scrollable card (the mockup is a tall card), so it
+   fills the rail; the board is reachable via the workspace tabs. Loaded
+   AFTER workspace.css / avatar-fullbody.css so .psc-* wins.
+   ============================================================ */
+
+/* ── "Me tab": Board ⇄ My Progress switcher + profile overlay ──────
+   The docked #cr-player-card slot becomes a slim segmented switcher pinned to
+   the bottom of the rail (its height is --cr-player-card-h, which also insets
+   the board mount — see workspace.css). The full profile card mounts as
+   #psc-profile, an absolute overlay filling the rail ABOVE the switcher,
+   hidden until "My Progress" is selected — so the board stays the default and
+   tutoring is untouched. */
+:root { --cr-player-card-h: 50px; }
+
+/* the docked switcher */
+#cr-player-card.psc-toggle {
+  position: absolute; left: 0; right: 0; bottom: 0;
+  height: var(--cr-player-card-h);
+  z-index: 6;                 /* above both the board and the profile overlay */
+  display: flex; align-items: center; gap: 6px;
+  padding: 6px 8px; margin: 0;
+  box-sizing: border-box;
+  border-top: 1px solid var(--cr-border, #eef2f4);
+  background: var(--cr-bg-panel, #fff);
+}
+.psc-seg {
+  flex: 1 1 0; min-width: 0;
+  display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+  height: 100%; padding: 0 8px;
+  border: none; border-radius: 10px; cursor: pointer;
+  font: 800 12px/1 Inter, system-ui, sans-serif;
+  color: var(--cr-text-dim, #5b6876); background: transparent;
+  transition: background .15s ease, color .15s ease;
+}
+.psc-seg i { font-size: 12px; }
+.psc-seg:hover { background: var(--cr-pill-bg, rgba(108,92,231,.1)); color: var(--cr-text); }
+.psc-seg.is-active { color: #fff; background: linear-gradient(135deg, #8b7bff, #6c5ce7); }
+.psc-seg:focus-visible { outline: 2px solid var(--cr-accent); outline-offset: 2px; }
+
+/* the profile overlay (holds .psc-full) */
+#psc-profile {
+  position: absolute; inset: 0 0 var(--cr-player-card-h) 0;
+  z-index: 5;                 /* above the board, below the switcher */
+  background: var(--cr-bg-0, #f5f7fb);
+  overflow-y: auto; overflow-x: hidden;
+  animation: psc-fade .18s ease-out both;
+}
+#psc-profile[hidden] { display: none; }
+@keyframes psc-fade { from { opacity: 0; } to { opacity: 1; } }
+@media (prefers-reduced-motion: reduce) { #psc-profile { animation: none; } }
+
+.psc-full { display: flex; flex-direction: column; gap: 14px; padding: 14px; }
+
+/* ── header: character + greeting ───────────────────────────────── */
+.psc-head { display: flex; align-items: center; gap: 12px; }
+.psc-head #sidebar-avatar-panel, .psc-head-ava { flex: 0 0 auto; width: auto; display: flex; justify-content: center; }
+.psc-head .fba-stage { height: 88px !important; }
+.psc-head-txt { min-width: 0; }
+.psc-head-name { font: 800 18px/1.1 Inter, system-ui, sans-serif; color: var(--cr-text, #18202b); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.psc-head-sub { font: 600 11.5px/1.3 Inter, system-ui, sans-serif; color: var(--cr-text-dim, #5b6876); margin-top: 2px; }
+
+/* ── hero: gradient Level / XP / trophy ─────────────────────────── */
+.psc-hero {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 20px;
+  color: #fff;
+  background:
+    radial-gradient(120% 140% at 100% 0%, rgba(255,255,255,.28), transparent 55%),
+    linear-gradient(135deg, #8b7bff 0%, #6c5ce7 60%, #5a49d6 100%);
+  box-shadow: 0 10px 26px rgba(108, 92, 231, .35);
+  overflow: hidden;
+}
+.psc-badge {
+  display: flex; flex-direction: column; align-items: center; gap: 4px;
+  text-align: center; min-width: 72px;
+}
+.psc-badge-shield {
+  width: 56px; height: 56px; border-radius: 16px;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 26px;
+  background: rgba(255,255,255,.18);
+  border: 1px solid rgba(255,255,255,.3);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.4);
+}
+.psc-badge-lvl { font: 800 11px/1 Inter, system-ui, sans-serif; opacity: .92; }
+.psc-badge-lvl b { font-size: 15px; }
+.psc-badge-rank {
+  font: 800 9.5px/1.1 Inter, system-ui, sans-serif; letter-spacing: .02em;
+  padding: 3px 8px; border-radius: 999px;
+  background: rgba(255,255,255,.2);
+}
+.psc-hero-mid { min-width: 0; }
+.psc-hero-xplabel { font: 800 10px/1 Inter, system-ui, sans-serif; letter-spacing: .12em; opacity: .85; }
+.psc-hero-xpval { font: 800 22px/1.1 Inter, system-ui, sans-serif; margin: 2px 0 8px; }
+.psc-hero-xpval small { font-size: 13px; opacity: .8; font-weight: 700; }
+.psc-hero-bar { height: 9px; border-radius: 999px; background: rgba(255,255,255,.25); overflow: hidden; }
+.psc-hero-fill { height: 100%; border-radius: 999px; background: #fff; box-shadow: 0 0 10px rgba(255,255,255,.6); transition: width .6s cubic-bezier(.2,1,.3,1); }
+.psc-hero-sub { font: 600 10.5px/1.2 Inter, system-ui, sans-serif; opacity: .9; margin-top: 7px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.psc-trophy { font-size: 40px; filter: drop-shadow(0 6px 10px rgba(0,0,0,.25)); }
+
+/* ── stat tiles ─────────────────────────────────────────────────── */
+.psc-tiles { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; }
+.psc-tile {
+  display: flex; flex-direction: column; gap: 2px;
+  padding: 12px 10px;
+  border-radius: 16px;
+  background: var(--cr-bg-panel, #fff);
+  border: 1px solid var(--cr-border, #eef2f4);
+  box-shadow: 0 4px 12px rgba(15, 26, 36, .05);
+}
+.psc-tile-top { display: flex; align-items: center; gap: 5px; font: 800 10px/1 Inter, system-ui, sans-serif; color: var(--cr-text-dim, #5b6876); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.psc-tile-top i { font-size: 11px; flex: 0 0 auto; }
+.psc-tile-val { font: 800 21px/1 Inter, system-ui, sans-serif; font-variant-numeric: tabular-nums; white-space: nowrap; }
+.psc-tile-val small { font-size: 10px; font-weight: 700; color: var(--cr-text-dim, #5b6876); }
+.psc-tile-sub { font: 700 9.5px/1.1 Inter, system-ui, sans-serif; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.psc-tile[data-c="streak"] .psc-tile-val, .psc-tile[data-c="streak"] i { color: #f5842a; }
+.psc-tile[data-c="streak"] .psc-tile-sub { color: #f5842a; }
+.psc-tile[data-c="solved"] .psc-tile-val, .psc-tile[data-c="solved"] i { color: #2fa96a; }
+.psc-tile[data-c="solved"] .psc-tile-sub { color: #2fa96a; }
+.psc-tile[data-c="acc"] .psc-tile-val, .psc-tile[data-c="acc"] i { color: var(--cr-accent, #6c5ce7); }
+.psc-tile[data-c="acc"] .psc-tile-sub { color: var(--cr-accent, #6c5ce7); }
+
+/* ── section heading ────────────────────────────────────────────── */
+.psc-sect { display: flex; align-items: center; gap: 8px; font: 800 14px/1.2 Inter, system-ui, sans-serif; color: var(--cr-text, #18202b); margin: 2px 2px -2px; }
+.psc-sect .psc-sect-ic { font-size: 15px; }
+
+/* ── skill rows ─────────────────────────────────────────────────── */
+.psc-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
+.psc-row {
+  display: flex; align-items: center; gap: 11px;
+  padding: 12px 13px;
+  border-radius: 16px;
+  background: var(--cr-bg-panel, #fff);
+  border: 1px solid var(--cr-border, #eef2f4);
+  box-shadow: 0 3px 10px rgba(15, 26, 36, .04);
+}
+.psc-row-badge {
+  flex: 0 0 auto;
+  width: 34px; height: 34px; border-radius: 11px;
+  display: inline-flex; align-items: center; justify-content: center;
+  font: 800 12px/1 Inter, system-ui, sans-serif; color: #fff;
+}
+.psc-row-check {
+  flex: 0 0 auto; width: 26px; height: 26px; border-radius: 50%;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: #2fa96a; color: #fff; font-size: 13px;
+}
+.psc-row-body { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; gap: 6px; }
+.psc-row-name { font: 700 13.5px/1.2 Inter, system-ui, sans-serif; color: var(--cr-text, #18202b); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.psc-row-progline { display: flex; align-items: center; gap: 8px; }
+.psc-row-bar { flex: 1 1 auto; height: 6px; border-radius: 999px; background: var(--cr-bg-2, #eef1f7); overflow: hidden; }
+.psc-row-fill { height: 100%; border-radius: 999px; background: linear-gradient(90deg, #34d399, #10b981); }
+.psc-row-pct { flex: 0 0 auto; font: 800 11px/1 Inter, system-ui, sans-serif; color: var(--cr-text-dim, #5b6876); font-variant-numeric: tabular-nums; }
+.psc-row-meta { flex: 0 0 auto; display: flex; align-items: center; gap: 8px; }
+.psc-xp-pill {
+  font: 800 10.5px/1 Inter, system-ui, sans-serif; color: var(--cr-accent-strong, #4d3dd1);
+  background: var(--cr-pill-bg, rgba(108,92,231,.12)); padding: 4px 8px; border-radius: 999px; white-space: nowrap;
+}
+.psc-star { color: #f5b301; font-size: 14px; }
+.psc-star.is-dim { color: var(--cr-border-strong, #cdd4e0); }
+
+/* type-badge palette for "What's Next" */
+.psc-row-badge[data-b="0"] { background: linear-gradient(135deg,#8b7bff,#6c5ce7); }
+.psc-row-badge[data-b="1"] { background: linear-gradient(135deg,#22c3b8,#0ea5a3); }
+.psc-row-badge[data-b="2"] { background: linear-gradient(135deg,#ffa94d,#f5842a); }
+.psc-row-badge[data-b="3"] { background: linear-gradient(135deg,#f472b6,#db2777); }
+/* star badge palette for mastered rows */
+.psc-row-star[data-b="0"] { background: linear-gradient(135deg,#a78bfa,#7c3aed); }
+.psc-row-star[data-b="1"] { background: linear-gradient(135deg,#60a5fa,#2563eb); }
+.psc-row-star[data-b="2"] { background: linear-gradient(135deg,#34d399,#059669); }
+
+/* ── CTA banner ─────────────────────────────────────────────────── */
+.psc-cta {
+  display: flex; align-items: center; gap: 12px;
+  padding: 13px 14px; border-radius: 18px;
+  background: linear-gradient(135deg, rgba(139,123,255,.14), rgba(108,92,231,.10));
+  border: 1px solid var(--cr-border, #eef2f4);
+}
+.psc-cta-star {
+  flex: 0 0 auto; width: 40px; height: 40px; border-radius: 12px;
+  display: inline-flex; align-items: center; justify-content: center; font-size: 20px;
+  background: linear-gradient(135deg,#ffd166,#f5b301); color: #fff;
+  box-shadow: 0 5px 14px rgba(245, 179, 1, .4);
+}
+.psc-cta-body { flex: 1 1 auto; min-width: 0; }
+.psc-cta-t { font: 800 13px/1.2 Inter, system-ui, sans-serif; color: var(--cr-text, #18202b); }
+.psc-cta-s { font: 600 11px/1.3 Inter, system-ui, sans-serif; color: var(--cr-text-dim, #5b6876); }
+.psc-cta-btn {
+  flex: 0 0 auto; cursor: pointer; border: none;
+  padding: 9px 15px; border-radius: 999px; color: #fff;
+  font: 800 12px/1 Inter, system-ui, sans-serif;
+  background: linear-gradient(135deg,#8b7bff,#6c5ce7);
+  box-shadow: 0 5px 14px rgba(108, 92, 231, .4);
+}
+.psc-cta-btn:hover { filter: brightness(1.05); }
+.psc-cta-btn:focus-visible { outline: 2px solid var(--cr-accent); outline-offset: 2px; }
+
+/* empty / pre-assessment */
+.psc-empty { text-align: center; padding: 26px 14px; display: flex; flex-direction: column; align-items: center; gap: 7px; }
+.psc-empty-ic { font-size: 30px; opacity: .7; }
+.psc-empty-t { font: 800 14px/1.3 Inter, system-ui, sans-serif; color: var(--cr-text, #18202b); }
+.psc-empty-s { font: 600 12px/1.45 Inter, system-ui, sans-serif; color: var(--cr-text-dim, #5b6876); max-width: 240px; }
+
+@media (prefers-reduced-motion: reduce) {
+  .psc-hero-fill { transition: none; }
+}

--- a/public/js/modules/playerStatsCard.js
+++ b/public/js/modules/playerStatsCard.js
@@ -1,0 +1,328 @@
+/* ============================================================
+   playerStatsCard.js — full profile card for the chat right rail, built
+   to match the profile mockup: a gradient Level/XP hero with a trophy,
+   colored stat tiles, "Skills Recently Mastered" and "What's Next?" rows,
+   and a CTA banner. Replaces the plain avatar+name player card.
+
+   WHY a window-global IIFE (not an ES module): script.js populates the
+   avatar (#sidebar-avatar-panel) and name (#cr-player-name) inline in
+   setupChatUI once window.currentUser is loaded, then calls
+   window.PlayerStatsCard.init(currentUser) — no import threading needed.
+   Mirrors avatarFullBody.js / boardCommandHandler.js.
+
+   DATA (see the data audit that preceded this):
+   - Hero + band read window.currentUser (level, xp, xpForCurrentLevel/
+     NextLevel, dailyQuests.currentStreak) — already loaded, instant.
+   - Tiles' accuracy/solved and the skills sections come from ONE
+     GET /api/student/progress/summary (the same bundle the student
+     dashboard uses; display-ready names, so we never title-case a raw id).
+
+   NO FABRICATION: the mockup's "top X% of learners" and weekly
+   time-practiced have no real source here, so they are replaced with real,
+   motivating copy (XP-to-next-level) / omitted. accuracy is null until ≥5
+   graded problems in-window — shown as "—", never faked.
+   ============================================================ */
+(function (root) {
+  'use strict';
+
+  var SUMMARY_URL = '/api/student/progress/summary';
+  var summaryCache = null;
+  var summaryPending = null;
+  var mounted = false;
+  var lastUser = null;
+
+  function h(tag, cls, html) {
+    var e = document.createElement(tag);
+    if (cls) e.className = cls;
+    if (html != null) e.innerHTML = html;
+    return e;
+  }
+  function num(v, f) { var n = Number(v); return Number.isFinite(n) ? n : (f == null ? 0 : f); }
+  function txt(el, s) { if (el) el.textContent = (s == null ? '' : String(s)); }
+
+  // Friendly level-tier title (cosmetic label, not a data claim).
+  function rankFor(level) {
+    var l = num(level, 1);
+    if (l >= 40) return 'Math Master';
+    if (l >= 25) return 'Math Explorer';
+    if (l >= 15) return 'Problem Solver';
+    if (l >= 6) return 'Rising Star';
+    return 'Rookie';
+  }
+  function streakSub(d) { d = num(d); return d >= 14 ? 'On fire!' : d >= 5 ? 'Keep it up!' : d >= 1 ? 'Nice start!' : 'Start today!'; }
+  function accSub(a) { if (a == null) return 'Warming up'; return a >= 90 ? 'Amazing!' : a >= 75 ? 'Great work!' : a >= 60 ? 'Getting there' : 'Keep going'; }
+  function solvedSub(n) { n = num(n); return n >= 100 ? 'Excellent!' : n >= 25 ? 'Great pace!' : n >= 1 ? 'Keep going!' : 'Let’s begin'; }
+  function shortDate(iso) {
+    if (!iso) return '';
+    try { var d = new Date(iso); return isNaN(d.getTime()) ? '' : d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }); }
+    catch (_) { return ''; }
+  }
+
+  function heroData(user) {
+    var cur = num(user && user.xpForCurrentLevel, 0);
+    var need = num(user && user.xpForNextLevel, 100);
+    var pct = need > 0 ? Math.max(0, Math.min(100, (cur / need) * 100)) : 0;
+    var level = num(user && user.level, 1);
+    return { cur: cur, need: need, pct: pct, level: level, remaining: Math.max(0, need - cur) };
+  }
+  function streakOf(user) { return num(user && user.dailyQuests && user.dailyQuests.currentStreak, 0); }
+
+  // ── scaffold: turn the docked card into a Board/Me switcher + build the
+  //    profile overlay that holds the full card. Idempotent. ────────────────
+  var elProfile = null;
+  function scaffold(host) {
+    if (elProfile && document.body.contains(elProfile)) return elProfile;
+    var region = host.closest('#cr-workspace') || host.parentNode || host;
+    if (getComputedStyle(region).position === 'static') region.style.position = 'relative';
+
+    // The profile overlay (fills the rail above the switcher, hidden by default).
+    elProfile = document.getElementById('psc-profile');
+    if (!elProfile) {
+      elProfile = h('div', 'psc-profile');
+      elProfile.id = 'psc-profile';
+      elProfile.hidden = true;
+      elProfile.setAttribute('role', 'tabpanel');
+      elProfile.setAttribute('aria-label', 'My progress');
+      elProfile.appendChild(h('div', 'psc-full'));
+      region.appendChild(elProfile);
+    }
+
+    // Turn #cr-player-card into the segmented switcher. Move the avatar/name
+    // that script.js filled into the profile header first.
+    var name = host.querySelector('#cr-player-name');
+    if (name) { host._pscName = (name.textContent || ''); if (name.parentNode) name.parentNode.removeChild(name); }
+    var avatar = host.querySelector('#sidebar-avatar-panel');
+    if (avatar) { host._pscAvatar = avatar; if (avatar.parentNode) avatar.parentNode.removeChild(avatar); }
+
+    if (!host.classList.contains('psc-toggle')) {
+      host.classList.add('psc-toggle');
+      host.classList.remove('psc-card', 'cr-player-card');   // shed old centered-column styling
+      host.textContent = '';
+      var segBoard = h('button', 'psc-seg is-active', '<i class="fas fa-pen"></i><span>Board</span>');
+      segBoard.type = 'button'; segBoard.setAttribute('role', 'tab');
+      var segMe = h('button', 'psc-seg', '<i class="fas fa-user"></i><span>My Progress</span>');
+      segMe.type = 'button'; segMe.setAttribute('role', 'tab');
+      segBoard.addEventListener('click', function () { showProfile(false); });
+      segMe.addEventListener('click', function () { showProfile(true); });
+      host.appendChild(segBoard); host.appendChild(segMe);
+      host._segBoard = segBoard; host._segMe = segMe;
+    }
+    return elProfile;
+  }
+
+  function showProfile(on) {
+    var host = document.getElementById('cr-player-card');
+    if (!elProfile || !host) return;
+    elProfile.hidden = !on;
+    if (host._segMe) host._segMe.classList.toggle('is-active', on);
+    if (host._segBoard) host._segBoard.classList.toggle('is-active', !on);
+    if (host._segMe) host._segMe.setAttribute('aria-selected', on ? 'true' : 'false');
+    if (host._segBoard) host._segBoard.setAttribute('aria-selected', on ? 'false' : 'true');
+    if (on && elProfile) elProfile.scrollTop = 0;
+  }
+
+  // ── render the full card into the profile overlay ───────────────────────
+  function render(host, user, summary) {
+    var ws = (summary && summary.weeklyStats) || {};
+    var hd = heroData(user);
+    var pre = summary && summary.assessmentCompleted === false;
+
+    scaffold(host);
+    var nameText = host._pscName || (user && user.firstName) || 'Mathematician';
+    var avatar = host._pscAvatar || null;
+    if (avatar && avatar.parentNode) avatar.parentNode.removeChild(avatar);  // detach for re-append
+
+    var full = elProfile.querySelector('.psc-full');
+    full.textContent = '';
+
+    // header: character + greeting
+    var head = h('div', 'psc-head');
+    if (avatar) head.appendChild(avatar); else head.appendChild(h('div', 'psc-head-ava'));
+    var greet = h('div', 'psc-head-txt',
+      '<div class="psc-head-name"></div><div class="psc-head-sub">Keep learning, keep growing 💜</div>');
+    txt(greet.querySelector('.psc-head-name'), nameText);
+    head.appendChild(greet);
+    full.appendChild(head);
+
+    // hero
+    var hero = h('div', 'psc-hero');
+    var badge = h('div', 'psc-badge',
+      '<div class="psc-badge-shield">🛡️</div>' +
+      '<div class="psc-badge-lvl">Level <b></b></div>' +
+      '<div class="psc-badge-rank"></div>');
+    txt(badge.querySelector('.psc-badge-lvl b'), hd.level);
+    txt(badge.querySelector('.psc-badge-rank'), rankFor(hd.level));
+    var mid = h('div', 'psc-hero-mid',
+      '<div class="psc-hero-xplabel">XP</div>' +
+      '<div class="psc-hero-xpval"><b></b> <small></small></div>' +
+      '<div class="psc-hero-bar"><div class="psc-hero-fill"></div></div>' +
+      '<div class="psc-hero-sub"></div>');
+    txt(mid.querySelector('.psc-hero-xpval b'), hd.cur.toLocaleString());
+    txt(mid.querySelector('.psc-hero-xpval small'), '/ ' + hd.need.toLocaleString());
+    mid.querySelector('.psc-hero-fill').style.width = hd.pct.toFixed(1) + '%';
+    txt(mid.querySelector('.psc-hero-sub'), '📈 ' + hd.remaining.toLocaleString() + ' XP to Lv ' + (hd.level + 1));
+    hero.appendChild(badge);
+    hero.appendChild(mid);
+    hero.appendChild(h('div', 'psc-trophy', '🏆'));
+    full.appendChild(hero);
+
+    // stat tiles
+    var tiles = h('div', 'psc-tiles');
+    tiles.appendChild(tile('streak', 'fa-fire', 'Streak', streakOf(user), 'days', streakSub(streakOf(user))));
+    tiles.appendChild(tile('solved', 'fa-magnifying-glass', 'Problems', pre ? 0 : num(ws.problemsSolved, 0), '/wk', solvedSub(ws.problemsSolved)));
+    tiles.appendChild(tile('acc', 'fa-bullseye', 'Accuracy', (ws.accuracy == null ? '—' : ws.accuracy), (ws.accuracy == null ? '' : '%'), accSub(ws.accuracy)));
+    full.appendChild(tiles);
+
+    if (pre) {
+      full.appendChild(h('div', 'psc-empty',
+        '<div class="psc-empty-ic">📋</div>' +
+        '<div class="psc-empty-t">Take your placement to unlock progress</div>' +
+        '<div class="psc-empty-s">Once you start solving, your mastered skills and next steps show up here.</div>'));
+      appendCta(full);
+      return;
+    }
+
+    // Skills Recently Mastered
+    var mastered = [];
+    if (Array.isArray(summary && summary.recentWins) && summary.recentWins.length) {
+      mastered = summary.recentWins.slice(0, 3).map(function (w) { return { name: w.description, date: w.date }; });
+    } else if (summary && summary.recentMastery) {
+      mastered = [{ name: summary.recentMastery.displayName, date: summary.recentMastery.date }];
+    }
+    if (mastered.length) {
+      full.appendChild(section('🎓', 'Skills Recently Mastered'));
+      var ul = h('ul', 'psc-list');
+      mastered.forEach(function (m, i) {
+        var li = h('li', 'psc-row');
+        li.appendChild(h('span', 'psc-row-check', '✓'));
+        var body = h('div', 'psc-row-body', '<span class="psc-row-name"></span>');
+        txt(body.querySelector('.psc-row-name'), m.name);
+        li.appendChild(body);
+        var meta = h('div', 'psc-row-meta');
+        if (m.date) { var dEl = h('span', 'psc-xp-pill'); txt(dEl, shortDate(m.date)); meta.appendChild(dEl); }
+        var star = h('span', 'psc-star', '★'); star.setAttribute('aria-hidden', 'true'); meta.appendChild(star);
+        li.appendChild(meta);
+        ul.appendChild(li);
+      });
+      full.appendChild(ul);
+    }
+
+    // What's Next
+    var next = [];
+    if (summary && summary.currentLearning) next.push({ name: summary.currentLearning.displayName, pct: num(summary.currentLearning.progress, 0), ready: false });
+    if (summary && summary.nextReady) next.push({ name: summary.nextReady.displayName, pct: null, ready: true });
+    if (next.length) {
+      full.appendChild(section('🚀', 'What’s Next?'));
+      var ul2 = h('ul', 'psc-list');
+      next.forEach(function (n, i) {
+        var li = h('li', 'psc-row');
+        var b = h('span', 'psc-row-badge', glyphFor(n.name));
+        b.setAttribute('data-b', String(i % 4));
+        li.appendChild(b);
+        var body = h('div', 'psc-row-body', '<span class="psc-row-name"></span>');
+        txt(body.querySelector('.psc-row-name'), n.name);
+        if (!n.ready) {
+          var pl = h('div', 'psc-row-progline',
+            '<div class="psc-row-bar"><div class="psc-row-fill"></div></div><span class="psc-row-pct"></span>');
+          pl.querySelector('.psc-row-fill').style.width = Math.max(0, Math.min(100, n.pct)) + '%';
+          txt(pl.querySelector('.psc-row-pct'), n.pct + '%');
+          body.appendChild(pl);
+        }
+        li.appendChild(body);
+        var meta = h('div', 'psc-row-meta');
+        if (n.ready) { var r = h('span', 'psc-xp-pill'); txt(r, 'Ready'); meta.appendChild(r); }
+        var star2 = h('span', 'psc-star' + (n.ready ? ' is-dim' : ''), '★'); star2.setAttribute('aria-hidden', 'true'); meta.appendChild(star2);
+        li.appendChild(meta);
+        ul2.appendChild(li);
+      });
+      full.appendChild(ul2);
+    }
+
+    if (!mastered.length && !next.length) {
+      full.appendChild(h('div', 'psc-empty',
+        '<div class="psc-empty-ic">✍️</div>' +
+        '<div class="psc-empty-t">Your progress is warming up</div>' +
+        '<div class="psc-empty-s">Solve a few problems and your mastered skills and next steps appear here.</div>'));
+    }
+
+    appendCta(full);
+  }
+
+  function tile(c, icon, label, val, unit, sub) {
+    var t = h('div', 'psc-tile',
+      '<div class="psc-tile-top"><i class="fas ' + icon + '"></i><span></span></div>' +
+      '<div class="psc-tile-val"><b></b><small></small></div>' +
+      '<div class="psc-tile-sub"></div>');
+    t.setAttribute('data-c', c);
+    txt(t.querySelector('.psc-tile-top span'), label);
+    txt(t.querySelector('.psc-tile-val b'), val);
+    txt(t.querySelector('.psc-tile-val small'), unit ? ' ' + unit : '');
+    txt(t.querySelector('.psc-tile-sub'), sub);
+    return t;
+  }
+  function section(ic, title) {
+    var s = h('div', 'psc-sect', '<span class="psc-sect-ic"></span><span class="psc-sect-t"></span>');
+    txt(s.querySelector('.psc-sect-ic'), ic);
+    txt(s.querySelector('.psc-sect-t'), title);
+    return s;
+  }
+  // A short 2-char glyph for a What's-Next badge, derived from the name.
+  function glyphFor(name) {
+    var s = String(name || '').replace(/[^A-Za-z0-9]/g, '');
+    return (s.slice(0, 2) || '▸').toUpperCase();
+  }
+  function appendCta(full) {
+    var cta = h('div', 'psc-cta',
+      '<div class="psc-cta-star">⭐</div>' +
+      '<div class="psc-cta-body"><div class="psc-cta-t">You’re on a roll!</div>' +
+      '<div class="psc-cta-s">Every problem you solve makes you stronger.</div></div>');
+    var btn = h('button', 'psc-cta-btn', 'Let’s Go 🚀');
+    btn.type = 'button';
+    btn.addEventListener('click', function () {
+      var input = document.getElementById('user-input');
+      if (input) { try { input.focus(); input.scrollIntoView({ block: 'center' }); } catch (_) {} }
+    });
+    cta.appendChild(btn);
+    full.appendChild(cta);
+  }
+
+  // ── summary fetch (once, cached) ────────────────────────────────────────
+  function loadSummary() {
+    if (summaryCache) return Promise.resolve(summaryCache);
+    if (summaryPending) return summaryPending;
+    summaryPending = fetch(SUMMARY_URL, { credentials: 'include' })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (data) {
+        summaryCache = data || null;
+        summaryPending = null;
+        var host = document.getElementById('cr-player-card');
+        if (host && lastUser) render(host, lastUser, summaryCache); // re-render with real skills
+        return summaryCache;
+      })
+      .catch(function (err) { console.warn('[PlayerStatsCard] summary fetch failed', err); summaryPending = null; return null; });
+    return summaryPending;
+  }
+
+  // ── public API ──────────────────────────────────────────────────────────
+  // init(user, opts): opts.summary injects data and skips the fetch (harness).
+  function init(user, opts) {
+    opts = opts || {};
+    var host = document.getElementById('cr-player-card');
+    if (!host || !user) return;
+    lastUser = user;
+    mounted = true;
+    if (opts.summary !== undefined) { summaryCache = opts.summary; render(host, user, summaryCache); return; }
+    render(host, user, summaryCache);   // paint instantly with band data
+    loadSummary();                       // fill tiles + skills when it lands
+  }
+
+  // refresh(user): re-paint after a chat turn (level/xp/streak may change).
+  function refresh(user) {
+    if (!mounted || !user) return;
+    lastUser = user;
+    var host = document.getElementById('cr-player-card');
+    if (host) render(host, user, summaryCache);
+  }
+
+  root.PlayerStatsCard = { init: init, refresh: refresh, _loadSummary: loadSummary };
+})(typeof window !== 'undefined' ? window : this);

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -457,6 +457,10 @@ document.addEventListener("DOMContentLoaded", () => {
             }
             const playerName = document.getElementById('cr-player-name');
             if (playerName) playerName.textContent = currentUser.firstName || '';
+            // Enrich the card into a stats band + expand-up progress panel.
+            // Instant stats come from currentUser; the panel and accuracy/solved
+            // chips lazy-load from /api/student/progress/summary on first paint.
+            if (window.PlayerStatsCard) window.PlayerStatsCard.init(currentUser);
         } catch (e) { console.warn('Player card render failed', e); }
 
         // Sidebar coin counter → shop (closes the earn→spend loop right where
@@ -3265,6 +3269,8 @@ document.addEventListener("DOMContentLoaded", () => {
                 updateGamificationDisplay();
                 // Identity chip: refresh level ring + rank title from the fresh XP state.
                 try { updateIdentityChip(currentUser); } catch (e) { console.warn('Identity chip update failed', e); }
+                // Player card band: same fresh XP/level/streak, live after the turn.
+                try { if (window.PlayerStatsCard) window.PlayerStatsCard.refresh(currentUser); } catch (e) { console.warn('Player card refresh failed', e); }
 
                 // Show unlock proximity teaser (after level-up or when close)
                 if (data.xpLadder?.leveledUp) {


### PR DESCRIPTION
Adds a gamified profile card to the chat right rail, built to match the profile mockup: a character + greeting header, a gradient Level/XP hero with a shield rank badge and trophy, colored stat tiles (streak / problems / accuracy) with subtitles, "Skills Recently Mastered" and "What's Next?" rows, and a "You're on a roll!" CTA.

Coexists with the board via a "Me tab" (the option chosen): the docked #cr-player-card slot becomes a slim [ Board | My Progress ] switcher pinned to the bottom of the rail. Board is the default so tutoring is untouched; tapping "My Progress" reveals the full card as an overlay above the switcher, tapping "Board" returns. Nothing is hidden — one tap apart. The Living Workspace swap already keeps #cr-player-card visible, so no chat-workspace.js change is needed; the board mount is already inset above the docked slot by --cr-player-card-h.

Data: the hero/streak come from window.currentUser (instant); accuracy, problems solved, and the skills sections come from ONE GET /api/student/progress/summary (the same bundle the student dashboard uses — no new server code). Client field reads were verified against routes/student.js:500 (exact response shape).

Honest with data: accuracy shows "—" until >=5 graded problems in-window (never faked); the mockup's "top X% of learners" and weekly time-practiced have no real source here, so they are replaced with real copy (XP-to-next-level) / omitted rather than invented. Skill names use the endpoint's display-ready names, so no raw id like "MS.QNT.8" is ever surfaced.

window-global module (mirrors avatarFullBody.js); script.js inits it from setupChatUI once the user doc loads and refresh()es the hero after each turn's XP update. Verified in a harness across rich / low-sample / pre-assessment data and light + dark themes, and the Board<->My Progress toggle both directions. Not yet screenshotted in the fully-running app (needs backend + an authed student with seeded progress).