### PR TITLE
fix(workspace): stop the legacy 4-tab board flashing before the new o…

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -37,6 +37,16 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     if (window.MM_FEATURES.boardPanel === false) {
       document.documentElement.classList.add('mm-board-hidden');
     }
+    // Living Workspace replaces the legacy tabbed board. Mark it SYNCHRONOUSLY,
+    // before the body paints, so CSS can hide the legacy board's chrome from the
+    // first frame. Without this the old 4-tab board renders and is only hidden
+    // later — in JS, once chat-workspace.js + its modules finish loading — which
+    // students saw as the legacy board flashing, then being covered by the new
+    // surface. The 'off' kill switch does not add the class, so the legacy board
+    // returns untouched.
+    if (window.MM_FEATURES.livingWorkspace === 'live') {
+      document.documentElement.classList.add('mm-lws-live');
+    }
 
     // Visual-board tool scripts (fabric + whiteboard/graph/calc) are ~680KB and
     // only needed when the board is enabled — which it is not by default. Load

--- a/public/css/workspace.css
+++ b/public/css/workspace.css
@@ -1049,3 +1049,14 @@
   .cr-ws-board-card { transition: none; }
   .cr-ws-board-card--enter { opacity: 1; transform: none; }
 }
+
+/* ── Living Workspace pre-hide (MM_FEATURES.livingWorkspace='live' → html.mm-lws-live) ──
+   chat-workspace.js swaps the new board in over #cr-workspace by hiding the
+   legacy tabbed chrome IN JAVASCRIPT, after its modules load — so the old 4-tab
+   board painted first and flashed before being covered. Hide that chrome from
+   first paint instead. The player card stays (pinned bottom); the new surface
+   mounts into #lws-chat-mount, which is intentionally NOT matched here. Scoped to
+   'live' only — the 'off' kill switch leaves the legacy board untouched. */
+html.mm-lws-live #cr-workspace > .cr-ws-close,
+html.mm-lws-live #cr-workspace > .cr-ws-tabs,
+html.mm-lws-live #cr-workspace > #cr-ws-body { display: none; }

--- a/tests/unit/lwsLegacyBoardHide.test.js
+++ b/tests/unit/lwsLegacyBoardHide.test.js
@@ -1,0 +1,74 @@
+/**
+ * Living Workspace legacy-board pre-hide wiring.
+ *
+ * The new board (Living Workspace) swaps in over #cr-workspace by hiding the
+ * legacy 4-tab board IN JAVASCRIPT, after chat-workspace.js and its modules load.
+ * That left the legacy board visible for a beat — students saw the old "Work
+ * Board / Graph / Tiles / Calc" panel flash, then get covered by the new surface.
+ *
+ * The fix pre-hides the legacy chrome from first paint: chat.html adds
+ * html.mm-lws-live synchronously when livingWorkspace is 'live', and workspace.css
+ * hides the legacy children under that class. This test guards the WIRING — the
+ * class is added under the right flag, and the CSS rule targets elements that
+ * actually exist. It does NOT prove the flash is gone at paint time; that needs a
+ * real browser.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '../..');
+const html = fs.readFileSync(path.join(ROOT, 'public', 'chat.html'), 'utf8');
+const css = fs.readFileSync(path.join(ROOT, 'public', 'css', 'workspace.css'), 'utf8');
+
+describe('the flag adds the class synchronously', () => {
+  test('chat.html adds mm-lws-live when livingWorkspace is live', () => {
+    // Must be in an inline <script> in the head, not a deferred/bundled file, so
+    // it runs before the body paints.
+    expect(html).toMatch(/livingWorkspace\s*===\s*['"]live['"]/);
+    expect(html).toMatch(/classList\.add\(\s*['"]mm-lws-live['"]\s*\)/);
+  });
+
+  test('the class add sits next to the existing mm-board-hidden flag block', () => {
+    // Same first-paint inline script — a proxy for "runs before body paint".
+    const boardIdx = html.indexOf("classList.add('mm-board-hidden')");
+    const lwsIdx = html.indexOf("classList.add('mm-lws-live')");
+    expect(boardIdx).toBeGreaterThan(-1);
+    expect(lwsIdx).toBeGreaterThan(boardIdx);
+    // and both before the body opens
+    expect(lwsIdx).toBeLessThan(html.indexOf('<body'));
+  });
+});
+
+describe('the CSS pre-hides the legacy board', () => {
+  test('workspace.css hides the legacy chrome under mm-lws-live', () => {
+    expect(css).toMatch(/html\.mm-lws-live[\s\S]*display:\s*none/);
+    ['.cr-ws-close', '.cr-ws-tabs', '#cr-ws-body'].forEach((sel) => {
+      expect(css.includes(`#cr-workspace > ${sel}`)).toBe(true);
+    });
+  });
+
+  test('workspace.css is loaded in the head (first paint), not deferred', () => {
+    const linkIdx = html.indexOf('css/workspace.css');
+    expect(linkIdx).toBeGreaterThan(-1);
+    expect(linkIdx).toBeLessThan(html.indexOf('<body'));
+  });
+
+  test('the player card and the new mount are NOT hidden', () => {
+    // Hiding these would blank the avatar or the new board itself.
+    expect(css).not.toMatch(/mm-lws-live[^{]*#cr-player-card[^{]*display:\s*none/);
+    expect(css).not.toMatch(/mm-lws-live[^{]*#lws-chat-mount[^{]*display:\s*none/);
+  });
+});
+
+describe('the rule targets elements that actually exist', () => {
+  test('#cr-workspace really contains cr-ws-close, cr-ws-tabs and cr-ws-body', () => {
+    // If any of these are renamed/moved, the pre-hide silently stops working and
+    // the flash returns — so pin them here.
+    const ws = html.slice(html.indexOf('id="cr-workspace"'), html.indexOf('/.cr-stage'));
+    expect(ws).toMatch(/class="cr-ws-close"/);
+    expect(ws).toMatch(/class="cr-ws-tabs"/);
+    expect(ws).toMatch(/id="cr-ws-body"/);
+    expect(ws).toMatch(/id="cr-player-card"/);
+  });
+});


### PR DESCRIPTION
…ne mounts

Students saw the old board — "Work Board", Board/Graph/Tiles/Calc tabs, "Your steps will land here" — render fully, then get covered by the new Living Workspace surface. A visible flash of a deprecated UI on every course/board load.

Cause is timing. Living Workspace ('live') is meant to REPLACE the legacy tabbed board: chat-workspace.js's buildPanel() takes over #cr-workspace by hiding the legacy children (.cr-ws-close, .cr-ws-tabs, #cr-ws-body) and mounting the new surface. But that hide runs in JAVASCRIPT, only after chat-workspace.js and its sub-modules finish loading (deferred). Until then the legacy board is painted and visible — the flash.

Fix: pre-hide the legacy chrome from the FIRST paint, the same way the boardPanel flag already works. chat.html's inline feature-flag script now adds html.mm-lws-live synchronously when livingWorkspace === 'live', and workspace.css (head-loaded, render-blocking) hides the three legacy children under that class. The JS swap still runs and is now simply redundant for those nodes.

Deliberately NOT hidden: #cr-player-card (the avatar, pinned bottom) and #lws-chat-mount (the new surface, added by the swap) — hiding either would blank the avatar or the board itself. Scoped to 'live': the livingWorkspace:'off' kill switch does not add the class, so the legacy board returns untouched.

Trade-off, stated plainly: if the Living Workspace fails to mount while 'live' (a JS error), the legacy chrome stays hidden and the region shows only the player card — a blank board rather than a flash of the old one. That is rare, live-mode only, and arguably better than a confusing double board; the 'off' switch is the escape hatch.

6 tests guard the WIRING: the class is added under the right flag in a first-paint inline script, the CSS rule targets the three legacy selectors and NOT the player card or mount, and those selectors correspond to elements that actually exist in #cr-workspace (so a rename can't silently bring the flash back). Not tested: the paint timing itself — that needs a real browser, called out in the test file.