### PR TITLE
fix(courses): refuse the tutor greeting server-side until the baselin…

### DIFF
--- a/public/js/courseCatalog.js
+++ b/public/js/courseCatalog.js
@@ -1008,6 +1008,16 @@ class CourseManager {
 
             const data = await res.json();
 
+            // The server withheld the greeting because a required baseline is not
+            // done. Show the baseline card and teach nothing — the server is the
+            // source of truth here, so even if the client gate was bypassed (or
+            // its bundle failed to load), no greeting is rendered or persisted.
+            if (data.baselineRequired) {
+                this._baselinePending = true;
+                if (data.diagnostic) this.showDiagnosticCard(data.diagnostic);
+                return;
+            }
+
             // If the current module is a checkpoint, open the card-based UI instead of chat
             if (data.isCheckpoint && window.floatingCheckpoint) {
                 window.floatingCheckpoint.open({ title: data.checkpointTitle });

--- a/routes/courseChat.js
+++ b/routes/courseChat.js
@@ -17,6 +17,7 @@ const TUTOR_CONFIG = require('../utils/tutorConfig');
 const BRAND_CONFIG = require('../utils/brand');
 const { detectAndFetchResource, detectResourceMention } = require('../utils/resourceDetector');
 const { buildProgressUpdate } = require('../utils/progressState');
+const { isRequiredBaselinePending } = require('../utils/courseDiagnostic');
 const { runPipeline, verify: pipelineVerify } = require('../utils/pipeline');
 const { buildCoursePipelineContext, postProcessCourseResult } = require('../utils/pipeline/courseAdapter');
 const { FREE_WEEKLY_SECONDS } = require('../middleware/usageGate');
@@ -371,6 +372,38 @@ async function handleCourseGreeting(req, res, userId) {
         const courseSession = await CourseSession.findById(user.activeCourseSessionId);
         if (!courseSession || courseSession.status !== 'active') {
             return res.status(400).json({ message: 'Course session not found or inactive.' });
+        }
+
+        // ── BASELINE GATE ───────────────────────────────────────────────────
+        // The tutor must not start teaching until a REQUIRED baseline (the full
+        // ACT practice test, a course pre-assessment) is done — the baseline is
+        // what adapts the plan to the student. This is enforced here, on the
+        // server, because the client-side gate cannot be trusted: production has
+        // shipped a chat bundle that 404s, and a stale tab or a second client
+        // path would otherwise leak a premature "let's learn what a real number
+        // is" and PERSIST it into the conversation. Refusing here means no
+        // premature greeting is ever generated or saved, whatever the client does.
+        try {
+            const { pending, diagnostic } = await isRequiredBaselinePending(user, courseSession.courseId);
+            if (pending) {
+                console.log(`📚 [CourseGreeting] ${user.firstName} → baseline pending for ${courseSession.courseId}, withholding greeting`);
+                return res.json({
+                    baselineRequired: true,
+                    diagnostic,
+                    isGreeting: true,
+                    courseContext: {
+                        courseId: courseSession.courseId,
+                        courseName: courseSession.courseName,
+                        currentModuleId: courseSession.currentModuleId,
+                        overallProgress: courseSession.overallProgress
+                    }
+                });
+            }
+        } catch (gateErr) {
+            // A gate failure must not brick the course. Log and fall through to
+            // the normal greeting rather than leaving the student staring at a
+            // silent tutor.
+            console.error('[CourseGreeting] baseline gate failed (non-fatal):', gateErr.message);
         }
 
         // Load pathway + module

--- a/routes/courseSession.js
+++ b/routes/courseSession.js
@@ -22,96 +22,16 @@ const { getSkillMasteryEntry, setSkillMasteryEntry, decodedMasteryMap } = requir
 const { buildGraph, applyProofCascade } = require('../utils/skillClosure');
 const { buildProgressUpdate } = require('../utils/progressState');
 
-// Day-one diagnostic prompt shown as a card on course entry, so the tutor can
-// target the course to the student's real level. Per course:
-//   - ACT prep → a full practice ACT (window.openActTest), gated on having taken one.
-//   - Algebra / Calculus / Precalc → the adaptive Starting Point placement
-//     (window.openStartingPoint), gated on user.assessmentCompleted.
-// Persists until the student completes it. Returns a welcomeData.diagnostic
-// descriptor, or null. Extend by adding a course entry below.
-const STARTING_POINT_CARD = {
-  type: 'starting-point',
-  title: 'Find your Starting Point',
-  body: 'Take a short adaptive placement first — no studying needed. Your tutor uses it to '
-    + 'start you at exactly the right level and focus each session on what you actually need.',
-  cta: 'Take the Starting Point',
-};
-// Every course opens with a pre-assessment. A course is prep and readiness, not
-// the whole curriculum, so the first thing it should do is establish what the
-// student already owns — then clear those skills and aim the course at what is
-// left. Courses with a purpose-built diagnostic keep it; everything else gets the
-// course pre-assessment, which tests that course's OWN skills rather than a
-// generic placement.
-const PRE_ASSESSMENT_CARD = {
-  type: 'course-preassessment',
-  title: 'Start with a quick check',
-  body: 'Answer a few questions first so this course can skip what you already know '
-    + 'and spend its time on what you actually need. Anything you get right is marked '
-    + 'as yours — you will not be taught it again.',
-  cta: 'Start the check',
-};
-const COURSE_DIAGNOSTICS = {
-  'act-prep': {
-    type: 'act-practice',
-    title: 'Start with a full Practice ACT',
-    body: 'Take a timed practice ACT Math test first — this is your baseline. Your tutor uses '
-      + 'the results to pinpoint exactly which skills to focus your bootcamp on, and anything '
-      + 'you already ace is marked as yours so the bootcamp skips it.',
-    cta: 'Take the Practice ACT',
-    // ACT prep BEGINS with a full timed baseline. Unlike a short warm-up check,
-    // the point is the real thing under real conditions: the scaled score is the
-    // number the student is trying to move, so a partial substitute would give
-    // them nothing to measure against.
-    required: true,
-  },
-  'algebra-1': STARTING_POINT_CARD,
-  'algebra-2': STARTING_POINT_CARD,
-  'ap-calculus-ab': STARTING_POINT_CARD,
-  'calculus-bc': STARTING_POINT_CARD,
-  'precalculus': STARTING_POINT_CARD,
-};
-
-async function buildCourseDiagnostic(user, courseId) {
-  // Default rather than an allowlist — a course with no entry used to open with
-  // no diagnostic at all, which is how a student ends up being taught a module
-  // they could already pass.
-  const card = COURSE_DIAGNOSTICS[courseId] || PRE_ASSESSMENT_CARD;
-  if (!card || !user) return null;
-  if (card.type === 'course-preassessment') {
-    // Only once per course: a completed session's pre-assessment stands.
-    try {
-      const done = await CourseSession.countDocuments({
-        userId: user._id, courseId, preAssessmentCompletedAt: { $ne: null }
-      });
-      if (done > 0) return null;
-    } catch (err) {
-      console.error('[CourseSession] pre-assessment check failed (non-fatal):', err.message);
-      return null;
-    }
-    return {
-      type: card.type, title: card.title, body: card.body, cta: card.cta,
-      courseId, required: true
-    };
-  }
-  try {
-    if (card.type === 'act-practice') {
-      const taken = await ActTestSession.countDocuments({ userId: user._id, status: 'completed' });
-      if (taken > 0) return null;                 // already took a practice ACT
-    } else if (card.type === 'starting-point') {
-      const expired = user.assessmentExpiresAt && new Date(user.assessmentExpiresAt) < new Date();
-      if (user.assessmentCompleted && !expired) return null; // already placed (and current)
-    }
-  } catch (err) {
-    console.error('[CourseSession] diagnostic check failed (non-fatal):', err.message);
-    return null;
-  }
-  // `required` tells the UI to gate course entry rather than render a dismissible
-  // nudge. A baseline the student can click past is not a baseline.
-  return {
-    type: card.type, title: card.title, body: card.body, cta: card.cta,
-    required: !!card.required
-  };
-}
+// The diagnostic-card definitions and the "is a baseline pending" logic moved to
+// utils/courseDiagnostic.js so the SERVER greeting path can share the exact same
+// rule (see that file). Re-exported names below keep the rest of this route
+// unchanged.
+const {
+  STARTING_POINT_CARD,
+  PRE_ASSESSMENT_CARD,
+  COURSE_DIAGNOSTICS,
+  buildCourseDiagnostic,
+} = require('../utils/courseDiagnostic');
 
 /* ============================================================
    GET /api/course-sessions/catalog

--- a/tests/integration/courseGreetingBaselineGate.test.js
+++ b/tests/integration/courseGreetingBaselineGate.test.js
@@ -1,0 +1,124 @@
+/**
+ * The SERVER-SIDE baseline gate on the course greeting, against a real database.
+ *
+ * The client gate (hold the tutor greeting until the baseline is done) is not
+ * enough on its own — production shipped a chat bundle that 404s, so the gating
+ * code may never load, and a stale tab is a second uncontrolled client. The
+ * server must refuse to generate a greeting while a required baseline is pending,
+ * so no premature "let's learn what a real number is" is ever produced OR
+ * persisted, whatever the client does.
+ *
+ * These drive the real /api/course-chat greeting handler. The LLM is not reached
+ * on the withheld path (that is the whole point); on the allowed path we stub the
+ * gateway so no live model is called.
+ */
+
+jest.mock('../../utils/llmGateway', () => ({
+  callLLM: jest.fn().mockResolvedValue({ choices: [{ message: { content: 'Welcome to the course!' } }] })
+}));
+
+const express = require('express');
+const supertest = require('supertest');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const User = require('../../models/user');
+const CourseSession = require('../../models/courseSession');
+const ActTestSession = require('../../models/actTestSession');
+const Conversation = require('../../models/conversation');
+
+let mem;
+let app;
+let currentUserId;
+
+beforeAll(async () => {
+  mem = await MongoMemoryServer.create();
+  await mongoose.connect(mem.getUri());
+
+  const router = require('../../routes/courseChat');
+  app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => { req.user = { _id: currentUserId }; req.isAuthenticated = () => true; next(); });
+  app.use('/api/course-chat', router);
+}, 60000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  if (mem) await mem.stop();
+});
+
+afterEach(async () => {
+  await User.deleteMany({});
+  await CourseSession.deleteMany({});
+  await ActTestSession.deleteMany({});
+  await Conversation.deleteMany({});
+});
+
+const enrollActPrep = async () => {
+  const u = await User.create({ username: `g${Date.now()}`, email: `g${Date.now()}@e.com`, firstName: 'G', lastName: 'H' });
+  currentUserId = u._id;
+  const s = await CourseSession.create({
+    userId: u._id, courseId: 'act-prep', status: 'active',
+    pathwayId: 'act-prep-pathway', courseName: 'ACT Math Prep',
+    currentModuleId: 'unit1'
+  });
+  await User.findByIdAndUpdate(u._id, { activeCourseSessionId: s._id });
+  return u;
+};
+
+const greet = () => supertest(app).post('/api/course-chat').send({ isGreeting: true });
+
+describe('ACT prep with no baseline taken', () => {
+  test('the greeting is withheld and the baseline card is returned instead', async () => {
+    await enrollActPrep();
+    const res = await greet();
+
+    expect(res.status).toBe(200);
+    expect(res.body.baselineRequired).toBe(true);
+    expect(res.body.diagnostic).toMatchObject({ type: 'act-practice', required: true });
+    // No teaching text — the tutor said nothing about real numbers.
+    expect(res.body.text).toBeUndefined();
+  });
+
+  test('no greeting is persisted into the conversation while the baseline is pending', async () => {
+    const u = await enrollActPrep();
+    await greet();
+
+    const session = await CourseSession.findOne({ userId: u._id });
+    if (session.conversationId) {
+      const convo = await Conversation.findById(session.conversationId);
+      const assistantMsgs = (convo?.messages || []).filter((m) => m.role === 'assistant');
+      expect(assistantMsgs).toHaveLength(0);
+    }
+    // Either no conversation was created, or it holds no assistant greeting.
+  });
+});
+
+describe('the gate decision (the exact check the route runs)', () => {
+  // The route's "allowed" branch continues into the full greeting pipeline, which
+  // is out of scope here — this feature IS the withhold decision. Test that
+  // decision directly against the real DB for both states, so the gate is proven
+  // without dragging in the LLM greeting generator.
+  const { isRequiredBaselinePending } = require('../../utils/courseDiagnostic');
+
+  test('pending while no practice ACT is completed', async () => {
+    const u = await enrollActPrep();
+    const { pending, diagnostic } = await isRequiredBaselinePending(u, 'act-prep');
+    expect(pending).toBe(true);
+    expect(diagnostic).toMatchObject({ type: 'act-practice', required: true });
+  });
+
+  test('not pending once a practice ACT is completed', async () => {
+    const u = await enrollActPrep();
+    await ActTestSession.create({ userId: u._id, status: 'completed' });
+    const { pending } = await isRequiredBaselinePending(u, 'act-prep');
+    expect(pending).toBe(false);
+  });
+
+  test('an in-progress (not completed) ACT still counts as pending', async () => {
+    const u = await enrollActPrep();
+    await ActTestSession.create({ userId: u._id, status: 'in_progress' });
+    const { pending } = await isRequiredBaselinePending(u, 'act-prep');
+    expect(pending).toBe(true);
+  });
+});

--- a/utils/courseDiagnostic.js
+++ b/utils/courseDiagnostic.js
@@ -1,0 +1,113 @@
+/**
+ * COURSE DIAGNOSTIC — the one definition of "what baseline does this course open
+ * with, and has the student done it yet?"
+ *
+ * Extracted from routes/courseSession.js so the SERVER greeting path
+ * (routes/courseChat.js) can consult the same rule. The frontend gate (hold the
+ * tutor greeting until a required baseline is done) is only as good as the
+ * frontend loading correctly — and production has shown a chat bundle 404 and
+ * stale builds. So the greeting must be refused server-side too, where no missing
+ * script or second tab can leak a premature "let's learn about real numbers".
+ *
+ * ONE definition, shared: the diagnostic-card endpoints and the greeting gate
+ * must never disagree about whether a baseline is pending — that drift is the
+ * exact bug class this codebase keeps hitting.
+ */
+
+const CourseSession = require('../models/courseSession');
+const ActTestSession = require('../models/actTestSession');
+
+const STARTING_POINT_CARD = {
+  type: 'starting-point',
+  title: 'Find your Starting Point',
+  body: 'Take a short adaptive placement first — no studying needed. Your tutor uses it to '
+    + 'start you at exactly the right level and focus each session on what you actually need.',
+  cta: 'Take the Starting Point',
+};
+
+const PRE_ASSESSMENT_CARD = {
+  type: 'course-preassessment',
+  title: 'Start with a quick check',
+  body: 'Answer a few questions first so this course can skip what you already know '
+    + 'and spend its time on what you actually need. Anything you get right is marked '
+    + 'as yours — you will not be taught it again.',
+  cta: 'Start the check',
+};
+
+const COURSE_DIAGNOSTICS = {
+  'act-prep': {
+    type: 'act-practice',
+    title: 'Start with a full Practice ACT',
+    body: 'Take a timed practice ACT Math test first — this is your baseline. Your tutor uses '
+      + 'the results to pinpoint exactly which skills to focus your bootcamp on, and anything '
+      + 'you already ace is marked as yours so the bootcamp skips it.',
+    cta: 'Take the Practice ACT',
+    // ACT prep BEGINS with a full timed baseline. The scaled score is the number
+    // the student is trying to move, so a partial substitute gives them nothing
+    // to measure against.
+    required: true,
+  },
+  'algebra-1': STARTING_POINT_CARD,
+  'algebra-2': STARTING_POINT_CARD,
+  'ap-calculus-ab': STARTING_POINT_CARD,
+  'calculus-bc': STARTING_POINT_CARD,
+  'precalculus': STARTING_POINT_CARD,
+};
+
+/**
+ * The diagnostic card a course should show on entry, or null if the student has
+ * already satisfied it. Default (not an allowlist): a course with no explicit
+ * entry gets the course pre-assessment, so no course opens with no diagnostic.
+ */
+async function buildCourseDiagnostic(user, courseId) {
+  const card = COURSE_DIAGNOSTICS[courseId] || PRE_ASSESSMENT_CARD;
+  if (!card || !user) return null;
+
+  if (card.type === 'course-preassessment') {
+    try {
+      const done = await CourseSession.countDocuments({
+        userId: user._id, courseId, preAssessmentCompletedAt: { $ne: null }
+      });
+      if (done > 0) return null;
+    } catch (err) {
+      console.error('[courseDiagnostic] pre-assessment check failed (non-fatal):', err.message);
+      return null;
+    }
+    return { type: card.type, title: card.title, body: card.body, cta: card.cta, courseId, required: true };
+  }
+
+  try {
+    if (card.type === 'act-practice') {
+      const taken = await ActTestSession.countDocuments({ userId: user._id, status: 'completed' });
+      if (taken > 0) return null;                 // already took a practice ACT
+    } else if (card.type === 'starting-point') {
+      const expired = user.assessmentExpiresAt && new Date(user.assessmentExpiresAt) < new Date();
+      if (user.assessmentCompleted && !expired) return null; // already placed (and current)
+    }
+  } catch (err) {
+    console.error('[courseDiagnostic] diagnostic check failed (non-fatal):', err.message);
+    return null;
+  }
+
+  return {
+    type: card.type, title: card.title, body: card.body, cta: card.cta,
+    required: !!card.required
+  };
+}
+
+/**
+ * Is a REQUIRED baseline still pending for this course? The server greeting path
+ * uses this to refuse teaching until the baseline is done.
+ */
+async function isRequiredBaselinePending(user, courseId) {
+  const diagnostic = await buildCourseDiagnostic(user, courseId);
+  return { pending: !!(diagnostic && diagnostic.required), diagnostic };
+}
+
+module.exports = {
+  STARTING_POINT_CARD,
+  PRE_ASSESSMENT_CARD,
+  COURSE_DIAGNOSTICS,
+  buildCourseDiagnostic,
+  isRequiredBaselinePending,
+};


### PR DESCRIPTION
…e is done

The client gate (previous commit) was necessary but not sufficient. A fresh ACT enrollee who had NOT taken the practice test still got the tutor opening on "what is a real number" — because the gate can be defeated:

  - Production shipped a chat bundle that 404s ("Refused to execute script ... MIME type text/html"), so the gating code may never load.
  - A stale tab, a second client, or the load-into-active-course path are all uncontrolled entry points the client gate does not cover.
  - Worst, once a premature greeting is generated it is PERSISTED into the conversation and replays on every load forever.

So the gate now lives where it cannot be bypassed: handleCourseGreeting refuses to generate a greeting while a REQUIRED baseline is pending, and returns the diagnostic card instead. No premature greeting is ever produced or saved, whatever the client does. The client learns to show the card on a { baselineRequired: true } response.

ONE definition of "is a baseline pending". buildCourseDiagnostic and its card definitions moved from routes/courseSession.js to utils/courseDiagnostic.js so the greeting path shares the EXACT rule the diagnostic-card endpoints use — adding isRequiredBaselinePending(user, courseId). The diagnostic-card endpoints and the greeting gate must never disagree about whether the baseline is done; that drift is the bug class this codebase keeps hitting.

The gate is wrapped non-fatally: a check failure logs and falls through to the normal greeting rather than leaving the student facing a silent tutor.

5 tests against a real mongod: the ACT greeting is withheld and returns the card with no teaching text and nothing persisted; and isRequiredBaselinePending is correct for no-test (pending), completed-test (not pending), and in-progress-test (still pending).

Unit suite 4229 pass (263 suites); the new integration suite passes (5/5).

Note: the deployed chat-js4 bundle 404 is a separate build/deploy-integrity problem — chat.html references a bundle hash not present on the server. Flagged for the owner; not fixable from application code.