### PR TITLE
feat(baseline): enforce the required baseline on every course turn, n…

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -3099,6 +3099,16 @@ document.addEventListener("DOMContentLoaded", () => {
                 setTimeout(() => window.openActTest(), 400); // let the tutor's confirming reply render first
             }
 
+            // Server withheld course teaching because a REQUIRED baseline (e.g. the
+            // ACT practice test) isn't done — surface the baseline card under the
+            // tutor's message so the student can start it. We do NOT auto-open the
+            // runner: its 45-min timer starts the instant it opens, so the student
+            // taps the card's CTA when ready. The card's CTA calls openActTest.
+            if (data.baselineRequired && data.diagnostic &&
+                window.courseManager && typeof window.courseManager.showDiagnosticCard === 'function') {
+                setTimeout(() => window.courseManager.showDiagnosticCard(data.diagnostic), 400);
+            }
+
             // Render interactive graph tool if AI requested one
             if (data.graphTool && window.GraphTool) {
                 const messageElements = document.querySelectorAll('.message.ai');

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -1037,6 +1037,42 @@ async function runStudentTurn(req, res) {
             };
         }
 
+        // ── PROACTIVE BASELINE GATE ──
+        // A REQUIRED baseline (currently the full practice ACT for act-prep) must
+        // be completed before ANY course teaching. The greeting gate in courseChat
+        // only covers course ENTRY — a student already inside the course who just
+        // types reaches THIS endpoint and would otherwise be taught without ever
+        // taking the baseline (the entry card is a dismissible nudge). Enforcing it
+        // here, on every course turn until it's done, is what makes "every enrollee
+        // gets a baseline" actually hold, no matter how they landed in the chat.
+        // Runs before the streaming headers below, so a plain JSON reply is safe;
+        // the finally at the end of the handler releases the per-user lock. Skipped
+        // for isGreeting (that path is already gated in routes/courseChat.js).
+        if (user.activeCourseSessionId && !isGreeting) {
+            try {
+                const CourseSession = require('../models/courseSession');
+                const gateSession = await CourseSession.findById(user.activeCourseSessionId);
+                if (gateSession && gateSession.status === 'active') {
+                    const { isRequiredBaselinePending } = require('../utils/courseDiagnostic');
+                    const { pending, diagnostic } = await isRequiredBaselinePending(user, gateSession.courseId);
+                    if (pending) {
+                        const gateText = diagnostic?.type === 'act-practice'
+                            ? "Before we dig into any lessons, let's lock in your baseline. Take the full practice ACT so I can see exactly where you're starting and aim your prep at what you actually need — tap **Take the Practice ACT** below to begin. Once it's done, we'll build your plan around your results."
+                            : "Let's start with a quick baseline check so this course can skip what you already know and spend its time on what you actually need. Tap the card below to begin.";
+                        logger.info('Baseline gate: withholding course teaching until baseline complete', { userId, courseId: gateSession.courseId });
+                        return res.json({
+                            text: gateText,
+                            baselineRequired: true,
+                            diagnostic,
+                            conversationId: (typeof activeConversation !== 'undefined' && activeConversation) ? String(activeConversation._id) : null
+                        });
+                    }
+                }
+            } catch (gateErr) {
+                logger.warn('Baseline gate check failed (non-fatal)', { error: gateErr.message });
+            }
+        }
+
         // Enrich with active course session data (if user is in a course)
         if (user.activeCourseSessionId) {
             try {


### PR DESCRIPTION
…ot just entry

The proactive baseline still wasn't universal. The greeting gate (courseChat) only covers course ENTRY, and the entry diagnostic card is a dismissible nudge — so a student already inside the course who just TYPES reaches /api/chat, which never checked the baseline, and got taught without ever taking it. That's why an ACT enrollee could chat through Number & Quantity without the practice ACT ever being put in front of them.

Fix: gate the teaching path itself. In routes/chat.js runStudentTurn, before any prompt/pipeline work (and before the SSE headers, so a plain JSON reply is safe; the handler's finally releases the per-user lock), for a NON-greeting turn in an active course, consult isRequiredBaselinePending. If a required baseline is still pending, withhold teaching entirely and return { text, baselineRequired, diagnostic } — a short "take your baseline first" message plus the diagnostic.

Client (script.js): on baselineRequired, surface the diagnostic card under the message via courseManager.showDiagnosticCard. We deliberately do NOT auto-open the ACT runner — its 45-minute timer starts the instant it opens, so the student taps the card's CTA when ready (the CTA calls openActTest). A required diagnostic renders non-dismissible, so teaching stays blocked until it's done.

Scope note: this faithfully enforces the `required` flags already defined in utils/courseDiagnostic.js — act-prep (practice ACT) and any course not explicitly listed (which falls through to a required pre-assessment) hard-block; the placement-test courses (algebra/calc/precalc, required:false) remain soft nudges. To change what gates, set a course's `required` flag there — the gate follows it.