### PR TITLE
fix(deploy): rebuild chat bundles at build time so they can't drift f…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,20 @@ RUN npm ci --omit=dev
 # 7. Copy the rest of your application code
 COPY . .
 
+# 7b. Regenerate the chat JS/CSS bundles FROM THE SOURCE THAT IS DEPLOYING.
+#     public/dist/js/chat-js*.js are pre-built bundles committed to the repo, but
+#     the deploy runs no build step — so every edit to a bundled source file
+#     (e.g. inlineChatVisuals.js, courseCatalog.js) drifted the committed bundle
+#     from chat.html and from the source. That shipped two silent failures:
+#       - chat.html referenced a bundle hash whose file was never recommitted
+#         after the edit  ->  chat-js4 404'd, killing that whole chunk.
+#       - a bundle whose source changed but hash didn't  ->  stale behaviour
+#         (a merged courseCatalog.js fix that never actually ran).
+#     Rebuilding here regenerates each bundle from public/js and rewrites
+#     chat.html to the matching hashes, so the deployed artifacts can never drift
+#     from the source in the same image. node builtins only — no dev deps needed.
+RUN node scripts/buildChatBundles.js
+
 # 8. Create non-root user and set ownership
 RUN groupadd --system appgroup && useradd --system --gid appgroup appuser \
     && chown -R appuser:appgroup /usr/src/app

--- a/public/chat.html
+++ b/public/chat.html
@@ -74,7 +74,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     if (window.MM_FEATURES.boardPanel === true) window.loadBoardTools();
   </script>
   <link rel="stylesheet" href="/style.css" />
-  <link rel="stylesheet" href="/dist/css/chat-css0.2422dcfc.css" />
+  <link rel="stylesheet" href="/dist/css/chat-css0.9b2fba38.css" />
 <!-- returning-user-modal removed — returning users now get an AI welcome directly -->
   <link rel="stylesheet" href="/dist/css/chat-css1.dae1c280.css" />
 <!-- Design tokens (single source of truth) — must precede chat-redesign.css -->
@@ -2403,14 +2403,14 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <script defer src="/js/adjustable-panels.js?v=20260721"></script>
   <!-- Drive the "Live with <tutor>" pill bars from real TTS playback -->
   <script type="module" src="/js/chat-voice-meter.js"></script>
-  <script src="/dist/js/chat-js2.dacbff7b.js"></script>
+  <script src="/dist/js/chat-js2.a7b2685b.js"></script>
 <!-- Voice as a layout mode of the chat stage -->
   <script src="/js/voice-mode.js?v=3"></script>
   <!-- Voice-mode captions: karaoke subtitles + student STT echo + replay/history -->
   <script defer src="/js/voice-subtitles.js?v=20260718b"></script>
   <!-- Whiteboard stack lazy-loaded via loadBoardTools() (see boardPanel block
        below) — only needed when the visual board is enabled (boardPanel:true). -->
-  <script src="/dist/js/chat-js3.babd546b.js"></script>
+  <script src="/dist/js/chat-js3.895af699.js"></script>
 <!-- returningUserModal.js removed — no longer used -->
   <script src="/dist/js/chat-js4.301bba99.js"></script>
 <link rel="stylesheet" href="/css/algebra-tiles.css">
@@ -2471,7 +2471,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       updateUI();
     })();
   </script>
-  <script src="/dist/js/chat-js8.2b53a001.js"></script>
+  <script src="/dist/js/chat-js8.105c8817.js"></script>
 <!-- Player stats card: window-global, loaded before script.js which calls
      window.PlayerStatsCard.init(currentUser) once the user doc is fetched. -->
 <script defer src="/js/modules/playerStatsCard.js?v=20260723c"></script>

--- a/public/dist/chat-bundles.manifest.json
+++ b/public/dist/chat-bundles.manifest.json
@@ -1,7 +1,7 @@
 {
   "css": [
     {
-      "href": "/dist/css/chat-css0.2422dcfc.css",
+      "href": "/dist/css/chat-css0.9b2fba38.css",
       "files": [
         "/css/file-upload.css",
         "/css/calculator.css",
@@ -62,14 +62,14 @@
       ]
     },
     {
-      "src": "/dist/js/chat-js2.dacbff7b.js",
+      "src": "/dist/js/chat-js2.a7b2685b.js",
       "files": [
         "/js/voice-stream-client.js?v=3",
         "/js/voice-controller.js"
       ]
     },
     {
-      "src": "/dist/js/chat-js3.babd546b.js",
+      "src": "/dist/js/chat-js3.895af699.js",
       "files": [
         "/js/chat-board-integration.js",
         "/js/floating-screener.js",
@@ -80,7 +80,7 @@
       ]
     },
     {
-      "src": "/dist/js/chat-js4.c195e962.js",
+      "src": "/dist/js/chat-js4.301bba99.js",
       "files": [
         "/js/diagram-display.js",
         "/js/inlineChatVisuals.js"
@@ -119,7 +119,7 @@
       ]
     },
     {
-      "src": "/dist/js/chat-js8.2b53a001.js",
+      "src": "/dist/js/chat-js8.105c8817.js",
       "files": [
         "/js/student-resources.js",
         "/js/settings.js",

--- a/public/dist/css/chat-css0.9b2fba38.css
+++ b/public/dist/css/chat-css0.9b2fba38.css
@@ -8289,50 +8289,6 @@ html.theme-transitioning *::after {
 }
 
 /* ============================================================================
-   HINT BUTTON — XP-gated hint request
-   ============================================================================ */
-.hint-button-row {
-  margin-top: 8px;
-  display: flex;
-  justify-content: flex-start;
-}
-
-.hint-button {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 14px;
-  font-size: 0.82rem;
-  font-weight: 500;
-  color: #5B21B6;
-  background: #EDE9FE;
-  border: 1px solid #C4B5FD;
-  border-radius: 20px;
-  cursor: pointer;
-  transition: background 0.15s, transform 0.1s;
-}
-
-.hint-button:hover:not(:disabled) {
-  background: #DDD6FE;
-  transform: translateY(-1px);
-}
-
-.hint-button:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-[data-theme="dark"] .hint-button {
-  color: #C4B5FD;
-  background: #2E1065;
-  border-color: #5B21B6;
-}
-
-[data-theme="dark"] .hint-button:hover:not(:disabled) {
-  background: #3B0764;
-}
-
-/* ============================================================================
    PAPER PRACTICE SUGGESTION — "Practice on paper?" prompt in chat
    ============================================================================ */
 .paper-practice-suggestion {

--- a/public/dist/js/chat-js2.a7b2685b.js
+++ b/public/dist/js/chat-js2.a7b2685b.js
@@ -171,6 +171,17 @@
                 this.audioCtx = new (window.AudioContext || window.webkitAudioContext)({
                     latencyHint: 'interactive',
                 });
+                // Unlock IMMEDIATELY, before the async worklet fetch below. iOS
+                // Safari only honors resume() inside the user gesture that
+                // reached here (the orb tap / voice-mode entry). The worklet
+                // addModule() is a network load that ends the gesture window, so
+                // resuming AFTER it leaves the context suspended — AI audio then
+                // stays silent until the student taps again, which reads as
+                // "tap to advance". Kick resume() off synchronously now; the
+                // statechange handler and _playPcmS16 cover any later re-suspend.
+                if (this.audioCtx.state === 'suspended') {
+                    this.audioCtx.resume().catch(() => { /* gesture lost — retried on next tap */ });
+                }
                 this.outGain = this.audioCtx.createGain();
                 this.outGain.gain.value = 1.0;
                 // outGain → analyser → destination, mirroring modules/audio.js,
@@ -743,7 +754,7 @@ class VoiceController {
                 console.warn('[Voice] stream disconnected — falling back to legacy path');
                 this.useStreamingPipeline = false;
                 this.streamClient = null;
-                this.updateUI('idle');
+                this._resumeOnLegacyAfterFallback();
                 break;
 
             case 'error':
@@ -758,10 +769,32 @@ class VoiceController {
                         try { this.streamClient.disconnect(); } catch (_) {}
                         this.streamClient = null;
                     }
-                    if (this.isListening || this.isAISpeaking) this.updateUI('idle');
+                    this._resumeOnLegacyAfterFallback();
                 }
                 break;
         }
+    }
+
+    // Streaming just died (e.g. Deepgram 429 rate-limit, or a worklet load
+    // failure). If the student was mid-session — actively listening, or in the
+    // full voice-mode call — seamlessly re-open the mic on the LEGACY path
+    // instead of dropping to "Click to start voice" and making them tap to
+    // continue. Legacy STT is a different provider (Whisper), so it keeps
+    // working while Deepgram is rate-limited. If they weren't engaged (or the
+    // tutor is mid-utterance), just settle to idle. No loop risk: the legacy
+    // path never emits these stream events, and a legacy failure lands on idle.
+    _resumeOnLegacyAfterFallback() {
+        const inVoiceMode = typeof document !== 'undefined' &&
+            document.body && document.body.classList.contains('cr-voice');
+        const wasEngaged = this.isListening || inVoiceMode;
+        this.isListening = false; // clear the dead streaming session's flag
+        if (this.isAISpeaking || !wasEngaged) {
+            this.updateUI('idle');
+            return;
+        }
+        Promise.resolve()
+            .then(() => this.startListening())   // useStreamingPipeline is now false → legacy
+            .catch(() => this.updateUI('idle'));
     }
 
     /**

--- a/public/dist/js/chat-js3.895af699.js
+++ b/public/dist/js/chat-js3.895af699.js
@@ -3183,6 +3183,12 @@ class CourseManager {
             if (window.lessonTracker) {
                 window.lessonTracker.rehydrate(match._id);
             }
+
+            // Day-one diagnostic (e.g. ACT-prep practice test): when a student
+            // loads straight into an already-active course, neither the enroll
+            // splash nor an explicit activate fires — so surface the card here
+            // too. Server gates it (returns null once they've taken it).
+            this.maybeShowActiveDiagnostic(match._id);
         } else {
             wrapper.style.display = 'none';
             this.activeCourseSessionId = null;
@@ -3822,8 +3828,13 @@ class CourseManager {
                 this.showToast(`Enrolled in ${data.session.courseName}! Let's get started.`);
             }
 
-            // Fire course greeting — AI introduces the first module
-            this.sendCourseGreeting();
+            // Begin teaching — UNLESS a required baseline (ACT practice test,
+            // course pre-assessment) is pending. A course is prep and readiness,
+            // so it must find out what the student already knows BEFORE it starts
+            // teaching; otherwise it opens every student at module 1 ("what is a
+            // real number") and the baseline never adapts the plan. The greeting
+            // fires from onBaselineComplete() once the test is done.
+            this.beginTeachingUnlessBaselinePending(data.welcomeData && data.welcomeData.diagnostic);
 
         } catch (err) {
             console.error('[CourseManager] Enrollment error:', err);
@@ -3865,12 +3876,46 @@ class CourseManager {
             // Switch sidebar to course context (hides sessions, leaderboard, quests)
             if (window.sidebar) window.sidebar.setContext('course');
 
-            // Fire silent course greeting — AI introduces the course/module
-            this.sendCourseGreeting();
+            // Day-one diagnostic nudge for returning students (e.g. ACT-prep student
+            // who never took the practice test) — shown as a standalone card.
+            if (data.diagnostic) this.showDiagnosticCard(data.diagnostic);
+
+            // Same gate as enroll: no teaching until a required baseline is done.
+            this.beginTeachingUnlessBaselinePending(data.diagnostic);
 
         } catch (err) {
             console.error('[CourseManager] Failed to activate course:', err);
         }
+    }
+
+    // --------------------------------------------------
+    // --------------------------------------------------
+    // Begin teaching, unless a required baseline is still pending.
+    //
+    // The tutor greeting introduces module 1 and starts teaching. It must NOT
+    // fire while a `required` diagnostic (ACT practice test, course
+    // pre-assessment) is unanswered — the whole point of the baseline is to run
+    // FIRST and adapt the plan. When one is pending we stay quiet and let the
+    // diagnostic card lead; onBaselineComplete() fires the greeting afterward,
+    // by which time the course has been retargeted to the student's real level.
+    // --------------------------------------------------
+    beginTeachingUnlessBaselinePending(diagnostic) {
+        if (diagnostic && diagnostic.required) {
+            this._baselinePending = true;
+            return;
+        }
+        this._baselinePending = false;
+        this.sendCourseGreeting();
+    }
+
+    // Called by the ACT test and the pre-assessment when their baseline finishes.
+    // Fires the greeting that beginTeachingUnlessBaselinePending() held back, now
+    // that the course knows the student's level. Guarded so a stray call (e.g. a
+    // cancelled test) or a course that never gated cannot double-greet.
+    onBaselineComplete() {
+        if (!this._baselinePending) return;
+        this._baselinePending = false;
+        this.sendCourseGreeting();
     }
 
     // --------------------------------------------------
@@ -3894,6 +3939,16 @@ class CourseManager {
             if (window.showThinkingIndicator) window.showThinkingIndicator(false);
 
             const data = await res.json();
+
+            // The server withheld the greeting because a required baseline is not
+            // done. Show the baseline card and teach nothing — the server is the
+            // source of truth here, so even if the client gate was bypassed (or
+            // its bundle failed to load), no greeting is rendered or persisted.
+            if (data.baselineRequired) {
+                this._baselinePending = true;
+                if (data.diagnostic) this.showDiagnosticCard(data.diagnostic);
+                return;
+            }
 
             // If the current module is a checkpoint, open the card-based UI instead of chat
             if (data.isCheckpoint && window.floatingCheckpoint) {
@@ -4024,6 +4079,77 @@ class CourseManager {
     }
 
     // --------------------------------------------------
+    // Day-one diagnostic card (e.g. ACT prep → "Take the Practice ACT"). The CTA
+    // launches the practice test; the button removes whichever card container it
+    // lives in (the welcome splash when embedded, or its own card when standalone).
+    // --------------------------------------------------
+    diagnosticCardHtml(diag) {
+        if (!diag || !diag.type) return '';
+        // type → the client launcher invoked by the CTA. Starting Point mirrors
+        // the existing inline-CTA path (floatingScreener, falling back to
+        // window.openStartingPoint). Unknown types render nothing.
+        const sessionId = this.activeCourseSessionId || '';
+        const launchers = {
+            'act-practice': 'if (window.openActTest) { window.openActTest(); }',
+            'starting-point': "if (window.floatingScreener) { Promise.resolve(window.floatingScreener.checkAssessmentStatus()).then(function(){ window.floatingScreener.open(); }).catch(function(){}); } else if (window.openStartingPoint) { window.openStartingPoint(); }",
+            'course-preassessment': `if (window.openCoursePreAssessment) { window.openCoursePreAssessment('${sessionId}', { required: ${!!diag.required} }); }`,
+        };
+        const launch = launchers[diag.type];
+        if (!launch) return '';
+        // A REQUIRED diagnostic (the ACT baseline, a course pre-assessment) must
+        // not remove its own card on click. If the student closes the test
+        // without finishing, the card has to still be there — otherwise "required"
+        // means "required until you click it once".
+        const dismiss = diag.required
+            ? ''
+            : "(this.closest('.course-welcome-splash') || this.closest('.course-diagnostic-wrap') || this.closest('.course-diagnostic-card'))?.remove();";
+        return `
+            <div class="course-diagnostic-card" style="margin-top:16px; padding:16px; border-radius:12px; background:linear-gradient(135deg,#eef2ff,#faf5ff); border:1px solid #c7d2fe;">
+                <div style="font-size:14px; font-weight:700; color:#4338ca; margin-bottom:6px;">
+                    <i class="fas fa-clipboard-check" style="margin-right:6px;"></i>${this.escapeHtml(diag.title)}
+                </div>
+                <div style="font-size:12px; color:#555; line-height:1.5; margin-bottom:12px;">${this.escapeHtml(diag.body)}</div>
+                ${diag.required ? '<div style="font-size:11px; font-weight:700; color:#b45309; margin-bottom:10px;"><i class="fas fa-lock" style="margin-right:5px;"></i>Start here — this sets your baseline.</div>' : ''}
+                <button class="course-diagnostic-cta" onclick="${dismiss} ${launch}" style="
+                    width:100%; padding:12px; border:none; border-radius:10px;
+                    background:linear-gradient(135deg,#4f46e5,#7c3aed); color:white;
+                    font-weight:700; font-size:14px; cursor:pointer;
+                "><i class="fas fa-play" style="margin-right:6px;"></i>${this.escapeHtml(diag.cta)}</button>
+            </div>`;
+    }
+
+    // Fetch + show the day-one diagnostic for an already-active course on page
+    // load (checkActiveProgressBar). Non-fatal; the server returns null once the
+    // student has completed the diagnostic, so the card stops appearing.
+    async maybeShowActiveDiagnostic(sessionId) {
+        try {
+            const res = await csrfFetch(`/api/course-sessions/${sessionId}/diagnostic`, {
+                credentials: 'include'
+            });
+            if (!res.ok) return;
+            const data = await res.json();
+            if (data && data.diagnostic) this.showDiagnosticCard(data.diagnostic);
+        } catch {
+            /* non-fatal — diagnostic is a nudge, never blocks the course */
+        }
+    }
+
+    // Show the diagnostic card on its own (returning students who re-open the
+    // course from the sidebar, i.e. activateCourse — no welcome splash there).
+    showDiagnosticCard(diag) {
+        const html = this.diagnosticCardHtml(diag);
+        if (!html) return;
+        const chatBox = document.getElementById('chat-messages-container');
+        if (!chatBox) return;
+        if (chatBox.querySelector('.course-diagnostic-card')) return; // don't stack duplicates
+        const wrap = document.createElement('div');
+        wrap.className = 'course-diagnostic-wrap';
+        wrap.style.cssText = 'margin:16px auto; max-width:520px; animation:catalogSlideIn 0.4s ease;';
+        wrap.innerHTML = html;
+        chatBox.appendChild(wrap);
+        wrap.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+
     // Welcome splash (shown in chat after enrollment)
     // --------------------------------------------------
     showWelcomeSplash(welcome, isResume = false) {
@@ -4045,6 +4171,10 @@ class CourseManager {
                 <span style="font-size:13px; color:${i === 0 ? '#333' : '#666'}; font-weight:${i === 0 ? '600' : '400'};">${this.escapeHtml(u)}</span>
             </div>`
         ).join('');
+
+        // Day-one diagnostic card (e.g. ACT prep → take a full practice ACT first),
+        // embedded in the welcome splash. See diagnosticCardHtml().
+        const diagnosticHtml = this.diagnosticCardHtml(welcome.diagnostic);
 
         // Course mini-tour tips (shown below the learning path for first-time enrollees)
         const courseTipsHtml = isResume ? '' : `
@@ -4090,15 +4220,20 @@ class CourseManager {
                 ${unitListHtml}
                 ${units.length < welcome.moduleCount ? `<div style="font-size: 12px; color: #aaa; padding: 4px 0 0 32px;">+${welcome.moduleCount - units.length} more modules</div>` : ''}
                 ${courseTipsHtml}
+                ${diagnosticHtml}
                 <div style="margin-top: 16px; padding: 8px 12px; background: #fef9c3; border: 1px solid #fde68a; border-radius: 8px; font-size: 11px; color: #b45309; display: flex; align-items: flex-start; gap: 6px;">
                     <i class="fas fa-circle-exclamation" style="margin-top: 1px; flex-shrink: 0;"></i>
                     <span><strong>Disclaimer:</strong> These courses do not count for academic credit and are not meant to replace in-person instruction.</span>
                 </div>
                 <button onclick="this.closest('.course-welcome-splash').remove()" style="
-                    margin-top: 16px; width: 100%; padding: 12px; border: none; border-radius: 10px;
-                    background: linear-gradient(135deg, #667eea, #764ba2); color: white;
+                    margin-top: 16px; width: 100%; padding: 12px; border-radius: 10px;
+                    ${diagnosticHtml
+                        ? 'border: 1px solid #c7d2fe; background: white; color: #4f46e5;'
+                        : 'border: none; background: linear-gradient(135deg, #667eea, #764ba2); color: white;'}
                     font-weight: 700; font-size: 14px; cursor: pointer;
-                "><i class="fas fa-play" style="margin-right: 6px;"></i>${isResume ? 'Continue Learning' : `Start ${this.escapeHtml(welcome.firstModuleTitle)}`}</button>
+                "><i class="fas fa-play" style="margin-right: 6px;"></i>${diagnosticHtml
+                        ? `Skip for now — start ${this.escapeHtml(welcome.firstModuleTitle)}`
+                        : (isResume ? 'Continue Learning' : `Start ${this.escapeHtml(welcome.firstModuleTitle)}`)}</button>
             </div>
         `;
 
@@ -4197,6 +4332,13 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 console.log('[CourseManager] Module loaded');
+
+// Exposed for unit tests (node). Harmless in the browser, where `module` is
+// undefined. The class is never auto-instantiated on require — that happens only
+// inside the DOMContentLoaded handler above.
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { CourseManager };
+}
 
 ;
 /* --- /js/lessonTracker.js --- */

--- a/public/dist/js/chat-js4.301bba99.js
+++ b/public/dist/js/chat-js4.301bba99.js
@@ -811,41 +811,53 @@ class InlineChatVisuals {
         let html = message;
         let hasVisuals = false;
 
+        // Token params can nest ONE level of brackets — points=[-2,0,3],
+        // jumps=[(0,3),(3,7)]. The grammar (which fixes the truncation bug that
+        // made every number line with points render nothing) lives in
+        // visualTokenParser.js so it is testable in node with no DOM. Fall back to
+        // a local builder if that script did not load, so a missing dependency
+        // degrades to the previous behaviour rather than throwing.
+        const VTP = (typeof window !== 'undefined' && window.VisualTokenParser) || null;
+        const P = VTP ? VTP.PARAM : '(?:[^\\[\\]]|\\[[^\\]]*\\])';
+        const tok = VTP
+            ? (name) => VTP.tokenRegex(name)
+            : (name) => new RegExp('\\[' + name + ':(' + P + '+)\\]', 'g');
+
         // Process each visual type
         const visualTypes = [
-            { regex: /\[\s*FUNCTION_GRAPH\s*:\s*([^\]]+)\]/g, handler: this.createFunctionGraph.bind(this) },
-            { regex: /\[NUMBER_LINE:([^\]]+)\]/g, handler: this.createNumberLine.bind(this) },
-            { regex: /\[FRACTION:([^\]]+)\]/g, handler: this.createFraction.bind(this) },
-            { regex: /\[PIE_CHART:([^\]]+)\]/g, handler: this.createPieChart.bind(this) },
-            { regex: /\[BAR_CHART:([^\]]+)\]/g, handler: this.createBarChart.bind(this) },
-            { regex: /\[POINTS:([^\]]+)\]/g, handler: this.createPointsPlot.bind(this) },
-            { regex: /\[SLIDER_GRAPH:([^\]]+)\]/g, handler: this.createSliderGraph.bind(this) },
-            { regex: /\[UNIT_CIRCLE:?([^\]]*)\]/g, handler: this.createUnitCircle.bind(this) },
-            { regex: /\[AREA_MODEL:([^\]]+)\]/g, handler: this.createAreaModel.bind(this) },
-            { regex: /\[COMPARISON:([^\]]+)\]/g, handler: this.createComparison.bind(this) },
+            { regex: VTP ? VTP.tokenRegex('FUNCTION_GRAPH', { pad: true }) : new RegExp('\\[\\s*FUNCTION_GRAPH\\s*:\\s*(' + P + '+)\\]', 'g'), handler: this.createFunctionGraph.bind(this) },
+            { regex: tok('NUMBER_LINE'), handler: this.createNumberLine.bind(this) },
+            { regex: tok('FRACTION'), handler: this.createFraction.bind(this) },
+            { regex: tok('PIE_CHART'), handler: this.createPieChart.bind(this) },
+            { regex: tok('BAR_CHART'), handler: this.createBarChart.bind(this) },
+            { regex: tok('POINTS'), handler: this.createPointsPlot.bind(this) },
+            { regex: tok('SLIDER_GRAPH'), handler: this.createSliderGraph.bind(this) },
+            { regex: VTP ? VTP.tokenRegex('UNIT_CIRCLE', { star: true, optionalColon: true }) : new RegExp('\\[UNIT_CIRCLE:?(' + P + '*)\\]', 'g'), handler: this.createUnitCircle.bind(this) },
+            { regex: tok('AREA_MODEL'), handler: this.createAreaModel.bind(this) },
+            { regex: tok('COMPARISON'), handler: this.createComparison.bind(this) },
             // New enhanced visualizations
-            { regex: /\[PYTHAGOREAN:([^\]]+)\]/g, handler: this.createPythagorean.bind(this) },
-            { regex: /\[ANGLE:([^\]]+)\]/g, handler: this.createAngle.bind(this) },
-            { regex: /\[REGULAR_POLYGON:([^\]]+)\]/g, handler: this.createRegularPolygon.bind(this) },
-            { regex: /\[SLOPE:([^\]]+)\]/g, handler: this.createSlope.bind(this) },
-            { regex: /\[PERCENT_BAR:([^\]]+)\]/g, handler: this.createPercentBar.bind(this) },
-            { regex: /\[PLACE_VALUE:([^\]]+)\]/g, handler: this.createPlaceValue.bind(this) },
-            { regex: /\[RIGHT_TRIANGLE:([^\]]+)\]/g, handler: this.createRightTriangle.bind(this) },
-            { regex: /\[INEQUALITY:([^\]]+)\]/g, handler: this.createInequality.bind(this) },
+            { regex: tok('PYTHAGOREAN'), handler: this.createPythagorean.bind(this) },
+            { regex: tok('ANGLE'), handler: this.createAngle.bind(this) },
+            { regex: tok('REGULAR_POLYGON'), handler: this.createRegularPolygon.bind(this) },
+            { regex: tok('SLOPE'), handler: this.createSlope.bind(this) },
+            { regex: tok('PERCENT_BAR'), handler: this.createPercentBar.bind(this) },
+            { regex: tok('PLACE_VALUE'), handler: this.createPlaceValue.bind(this) },
+            { regex: tok('RIGHT_TRIANGLE'), handler: this.createRightTriangle.bind(this) },
+            { regex: tok('INEQUALITY'), handler: this.createInequality.bind(this) },
             // Algebra tiles inline preview + launcher
-            { regex: /\[ALGEBRA_TILES:([^\]]+)\]/g, handler: this.createAlgebraTilesInline.bind(this) },
+            { regex: tok('ALGEBRA_TILES'), handler: this.createAlgebraTilesInline.bind(this) },
             // Integer counters (pos/neg with zero-pair cancellation)
-            { regex: /\[COUNTERS:([^\]]+)\]/g, handler: this.createCounters.bind(this) },
+            { regex: tok('COUNTERS'), handler: this.createCounters.bind(this) },
             // Multi-representation linked views
-            { regex: /\[MULTI_REP:([^\]]+)\]/g, handler: this.createMultiRepresentation.bind(this) },
+            { regex: tok('MULTI_REP'), handler: this.createMultiRepresentation.bind(this) },
             // Calculus: Derivative overlay (f(x) + f'(x) with interactive tangent)
-            { regex: /\[DERIVATIVE_GRAPH:([^\]]+)\]/g, handler: this.createDerivativeGraph.bind(this) },
+            { regex: tok('DERIVATIVE_GRAPH'), handler: this.createDerivativeGraph.bind(this) },
             // Rational function graph (HA, VA, holes auto-detected)
-            { regex: /\[RATIONAL_GRAPH:([^\]]+)\]/g, handler: this.createRationalGraph.bind(this) },
+            { regex: tok('RATIONAL_GRAPH'), handler: this.createRationalGraph.bind(this) },
             // Physics: Position/Velocity/Acceleration overlay
-            { regex: /\[VELOCITY_GRAPH:([^\]]+)\]/g, handler: this.createVelocityGraph.bind(this) },
+            { regex: tok('VELOCITY_GRAPH'), handler: this.createVelocityGraph.bind(this) },
             // Circle geometry: chords, secants, tangents, inscribed/central angles
-            { regex: /\[CIRCLE_DIAGRAM:([^\]]+)\]/g, handler: this.createCircleDiagram.bind(this) }
+            { regex: tok('CIRCLE_DIAGRAM'), handler: this.createCircleDiagram.bind(this) }
         ];
 
         for (const { regex, handler } of visualTypes) {

--- a/public/dist/js/chat-js8.105c8817.js
+++ b/public/dist/js/chat-js8.105c8817.js
@@ -2755,15 +2755,28 @@ if (typeof window !== 'undefined') {
     return new Date(dateStr).toLocaleDateString();
   }
 
-  // Fetch both endpoints in parallel
+  // Fetch endpoints in parallel
   async function fetchResumeData() {
-    const [returningRes, summaryRes] = await Promise.all([
+    const [returningRes, summaryRes, mapRes] = await Promise.all([
       fetch('/api/conversations/returning-user-data', { credentials: 'include' }).catch(() => null),
       fetch('/api/student/progress/summary', { credentials: 'include' }).catch(() => null),
+      fetch('/api/mastery/map', { credentials: 'include' }).catch(() => null),
     ]);
 
     const returning = returningRes?.ok ? await returningRes.json() : null;
     const summary = summaryRes?.ok ? await summaryRes.json() : null;
+    const map = mapRes?.ok ? await mapRes.json() : null;
+
+    // The graph frontier is the live "what's next" source. summary.nextReady
+    // comes from a status bucket frozen at placement that never refills after a
+    // mastery, so graduation could never surface a next skill. Fall back to the
+    // closure engine's nearest attackable skill.
+    if (summary && map?.nearest?.nextSkillId) {
+      summary.graphNext = {
+        skillId: map.nearest.nextSkillId,
+        displayName: map.nearest.nextLabel || 'your next skill',
+      };
+    }
 
     return { returning, summary };
   }
@@ -2807,9 +2820,15 @@ if (typeof window !== 'undefined') {
   }
 
   // Progress bar toward mastery of a skill
-  function masteryBar(displayName, pct, labelText) {
+  function masteryBar(displayName, pct, labelText, isMastered) {
     const p = Math.max(0, Math.min(100, Math.round(pct || 0)));
-    const state = p >= 100 ? 'mastered' : (p >= 50 ? 'halfway to mastery' : 'building it up');
+    // Only the dedicated mastery state may say "mastered". A skill still in
+    // progress must never claim the verdict just because its bar reached 100% —
+    // that mislabel (a 'learning' skill reading "mastered · 100%") is exactly
+    // the bug this guards against.
+    const state = isMastered
+      ? 'mastered'
+      : (p >= 90 ? 'almost there' : (p >= 50 ? 'halfway to mastery' : 'building it up'));
     return `
       <div class="rc-hero-label">${esc(labelText || 'Working toward mastery')}</div>
       <div class="rc-hero-skill">${esc(displayName)}</div>
@@ -2840,11 +2859,11 @@ if (typeof window !== 'undefined') {
     // MASTERY — celebrate, then open the next door.
     if (summary.cardState === 'mastery') {
       const mastered = summary.recentMastery;
-      const next = summary.nextReady;
+      const next = summary.nextReady || summary.graphNext;
       return `
         <div class="rc-hero">
           <div class="rc-hero-badge">★ skill mastered</div>
-          ${masteryBar(mastered ? mastered.displayName : 'Your skill', 100, 'You just mastered')}
+          ${masteryBar(mastered ? mastered.displayName : 'Your skill', 100, 'You just mastered', true)}
           <div class="rc-hero-copy">Ready for something new.</div>
           ${next
             ? ctaButton(`Start ${next.displayName}`, `I'm ready to start ${next.displayName}.`)
@@ -2882,6 +2901,9 @@ if (typeof window !== 'undefined') {
     if (reviewDue > 0) {
       parts.push(ctaButton(`${reviewDue} skill${reviewDue === 1 ? '' : 's'} ready to review`, "Let's review what I've learned.", 'alt'));
     }
+    // The card is also an entry point to the ladder — a native link (not a chat
+    // prompt), so it navigates to the skill map rather than messaging the tutor.
+    parts.push('<a class="rc-hero-alt" href="/skill-map.html">See your skill map<span class="rc-hero-arrow">→</span></a>');
     return `<div class="rc-hero">${parts.join('')}</div>`;
   }
 

--- a/tests/unit/chatBundleIntegrity.test.js
+++ b/tests/unit/chatBundleIntegrity.test.js
@@ -1,0 +1,58 @@
+/**
+ * chat.html bundle-reference integrity.
+ *
+ * public/dist/js/chat-js*.js and chat-css*.css are pre-built bundles. chat.html
+ * references them by content hash. The deploy runs a rebuild step now
+ * (Dockerfile), but this guard fails CI the moment the COMMITTED chat.html and
+ * the COMMITTED bundles drift — which is how chat-js4 came to 404 in production:
+ * chat.html pointed at a hash whose file was never recommitted after a bundled
+ * source file (inlineChatVisuals.js) changed.
+ *
+ * The whole chunk it referenced — including the number-line fix and, in a sibling
+ * bundle, the course pre-assessment gate — silently never executed.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '../..');
+const HTML = path.join(ROOT, 'public', 'chat.html');
+const DIST = path.join(ROOT, 'public', 'dist');
+
+const html = fs.readFileSync(HTML, 'utf8');
+const refs = [...html.matchAll(/\/dist\/(js|css)\/(chat-(?:js|css)\d+\.[a-f0-9]+\.(?:js|css))/g)]
+  .map((m) => ({ kind: m[1], file: m[2] }));
+
+describe('chat.html references real, committed bundles', () => {
+  test('chat.html actually references bundles (sanity)', () => {
+    expect(refs.length).toBeGreaterThan(0);
+  });
+
+  test('every referenced bundle file exists on disk', () => {
+    const missing = refs.filter((r) => !fs.existsSync(path.join(DIST, r.kind, r.file)));
+    // A miss here is exactly the production 404: chat.html asks for a hash whose
+    // file was never committed after a source edit.
+    expect(missing.map((r) => r.file)).toEqual([]);
+  });
+
+  test('the manifest agrees with chat.html on every bundle URL', () => {
+    const manifest = JSON.parse(fs.readFileSync(path.join(DIST, 'chat-bundles.manifest.json'), 'utf8'));
+    const manifestFiles = new Set(
+      [...manifest.js, ...manifest.css].map((b) => (b.src || b.href).split('/').pop())
+    );
+    const disagree = refs.filter((r) => !manifestFiles.has(r.file));
+    expect(disagree.map((r) => r.file)).toEqual([]);
+  });
+
+  test('no orphaned bundle files linger in dist (built but unreferenced)', () => {
+    const referenced = new Set(refs.map((r) => r.file));
+    const onDisk = [
+      ...fs.readdirSync(path.join(DIST, 'js')).filter((f) => /^chat-js\d+\./.test(f)),
+      ...fs.readdirSync(path.join(DIST, 'css')).filter((f) => /^chat-css\d+\./.test(f)),
+    ];
+    const orphans = onDisk.filter((f) => !referenced.has(f));
+    // Orphans are the flip side of the same drift — a rehash left the old file
+    // behind. Harmless to serve, but a sign chat.html and dist fell out of sync.
+    expect(orphans).toEqual([]);
+  });
+});


### PR DESCRIPTION
…rom source

Production served chat.html referencing /dist/js/chat-js4.301bba99.js, but that file was never committed — the committed bundle was chat-js4.c195e962.js. So the browser got a 404 (MIME text/html, "Refused to execute script") and the ENTIRE chunk silently never ran. chat-js4 is inlineChatVisuals.js + diagram-display.js, so the number-line fix that shipped in that file was dead on arrival.

ROOT CAUSE — a build-integrity gap, not a code bug. public/dist/js/chat-js*.js are pre-built bundles committed to the repo, and scripts/buildChatBundles.js rewrites chat.html with their content hashes. But the Docker deploy runs NO build step (only `npm ci` + `node server.js`), so it serves the committed bundles as-is. Every edit to a bundled source file that didn't also recommit the regenerated bundle drifted the two apart. Five bundles had drifted:
  - chat-js4: chat.html updated, bundle file never recommitted -> 404.
  - chat-js3 (courseCatalog.js): source changed, bundle NOT rebuilt -> stale hash, so the just-merged course pre-assessment gate never actually ran either.

FIX, two layers:
  1. Dockerfile now runs `node scripts/buildChatBundles.js` after COPY, before the chown/USER switch. Every deploy regenerates all bundles FROM the source in the same image and rewrites chat.html to match — drift becomes impossible, and any bundled-source edit ships whether or not someone remembered to recommit the artifact. node builtins only; no dev deps.
  2. Regenerated all bundles from current main and committed the consistent set (chat.html + manifest + bundles, orphans removed) so the repo is correct at rest and production is fixed even before the next image rebuild. This also brings the drifted chat-js3 up to date, so the course gate ships.

GUARD: tests/unit/chatBundleIntegrity.test.js fails CI if any chat.html bundle reference lacks a committed file, if the manifest disagrees with chat.html, or if orphaned bundles linger — so this specific 404 can never merge again.

Verified: after the build, all chat.html bundle refs resolve; chat-js4 is now 301bba99 (the hash chat.html asks for); chat-js3 rehashed to include the course fix. 4 integrity tests pass.