### PR TITLE
feat(act): make the course actually adapt to the baseline (skip what …

### DIFF
--- a/routes/actTest.js
+++ b/routes/actTest.js
@@ -267,6 +267,7 @@ router.post('/complete', async (req, res) => {
     let clearedFromBaseline = [];
     try {
       const { creditFromTallies } = require('../utils/coursePreAssessment');
+      const { mergeTalliesToCourse } = require('../utils/actCrosswalk');
       const { advanceRung } = require('../utils/skillRung');
       const { getSkillMasteryEntry, setSkillMasteryEntry, decodedMasteryMap } = require('../utils/masteryGuard');
       const { buildGraph, applyProofCascade } = require('../utils/skillClosure');
@@ -274,7 +275,14 @@ router.post('/complete', async (req, res) => {
       const Skill = require('../models/skill');
       const User = require('../models/user');
 
-      const { credited } = creditFromTallies(bySkill);
+      // Credit under COURSE skill ids, not the baseline's finer ids: the ACT
+      // course teaches by course ids, so mastery stored under a baseline id it
+      // never references would be invisible ("skip what you aced" would silently
+      // do nothing). mergeTalliesToCourse re-keys + sums via seeds/act-crosswalk
+      // .json; a course skill is credited only if every baseline item under it
+      // was correct. Unmapped baseline ids fall away (no course home yet).
+      const courseBySkill = mergeTalliesToCourse(bySkill);
+      const { credited } = creditFromTallies(courseBySkill);
       if (credited.length) {
         const user = await User.findById(req.user._id);
         credited.forEach((skillId) => {

--- a/seeds/act-crosswalk.json
+++ b/seeds/act-crosswalk.json
@@ -1,0 +1,53 @@
+{
+  "_README": "Baseline-ACT skill id -> ACT course-module skill id. The practice-ACT item bank (seeds/act-math-blueprint.json, 44 fine-grained skills) and the ACT course modules (public/modules/act-prep/*, 36 coarser skills) grew separate act-* taxonomies (only 8 ids matched). /api/act-test/complete credits mastery by BASELINE ids, but the course teaches by COURSE ids — so 'skip what you aced' never reached the course. This maps baseline -> course so credited mastery lands on the id the course actually reads. Many-to-one is expected (baseline is finer). `confidence`: high = same concept; med = close/subsumed; low = best-available bucket, REVIEW. Course strategy skills (backsolving, pacing, …) have no content-skill baseline equivalent and are intentionally absent. Keys with no course home are omitted (they credit nothing until the course adds a matching skill).",
+
+  "act-complex-numbers":                        { "course": "act-real-complex-numbers", "confidence": "high" },
+  "act-exponent-rules":                         { "course": "act-exponents-roots", "confidence": "high" },
+  "act-radicals-roots":                         { "course": "act-exponents-roots", "confidence": "high" },
+  "act-matrices-vectors":                       { "course": "act-matrices-vectors", "confidence": "high" },
+  "act-scientific-notation":                    { "course": "act-exponents-roots", "confidence": "low", "note": "scientific notation is exponent-based; no dedicated course skill" },
+
+  "act-linear-equations":                       { "course": "act-linear-equations", "confidence": "high" },
+  "act-linear-inequalities":                    { "course": "act-linear-equations", "confidence": "med" },
+  "act-absolute-value-equations-inequalities":  { "course": "act-linear-equations", "confidence": "low", "note": "no abs-value course skill; nearest is linear equations/inequalities" },
+  "act-systems-of-equations":                   { "course": "act-systems-of-equations", "confidence": "high" },
+  "act-quadratic-equations":                    { "course": "act-quadratic-equations", "confidence": "high" },
+  "act-polynomial-expressions":                 { "course": "act-polynomial-expressions", "confidence": "high" },
+  "act-radical-rational-equations":             { "course": "act-radical-rational-expressions", "confidence": "high" },
+  "act-variation-direct-inverse":               { "course": "act-radical-rational-expressions", "confidence": "low", "note": "inverse variation is rational; direct is linear — imperfect single bucket" },
+  "act-word-problems-modeling":                 { "course": "act-algebraic-reasoning-context", "confidence": "med" },
+
+  "act-function-evaluation-notation":           { "course": "act-function-notation-evaluation", "confidence": "high", "note": "same concept, name order differs" },
+  "act-function-composition":                   { "course": "act-function-notation-evaluation", "confidence": "med" },
+  "act-linear-functions-models":                { "course": "act-linear-functions", "confidence": "high" },
+  "act-quadratic-functions-parabolas":          { "course": "act-quadratic-functions", "confidence": "high" },
+  "act-exponential-models":                     { "course": "act-polynomial-exponential-log", "confidence": "high" },
+  "act-logarithms":                             { "course": "act-polynomial-exponential-log", "confidence": "high" },
+  "act-trigonometric-functions":                { "course": "act-trig-functions", "confidence": "high" },
+  "act-graph-transformations":                  { "course": "act-function-transformations", "confidence": "high" },
+  "act-sequences":                              { "course": "act-algebraic-reasoning-context", "confidence": "low", "note": "no sequences course skill; parked under algebraic reasoning" },
+
+  "act-angles-parallel-lines":                  { "course": "act-angles-lines-triangles", "confidence": "high" },
+  "act-triangles-angle-relationships":          { "course": "act-angles-lines-triangles", "confidence": "high" },
+  "act-triangles-pythagorean-theorem":          { "course": "act-right-triangle-trig", "confidence": "high" },
+  "act-right-triangle-trigonometry":            { "course": "act-right-triangle-trig", "confidence": "high" },
+  "act-law-of-sines-cosines":                   { "course": "act-right-triangle-trig", "confidence": "med" },
+  "act-similar-congruent-figures":              { "course": "act-congruence-similarity", "confidence": "high" },
+  "act-circles":                                { "course": "act-polygons-circles", "confidence": "high" },
+  "act-area-perimeter":                         { "course": "act-area-volume-surface-area", "confidence": "med" },
+  "act-volume-surface-area":                    { "course": "act-area-volume-surface-area", "confidence": "high" },
+  "act-coordinate-geometry":                    { "course": "act-coordinate-geometry", "confidence": "high" },
+
+  "act-center-spread":                          { "course": "act-center-spread", "confidence": "high" },
+  "act-probability":                            { "course": "act-probability", "confidence": "high" },
+  "act-conditional-probability":                { "course": "act-two-way-tables", "confidence": "med", "note": "conditional probability is commonly assessed via two-way tables" },
+  "act-expected-value":                         { "course": "act-probability", "confidence": "med" },
+  "act-counting-arrangements":                  { "course": "act-counting-techniques", "confidence": "high" },
+
+  "act-percentages":                            { "course": "act-percent-applications", "confidence": "high" },
+  "act-ratios-proportions":                     { "course": "act-multi-step-rate-proportion", "confidence": "high" },
+  "act-rates-unit-conversion":                  { "course": "act-measurement-unit-conversion", "confidence": "med" },
+  "act-multi-step-arithmetic":                  { "course": "act-multi-step-rate-proportion", "confidence": "med" },
+  "act-basic-geometry-measures":                { "course": "act-area-perimeter-composite", "confidence": "med" },
+  "act-time-schedule-arithmetic":               { "course": "act-measurement-unit-conversion", "confidence": "low", "note": "elapsed-time/schedule arithmetic; nearest is unit conversion / multi-step" }
+}

--- a/tests/unit/actBaselineAdaptation.test.js
+++ b/tests/unit/actBaselineAdaptation.test.js
@@ -1,0 +1,99 @@
+/**
+ * PROOF that completing the baseline actually adapts the course — the thing that
+ * "the test runs" never established. Two seams had to close for it to be real:
+ *
+ *   1. Crediting was keyed by the baseline's fine skill ids, but the course
+ *      teaches by its own coarser ids (only 8 of 44 matched). So mastery was
+ *      stored where the course never looks. seeds/act-crosswalk.json + the
+ *      re-key/merge fix credit under COURSE ids.
+ *   2. The every-turn course prompt never read skillMastery, so a skill the
+ *      student PROVED on the baseline was still taught from scratch. The prompt
+ *      now surfaces the module's already-proven skills.
+ *
+ * Together these two mean: ace a skill on the baseline -> it's credited under the
+ * course id -> the course prompt tells the tutor to skip it. This test proves
+ * both halves and the join between them.
+ */
+
+const { mergeTalliesToCourse, toCourseSkill } = require('../../utils/actCrosswalk');
+const { creditFromTallies } = require('../../utils/coursePreAssessment');
+const { buildCourseSystemPrompt } = require('../../utils/coursePrompt');
+
+describe('seam 1 — the baseline credits under COURSE skill ids', () => {
+  test('the crosswalk maps a fine baseline id to the course id the modules use', () => {
+    expect(toCourseSkill('act-percentages')).toBe('act-percent-applications');
+    expect(toCourseSkill('act-function-evaluation-notation')).toBe('act-function-notation-evaluation');
+    expect(toCourseSkill('act-linear-equations')).toBe('act-linear-equations'); // one of the 8 that already matched
+  });
+
+  test('many-to-one baseline tallies MERGE onto one course skill; clean ones credit', () => {
+    // Baseline: aced linear equations (2/2), aced BOTH ratio skills that roll up
+    // into one course skill, and MISSED quadratics (1/2).
+    const baselineTallies = {
+      'act-linear-equations': { correct: 2, total: 2 },
+      'act-ratios-proportions': { correct: 1, total: 1 },   // -> act-multi-step-rate-proportion
+      'act-multi-step-arithmetic': { correct: 1, total: 1 },// -> act-multi-step-rate-proportion (merges)
+      'act-quadratic-equations': { correct: 1, total: 2 },  // missed one -> NOT credited
+    };
+    const courseTallies = mergeTalliesToCourse(baselineTallies);
+
+    // Re-keyed onto course ids, and the two rate/proportion skills summed.
+    expect(courseTallies['act-multi-step-rate-proportion']).toEqual({ correct: 2, total: 2 });
+    expect(courseTallies['act-linear-equations']).toEqual({ correct: 2, total: 2 });
+    expect(courseTallies['act-quadratic-equations']).toEqual({ correct: 1, total: 2 });
+
+    const { credited } = creditFromTallies(courseTallies);
+    expect(credited).toContain('act-linear-equations');
+    expect(credited).toContain('act-multi-step-rate-proportion');
+    expect(credited).not.toContain('act-quadratic-equations'); // a miss is never credited
+  });
+
+  test('an unmapped baseline id is dropped (no course home), never crashes', () => {
+    const out = mergeTalliesToCourse({ 'act-nonexistent-skill': { correct: 1, total: 1 } });
+    expect(out).toEqual({});
+  });
+});
+
+describe('seam 2 — the course prompt SKIPS what the student already proved', () => {
+  const baseArgs = () => ({
+    tutorProfile: { name: 'Mr. Nappier', persona: '' },
+    courseSession: { courseId: 'act-prep', courseName: 'ACT Math Prep', currentModuleId: 'algebra', modules: [] },
+    pathway: { track: 'ACT Math Prep', modules: [] },
+    scaffoldData: null,
+    currentModule: { title: 'Algebra', skills: ['act-linear-equations', 'act-quadratic-equations'] },
+  });
+
+  test('a module skill the student proved is surfaced as ALREADY PROVEN', () => {
+    const userProfile = {
+      firstName: 'Jason',
+      // credited by the baseline (seam 1) under the COURSE id:
+      skillMastery: { 'act-linear-equations': { status: 'mastered', rung: 'proved' } },
+    };
+    const prompt = buildCourseSystemPrompt({ ...baseArgs(), userProfile });
+
+    expect(prompt).toMatch(/ALREADY PROVEN/);
+    expect(prompt).toMatch(/linear equations/);      // proven -> named for spot-check
+    expect(prompt).not.toMatch(/quadratic equations[^]*ALREADY PROVEN/); // not proven -> not in the proven list
+  });
+
+  test('no ALREADY-PROVEN block when the student has proved nothing in the module', () => {
+    const userProfile = { firstName: 'Jason', skillMastery: {} };
+    const prompt = buildCourseSystemPrompt({ ...baseArgs(), userProfile });
+    expect(prompt).not.toMatch(/ALREADY PROVEN/);
+  });
+
+  test('the join: baseline-credited id (seam 1) is exactly the id the prompt reads (seam 2)', () => {
+    // Prove the two halves speak the SAME id — the whole point of the crosswalk.
+    const credited = creditFromTallies(mergeTalliesToCourse({ 'act-percentages': { correct: 3, total: 3 } })).credited;
+    expect(credited).toContain('act-percent-applications');
+
+    const userProfile = { firstName: 'J', skillMastery: { 'act-percent-applications': { rung: 'proved' } } };
+    const prompt = buildCourseSystemPrompt({
+      ...baseArgs(),
+      currentModule: { title: 'Integrating Essential Skills', skills: ['act-percent-applications'] },
+      userProfile,
+    });
+    expect(prompt).toMatch(/ALREADY PROVEN/);
+    expect(prompt).toMatch(/percent applications/);
+  });
+});

--- a/utils/actCrosswalk.js
+++ b/utils/actCrosswalk.js
@@ -1,0 +1,62 @@
+// utils/actCrosswalk.js
+//
+// Bridges the two ACT skill taxonomies that grew apart: the practice-ACT item
+// bank tags items with fine-grained BASELINE ids (seeds/act-math-blueprint.json,
+// 44 skills), while the ACT course teaches by coarser COURSE ids
+// (public/modules/act-prep/*, 36 skills) — only 8 ids ever matched. Because
+// /api/act-test/complete credits mastery by baseline id but the course reads
+// course ids, "skip what you aced" never reached the course. seeds/act-crosswalk
+// .json maps baseline -> course; this loads it and merges per-skill tallies onto
+// the course id so credited mastery lands where the course will see it.
+
+const fs = require('fs');
+const path = require('path');
+
+let MAP = null;
+
+function loadMap() {
+  if (MAP) return MAP;
+  MAP = {};
+  try {
+    const raw = JSON.parse(fs.readFileSync(path.join(__dirname, '../seeds/act-crosswalk.json'), 'utf8'));
+    for (const [k, v] of Object.entries(raw)) {
+      if (k === '_README' || !v || !v.course) continue;
+      MAP[k] = v.course;
+    }
+  } catch (err) {
+    // No crosswalk / unreadable → empty map. Crediting simply falls back to the
+    // raw baseline ids (the prior behaviour), never throws.
+    MAP = {};
+  }
+  return MAP;
+}
+
+/** The course skill id a baseline skill id credits toward, or null if unmapped. */
+function toCourseSkill(baselineSkillId) {
+  return loadMap()[baselineSkillId] || null;
+}
+
+/**
+ * Re-key per-skill tallies from baseline ids to course ids, SUMMING when several
+ * baseline skills map to one course skill (the baseline is finer). A course skill
+ * is only "clean" (and thus creditable) when every baseline item under it was
+ * correct — exactly the semantics creditFromTallies expects. Unmapped baseline
+ * ids are dropped (they have no course home to credit yet).
+ *
+ * @param {Object<string,{correct:number,total:number}>} bySkill baseline tallies
+ * @returns {Object<string,{correct:number,total:number}>} course-keyed tallies
+ */
+function mergeTalliesToCourse(bySkill) {
+  const map = loadMap();
+  const out = {};
+  for (const [id, v] of Object.entries(bySkill || {})) {
+    const course = map[id];
+    if (!course) continue;
+    out[course] = out[course] || { correct: 0, total: 0 };
+    out[course].correct += v.correct || 0;
+    out[course].total += v.total || 0;
+  }
+  return out;
+}
+
+module.exports = { toCourseSkill, mergeTalliesToCourse, _loadMap: loadMap };

--- a/utils/coursePrompt.js
+++ b/utils/coursePrompt.js
@@ -149,6 +149,35 @@ function buildCourseSystemPrompt({ userProfile, tutorProfile, courseSession, pat
   // denies it exists. See routes/chat.js.
   const practiceActGuidance = buildActPracticeGuidance(courseSession);
 
+  // Skip-what-you-aced, at the SKILL level. The every-turn course prompt never
+  // read the student's mastery, so a baseline (or prior work) that PROVED a skill
+  // in this very module was still taught from scratch. Surface the module's
+  // already-proven skills so the tutor spot-checks instead of re-teaching. Reads
+  // the same skillMastery the practice-ACT crediting writes (now under course ids
+  // via the crosswalk), so the loop actually closes.
+  let provenSkillsGuidance = '';
+  try {
+    const { getSkillMasteryEntry } = require('./masteryGuard');
+    const moduleSkillIds = (scaffoldData?.skills || currentModule?.skills || [])
+      .map((s) => (typeof s === 'string' ? s : (s && (s.skillId || s.id))))
+      .filter(Boolean);
+    const proven = moduleSkillIds.filter((sid) => {
+      const e = getSkillMasteryEntry(userProfile, sid);
+      return !!(e && (e.status === 'mastered' || e.rung === 'proved' || e.rung === 'taught'));
+    });
+    if (proven.length) {
+      const label = (sid) => sid.replace(/^act-/, '').replace(/-/g, ' ');
+      provenSkillsGuidance = `\n\n====================================================================
+ALREADY PROVEN — DO NOT RE-TEACH FROM SCRATCH
+====================================================================
+This student already demonstrated these skills in THIS module (baseline or prior
+work): ${proven.map(label).join(', ')}. Confirm each with ONE quick check question,
+and if they nail it, move on — skipping ahead to what they have NOT proven. Never
+walk them through a full lesson on a skill they've already proved; that is the
+re-grinding this course exists to prevent.`;
+    }
+  } catch (e) { /* non-fatal: mastery is an enhancement, never blocks teaching */ }
+
   return `You are ${tutorName}, an AI math instructor leading a structured, self-paced course.
 ${tutorPersonality ? `Personality: ${tutorPersonality}` : ''}
 
@@ -597,7 +626,7 @@ TEACHER RESOURCE REFERENCE: "${resourceContext.displayName}"
 ====================================================================
 The student is referencing a teacher-assigned resource called "${resourceContext.displayName}" but its content is not loaded.
 Acknowledge it by name, ask which specific problem they are on, then guide them through it once they share it.
-` : ''}` + practiceActGuidance;
+` : ''}` + practiceActGuidance + provenSkillsGuidance;
 }
 
 /**


### PR DESCRIPTION
…you aced)

Completing the practice ACT retargeted the course at the CATEGORY level (module jump + greeting recap), but "anything you ace is marked as yours and skipped" was silently false at the SKILL level, for two concrete reasons found by tracing it:

1. Crediting was keyed by the baseline's fine skill ids, but the ACT course teaches by its own coarser ids — only 8 of 44 matched. So a baseline that proved e.g. act-percentages stored mastery under an id the course never reads.
2. The every-turn buildCourseSystemPrompt never read skillMastery at all, so even a matching proven skill was still taught from scratch.

Fix (both seams, and the join between them):
- seeds/act-crosswalk.json: reviewed baseline-ACT -> course-ACT skill map (all 44 covered; 29 high / 10 med / 5 low confidence, flagged inline for review).
- utils/actCrosswalk.js: mergeTalliesToCourse re-keys + SUMS baseline tallies onto the course id (a course skill credits only if every baseline item under it was correct). Unmapped ids drop; missing/unreadable crosswalk falls back safely.
- routes/actTest.js /complete: credit from the course-keyed tallies, so mastery lands where the course looks.
- utils/coursePrompt.js: the every-turn prompt now lists the current module's already-proven skills and tells the tutor to spot-check, not re-teach.

Proof: tests/unit/actBaselineAdaptation.test.js drives both seams and asserts the JOIN — the id credited by the baseline is exactly the id the prompt then skips.

Not addressed here (separate follow-up): act-* -> UNIFIED crosswalk so these masteries also light up the unified skill-map/pie. This change is about the course adapting, which is the student-facing promise.