### PR TITLE
fix(tests): guard window reference that broke CI on main

### DIFF
--- a/public/js/courseCatalog.js
+++ b/public/js/courseCatalog.js
@@ -978,7 +978,9 @@ class CourseManager {
             // and calls onBaselineComplete(); the welcome splash + its card remain
             // behind the modal as the fallback if the student closes it early.
             // Other required diagnostics keep the existing card-only behaviour.
-            if (diagnostic.type === 'act-practice' && window.openActTest) {
+            // `typeof` guard: this file is also loaded in node by the unit tests,
+            // where `window` does not exist.
+            if (diagnostic.type === 'act-practice' && typeof window !== 'undefined' && window.openActTest) {
                 setTimeout(() => { try { window.openActTest(); } catch (e) {} }, 350);
             }
             return;


### PR DESCRIPTION
## What

One-line `typeof window !== 'undefined'` guard in `beginTeachingUnlessBaselinePending()` (public/js/courseCatalog.js).

## Why

[#1293](https://github.com/jnappier7/mathmatix-ai/pull/1293) added the ACT auto-open (`window.openActTest`) inside this method. The `courseBaselineGate` unit tests load this file in node (stubbing only `document`) and call the method directly, so the bare `window` reference throws `ReferenceError` — **main's CI has been red since that merge** (run 30171338411), and every open PR inherits the failure via the merge ref (e.g. #1294).

## Verification

- Without the guard: `tests/unit/courseBaselineGate.test.js` fails 2/7 — the exact CI failures.
- With the guard: 7/7 pass.
- Browser behavior is unchanged (`window` always exists there); no cache-bust needed — the file ships in a content-hashed Vite bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)