### PR TITLE
feat(lws): persist the Problem Card lifecycle — the board survives reloads

### DIFF
--- a/models/conversation.js
+++ b/models/conversation.js
@@ -237,6 +237,16 @@ const conversationSchema = new Schema({
         type: Schema.Types.Mixed,
         default: null
     },
+    // Persistent Problem Card lifecycle for the Living Workspace board.
+    // { current: { problemTex, posedAt, steps:[boardCommand] } | null,
+    //   completed: [{ problemTex, steps, solved, completedAt }] } — capped
+    // (12 problems / 60 steps each) by utils/pipeline/boardLedger.js, which is
+    // the only writer. Replayed client-side on session switch / re-mount so
+    // the board survives a reload. Null until the first board command lands.
+    boardLedger: {
+        type: Schema.Types.Mixed,
+        default: null
+    },
     // Session summary: compact snapshot for cross-session pattern detection.
     // Written at periodic intervals (every 10 turns) by the pipeline.
     sessionSummary: {

--- a/public/chat.html
+++ b/public/chat.html
@@ -133,7 +133,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
        LivingWorkspace flag is dev|beta|live (?livingWorkspace=dev). When on,
        it lazy-loads the workspace and mirrors the tutor's board output onto
        the new surface beside the old board. Default OFF → zero impact. -->
-  <script defer src="/js/living-workspace/chat-workspace.js?v=20260724a"></script>
+  <script defer src="/js/living-workspace/chat-workspace.js?v=20260725a"></script>
   <!-- Final safety net: strips any inline visual tag no renderer handled -->
   <script defer src="/js/stripVisualTags.js"></script>
   <!-- Non-core libs (lazy-loaded after first interaction) -->
@@ -2485,7 +2485,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- Player stats card: window-global, loaded before script.js which calls
      window.PlayerStatsCard.init(currentUser) once the user doc is fetched. -->
 <script defer src="/js/modules/playerStatsCard.js?v=20260724b"></script>
-<script src="/js/script.js?v=20260723b" type="module"></script>
+<script src="/js/script.js?v=20260725a" type="module"></script>
   <script src="/js/guidedPath.js" type="module"></script>
   <script src="/dist/js/chat-js9.bc0be9a3.js"></script>
   <!-- Companion HOME screen (phones only; flag-gated OFF by default) -->

--- a/public/js/living-workspace/chat-workspace.js
+++ b/public/js/living-workspace/chat-workspace.js
@@ -57,6 +57,9 @@
     // when the server rolls the conversation over after an idle gap — the new
     // session must not open onto the previous one's work.
     reset: function () {},
+    // Rebuild the board from a persisted conversation.boardLedger (session
+    // switch / page re-mount). No-op when the workspace is off.
+    hydrate: function () {},
   };
   window.LWS_CHAT = api;
   if (!ON) return;
@@ -65,11 +68,11 @@
   // public/ with a 7-day cache and no content hashing, so bump this whenever
   // any living-workspace asset changes (and the chat.html <script ?v=> tag to
   // match, so this file itself refreshes). See project_asset_cache_busting.
-  var ASSET_V = '?v=20260724a';
+  var ASSET_V = '?v=20260725a';
   var BASE = '/js/living-workspace/';
   var SCRIPTS = [
     'core/flags.js', 'core/viewport.js', 'core/elementRegistry.js',
-    'core/snapshotManager.js', 'core/a11yCommands.js',
+    'core/snapshotManager.js', 'core/a11yCommands.js', 'core/ledgerReplay.js',
     'dom/gridRenderer.js', 'dom/overlayManager.js', 'dom/equationElement.js',
     'dom/tileElement.js', 'dom/numberLineElement.js', 'dom/graphElement.js',
     'dom/noteElement.js', 'dom/imageElement.js', 'dom/studentMoveClient.js',
@@ -82,6 +85,7 @@
   var dv = null;
   var ready = false;
   var pending = null;        // latest board_commands received before ready
+  var pendingLedger;         // ledger passed to hydrate() before ready (undefined = none)
   var turn = 0;
 
   function injectCss() {
@@ -247,8 +251,29 @@
 
   api.reset = function () {
     pending = null;                 // don't let a queued turn repaint the old session
+    pendingLedger = undefined;
     if (!dv) return;
     try { dv.resetAll(); } catch (e) { console.error('[LWS_CHAT] reset failed', e); }
+  };
+
+  // Rebuild the board from a persisted conversation.boardLedger: each finished
+  // problem replays and is parked on the rail, the in-progress one lands in
+  // focus. Replays run through the SAME adapter/render path as live turns, so
+  // hydration can't drift from live behavior. hydrate(null) is a plain reset
+  // (a conversation with no board history must show an empty board).
+  function doHydrate(ledger) {
+    try { dv.resetAll(); } catch (e) { console.error('[LWS_CHAT] hydrate reset failed', e); }
+    if (!ledger || typeof window.LWS.ledgerToTurns !== 'function') return;
+    var turns;
+    try { turns = window.LWS.ledgerToTurns(ledger); }
+    catch (e) { console.error('[LWS_CHAT] ledger replay failed', e); return; }
+    turns.forEach(render);
+  }
+
+  api.hydrate = function (ledger) {
+    pending = null;                 // queued live turns belong to the old view
+    if (!ready || !dv) { pendingLedger = ledger || null; return; }
+    doHydrate(ledger);
   };
 
   // A student filling a scaffold's blanks is answering the tutor — send it as a
@@ -266,6 +291,10 @@
       var mount = buildPanel();
       dv = new window.LWS.DerivationView(mount, { renderers: makeRenderers(), onBlankSubmit: submitBlanks });
       ready = true;
+      // Queued work replays in arrival order: hydrate() clears any turn queued
+      // before it, so a `pending` that is still set alongside a pendingLedger
+      // arrived AFTER the hydrate and renders on top of the rebuilt board.
+      if (pendingLedger !== undefined) { var l = pendingLedger; pendingLedger = undefined; doHydrate(l); }
       if (pending) { var p = pending; pending = null; render(p); }
       console.log('[LWS_CHAT] mounted (derivation, mode=' + MODE + ')');
     });

--- a/public/js/living-workspace/core/ledgerReplay.js
+++ b/public/js/living-workspace/core/ledgerReplay.js
@@ -1,0 +1,57 @@
+/* ============================================================
+   ledgerReplay.js — turn a persisted board ledger back into turns.
+
+   The server folds every turn's board commands into
+   conversation.boardLedger (utils/pipeline/boardLedger.js):
+
+     { current:   { problemTex, posedAt, steps:[boardCommand] } | null,
+       completed: [ { problemTex, steps, solved, completedAt } ] }
+
+   This module converts that ledger into an ordered list of command
+   ARRAYS ("turns") that chat-workspace.js feeds through the normal
+   render path (P5 adapter → DerivationView.apply). Replaying through
+   the live path — rather than poking view internals — reproduces the
+   exact board the student last saw: each completed problem renders and
+   is then archived to the rail by an explicit `clear` (the same signal
+   a live session uses), and the in-progress problem lands in focus
+   last, with its scaffold blanks editable again.
+
+   The explicit `clear` between completed problems (instead of relying
+   on the next pose to archive) matters for one edge: the same problem
+   solved twice back-to-back. Pose-triggered archiving compares tex and
+   skips identical math; `clear` archives unconditionally.
+
+   Pure and headless-testable. UMD-lite like the rest of core/.
+   ============================================================ */
+(function (root, factory) {
+  var mod = factory();
+  if (typeof module !== 'undefined' && module.exports) module.exports = mod;
+  if (root) (root.LWS = root.LWS || {}).ledgerToTurns = mod.ledgerToTurns;
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  function problemTurn(entry) {
+    if (!entry || !entry.problemTex) return null;
+    var steps = Array.isArray(entry.steps) ? entry.steps : [];
+    return [{ action: 'pose', tex: entry.problemTex }].concat(steps);
+  }
+
+  function ledgerToTurns(ledger) {
+    var turns = [];
+    if (!ledger || typeof ledger !== 'object') return turns;
+
+    (Array.isArray(ledger.completed) ? ledger.completed : []).forEach(function (entry) {
+      var t = problemTurn(entry);
+      if (!t) return;
+      turns.push(t);
+      turns.push([{ action: 'clear' }]);   // park it on the rail
+    });
+
+    var cur = problemTurn(ledger.current);
+    if (cur) turns.push(cur);              // back in focus, still open
+
+    return turns;
+  }
+
+  return { ledgerToTurns: ledgerToTurns };
+});

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -698,7 +698,7 @@ document.addEventListener("DOMContentLoaded", () => {
             if (data.continued && Array.isArray(data.messages)) {
                 if (data.messages.length > 0 && typeof window.updateChatForSession === 'function') {
                     window.updateChatForSession(
-                        { _id: data.conversationId, conversationType: 'general' },
+                        { _id: data.conversationId, conversationType: 'general', boardLedger: data.boardLedger || null },
                         data.messages
                     );
                 }
@@ -5481,6 +5481,15 @@ document.addEventListener("DOMContentLoaded", () => {
                 );
             }
             // For course and general conversations, the caller handles the greeting
+        }
+
+        // Rebuild the workspace board to match this conversation: finished
+        // problems return to the rail, the in-progress one lands back in focus.
+        // A conversation with no board history hydrates to an empty board, so
+        // the previous session's work never bleeds across a switch.
+        if (window.LWS_CHAT && typeof window.LWS_CHAT.hydrate === 'function') {
+            try { window.LWS_CHAT.hydrate(conversation.boardLedger || null); }
+            catch (err) { console.error('[updateChatForSession] board hydrate failed:', err); }
         }
 
         console.log('[updateChatForSession] Loaded', messages?.length || 0, 'messages');

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -2381,7 +2381,7 @@ async function handleGreetingRequest(req, res, userId) {
                     res.setHeader('Connection', 'keep-alive');
                     res.setHeader('X-Accel-Buffering', 'no');
                     res.flushHeaders();
-                    res.write(`data: ${JSON.stringify({ done: true, voiceId: contTutor.cartesiaVoiceId, isGreeting: true, continued: true, conversationId: activeConversation._id, messages: visibleMessages })}\n\n`);
+                    res.write(`data: ${JSON.stringify({ done: true, voiceId: contTutor.cartesiaVoiceId, isGreeting: true, continued: true, conversationId: activeConversation._id, messages: visibleMessages, boardLedger: activeConversation.boardLedger || null })}\n\n`);
                     return res.end();
                 }
                 // QA P1-6: send WITHIN-level XP (and a level reconciled from
@@ -2393,6 +2393,7 @@ async function handleGreetingRequest(req, res, userId) {
                     continued: true,
                     conversationId: activeConversation._id,
                     messages: visibleMessages,
+                    boardLedger: activeConversation.boardLedger || null,
                     voiceId: contTutor.cartesiaVoiceId,
                     isGreeting: true,
                     userXp: contXp.xpForCurrentLevel,
@@ -2434,7 +2435,7 @@ async function handleGreetingRequest(req, res, userId) {
                 res.setHeader('Connection', 'keep-alive');
                 res.setHeader('X-Accel-Buffering', 'no');
                 res.flushHeaders();
-                res.write(`data: ${JSON.stringify({ done: true, voiceId: contTutor.cartesiaVoiceId, isGreeting: true, continued: true, conversationId: activeConversation._id, messages: visibleMessages })}\n\n`);
+                res.write(`data: ${JSON.stringify({ done: true, voiceId: contTutor.cartesiaVoiceId, isGreeting: true, continued: true, conversationId: activeConversation._id, messages: visibleMessages, boardLedger: activeConversation.boardLedger || null })}\n\n`);
                 return res.end();
             }
             return res.json({
@@ -2442,6 +2443,7 @@ async function handleGreetingRequest(req, res, userId) {
                 continued: true,
                 conversationId: activeConversation._id,
                 messages: visibleMessages,
+                boardLedger: activeConversation.boardLedger || null,
                 voiceId: contTutor.cartesiaVoiceId,
                 isGreeting: true,
                 userXp: user.xp || 0,

--- a/routes/conversations.js
+++ b/routes/conversations.js
@@ -416,7 +416,11 @@ router.post('/:id/switch', isAuthenticated, validateObjectId('id'), async (req, 
         topicEmoji: conversation.topicEmoji,
         name: conversation.conversationName || conversation.topic || 'General Chat',
         conversationType: conversation.conversationType,
-        currentTopic: conversation.currentTopic
+        currentTopic: conversation.currentTopic,
+        // Rides inside `conversation` (not a sibling) so sidebar.js can stay
+        // untouched — it forwards this object verbatim to updateChatForSession,
+        // which replays the board from it.
+        boardLedger: conversation.boardLedger || null
       },
       messages: recentMessages
     });

--- a/tests/unit/boardLedger.test.js
+++ b/tests/unit/boardLedger.test.js
@@ -1,0 +1,119 @@
+/**
+ * The persistent Problem Card lifecycle (utils/pipeline/boardLedger.js).
+ *
+ * The ledger must mirror the client's own archive rules (DerivationView):
+ * a pose of different math or a clear parks the problem in focus on the
+ * completed rail; a re-pose of the same math is a redraw, not a new problem;
+ * a problem posed but never worked is dropped, not archived.
+ */
+const { applyTurnToLedger, MAX_COMPLETED, MAX_STEPS } = require('../../utils/pipeline/boardLedger');
+
+const NOW = new Date('2026-07-25T12:00:00Z');
+
+function turn(ledger, cmds) { return applyTurnToLedger(ledger, cmds, NOW); }
+
+describe('applyTurnToLedger', () => {
+  test('a pose starts the current problem', () => {
+    const l = turn(null, [{ action: 'pose', tex: '2x+5=13' }]);
+    expect(l.current).toMatchObject({ problemTex: '2x+5=13', steps: [] });
+    expect(l.completed).toEqual([]);
+  });
+
+  test('steps append to the current problem in order', () => {
+    let l = turn(null, [{ action: 'pose', tex: '2x+5=13' }]);
+    l = turn(l, [
+      { action: 'apply', op: 'subtract 5 from both sides' },
+      { action: 'resolve', tex: '2x=8' },
+    ]);
+    expect(l.current.steps.map(s => s.action)).toEqual(['apply', 'resolve']);
+    expect(l.current.steps[1].tex).toBe('2x=8');
+  });
+
+  test('a verify marks the problem solved when it is archived', () => {
+    let l = turn(null, [{ action: 'pose', tex: '2x+5=13' }]);
+    l = turn(l, [{ action: 'resolve', tex: '2x=8' }, { action: 'verify', tex: 'x=4' }]);
+    l = turn(l, [{ action: 'clear' }]);
+    expect(l.current).toBeNull();
+    expect(l.completed).toHaveLength(1);
+    expect(l.completed[0]).toMatchObject({ problemTex: '2x+5=13', solved: true, completedAt: NOW });
+  });
+
+  test('a pose of different math archives the outgoing problem (unsolved)', () => {
+    let l = turn(null, [{ action: 'pose', tex: '2x+5=13' }]);
+    l = turn(l, [{ action: 'resolve', tex: '2x=8' }]);
+    l = turn(l, [{ action: 'pose', tex: '3y-1=8' }]);
+    expect(l.current.problemTex).toBe('3y-1=8');
+    expect(l.completed).toHaveLength(1);
+    expect(l.completed[0].solved).toBe(false);
+  });
+
+  test('re-posing the same math (whitespace/case-insensitive) is a redraw, not a new problem', () => {
+    let l = turn(null, [{ action: 'pose', tex: '2x+5=13' }]);
+    l = turn(l, [{ action: 'resolve', tex: '2x=8' }]);
+    l = turn(l, [{ action: 'pose', tex: ' 2X + 5 = 13 ' }]);
+    expect(l.completed).toEqual([]);
+    expect(l.current.steps).toHaveLength(1);   // work kept, nothing archived
+  });
+
+  test('a problem posed but never worked is dropped on archive, mirroring the client', () => {
+    let l = turn(null, [{ action: 'pose', tex: '2x+5=13' }]);
+    l = turn(l, [{ action: 'clear' }]);
+    expect(l.current).toBeNull();
+    expect(l.completed).toEqual([]);
+  });
+
+  test('example and visual cards are recorded as steps for faithful replay', () => {
+    let l = turn(null, [{ action: 'pose', tex: 'y=2x' }]);
+    l = turn(l, [
+      { action: 'example', tex: 'y=3x' },
+      { action: 'graph', expression: 'y=2x' },
+    ]);
+    expect(l.current.steps.map(s => s.action)).toEqual(['example', 'graph']);
+  });
+
+  test('steps with no pinned problem are not attached to anything', () => {
+    const l = turn(null, [{ action: 'resolve', tex: '2x=8' }]);
+    expect(l.current).toBeNull();
+    expect(l.completed).toEqual([]);
+  });
+
+  test('completed problems cap at MAX_COMPLETED, oldest falling off', () => {
+    let l = null;
+    for (let i = 0; i < MAX_COMPLETED + 3; i++) {
+      l = turn(l, [{ action: 'pose', tex: `x+${i}=0` }]);
+      l = turn(l, [{ action: 'verify', tex: `x=-${i}` }]);
+      l = turn(l, [{ action: 'clear' }]);
+    }
+    expect(l.completed).toHaveLength(MAX_COMPLETED);
+    expect(l.completed[0].problemTex).toBe('x+3=0');   // 0..2 fell off
+  });
+
+  test('steps cap at MAX_STEPS per problem, oldest falling off', () => {
+    let l = turn(null, [{ action: 'pose', tex: '2x+5=13' }]);
+    const steps = [];
+    for (let i = 0; i < MAX_STEPS + 5; i++) steps.push({ action: 'resolve', tex: `step${i}` });
+    l = turn(l, steps);
+    expect(l.current.steps).toHaveLength(MAX_STEPS);
+    expect(l.current.steps[0].tex).toBe('step5');
+  });
+
+  test('unknown extra fields on commands are stripped before persistence', () => {
+    let l = turn(null, [{ action: 'pose', tex: 'y=x' }]);
+    l = turn(l, [{ action: 'resolve', tex: 'y=x', bulkyDebugBlob: 'x'.repeat(500) }]);
+    expect(l.current.steps[0].bulkyDebugBlob).toBeUndefined();
+  });
+
+  test('does not mutate the previous ledger (pure)', () => {
+    const first = turn(null, [{ action: 'pose', tex: '2x+5=13' }]);
+    const frozen = structuredClone(first);
+    turn(first, [{ action: 'resolve', tex: '2x=8' }, { action: 'pose', tex: 'y=1' }]);
+    expect(first).toEqual(frozen);
+  });
+
+  test('tolerates malformed input: null commands, junk entries, malformed prev', () => {
+    expect(turn(null, null)).toEqual({ current: null, completed: [] });
+    expect(turn({ current: 'junk', completed: 'junk' }, [{ action: 'pose', tex: 'y=x' }]).current.problemTex).toBe('y=x');
+    const l = turn(null, [null, 'nope', { noAction: true }, { action: 'pose' }]);
+    expect(l.current).toBeNull();
+  });
+});

--- a/tests/unit/workspace/boardHydration.test.js
+++ b/tests/unit/workspace/boardHydration.test.js
@@ -1,0 +1,101 @@
+/**
+ * Board hydration round trip, headless: the persistence contract end to end.
+ *
+ *   server: applyTurnToLedger (utils/pipeline/boardLedger)
+ *        → client: ledgerToTurns (core/ledgerReplay)
+ *        → client: adaptBoardCommands (dom/legacyBoardAdapter)
+ *        → client: DerivationView semantics (classify / hasSolution)
+ *
+ * This is the reload story: a student who solved a problem, abandoned another,
+ * and is mid-way through a third must come back to two rail thumbnails (the
+ * solved one ticked) and the third problem back in focus with its steps.
+ *
+ * Repo convention keeps DOM layout verification in-browser; here we assert on
+ * the adapted element stream + the view's exported pure semantics, which fully
+ * determine what DerivationView renders: a `problem` role pins the focus (a
+ * different problem archives the previous one), `clear` archives, and
+ * hasSolution() is exactly the ✓ on a rail thumbnail.
+ */
+const { applyTurnToLedger } = require('../../../utils/pipeline/boardLedger');
+const { ledgerToTurns } = require('../../../public/js/living-workspace/core/ledgerReplay.js');
+const { adaptBoardCommands } = require('../../../public/js/living-workspace/dom/legacyBoardAdapter.js');
+const { classify, hasSolution } = require('../../../public/js/living-workspace/dom/derivationView.js');
+
+const NOW = new Date('2026-07-25T12:00:00Z');
+
+// Replay a wire-format ledger the way chat-workspace.doHydrate does, and fold
+// the adapted turns into the same archive model the view keeps: `clear` or a
+// different `problem` parks the focused derivation, everything else appends.
+function simulateReplay(wireLedger) {
+  const board = { focus: null, rail: [] };
+  ledgerToTurns(wireLedger).forEach((turnCmds, i) => {
+    const out = adaptBoardCommands(turnCmds, { idPrefix: 'hyd' + i });
+    if (out.clear && board.focus) { board.rail.push(board.focus); board.focus = null; }
+    out.elements.forEach((el) => {
+      const kind = classify(el);
+      if (kind === 'problem') {
+        const tex = el.semantic.latex;
+        if (board.focus && board.focus.problemTex !== tex) { board.rail.push(board.focus); board.focus = null; }
+        if (!board.focus) board.focus = { problemTex: tex, elements: [] };
+        return;
+      }
+      if (board.focus) board.focus.elements.push(el);
+    });
+  });
+  return board;
+}
+
+describe('board hydration round trip', () => {
+  test('solved + abandoned problems return to the rail, the open one lands in focus', () => {
+    // Accumulate the ledger exactly as the pipeline would across a session.
+    let ledger = null;
+    ledger = applyTurnToLedger(ledger, [{ action: 'pose', tex: '2x+5=13' }], NOW);
+    ledger = applyTurnToLedger(ledger, [
+      { action: 'apply', op: 'subtract 5' },
+      { action: 'resolve', tex: '2x=8' },
+      { action: 'verify', tex: 'x=4' },
+    ], NOW);
+    ledger = applyTurnToLedger(ledger, [{ action: 'pose', tex: '3y-1=8' }], NOW); // archives #1
+    ledger = applyTurnToLedger(ledger, [{ action: 'resolve', tex: '3y=9' }], NOW);
+    ledger = applyTurnToLedger(ledger, [{ action: 'clear' }], NOW);               // archives #2 (unsolved)
+    ledger = applyTurnToLedger(ledger, [{ action: 'pose', tex: 'z^2=25' }], NOW);
+    ledger = applyTurnToLedger(ledger, [{ action: 'resolve', tex: 'z=\\pm 5' }], NOW);
+
+    // Survive Mongo/JSON transport, then replay client-side.
+    const board = simulateReplay(JSON.parse(JSON.stringify(ledger)));
+
+    expect(board.rail).toHaveLength(2);
+    expect(board.rail[0].problemTex).toBe('2x+5=13');
+    expect(hasSolution(board.rail[0].elements)).toBe(true);    // ✓ thumbnail
+    expect(board.rail[1].problemTex).toBe('3y-1=8');
+    expect(hasSolution(board.rail[1].elements)).toBe(false);   // no tick
+
+    expect(board.focus.problemTex).toBe('z^2=25');
+    expect(board.focus.elements.map(classify)).toEqual(['step']);
+    expect(board.focus.elements[0].semantic.latex).toContain('z=');
+  });
+
+  test('a ledger with no open problem replays to an empty focus and a populated rail', () => {
+    let ledger = null;
+    ledger = applyTurnToLedger(ledger, [{ action: 'pose', tex: 'x+1=2' }], NOW);
+    ledger = applyTurnToLedger(ledger, [{ action: 'verify', tex: 'x=1' }, { action: 'clear' }], NOW);
+
+    const board = simulateReplay(JSON.parse(JSON.stringify(ledger)));
+    expect(board.focus).toBeNull();
+    expect(board.rail).toHaveLength(1);
+    expect(hasSolution(board.rail[0].elements)).toBe(true);
+  });
+
+  test('every replayed step survives the adapter (nothing dropped in transport)', () => {
+    let ledger = null;
+    ledger = applyTurnToLedger(ledger, [{ action: 'pose', tex: 'y=2x' }], NOW);
+    ledger = applyTurnToLedger(ledger, [
+      { action: 'apply', op: 'double it' },
+      { action: 'scaffold', tex: 'y=\\boxed{}' },
+      { action: 'example', tex: 'y=3x' },
+    ], NOW);
+
+    const board = simulateReplay(JSON.parse(JSON.stringify(ledger)));
+    expect(board.focus.elements.map(classify)).toEqual(['operation', 'scaffold', 'example']);
+  });
+});

--- a/tests/unit/workspace/ledgerReplay.test.js
+++ b/tests/unit/workspace/ledgerReplay.test.js
@@ -1,0 +1,68 @@
+/**
+ * Ledger → replay turns (public/js/living-workspace/core/ledgerReplay.js).
+ *
+ * Hydration replays the persisted board through the SAME render path as live
+ * turns, so this contract is what keeps a reloaded board identical to the one
+ * the student left: completed problems each replay as [pose, ...steps] then an
+ * explicit clear (parking them on the rail), and the in-progress problem
+ * replays last with no clear, landing back in focus.
+ */
+const { ledgerToTurns } = require('../../../public/js/living-workspace/core/ledgerReplay.js');
+
+describe('ledgerToTurns', () => {
+  test('null / malformed ledgers replay to nothing', () => {
+    expect(ledgerToTurns(null)).toEqual([]);
+    expect(ledgerToTurns(undefined)).toEqual([]);
+    expect(ledgerToTurns('junk')).toEqual([]);
+    expect(ledgerToTurns({})).toEqual([]);
+  });
+
+  test('a completed problem replays as pose + steps, then an explicit clear', () => {
+    const turns = ledgerToTurns({
+      current: null,
+      completed: [{
+        problemTex: '2x+5=13',
+        steps: [{ action: 'resolve', tex: '2x=8' }, { action: 'verify', tex: 'x=4' }],
+        solved: true,
+      }],
+    });
+    expect(turns).toEqual([
+      [
+        { action: 'pose', tex: '2x+5=13' },
+        { action: 'resolve', tex: '2x=8' },
+        { action: 'verify', tex: 'x=4' },
+      ],
+      [{ action: 'clear' }],
+    ]);
+  });
+
+  test('the in-progress problem replays last, with no trailing clear', () => {
+    const turns = ledgerToTurns({
+      current: { problemTex: '3y-1=8', steps: [{ action: 'apply', op: 'add 1' }] },
+      completed: [{ problemTex: '2x+5=13', steps: [{ action: 'verify', tex: 'x=4' }], solved: true }],
+    });
+    expect(turns).toHaveLength(3);
+    expect(turns[2]).toEqual([
+      { action: 'pose', tex: '3y-1=8' },
+      { action: 'apply', op: 'add 1' },
+    ]);
+    expect(turns[2].some(c => c.action === 'clear')).toBe(false);
+  });
+
+  test('identical back-to-back problems still archive separately (the explicit clear)', () => {
+    // Pose-triggered archiving skips same-tex poses; the explicit clear between
+    // completed replays is what keeps two solves of the same problem as two
+    // rail thumbnails instead of one merged derivation.
+    const entry = { problemTex: '2x+5=13', steps: [{ action: 'verify', tex: 'x=4' }], solved: true };
+    const turns = ledgerToTurns({ current: null, completed: [entry, { ...entry }] });
+    expect(turns.map(t => t[0].action)).toEqual(['pose', 'clear', 'pose', 'clear']);
+  });
+
+  test('entries without a problemTex are skipped, steps default to empty', () => {
+    const turns = ledgerToTurns({
+      current: { problemTex: 'y=x' },                  // no steps array
+      completed: [{ steps: [{ action: 'verify' }] }],  // no problemTex
+    });
+    expect(turns).toEqual([[{ action: 'pose', tex: 'y=x' }]]);
+  });
+});

--- a/utils/pipeline/boardLedger.js
+++ b/utils/pipeline/boardLedger.js
@@ -1,0 +1,137 @@
+/**
+ * boardLedger.js — persistent Problem Card lifecycle for the Living Workspace.
+ *
+ * The DerivationView (public/js/living-workspace/dom/derivationView.js) keeps a
+ * per-page-load archive: the problem in focus plus a rail of finished problems.
+ * A reload or session switch loses all of it, because nothing server-side
+ * records what the board displayed — `conversation.boardProblem` is only the
+ * anti-cheat pin ({tex, posedAt}), dropped the moment a cycle closes.
+ *
+ * This module maintains `conversation.boardLedger`, a compact mirror of the
+ * board's lifecycle that the client can replay after a reload:
+ *
+ *   {
+ *     current:   { problemTex, posedAt, steps: [boardCommand] } | null,
+ *     completed: [ { problemTex, steps, solved, completedAt } ]   // oldest first
+ *   }
+ *
+ * Transitions intentionally mirror the client's own archive rules, so a
+ * replayed board matches what the student last saw:
+ *   • pose of DIFFERENT math  → archive current, start a new current
+ *   • pose of the same math   → no-op on the ledger (re-draw, not a new problem)
+ *   • clear                   → archive current, current = null
+ *   • anything else           → append to current.steps (verify marks it solved)
+ * A problem that was posed but never worked (no steps) is dropped on archive,
+ * matching DerivationView._archiveCurrent.
+ *
+ * Pure and side-effect free: returns a NEW ledger object; callers persist it.
+ * Steps are stored as the schema-checked board commands themselves, so the
+ * client replays them through the same adapter path as live turns.
+ */
+'use strict';
+
+// Mirror of DerivationView.MAX_ARCHIVE — the rail shows a session's worth of
+// recent work, not an unbounded archive, and the conversation doc stays small.
+const MAX_COMPLETED = 12;
+// Safety cap per problem: a marathon derivation should not bloat the document.
+// Oldest steps fall off; the problem statement and the newest work survive.
+const MAX_STEPS = 60;
+
+// Same normalization the client uses to decide "is this the same problem".
+function normTex(s) {
+  return String(s == null ? '' : s).replace(/\s+/g, '').toLowerCase();
+}
+
+function emptyLedger() {
+  return { current: null, completed: [] };
+}
+
+// Keep only the fields the client replay needs. Board commands are already
+// schema-checked upstream; this is belt-and-braces against oversized payloads
+// riding into Mongo (e.g. an unexpected extra field on a graph card).
+const COMMAND_FIELDS = [
+  'action', 'tex', 'op', 'caption', 'label', 'plain',
+  // visual/block cards
+  'graphType', 'expression', 'expressions', 'points', 'window', 'imageQuery',
+  'shape', 'params', 'highlight', 'steps',
+];
+function sanitizeCommand(cmd) {
+  const out = {};
+  for (const k of COMMAND_FIELDS) {
+    if (cmd[k] !== undefined) out[k] = cmd[k];
+  }
+  return out;
+}
+
+function archiveCurrent(ledger, now) {
+  const cur = ledger.current;
+  ledger.current = null;
+  if (!cur || !cur.problemTex) return;
+  if (!Array.isArray(cur.steps) || cur.steps.length === 0) return; // posed, never worked
+  ledger.completed.push({
+    problemTex: cur.problemTex,
+    steps: cur.steps,
+    solved: cur.steps.some(c => c && c.action === 'verify'),
+    completedAt: now,
+  });
+  while (ledger.completed.length > MAX_COMPLETED) ledger.completed.shift();
+}
+
+/**
+ * Fold one turn's verified board commands into the ledger.
+ *
+ * @param {object|null} prev - conversation.boardLedger (may be null/malformed)
+ * @param {Array} commands - the turn's verified board commands, in order
+ * @param {Date} [now] - injectable clock for tests
+ * @returns {object} a new ledger object
+ */
+function applyTurnToLedger(prev, commands, now = new Date()) {
+  const ledger = {
+    current: prev && prev.current && prev.current.problemTex
+      ? {
+          problemTex: prev.current.problemTex,
+          posedAt: prev.current.posedAt || now,
+          steps: Array.isArray(prev.current.steps) ? prev.current.steps.slice() : [],
+        }
+      : null,
+    completed: prev && Array.isArray(prev.completed) ? prev.completed.slice() : [],
+  };
+  if (!Array.isArray(commands)) return ledger;
+
+  for (const raw of commands) {
+    if (!raw || typeof raw !== 'object' || !raw.action) continue;
+    const cmd = sanitizeCommand(raw);
+
+    if (cmd.action === 'pose') {
+      if (!cmd.tex) continue;
+      if (ledger.current && normTex(cmd.tex) === normTex(ledger.current.problemTex)) {
+        continue; // same problem re-drawn (board-reference backstop etc.)
+      }
+      archiveCurrent(ledger, now);
+      ledger.current = { problemTex: cmd.tex, posedAt: now, steps: [] };
+      continue;
+    }
+
+    if (cmd.action === 'clear') {
+      archiveCurrent(ledger, now);
+      continue;
+    }
+
+    // apply / resolve / verify / scaffold / example / graph / image / diagram / model
+    if (ledger.current) {
+      ledger.current.steps.push(cmd);
+      while (ledger.current.steps.length > MAX_STEPS) ledger.current.steps.shift();
+    }
+    // No pinned problem → a stray line with nothing to attach it to; the live
+    // board would float it, but it is not part of any problem's lifecycle.
+  }
+
+  return ledger;
+}
+
+module.exports = {
+  applyTurnToLedger,
+  emptyLedger,
+  MAX_COMPLETED,
+  MAX_STEPS,
+};

--- a/utils/pipeline/index.js
+++ b/utils/pipeline/index.js
@@ -31,6 +31,7 @@ const { buildSidecar, mergeLlmSignals, getSignalStats } = require('./sidecar');
 const { computeSessionMood, buildMoodDirective } = require('./sessionMood');
 const { generateSuggestions } = require('./suggestions');
 const { assembleEvidence } = require('./evidenceAccumulator');
+const { applyTurnToLedger } = require('./boardLedger');
 
 // New data-driven engines
 const { updateBKT, initializeBKT } = require('../knowledgeTracer');
@@ -1180,6 +1181,21 @@ async function runPipeline(message, ctx) {
     } else if (lastEmitted === 'verify' || lastEmitted === 'clear') {
       ctx.conversation.boardProblem = null;
       ctx.conversation.markModified?.('boardProblem');
+    }
+  }
+
+  // Persistent Problem Card lifecycle (Live Workspace spec §4, MVP #20): fold
+  // this turn's board into conversation.boardLedger so a reload / session
+  // switch can replay the board — the in-focus derivation AND the rail of
+  // finished problems — instead of coming back blank. ALL verified commands
+  // are folded (not just cycleCards): the client renders example/scaffold
+  // lines too, and a faithful replay must include them. Non-fatal by design.
+  if (verified.boardCommands.length > 0 && ctx.conversation) {
+    try {
+      ctx.conversation.boardLedger = applyTurnToLedger(ctx.conversation.boardLedger, verified.boardCommands);
+      ctx.conversation.markModified?.('boardLedger');
+    } catch (ledgerErr) {
+      boardLogger.warn('Board ledger update failed (non-fatal)', { error: ledgerErr.message });
     }
   }
 


### PR DESCRIPTION
First implementation slice of the Live Workspace baseline spec ([docs/LIVE_WORKSPACE_REQUIREMENTS.md](https://github.com/jnappier7/mathmatix-ai/blob/main/docs/LIVE_WORKSPACE_REQUIREMENTS.md), §4 Problem Cards / MVP item 20 "Session persistence").

## The gap

The DerivationView already gives each problem a card-like lifecycle — focused derivation, archive rail with ✓ thumbnails, read-only reopen — but only in page memory. A reload or session switch replayed the transcript while the board came back **blank**: nothing server-side recorded what the board displayed (`conversation.boardProblem` is just the anti-cheat pin, dropped when a cycle closes).

## What this adds

**Server — `conversation.boardLedger`**
- `utils/pipeline/boardLedger.js` (new, pure): folds each turn's verified board commands into `{ current: {problemTex, posedAt, steps[]}, completed: [{problemTex, steps, solved, completedAt}] }`. Transitions mirror the client's own archive rules: a pose of different math or a `clear` parks the focused problem (solved = it reached a `verify`); a same-tex re-pose is a redraw; posed-but-never-worked drops. Caps: 12 problems / 60 steps, commands field-whitelisted.
- Wired into `utils/pipeline/index.js` right after the pin write-back; non-fatal on error. The anti-cheat pin contract is untouched.
- Exposed on `POST /api/conversations/:id/switch` (inside the `conversation` object, so the Vite-bundled sidebar.js forwards it with **zero changes**) and on all four `continued:true` greeting responses in `routes/chat.js` (the page-re-mount path).

**Client — replay, not reconstruction**
- `core/ledgerReplay.js` (new, pure): ledger → ordered command turns. Completed problems replay as `[pose, …steps]` + an explicit `clear`; the open problem replays last and lands back in focus (scaffold blanks editable again). The explicit clear keeps two back-to-back solves of the same problem as two thumbnails.
- `LWS_CHAT.hydrate(ledger)` in chat-workspace.js runs those turns through the **same P5-adapter → DerivationView path as live turns**, so hydration cannot drift from live behavior. `hydrate(null)` = clean board (no cross-session bleed). Pre-mount ordering handled (hydrate queued during script load; a live turn arriving after it still renders on top).
- `updateChatForSession` hydrates on every session switch / continuation.
- Cache-busting: `script.js` + `chat-workspace.js` `?v=20260725a` in chat.html; `ASSET_V` bumped for the lazily-loaded workspace modules.

## Verification

- 20 new tests: ledger transitions (caps, redraw, purity, malformed input), the replay contract, and a headless **round trip** — pipeline ledger → wire JSON → replay → adapter → view semantics (`classify`/`hasSolution`), asserting the exact reload story: solved ✓ thumbnail + abandoned thumbnail + open problem back in focus with its steps.
- Full suite: **305 suites / 4619 passed**, lint clean on all touched files.
- Not verified in a live browser: that needs an authenticated student session (I don't log in with credentials). Manual QA: with `?livingWorkspace=dev`, solve a problem, start another, reload → the solved one should be on the rail with a ✓ and the open one back in focus.

## Scope notes

- Voice-tutor turns don't flow through this ledger yet (separate WS path) — a voice-only session still reloads blank; follow-up.
- Trial chat is untouched (its board state is per-browser-session by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)