### PR TITLE
fix(practice-pack): PDFs download as JSON byte maps — Buffer-wrap page.pdf()

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -2485,7 +2485,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- Player stats card: window-global, loaded before script.js which calls
      window.PlayerStatsCard.init(currentUser) once the user doc is fetched. -->
 <script defer src="/js/modules/playerStatsCard.js?v=20260724b"></script>
-<script src="/js/script.js?v=20260725a" type="module"></script>
+<script src="/js/script.js?v=20260725b" type="module"></script>
   <script src="/js/guidedPath.js" type="module"></script>
   <script src="/dist/js/chat-js9.bc0be9a3.js"></script>
   <!-- Companion HOME screen (phones only; flag-gated OFF by default) -->

--- a/public/js/practicePack.js
+++ b/public/js/practicePack.js
@@ -128,7 +128,9 @@ class PracticePackManager {
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);
-      URL.revokeObjectURL(url);
+      // Delay the revoke: Firefox/Safari start the download async, and a
+      // synchronous revoke can yield a failed or 0-byte file.
+      setTimeout(() => URL.revokeObjectURL(url), 2000);
 
       if (statusEl) {
         statusEl.textContent = 'PDF downloaded! Print it, work the problems on paper, then upload a photo.';

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -3375,7 +3375,9 @@ document.addEventListener("DOMContentLoaded", () => {
                                     document.body.appendChild(a);
                                     a.click();
                                     document.body.removeChild(a);
-                                    URL.revokeObjectURL(url);
+                                    // Delay the revoke: Firefox/Safari start the download async,
+                                    // and a synchronous revoke can yield a failed/0-byte file.
+                                    setTimeout(() => URL.revokeObjectURL(url), 2000);
                                     if (typeof showToast === 'function') showToast('Practice Pack downloading! Print it and work the problems on paper.', 5000);
                                 })
                                 .catch(() => {

--- a/public/student-dashboard.html
+++ b/public/student-dashboard.html
@@ -1007,7 +1007,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </script>
 <script src="/js/sessionManager.js"></script>
 <script src="/js/ux-enhancements.js"></script>
-<script src="/js/practicePack.js"></script>
+<script src="/js/practicePack.js?v=20260725a"></script>
 <script src="/js/user-nudges.js"></script>
 </body>
 </html>

--- a/routes/practicePack.js
+++ b/routes/practicePack.js
@@ -52,6 +52,16 @@ const BROWSER_LAUNCH_OPTIONS = {
   ],
 };
 
+// Puppeteer v23+ returns page.pdf() as a Uint8Array, NOT a Buffer. Express 4's
+// res.send() only treats Buffers as binary — a plain Uint8Array falls through
+// to res.json(), which serializes the PDF bytes as {"0":37,"1":80,...}. The
+// download then arrives as a .pdf full of JSON that no reader can open (the
+// Content-Type header survives, so nothing errors anywhere). Every pdf
+// response MUST go through this.
+function toPdfBuffer(bytes) {
+  return Buffer.isBuffer(bytes) ? bytes : Buffer.from(bytes);
+}
+
 // ============================================================================
 // PROBLEM SELECTION — Adaptive, personalized to student
 // ============================================================================
@@ -688,11 +698,11 @@ router.get('/generate', isAuthenticated, async (req, res) => {
     const page = await browser.newPage();
     await page.setContent(html, { waitUntil: 'networkidle0' });
 
-    const pdfBuffer = await page.pdf({
+    const pdfBuffer = toPdfBuffer(await page.pdf({
       format: 'Letter',
       margin: { top: '0.5in', bottom: '0.5in', left: '0.75in', right: '0.75in' },
       printBackground: true,
-    });
+    }));
 
     await browser.close();
     browser = null;
@@ -860,11 +870,11 @@ router.get('/generate-for-child', isAuthenticated, async (req, res) => {
     const page = await browser.newPage();
     await page.setContent(html, { waitUntil: 'networkidle0' });
 
-    const pdfBuffer = await page.pdf({
+    const pdfBuffer = toPdfBuffer(await page.pdf({
       format: 'Letter',
       margin: { top: '0.5in', bottom: '0.5in', left: '0.75in', right: '0.75in' },
       printBackground: true,
-    });
+    }));
 
     await browser.close();
     browser = null;
@@ -942,11 +952,11 @@ router.get('/class-generate-pdf', isAuthenticated, async (req, res) => {
     const page = await browser.newPage();
     await page.setContent(html, { waitUntil: 'networkidle0' });
 
-    const pdfBuffer = await page.pdf({
+    const pdfBuffer = toPdfBuffer(await page.pdf({
       format: 'Letter',
       margin: { top: '0.5in', bottom: '0.5in', left: '0.75in', right: '0.75in' },
       printBackground: true,
-    });
+    }));
 
     await browser.close();
     browser = null;
@@ -974,7 +984,8 @@ router.get('/class-generate-pdf', isAuthenticated, async (req, res) => {
 router.__helpers = {
   resolveTheta,
   gradeLevelToBand,
-  thetaToGradeBand
+  thetaToGradeBand,
+  toPdfBuffer
 };
 
 module.exports = router;

--- a/tests/unit/practicePackHelpers.test.js
+++ b/tests/unit/practicePackHelpers.test.js
@@ -69,3 +69,55 @@ describe('gradeLevelToBand', () => {
     expect(gradeLevelToBand(undefined)).toBeNull();
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// toPdfBuffer — the "PDF downloads but won't open" bug.
+//
+// Puppeteer v23+ returns page.pdf() as a Uint8Array. Express 4's res.send()
+// only treats Buffers as binary; a plain Uint8Array falls through to
+// res.json(), which serializes the PDF bytes as {"0":37,"1":80,...} under a
+// 200 + application/pdf header — so the client happily saves an unopenable
+// file. These tests pin the conversion AND reproduce the transport failure
+// mode against real express, so a Puppeteer/Express upgrade that changes the
+// contract fails loudly here instead of shipping corrupt downloads.
+// ─────────────────────────────────────────────────────────────────────────────
+const { toPdfBuffer } = router.__helpers;
+
+describe('toPdfBuffer', () => {
+  const PDF_MAGIC = Uint8Array.from([0x25, 0x50, 0x44, 0x46, 0x2d]); // "%PDF-"
+
+  test('converts a Uint8Array to a Buffer, bytes intact', () => {
+    const buf = toPdfBuffer(PDF_MAGIC);
+    expect(Buffer.isBuffer(buf)).toBe(true);
+    expect(buf.toString('latin1')).toBe('%PDF-');
+  });
+
+  test('passes a real Buffer through untouched', () => {
+    const b = Buffer.from('%PDF-');
+    expect(toPdfBuffer(b)).toBe(b);
+  });
+
+  test('res.send(raw Uint8Array) really does JSON-mangle a PDF — and toPdfBuffer fixes it', async () => {
+    const express = require('express');
+    const request = require('supertest');
+    const app = express();
+    app.get('/raw', (req, res) => {
+      res.setHeader('Content-Type', 'application/pdf');
+      res.send(PDF_MAGIC);                 // the bug
+    });
+    app.get('/fixed', (req, res) => {
+      res.setHeader('Content-Type', 'application/pdf');
+      res.send(toPdfBuffer(PDF_MAGIC));    // the fix
+    });
+
+    const raw = await request(app).get('/raw').buffer(true).parse((res, cb) => {
+      const chunks = []; res.on('data', c => chunks.push(c)); res.on('end', () => cb(null, Buffer.concat(chunks)));
+    });
+    expect(raw.body.toString()).toContain('"0":37');            // JSON byte map, not a PDF
+
+    const fixed = await request(app).get('/fixed').buffer(true).parse((res, cb) => {
+      const chunks = []; res.on('data', c => chunks.push(c)); res.on('end', () => cb(null, Buffer.concat(chunks)));
+    });
+    expect(fixed.body.subarray(0, 5).toString('latin1')).toBe('%PDF-');
+  });
+});


### PR DESCRIPTION
Fixes the owner-reported bug: practice-pack PDFs "generate but cannot be opened or viewed."

## Root cause (confirmed by runtime repro)

Puppeteer v23+ changed `page.pdf()` to return a **`Uint8Array`**, not a `Buffer` (this repo is on v24). Express 4's `res.send()` only recognizes `Buffer` as binary — a plain `Uint8Array` falls through to **`res.json()`**, which serializes the PDF as a byte map: `{"0":37,"1":80,"2":68,...}`. The already-set `application/pdf` header survives, so the client sees a healthy 200, saves the blob as `.pdf` — and no PDF reader can open it. Quick confirmation on any previously-downloaded broken file: it starts with `{"0":37,"1":80` instead of `%PDF`, and is ~4–5× the expected size.

All three PDF endpoints were affected: `/generate`, `/generate-for-child`, `/class-generate-pdf`.

## Fix

- `toPdfBuffer()` (Buffer passthrough / `Buffer.from` a typed array) applied at all three `page.pdf()` sites, with a comment explaining why every PDF response must go through it.
- **Regression test that reproduces the transport bug against real Express** (via supertest): `res.send(Uint8Array)` → body contains `"0":37`; `res.send(toPdfBuffer(...))` → body starts with `%PDF-` magic bytes. A future Puppeteer/Express upgrade that changes this contract fails loudly instead of shipping corrupt downloads.
- Secondary client fix: `URL.revokeObjectURL` now runs on a 2s delay after `a.click()` — Firefox/Safari start downloads asynchronously and a synchronous revoke can produce a failed/0-byte file (the next way this feature could break once the server is fixed).
- Cache-busting: `practicePack.js` gains its missing `?v=`; `script.js` bumped.

## Verification

- 3 new tests incl. the supertest repro; full suite 4622 passed; lint clean.
- Not verified against a live authenticated session (needs a student login) — but the repro test exercises the exact express serialization path, and the fix is the documented Puppeteer v23 migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)