### PR TITLE
Tutor drives representation variety toward the transfer gate

### DIFF
--- a/tests/unit/pipeline.test.js
+++ b/tests/unit/pipeline.test.js
@@ -484,6 +484,42 @@ describe('Pipeline: Decide Stage', () => {
     expect(dec.directives).toContainEqual(expect.stringContaining('CORRECT STREAK'));
   });
 
+  // ── Build-transfer nudge (representation variety toward the 3-context gate) ──
+  const ctxWithContexts = (contexts) => ({
+    activeSkill: { skillId: 'frac-add' },
+    user: {
+      skillMastery: new Map([
+        ['frac-add', { pillars: { transfer: { contextsAttempted: contexts, contextsRequired: 3 } } }],
+      ]),
+    },
+  });
+
+  test('correct + skill seen in only 1 representation → BUILD TRANSFER, names an unseen form', () => {
+    const obs = makeObs(MESSAGE_TYPES.ANSWER_ATTEMPT, { answer: { value: '7' } });
+    const dec = decide(obs, correctDiag, ctxWithContexts(['numeric']));
+    expect(dec.directives).toContainEqual(expect.stringContaining('BUILD TRANSFER'));
+    // 'numeric' is seen → it must steer toward a form NOT yet used.
+    expect(dec.directives).toContainEqual(expect.stringContaining('word problem'));
+  });
+
+  test('correct but transfer gate already met (3 contexts) → no BUILD TRANSFER', () => {
+    const obs = makeObs(MESSAGE_TYPES.ANSWER_ATTEMPT, { answer: { value: '7' } });
+    const dec = decide(obs, correctDiag, ctxWithContexts(['numeric', 'word-problem', 'graphical']));
+    expect(dec.directives).not.toContainEqual(expect.stringContaining('BUILD TRANSFER'));
+  });
+
+  test('INCORRECT answer never triggers BUILD TRANSFER (only shape a succeeding move)', () => {
+    const obs = makeObs(MESSAGE_TYPES.ANSWER_ATTEMPT, { answer: { value: '5' } });
+    const dec = decide(obs, incorrectDiag, ctxWithContexts(['numeric']));
+    expect(dec.directives).not.toContainEqual(expect.stringContaining('BUILD TRANSFER'));
+  });
+
+  test('correct with no focused-skill transfer data → no BUILD TRANSFER, no crash', () => {
+    const obs = makeObs(MESSAGE_TYPES.ANSWER_ATTEMPT, { answer: { value: '7' } });
+    const dec = decide(obs, correctDiag, {});
+    expect(dec.directives).not.toContainEqual(expect.stringContaining('BUILD TRANSFER'));
+  });
+
   test('single correct (no streak) → no CORRECT STREAK directive', () => {
     const obs = makeObs(MESSAGE_TYPES.ANSWER_ATTEMPT, {
       answer: { value: '7' },

--- a/utils/pipeline/decide.js
+++ b/utils/pipeline/decide.js
@@ -24,6 +24,7 @@ const {
 
 const { MESSAGE_TYPES, messageStatesProblem } = require('./observe');
 const { VERIFICATION_STATES } = require('./verificationState');
+const { getSkillMasteryEntry } = require('../masteryGuard');
 
 // ── Tutoring actions the engine can choose ──
 const ACTIONS = {
@@ -84,6 +85,53 @@ const INSTRUCTIONAL_MODES = {
  * @param {Object} context.modeTransition - From modeTransitionDetector (optional)
  * @returns {Object} Decision: { action, phase, phasePrompt, scaffoldLevel, diagnosis, directives }
  */
+// Student-facing names for the transfer "contexts" that detectProblemContext
+// tags (observe.js). Keyed by those exact tags so seen/unseen math is reliable.
+const REPRESENTATION_FORMS = {
+  'numeric': 'a bare computation',
+  'word-problem': 'a word problem / real-world scenario',
+  'graphical': 'a graph or coordinate representation',
+  'visual': 'a diagram or visual model',
+  'conceptual': 'a "why does this work?" explain-it prompt',
+};
+
+/**
+ * Build-transfer nudge for a SUCCEEDING student.
+ *
+ * Mastery requires the skill be demonstrated across ≥3 distinct representations
+ * (the transfer pillar). A student can nail one format indefinitely and never
+ * cross that gate — so once they're succeeding but have seen the skill in only
+ * 1–2 forms, the forward move is a NEW representation, not another rep of the
+ * same one. This returns a directive naming the forms already seen and pointing
+ * at an unseen one; null when there's no focused skill, no transfer data, or the
+ * gate is already met (leave a proven-transfer student alone).
+ *
+ * Distinct from the failure-driven representation switch (approachEffectiveness):
+ * that fires when an approach ISN'T working; this fires when it IS, to broaden.
+ */
+function buildTransferDirective(context) {
+  const skillId = context.activeSkill?.skillId || context.tutorPlan?.currentTarget?.skillId;
+  if (!skillId || !context.user) return null;
+
+  const entry = getSkillMasteryEntry(context.user, skillId);
+  const transfer = entry?.pillars?.transfer;
+  if (!transfer || !Array.isArray(transfer.contextsAttempted)) return null;
+
+  const required = transfer.contextsRequired || 3;
+  const seen = [...new Set(transfer.contextsAttempted)];
+  // Nudge only in the middle band: they've shown it in at least one form but
+  // haven't yet transferred across the required number.
+  if (seen.length < 1 || seen.length >= required) return null;
+
+  const unseen = Object.keys(REPRESENTATION_FORMS).filter((f) => !seen.includes(f));
+  const seenLabels = seen.map((f) => REPRESENTATION_FORMS[f] || f).join(', ');
+  const suggestion = unseen.length
+    ? REPRESENTATION_FORMS[unseen[0]]
+    : 'a representation they have not used yet';
+
+  return `BUILD TRANSFER: they've shown this skill in ${seen.length} of ${required} representations so far (${seenLabels}). To move them toward mastery, pose the NEXT problem in a form they HAVEN'T used for this skill — e.g. ${suggestion}. Same skill, new representation. Repeating the format they've already nailed will not prove transfer and cannot complete mastery.`;
+}
+
 function decide(observation, diagnosis, context = {}) {
   const decision = decideCore(observation, diagnosis, context);
 
@@ -381,6 +429,14 @@ function decideCore(observation, diagnosis, context) {
           );
         }
       }
+
+      // Shape the forward move toward TRANSFER: a succeeding student who has only
+      // seen the skill in 1–2 representations needs a new form next, not another
+      // rep of the same one — that variety is what completes mastery. Applies
+      // whether or not they showed reasoning (a clean reasoned solve is exactly
+      // who's ready to transfer).
+      const transferDirective = buildTransferDirective(context);
+      if (transferDirective) decision.directives.push(transferDirective);
 
       // Update phase state via evidence-based evaluator
       if (phaseState) {


### PR DESCRIPTION
Mastery needs a skill shown across ≥3 representations (the transfer pillar), but nothing steered the tutor to VARY representation on a succeeding student — so a student could nail one format forever and never cross the gate. The SWITCH_REPRESENTATION action existed but was never triggered, and the "vary contexts" language was gated on instructional mode, not on actual transfer state.

On a correct answer, read the focused skill's transfer pillar: if it's been shown in 1–2 of the required representations, push a BUILD TRANSFER directive that names the forms already seen and points at an unseen one (word problem, graph, visual model, explain-it, bare computation). Same skill, new form — which is what completes mastery. Silent once the gate is met (leave a proven-transfer student alone) and on incorrect answers (that's the failure-driven representation switch, a different path).

Composes with the write-side fixes on the graduation branch: those make contexts accrue from the posed problem; this makes the tutor create the variety worth accruing. 149 pipeline unit tests pass (4 new).