### PR TITLE
Fix cosmetics that changed nothing (board + calculator skins pointed at dead selectors)

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -86,7 +86,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <!-- Personal status card modal (Progress button) -->
   <link rel="stylesheet" href="/css/status-card.css" />
   <!-- Cosmetics: equipped skins + shop modal -->
-  <link rel="stylesheet" href="/dist/css/chat-css2.128b182f.css" />
+  <link rel="stylesheet" href="/dist/css/chat-css2.047b015f.css" />
   <!-- Coin surfacing: sidebar counter + fly-in reward animation -->
   <link rel="stylesheet" href="/css/coin-fx.css" />
   <!-- Full-body student character render -->

--- a/public/css/cosmetics.css
+++ b/public/css/cosmetics.css
@@ -220,46 +220,54 @@ body[data-skin-avatarframe="frame.rainbow"] .sc-avatar-img {
  * of the work itself is never touched.
  * ========================================================================= */
 
-/* ---- Board (data-skin-board) — applies to the whiteboard frame when present ---- */
-body[data-skin-board="board.grid"] .board-frame {
+/* ---- Board (data-skin-board) — skins the math workspace panel (#cr-workspace),
+ * the surface the tutor's board/graph/tiles live on. The panel background shows
+ * around and behind the work cards, never behind the math itself. ---- */
+body[data-skin-board="board.grid"] #cr-workspace {
+  background-color: #eef4ff;
   background-image:
-    linear-gradient(rgba(59, 130, 246, 0.18) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(59, 130, 246, 0.18) 1px, transparent 1px);
+    linear-gradient(rgba(59, 130, 246, 0.28) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(59, 130, 246, 0.28) 1px, transparent 1px);
   background-size: 22px 22px;
 }
-body[data-skin-board="board.chalk"] .board-frame {
+body[data-skin-board="board.chalk"] #cr-workspace {
   background-color: #24322b;
-  background-image: radial-gradient(rgba(255, 255, 255, 0.05) 1px, transparent 1px);
-  background-size: 6px 6px;
+  background-image: radial-gradient(rgba(255, 255, 255, 0.08) 1px, transparent 1px);
+  background-size: 7px 7px;
 }
-body[data-skin-board="board.cheetah"] .board-frame {
+body[data-skin-board="board.cheetah"] #cr-workspace {
   background-color: #f2c14e;
   background-image:
-    radial-gradient(circle at 20% 30%, #5b3a1a 8%, transparent 9%),
-    radial-gradient(circle at 60% 70%, #5b3a1a 7%, transparent 8%),
-    radial-gradient(circle at 80% 25%, #5b3a1a 6%, transparent 7%),
-    radial-gradient(circle at 35% 80%, #5b3a1a 7%, transparent 8%);
-  background-size: 60px 60px;
+    radial-gradient(circle at 20% 30%, #5b3a1a 9%, transparent 10%),
+    radial-gradient(circle at 62% 68%, #5b3a1a 8%, transparent 9%),
+    radial-gradient(circle at 82% 22%, #5b3a1a 7%, transparent 8%),
+    radial-gradient(circle at 35% 82%, #5b3a1a 8%, transparent 9%);
+  background-size: 64px 64px;
 }
 
-/* ---- Calculator (data-skin-calculator) — accents the floating calculator ---- */
+/* ---- Calculator (data-skin-calculator) — skins the floating calculator (shows
+ * when the student opens it). Real markup: #floating-calculator >
+ * .calculator-header-bar + .calculator-body. ---- */
 body[data-skin-calculator="calc.hotpink"] #floating-calculator {
   border: 2px solid #ff2e93 !important;
   box-shadow: 0 8px 30px rgba(255, 46, 147, 0.4) !important;
 }
-body[data-skin-calculator="calc.hotpink"] #floating-calculator .calc-header,
-body[data-skin-calculator="calc.hotpink"] #floating-calculator .floating-calc-header {
+body[data-skin-calculator="calc.hotpink"] #floating-calculator .calculator-header-bar {
   background: linear-gradient(135deg, #ff5db1, #ff2e93) !important;
   color: #fff !important;
 }
+body[data-skin-calculator="calc.hotpink"] #floating-calculator .calculator-body {
+  background: #fff0f7 !important;
+}
 body[data-skin-calculator="calc.carbon"] #floating-calculator {
   border: 2px solid #2b2f36 !important;
-  background-image: repeating-linear-gradient(45deg, #2b2f36 0 4px, #23262c 4px 8px) !important;
 }
-body[data-skin-calculator="calc.carbon"] #floating-calculator .calc-header,
-body[data-skin-calculator="calc.carbon"] #floating-calculator .floating-calc-header {
+body[data-skin-calculator="calc.carbon"] #floating-calculator .calculator-header-bar {
   background: #16181c !important;
   color: #e5e7eb !important;
+}
+body[data-skin-calculator="calc.carbon"] #floating-calculator .calculator-body {
+  background: repeating-linear-gradient(45deg, #23262c 0 5px, #1e2126 5px 10px) !important;
 }
 
 /* ---- Header (data-skin-header) — patterns the top bar strip ---- */

--- a/public/dist/chat-bundles.manifest.json
+++ b/public/dist/chat-bundles.manifest.json
@@ -36,7 +36,7 @@
       ]
     },
     {
-      "href": "/dist/css/chat-css2.128b182f.css",
+      "href": "/dist/css/chat-css2.047b015f.css",
       "files": [
         "/css/cosmetics.css",
         "/css/shop.css"

--- a/public/dist/css/chat-css2.047b015f.css
+++ b/public/dist/css/chat-css2.047b015f.css
@@ -221,46 +221,54 @@ body[data-skin-avatarframe="frame.rainbow"] .sc-avatar-img {
  * of the work itself is never touched.
  * ========================================================================= */
 
-/* ---- Board (data-skin-board) — applies to the whiteboard frame when present ---- */
-body[data-skin-board="board.grid"] .board-frame {
+/* ---- Board (data-skin-board) — skins the math workspace panel (#cr-workspace),
+ * the surface the tutor's board/graph/tiles live on. The panel background shows
+ * around and behind the work cards, never behind the math itself. ---- */
+body[data-skin-board="board.grid"] #cr-workspace {
+  background-color: #eef4ff;
   background-image:
-    linear-gradient(rgba(59, 130, 246, 0.18) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(59, 130, 246, 0.18) 1px, transparent 1px);
+    linear-gradient(rgba(59, 130, 246, 0.28) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(59, 130, 246, 0.28) 1px, transparent 1px);
   background-size: 22px 22px;
 }
-body[data-skin-board="board.chalk"] .board-frame {
+body[data-skin-board="board.chalk"] #cr-workspace {
   background-color: #24322b;
-  background-image: radial-gradient(rgba(255, 255, 255, 0.05) 1px, transparent 1px);
-  background-size: 6px 6px;
+  background-image: radial-gradient(rgba(255, 255, 255, 0.08) 1px, transparent 1px);
+  background-size: 7px 7px;
 }
-body[data-skin-board="board.cheetah"] .board-frame {
+body[data-skin-board="board.cheetah"] #cr-workspace {
   background-color: #f2c14e;
   background-image:
-    radial-gradient(circle at 20% 30%, #5b3a1a 8%, transparent 9%),
-    radial-gradient(circle at 60% 70%, #5b3a1a 7%, transparent 8%),
-    radial-gradient(circle at 80% 25%, #5b3a1a 6%, transparent 7%),
-    radial-gradient(circle at 35% 80%, #5b3a1a 7%, transparent 8%);
-  background-size: 60px 60px;
+    radial-gradient(circle at 20% 30%, #5b3a1a 9%, transparent 10%),
+    radial-gradient(circle at 62% 68%, #5b3a1a 8%, transparent 9%),
+    radial-gradient(circle at 82% 22%, #5b3a1a 7%, transparent 8%),
+    radial-gradient(circle at 35% 82%, #5b3a1a 8%, transparent 9%);
+  background-size: 64px 64px;
 }
 
-/* ---- Calculator (data-skin-calculator) — accents the floating calculator ---- */
+/* ---- Calculator (data-skin-calculator) — skins the floating calculator (shows
+ * when the student opens it). Real markup: #floating-calculator >
+ * .calculator-header-bar + .calculator-body. ---- */
 body[data-skin-calculator="calc.hotpink"] #floating-calculator {
   border: 2px solid #ff2e93 !important;
   box-shadow: 0 8px 30px rgba(255, 46, 147, 0.4) !important;
 }
-body[data-skin-calculator="calc.hotpink"] #floating-calculator .calc-header,
-body[data-skin-calculator="calc.hotpink"] #floating-calculator .floating-calc-header {
+body[data-skin-calculator="calc.hotpink"] #floating-calculator .calculator-header-bar {
   background: linear-gradient(135deg, #ff5db1, #ff2e93) !important;
   color: #fff !important;
 }
+body[data-skin-calculator="calc.hotpink"] #floating-calculator .calculator-body {
+  background: #fff0f7 !important;
+}
 body[data-skin-calculator="calc.carbon"] #floating-calculator {
   border: 2px solid #2b2f36 !important;
-  background-image: repeating-linear-gradient(45deg, #2b2f36 0 4px, #23262c 4px 8px) !important;
 }
-body[data-skin-calculator="calc.carbon"] #floating-calculator .calc-header,
-body[data-skin-calculator="calc.carbon"] #floating-calculator .floating-calc-header {
+body[data-skin-calculator="calc.carbon"] #floating-calculator .calculator-header-bar {
   background: #16181c !important;
   color: #e5e7eb !important;
+}
+body[data-skin-calculator="calc.carbon"] #floating-calculator .calculator-body {
+  background: repeating-linear-gradient(45deg, #23262c 0 5px, #1e2126 5px 10px) !important;
 }
 
 /* ---- Header (data-skin-header) — patterns the top bar strip ---- */


### PR DESCRIPTION
You were right — I audited every cosmetic against the actual chat DOM, and two whole slots were pointing at selectors that don't exist, so equipping them did **nothing**:

| Slot | Was targeting | Reality | Fix |
|------|--------------|---------|-----|
| **Board** (Blueprint Grid, Chalkboard, Cheetah) | `.board-frame` | Doesn't exist — the whiteboard is shelved | Retargeted to the math workspace panel `#cr-workspace`; the pattern now shows around/behind the work cards (never behind the math) |
| **Calculator** (Hot Pink, Carbon Fiber) | `.calc-header` / `.floating-calc-header` | Real markup is `#floating-calculator > .calculator-header-bar + .calculator-body` | Fixed the selectors and tinted the body too — clearly visible when the calculator is open |

### Verified as already-working (hit real, visible elements)
- **Themes** → framing (`--cr-bg-0`) + accent buttons + subtle `color-mix` wash on the chat window/bubbles
- **Chat bubbles** → the student's own `.message.user` bubbles
- **Avatar frames** → ring on `.message-container.user .message-avatar img` (+ status-card portrait) — shows for students who've picked a character
- **Header** (Camo, Wave) → `.landing-header` (cosmetics loads after chat-redesign, same specificity → wins)

Rebuilt the `chat-css2` bundle; reverted the incidental drift the rebuild picked up in other bundles so the diff is just my CSS.

### Worth a look
The **calculator** skins only show while the floating calculator is open (by nature). If you'd rather the two calc skins be retired than be "open-only," say the word. And if the **themes** still feel too subtle, I can push the framing color / wash a notch stronger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9zNo7LtFvgW4DMxH8HiEi)_