### PR TITLE
fix(mastery): make encodeMasteryKey idempotent — stop the every-turn …

### DIFF
--- a/tests/unit/masteryKeyEncoding.test.js
+++ b/tests/unit/masteryKeyEncoding.test.js
@@ -45,8 +45,15 @@ describe('encode / decode', () => {
     });
   });
 
-  test('fails loudly rather than corrupting if an id contains the sentinel', () => {
-    expect(() => encodeMasteryKey('BAD_ID')).toThrow(/reserves/);
+  test('is idempotent: re-encoding an already-encoded key is a no-op', () => {
+    // No canonical id contains "_", so a value that has one is already a storage
+    // key. Re-encoding must NOT throw or corrupt it — an encoded key leaking back
+    // into logical position (a stale tutorPlan.currentTarget.skillId of "MS_QNT_8")
+    // used to throw here and take the whole TutorPlan load down every turn.
+    const key = encodeMasteryKey('MS.QNT.8'); // -> "MS_QNT_8"
+    expect(key).toBe('MS_QNT_8');
+    expect(encodeMasteryKey(key)).toBe('MS_QNT_8'); // idempotent, no throw
+    expect(decodeMasteryKey(encodeMasteryKey(key))).toBe('MS.QNT.8');
   });
 
   test('leaves an already-safe legacy id unchanged', () => {

--- a/utils/masteryGuard.js
+++ b/utils/masteryGuard.js
@@ -22,17 +22,21 @@ const { canonicalSkillId } = require('./skillCanonicalizer');
 // silently vanishes. That is a live data-loss bug for every crosswalked skill.
 //
 // Fix: store an ENCODED key ("ALG1_EQV_1") and keep the dotted id as the single
-// logical id everywhere else (graph, board, closure, canonicalizer). No skill id
-// in the catalog contains "_", so "." <-> "_" is a clean bijection; encode()
-// asserts that, so if an id ever does contain "_" this fails loudly at the write
-// instead of corrupting a key. No data migration is needed because the bug meant
-// no dotted key was ever successfully stored.
+// logical id everywhere else (graph, board, closure, canonicalizer). No canonical
+// skill id contains "_" (the namespace is dot- and hyphen-based: "MS.QNT.8",
+// "2d-shapes"), so "." <-> "_" is a clean bijection.
+//
+// encode() is IDEMPOTENT: a value that already contains "_" is an already-encoded
+// storage key, so it is returned unchanged. This matters because an encoded key
+// can leak back into logical-id position — e.g. a tutorPlan.currentTarget.skillId
+// persisted as "MS_QNT_8" by pre-fix code. An earlier version threw on that,
+// which took the whole (non-fatal-guarded) TutorPlan load down on EVERY turn and
+// silently stripped the tutor's persistent model of the student. Idempotence
+// makes the layer resilient to that stale data with no migration required.
 function encodeMasteryKey(id) {
   if (id == null) return id;
   const s = String(id);
-  if (s.includes('_')) {
-    throw new Error(`skill id "${s}" contains "_", which the mastery key encoding reserves as the "." substitute`);
-  }
+  if (s.includes('_')) return s; // already encoded — encode is a no-op
   return s.replace(/\./g, '_');
 }
 


### PR DESCRIPTION
…TutorPlan crash

Mongoose Maps reject "." in keys, so a dotted skill id ("MS.QNT.8") is stored with dots swapped for underscores ("MS_QNT_8"). encode() used to THROW if its input already contained "_", to catch double-encoding during development.

In production that guard did net harm. An encoded key can leak back into logical-id position — e.g. a tutorPlan.currentTarget.skillId persisted as "MS_QNT_8" by pre-fix code — and re-encoding it threw. That throw was swallowed by the pipeline's non-fatal TutorPlan catch, so on EVERY turn the tutor silently lost its persistent model of the student:

  [Pipeline] TutorPlan load error (non-fatal): skill id "MS_QNT_8" contains "_",
  which the mastery key encoding reserves as the "." substitute

No canonical skill id contains "_" (the namespace is dot- and hyphen-based: "MS.QNT.8", "2d-shapes", "ALG1.EQV.1" — verified zero underscores across the seed catalog), so a value that already has "_" is unambiguously an already- encoded key. encode() now returns it unchanged: encoding is idempotent. This makes the layer resilient to stale double-encoded ids with no data migration.

Test: the throw assertion is replaced by an idempotence/round-trip test on the exact "MS.QNT.8" -> "MS_QNT_8" -> "MS_QNT_8" -> "MS.QNT.8" path from the logs.