### PR TITLE
feat(lws): record the assistance ladder as independence evidence

### DIFF
--- a/tests/unit/assistanceLadder.test.js
+++ b/tests/unit/assistanceLadder.test.js
@@ -1,0 +1,106 @@
+/**
+ * The 11-level assistance ladder (utils/pipeline/assistanceLadder.js, spec §12).
+ *
+ * The contract that matters: a turn's level reflects the tutor's heaviest
+ * action, the ladder never reaches 10–11 from pipeline signals (anti-cheat
+ * forbids working the student's own problem), and levels 1–4 count as
+ * independent for the mastery engine.
+ */
+const {
+  LADDER,
+  INDEPENDENT_MAX,
+  assistanceLevelForTurn,
+  assistanceLabel,
+  isIndependent,
+  maxAssistance,
+} = require('../../utils/pipeline/assistanceLadder');
+
+describe('assistanceLevelForTurn', () => {
+  test('no signals → independent', () => {
+    expect(assistanceLevelForTurn({})).toBe(1);
+    expect(assistanceLevelForTurn(null)).toBe(1);
+    expect(assistanceLevelForTurn({ decisionAction: 'present_problem' })).toBe(1);
+  });
+
+  test('the action family maps onto the spec rungs', () => {
+    expect(assistanceLevelForTurn({ decisionAction: 'confirm_correct' })).toBe(2);
+    expect(assistanceLevelForTurn({ decisionAction: 'check_understanding' })).toBe(3);
+    expect(assistanceLevelForTurn({ decisionAction: 'redirect_to_math' })).toBe(4);
+    expect(assistanceLevelForTurn({ decisionAction: 'hint' })).toBe(5);
+    expect(assistanceLevelForTurn({ decisionAction: 'switch_representation' })).toBe(6);
+    expect(assistanceLevelForTurn({ decisionAction: 'guided_practice' })).toBe(7);
+    expect(assistanceLevelForTurn({ decisionAction: 'worked_example' })).toBe(8);
+    expect(assistanceLevelForTurn({ decisionAction: 'direct_instruction' })).toBe(9);
+  });
+
+  test('an unknown action contributes nothing (level 1, never a throw)', () => {
+    expect(assistanceLevelForTurn({ decisionAction: 'some_future_action' })).toBe(1);
+  });
+
+  test('board cards floor the level: scaffold=7, example=8, visuals=6', () => {
+    expect(assistanceLevelForTurn({
+      decisionAction: 'confirm_correct',
+      boardCommands: [{ action: 'scaffold', tex: 'x=\\boxed{}' }],
+    })).toBe(7);
+    expect(assistanceLevelForTurn({ boardCommands: [{ action: 'example', tex: 'y=3x' }] })).toBe(8);
+    expect(assistanceLevelForTurn({ boardCommands: [{ action: 'graph' }] })).toBe(6);
+    // The solve-cycle cards mirror the student's own verified moves — no help implied.
+    expect(assistanceLevelForTurn({ boardCommands: [{ action: 'pose' }, { action: 'resolve' }, { action: 'verify' }] })).toBe(1);
+  });
+
+  test('the turn level is the MAX of its signals, not the last one', () => {
+    expect(assistanceLevelForTurn({
+      decisionAction: 'direct_instruction',                 // 9
+      boardCommands: [{ action: 'graph' }],                 // 6
+    })).toBe(9);
+  });
+
+  test('heavy scaffold intensity floors a mild action', () => {
+    expect(assistanceLevelForTurn({ decisionAction: 'hint', scaffoldLevel: 5 })).toBe(6);
+    expect(assistanceLevelForTurn({ decisionAction: 'confirm_correct', scaffoldLevel: 4 })).toBe(5);
+    // ...but never lowers a heavier one.
+    expect(assistanceLevelForTurn({ decisionAction: 'direct_instruction', scaffoldLevel: 1 })).toBe(9);
+  });
+
+  test('no pipeline signal can reach tutor-modeled/tutor-completed (10–11)', () => {
+    // Exhaustive sweep of every action and board card at max intensity: the
+    // anti-cheat ceiling. If this test ever fails, containment broke upstream.
+    const actions = [
+      'elicit_first', 'present_problem', 'independent_practice', 'strengthen_challenge',
+      'continue_conversation', 'confirm_correct', 'acknowledge_progress', 'acknowledge_frustration',
+      'check_understanding', 'redirect_to_math', 'hint', 'probing_question', 'guide_incorrect',
+      'leverage_bridge', 'switch_representation', 'guided_practice', 'scaffold_down',
+      'worked_example', 'direct_instruction', 'phase_instruction', 'reteach_misconception',
+      'review_prerequisite', 'prerequisite_bridge', 'exit_ramp',
+    ];
+    const cards = ['pose', 'apply', 'resolve', 'verify', 'clear', 'scaffold', 'example', 'graph', 'image', 'diagram', 'model'];
+    for (const a of actions) {
+      const level = assistanceLevelForTurn({
+        decisionAction: a,
+        scaffoldLevel: 5,
+        boardCommands: cards.map(c => ({ action: c })),
+      });
+      expect(level).toBeLessThanOrEqual(9);
+    }
+  });
+});
+
+describe('independence + helpers', () => {
+  test('levels 1–4 are independent; 5+ is not', () => {
+    for (let l = 1; l <= INDEPENDENT_MAX; l++) expect(isIndependent(l)).toBe(true);
+    for (let l = INDEPENDENT_MAX + 1; l <= 11; l++) expect(isIndependent(l)).toBe(false);
+    expect(isIndependent(null)).toBe(true);   // no evidence of help ≠ evidence of help
+  });
+
+  test('every ladder rung has a label', () => {
+    for (let l = 1; l <= 11; l++) expect(typeof assistanceLabel(l)).toBe('string');
+    expect(assistanceLabel(0)).toBeNull();
+    expect(assistanceLabel(12)).toBeNull();
+  });
+
+  test('maxAssistance folds with nulls', () => {
+    expect(maxAssistance(null, 5)).toBe(5);
+    expect(maxAssistance(7, 3)).toBe(7);
+    expect(maxAssistance(null, null)).toBeNull();
+  });
+});

--- a/tests/unit/boardLedger.test.js
+++ b/tests/unit/boardLedger.test.js
@@ -6,7 +6,7 @@
  * completed rail; a re-pose of the same math is a redraw, not a new problem;
  * a problem posed but never worked is dropped, not archived.
  */
-const { applyTurnToLedger, MAX_COMPLETED, MAX_STEPS } = require('../../utils/pipeline/boardLedger');
+const { applyTurnToLedger, problemAssistance, MAX_COMPLETED, MAX_STEPS } = require('../../utils/pipeline/boardLedger');
 
 const NOW = new Date('2026-07-25T12:00:00Z');
 
@@ -108,6 +108,36 @@ describe('applyTurnToLedger', () => {
     const frozen = structuredClone(first);
     turn(first, [{ action: 'resolve', tex: '2x=8' }, { action: 'pose', tex: 'y=1' }]);
     expect(first).toEqual(frozen);
+  });
+
+  test('assistance max-folds across a problem and rides into the archive', () => {
+    let l = applyTurnToLedger(null, [{ action: 'pose', tex: '2x+5=13' }], NOW, 1);
+    l = applyTurnToLedger(l, [{ action: 'resolve', tex: '2x=8' }], NOW, 7);   // heavy help once
+    l = applyTurnToLedger(l, [{ action: 'verify', tex: 'x=4' }], NOW, 2);     // finish unaided
+    expect(l.current.assistance).toBe(7);                                     // max, not last
+    expect(problemAssistance(l)).toBe(7);
+    l = applyTurnToLedger(l, [{ action: 'clear' }], NOW, 1);
+    expect(l.completed[0].assistance).toBe(7);
+    expect(problemAssistance(l)).toBe(7);                                     // falls back to last completed
+  });
+
+  test('a new problem starts its assistance fresh (never inherited)', () => {
+    let l = applyTurnToLedger(null, [{ action: 'pose', tex: 'a=1' }], NOW, 9);
+    l = applyTurnToLedger(l, [{ action: 'resolve', tex: 'a' }], NOW, 9);
+    l = applyTurnToLedger(l, [{ action: 'pose', tex: 'b=2' }], NOW, 1);
+    // Level 1 is recorded affirmatively — "independent so far", not "unknown".
+    expect(l.current.assistance).toBe(1);
+    l = applyTurnToLedger(l, [{ action: 'resolve', tex: 'b' }], NOW, 5);
+    expect(l.current.assistance).toBe(5);         // not inherited from problem a (9)
+    expect(l.completed[0].assistance).toBe(9);    // a kept its own level
+  });
+
+  test('assistance omitted → untouched (older callers, voice path)', () => {
+    let l = applyTurnToLedger(null, [{ action: 'pose', tex: 'x=1' }], NOW);
+    l = applyTurnToLedger(l, [{ action: 'verify', tex: 'x=1' }], NOW);
+    expect(l.current.assistance).toBeNull();
+    expect(problemAssistance(l)).toBeNull();
+    expect(problemAssistance(null)).toBeNull();
   });
 
   test('tolerates malformed input: null commands, junk entries, malformed prev', () => {

--- a/utils/pipeline/assistanceLadder.js
+++ b/utils/pipeline/assistanceLadder.js
@@ -1,0 +1,160 @@
+/**
+ * assistanceLadder.js — the 11-level assistance ladder (Live Workspace spec §12).
+ *
+ * "Mathmatix must record how much support was required. A correct result
+ *  reached independently must generate stronger evidence than the same result
+ *  reached after heavy tutoring."
+ *
+ * The pipeline already KNOWS how much it helped — decide.js picks the
+ * instructional action and a 1–5 scaffold intensity, and the board emits
+ * scaffold/example cards — but none of that was recorded as evidence. The
+ * mastery engine's independence pillar ran on a word-scan proxy instead
+ * (grepping the student's messages for "help/stuck"), reading the student's
+ * words because nothing recorded the tutor's actions.
+ *
+ * This module maps the tutor's ACTUAL actions on a turn onto the spec ladder:
+ *
+ *    1 Independent            — problem posed / student works alone
+ *    2 Encouragement only     — affirmation, celebration, empathy
+ *    3 Directions restated    — clarifying what's being asked
+ *    4 Attention cue          — redirect to the math / to a step
+ *    5 Strategic question     — hint, probe, guided error-inspection
+ *    6 Visual scaffold        — representation switch, graph/visual model
+ *    7 Partial setup          — we-do, fill-in-the-blank scaffolds
+ *    8 Parallel example       — worked example on DIFFERENT math
+ *    9 Explicit instruction   — direct teaching, reteach, prerequisite review
+ *   10 Tutor-modeled step     — tutor does a step OF THE STUDENT'S problem
+ *   11 Tutor-completed solution
+ *
+ * Levels 10–11 are deliberately unmapped: the anti-cheat gauntlet forbids the
+ * tutor from working the student's own problem (worked examples are parallel
+ * math by construction, and board apply/resolve cards mirror the student's own
+ * verified moves). If those levels ever become reachable, something upstream
+ * has broken containment — they exist in the ladder so the data model matches
+ * the spec, not because the pipeline can legally produce them.
+ *
+ * A turn's level is the MAX of its signals; a problem's level is the MAX
+ * across its turns (folded into boardLedger). Pure module, no side effects.
+ */
+'use strict';
+
+const LADDER = {
+  1: 'independent',
+  2: 'encouragement_only',
+  3: 'directions_restated',
+  4: 'attention_cue',
+  5: 'strategic_question',
+  6: 'visual_scaffold',
+  7: 'partial_setup',
+  8: 'parallel_example',
+  9: 'explicit_instruction',
+  10: 'tutor_modeled_step',
+  11: 'tutor_completed_solution',
+};
+
+// Levels 1–4 leave the thinking entirely with the student; 5+ is substantive
+// help. This is the threshold the independence pillar counts against.
+const INDEPENDENT_MAX = 4;
+
+// decide.js ACTIONS → ladder level. Anything unlisted contributes level 1
+// (no instructional support implied by the action itself).
+const ACTION_LEVELS = {
+  // student works / no help
+  elicit_first: 1,
+  present_problem: 1,
+  independent_practice: 1,
+  strengthen_challenge: 1,
+  continue_conversation: 1,
+  // affirmation & empathy
+  confirm_correct: 2,
+  acknowledge_progress: 2,
+  acknowledge_frustration: 2,
+  // restating / checking the ask
+  check_understanding: 3,
+  // attention cues
+  redirect_to_math: 4,
+  // strategic questions & hints
+  hint: 5,
+  probing_question: 5,
+  guide_incorrect: 5,
+  leverage_bridge: 5,
+  // visual / representation support
+  switch_representation: 6,
+  // partial setup (we-do)
+  guided_practice: 7,
+  scaffold_down: 7,
+  // parallel example (anti-cheat guarantees it is not the student's problem)
+  worked_example: 8,
+  // explicit teaching
+  direct_instruction: 9,
+  phase_instruction: 9,
+  reteach_misconception: 9,
+  review_prerequisite: 9,
+  prerequisite_bridge: 9,
+  exit_ramp: 9,
+};
+
+// Board cards the tutor drew this turn → ladder floor. scaffold cards are
+// fill-in-the-blank partial setups (the guard REQUIRES a blank); example
+// cards are parallel worked examples; the visual family supports level 6.
+const BOARD_LEVELS = {
+  scaffold: 7,
+  example: 8,
+  graph: 6,
+  image: 6,
+  diagram: 6,
+  model: 6,
+};
+
+/**
+ * The assistance level for one tutor turn: max of the decide action, the
+ * board cards drawn, and a floor implied by heavy scaffold intensity.
+ *
+ * @param {object} signals
+ * @param {string} [signals.decisionAction] - decision.action from decide.js
+ * @param {number} [signals.scaffoldLevel] - decision.scaffoldLevel (1–5)
+ * @param {Array}  [signals.boardCommands] - the turn's verified board commands
+ * @returns {number} 1–11
+ */
+function assistanceLevelForTurn(signals) {
+  const s = signals || {};
+  let level = ACTION_LEVELS[s.decisionAction] || 1;
+
+  for (const cmd of Array.isArray(s.boardCommands) ? s.boardCommands : []) {
+    const floor = cmd && BOARD_LEVELS[cmd.action];
+    if (floor && floor > level) level = floor;
+  }
+
+  // Heavy scaffold intensity means substantive help even when the action
+  // reads mild (e.g. a "hint" pitched at maximum support).
+  const intensity = Number(s.scaffoldLevel);
+  if (intensity >= 5 && level < 6) level = 6;
+  else if (intensity >= 4 && level < 5) level = 5;
+
+  return level;
+}
+
+function assistanceLabel(level) {
+  return LADDER[level] || null;
+}
+
+function isIndependent(level) {
+  return !(Number(level) > INDEPENDENT_MAX);
+}
+
+/** Max-fold two levels; either side may be null/undefined. */
+function maxAssistance(a, b) {
+  const an = Number(a) || 0;
+  const bn = Number(b) || 0;
+  const m = Math.max(an, bn);
+  return m > 0 ? m : null;
+}
+
+module.exports = {
+  LADDER,
+  INDEPENDENT_MAX,
+  assistanceLevelForTurn,
+  assistanceLabel,
+  isIndependent,
+  maxAssistance,
+};

--- a/utils/pipeline/boardLedger.js
+++ b/utils/pipeline/boardLedger.js
@@ -72,6 +72,10 @@ function archiveCurrent(ledger, now) {
     problemTex: cur.problemTex,
     steps: cur.steps,
     solved: cur.steps.some(c => c && c.action === 'verify'),
+    // Max assistance level (spec §12 ladder) across the problem's turns —
+    // what the collapsed-card summary and teacher view read. Null when the
+    // ladder never reported (e.g. entries written before this field existed).
+    assistance: cur.assistance || null,
     completedAt: now,
   });
   while (ledger.completed.length > MAX_COMPLETED) ledger.completed.shift();
@@ -83,20 +87,24 @@ function archiveCurrent(ledger, now) {
  * @param {object|null} prev - conversation.boardLedger (may be null/malformed)
  * @param {Array} commands - the turn's verified board commands, in order
  * @param {Date} [now] - injectable clock for tests
+ * @param {number|null} [turnAssistance] - this turn's assistance level
+ *   (utils/pipeline/assistanceLadder.js); max-folded onto the problem in focus
  * @returns {object} a new ledger object
  */
-function applyTurnToLedger(prev, commands, now = new Date()) {
+function applyTurnToLedger(prev, commands, now = new Date(), turnAssistance = null) {
   const ledger = {
     current: prev && prev.current && prev.current.problemTex
       ? {
           problemTex: prev.current.problemTex,
           posedAt: prev.current.posedAt || now,
           steps: Array.isArray(prev.current.steps) ? prev.current.steps.slice() : [],
+          assistance: prev.current.assistance || null,
         }
       : null,
     completed: prev && Array.isArray(prev.completed) ? prev.completed.slice() : [],
   };
   if (!Array.isArray(commands)) return ledger;
+  const assist = Number(turnAssistance) > 0 ? Number(turnAssistance) : null;
 
   for (const raw of commands) {
     if (!raw || typeof raw !== 'object' || !raw.action) continue;
@@ -108,7 +116,7 @@ function applyTurnToLedger(prev, commands, now = new Date()) {
         continue; // same problem re-drawn (board-reference backstop etc.)
       }
       archiveCurrent(ledger, now);
-      ledger.current = { problemTex: cmd.tex, posedAt: now, steps: [] };
+      ledger.current = { problemTex: cmd.tex, posedAt: now, steps: [], assistance: null };
       continue;
     }
 
@@ -126,11 +134,33 @@ function applyTurnToLedger(prev, commands, now = new Date()) {
     // board would float it, but it is not part of any problem's lifecycle.
   }
 
+  // The turn's assistance belongs to whichever problem ended the turn in
+  // focus — max-folded, so one heavily-supported turn marks the whole problem.
+  if (ledger.current && assist) {
+    ledger.current.assistance = Math.max(ledger.current.assistance || 0, assist) || null;
+  }
+
   return ledger;
+}
+
+/**
+ * The assistance level of the problem the student is (or just was) working
+ * on: the one in focus, else the most recently completed. What the mastery
+ * engine reads when a verified answer lands. Null when nothing is known.
+ */
+function problemAssistance(ledger) {
+  if (!ledger || typeof ledger !== 'object') return null;
+  if (ledger.current && ledger.current.assistance) return ledger.current.assistance;
+  const done = Array.isArray(ledger.completed) ? ledger.completed : [];
+  for (let i = done.length - 1; i >= 0; i--) {
+    if (done[i] && done[i].assistance) return done[i].assistance;
+  }
+  return null;
 }
 
 module.exports = {
   applyTurnToLedger,
+  problemAssistance,
   emptyLedger,
   MAX_COMPLETED,
   MAX_STEPS,

--- a/utils/pipeline/index.js
+++ b/utils/pipeline/index.js
@@ -32,6 +32,7 @@ const { computeSessionMood, buildMoodDirective } = require('./sessionMood');
 const { generateSuggestions } = require('./suggestions');
 const { assembleEvidence } = require('./evidenceAccumulator');
 const { applyTurnToLedger } = require('./boardLedger');
+const { assistanceLevelForTurn } = require('./assistanceLadder');
 
 // New data-driven engines
 const { updateBKT, initializeBKT } = require('../knowledgeTracer');
@@ -1192,7 +1193,18 @@ async function runPipeline(message, ctx) {
   // lines too, and a faithful replay must include them. Non-fatal by design.
   if (verified.boardCommands.length > 0 && ctx.conversation) {
     try {
-      ctx.conversation.boardLedger = applyTurnToLedger(ctx.conversation.boardLedger, verified.boardCommands);
+      // How much help THIS turn gave (spec §12 ladder) — max-folded onto the
+      // problem in focus, so the completed card records the heaviest support
+      // the student needed anywhere in the problem. Read back by persist's
+      // mastery update: an answer reached at ladder ≥5 is not independent.
+      const turnAssistance = assistanceLevelForTurn({
+        decisionAction: decision?.action,
+        scaffoldLevel: decision?.scaffoldLevel,
+        boardCommands: verified.boardCommands,
+      });
+      ctx.conversation.boardLedger = applyTurnToLedger(
+        ctx.conversation.boardLedger, verified.boardCommands, new Date(), turnAssistance
+      );
       ctx.conversation.markModified?.('boardLedger');
     } catch (ledgerErr) {
       boardLogger.warn('Board ledger update failed (non-fatal)', { error: ledgerErr.message });

--- a/utils/pipeline/persist.js
+++ b/utils/pipeline/persist.js
@@ -26,6 +26,8 @@ const { checkForInterventionAlert } = require('../interventionAlerts');
 const { getReviewSummary } = require('../smartReviewQueue');
 const { canonicalSkillId } = require('../skillCanonicalizer');
 const { updateSkillMastery: engineUpdateSkillMastery, initializeSkillMastery } = require('../masteryEngine');
+const { problemAssistance } = require('./boardLedger');
+const { isIndependent } = require('./assistanceLadder');
 const { advanceRung, currentRung, clearsPrerequisites } = require('../skillRung');
 const { getSkillMasteryEntry, setSkillMasteryEntry, decodedMasteryMap } = require('../masteryGuard');
 
@@ -711,12 +713,18 @@ function updateSkillMastery(user, rawSkillId, observation, conversation, correct
   const existing = getSkillMasteryEntry(user, skillId) || initializeSkillMastery(skillId);
   const wasOwned = clearsPrerequisites(existing);
 
-  // Independence proxy: the student asking for help in recent turns. Weaker than
-  // a real hint counter — it reads the student's words, not the tutor's actions.
+  // Independence: primary signal is the assistance ladder (spec §12) — the
+  // tutor's RECORDED actions on this problem, max-folded into the board
+  // ledger. Ladder ≥5 (strategic question and up) means the thinking didn't
+  // happen unaided. The old word-scan proxy (the student asking for help)
+  // stays as a fallback: it still catches help requests on turns that never
+  // reached the board (ledger null), and costs nothing when the ladder fires.
   const recentMsgs = conversation.messages.slice(-6);
-  const usedHint = recentMsgs.some(msg =>
+  const askedForHelp = recentMsgs.some(msg =>
     msg.role === 'user' && /\b(hint|help|stuck|don'?t know|idk|confused)\b/i.test(msg.content)
   );
+  const assistance = problemAssistance(conversation.boardLedger);
+  const usedHint = (assistance != null) ? !isIndependent(assistance) || askedForHelp : askedForHelp;
 
   const updated = engineUpdateSkillMastery(existing, {
     correct: correct !== false,


### PR DESCRIPTION
Second Live Workspace slice ([spec §12](https://github.com/jnappier7/mathmatix-ai/blob/main/docs/LIVE_WORKSPACE_REQUIREMENTS.md), scaffold & independence tracking). Builds on the board ledger from #1296 (now merged).

## The gap

Spec: *"a correct result reached independently must generate stronger evidence than the same result reached after heavy tutoring."* The pipeline already knew how much it helped — `decide` picks the instructional action and a 1–5 scaffold intensity, the board emits scaffold/example cards — but none of it was recorded. The mastery engine judged independence by **grepping the student's last 6 messages for "help/stuck/hint"** (its own comment: *"Weaker than a real hint counter — it reads the student's words, not the tutor's actions"*).

## What this adds

- **`utils/pipeline/assistanceLadder.js`** (new, pure): maps each turn's decide action + board cards + scaffold intensity onto the spec's 11-level ladder, taking the max signal. E.g. `confirm_correct`→2, `redirect_to_math`→4, `hint`→5, `switch_representation`→6, `guided_practice`/scaffold-card→7, `worked_example`/example-card→8, `direct_instruction`→9. Levels 10–11 (tutor works the student's own problem) are **deliberately unreachable** — anti-cheat forbids that by construction — and a sweep test over every action × every board card at max intensity pins the ceiling at 9. If that test ever fails, containment broke upstream.
- **Per-problem assistance in the board ledger**: max-folded across the problem's turns; archived (completed) entries carry it. This is exactly what the §4.5 collapsed-card summary and the §20 teacher view will read in later slices. Level 1 is recorded affirmatively — "solved independently" is information, not absence of it.
- **Honest independence pillar**: `persist` now feeds the mastery engine `hintUsed` from the recorded ladder (≥5 = not unaided), keeping the word-scan as a fallback for turns that never reach the board. The engine's mechanics and thresholds are untouched — only its input signal changed.

## Verification

- 15 new/extended tests (ladder mapping, max-fold semantics, anti-cheat ceiling sweep, fresh-per-problem, omitted-arg back-compat for the voice path).
- Full suite: 4632 passed; lint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)