### PR TITLE
Never open a session by diagnosing a weakness (asset-based open)

### DIFF
--- a/tests/unit/assetBasedOpen.test.js
+++ b/tests/unit/assetBasedOpen.test.js
@@ -1,0 +1,67 @@
+/**
+ * Asset-based open — the tutor must NOT lead with a diagnosed weakness.
+ *
+ * Regression: with error-pattern / tutor-note context in the prompt, the tutor
+ * opened sessions by reciting a deficit ("looking at that last set of notes, I
+ * spotted the pattern in what's tripping you up") before the student had done
+ * anything — then the student aced every problem. Deficit framing is demoralizing
+ * and evidence-free at session start.
+ */
+
+const { generateSystemPrompt } = require('../../utils/promptCompact');
+const { buildPlanLayer } = require('../../utils/promptPlanLayer');
+
+const user = {
+  firstName: 'Jason',
+  lastName: 'N',
+  gradeLevel: '7',
+  mathCourse: 'Pre-Algebra',
+  tonePreference: 'warm',
+};
+const tutor = { name: 'Mr. Nappier', catchphrase: 'See the patterns', personality: 'Warm and direct.' };
+
+// errorPatterns is the 13th positional arg to generateSystemPrompt.
+function buildPrompt(errorPatterns) {
+  return generateSystemPrompt(
+    user, tutor, null, 'student',
+    null, null, null, [], null, null, null, null, errorPatterns, null,
+    null, null, null
+  );
+}
+
+describe('asset-based open — no deficit cold open', () => {
+  test('identity section forbids opening by diagnosing a weakness', () => {
+    const prompt = buildPrompt(null);
+    expect(prompt).toMatch(/never open by diagnosing a weakness/i);
+  });
+
+  test('error-pattern context is framed as private, not an opener', () => {
+    const errorPatterns = {
+      totalErrors: 12,
+      sessionsAnalyzed: 4,
+      patterns: { 'regrouping': 7, 'sign-errors': 5 },
+    };
+    const prompt = buildPrompt(errorPatterns);
+    // The data still reaches the model...
+    expect(prompt).toContain('regrouping');
+    // ...but explicitly gated against a deficit open.
+    expect(prompt).toMatch(/PRIVATE CONTEXT, NOT AN OPENER/i);
+    expect(prompt).toMatch(/never open the session with it/i);
+    expect(prompt).toMatch(/tripping them up/i); // named as a thing NOT to say
+    // The old un-gated instruction is gone.
+    expect(prompt).not.toMatch(/Mention naturally when relevant\./);
+  });
+
+  test('tutor notes are marked private and must not be narrated as a weakness', () => {
+    const plan = {
+      currentTarget: null,
+      tutorNotes: [
+        { content: 'Tends to drop the negative sign when subtracting.', category: 'misconception', createdAt: 2, supersededAt: null },
+      ],
+    };
+    const layer = buildPlanLayer(plan);
+    expect(layer).toMatch(/TUTOR NOTES \(PRIVATE/i);
+    expect(layer).toMatch(/do not open the session by narrating them/i);
+    expect(layer).toMatch(/lead with what the student can already do/i);
+  });
+});

--- a/utils/promptCompact.js
+++ b/utils/promptCompact.js
@@ -619,7 +619,8 @@ You are **${tutorProfile.name}**. Catchphrase: "${tutorProfile.catchphrase}"
 ${tutorProfile.personality}${behaviorsCtx}${culturalCtx}
 
 VOICE IS NON-NEGOTIABLE. The rules above are WHAT to do; your voice is HOW — in every line, not just greetings. The strip-the-name test: if your name were removed from this reply, ${firstName} should still know it's you from the word choice, the energy, and the kind of analogy you reach for. Two tutors must never be interchangeable.
-NEVER open with generic tutor boilerplate — not "I'm ${tutorProfile.name}, your math tutor, here to make this click", not "here to help you with math", not any job-description intro. Open the way only YOU would, lead with your signature energy, and never reuse an opener.`);
+NEVER open with generic tutor boilerplate — not "I'm ${tutorProfile.name}, your math tutor, here to make this click", not "here to help you with math", not any job-description intro. Open the way only YOU would, lead with your signature energy, and never reuse an opener.
+NEVER open by diagnosing a weakness. Do not start a session by telling ${firstName} what they "struggle with", are "bad at", or what is "tripping them up" — you have no evidence from THIS session yet, and leading with a deficit is demoralizing. Lead with what they can already do, or just get straight into the work. Any known difficulty is watched for silently and addressed only if it actually shows up.`);
 
   // Date/time
   parts.push(`
@@ -765,7 +766,7 @@ ${typeof curriculumContext === 'string' ? curriculumContext : JSON.stringify(cur
       .slice(0, 3)
       .map(([cat, count]) => `${cat}: ${count}`)
       .join(', ');
-    parts.push(`--- ERROR PATTERNS (last 2 weeks) ---\n${errorPatterns.totalErrors} errors across ${errorPatterns.sessionsAnalyzed} sessions. Top: ${topErrors}.\nMention naturally when relevant. Celebrate when they avoid their usual errors.`);
+    parts.push(`--- ERROR PATTERNS (last 2 weeks) — PRIVATE CONTEXT, NOT AN OPENER ---\n${errorPatterns.totalErrors} errors across ${errorPatterns.sessionsAnalyzed} sessions. Top: ${topErrors}.\nThis is background for YOU. NEVER open the session with it, and NEVER tell ${firstName} what they are "bad at", "struggle with", or what is "tripping them up" — least of all before they have shown it in THIS session. Watch for these patterns silently; raise one only AFTER ${firstName} actually makes that error here, and frame it as the approach that slipped, not the student. When they avoid a usual error, you may celebrate it.`);
   }
 
   // Grading context

--- a/utils/promptPlanLayer.js
+++ b/utils/promptPlanLayer.js
@@ -97,7 +97,7 @@ function buildPlanLayer(tutorPlan, options = {}) {
       const tag = n.category !== 'general' ? `[${n.category}]` : '';
       return `  ${tag} ${n.content}`;
     }).join('\n');
-    parts.push(`TUTOR NOTES:\n${noteLines}`);
+    parts.push(`TUTOR NOTES (PRIVATE — for your eyes only, never recited to the student):\n${noteLines}\nUse these to steer your teaching silently. Do NOT open the session by narrating them or by diagnosing a weakness ("looking at my notes, here's what trips you up"). Lead with what the student can already do; raise a noted difficulty only if and when it actually surfaces in the work.`);
   }
 
   // ── Student Signals (quick-access behavioral data) ──


### PR DESCRIPTION
## Problem
The tutor opened sessions by reciting a **deficit** — e.g. *"looking at that last set of notes, I spotted the pattern in what's tripping you up"* — before the student had done anything that session. The student then aced every problem, so the projected weakness wasn't even true. Deficit framing at session start is demoralizing and evidence-free.

## Root cause
Two dynamic context blocks fed the model prior-weakness data with no guard against leading with it:
- `promptCompact.js` **ERROR PATTERNS (last 2 weeks)** — said only "Mention naturally when relevant."
- `promptPlanLayer.js` **TUTOR NOTES** — persistent cross-session observations, un-gated.

## Fix
Reframe both as **private tutor context**, and add a general opening guard:
- ERROR PATTERNS → "background for YOU, never open with it, never tell the student what they're bad at / struggle with / what's tripping them up; watch silently and raise it only AFTER they make the error here."
- TUTOR NOTES → marked private / never recited; don't open by narrating them; lead with what the student can already do.
- IDENTITY block (live path, generalizes beyond those two) → "NEVER open by diagnosing a weakness — lead with what they can do or get straight to work."

## Testing
`tests/unit/assetBasedOpen.test.js` asserts the data still reaches the model but the deficit-open framing is gated. **Full unit suite green (12,724 passing), 0 lint errors.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)