### PR TITLE
feat(lws): collapsed-card summaries + live card state (spec §4.4–4.5)

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -133,7 +133,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
        LivingWorkspace flag is dev|beta|live (?livingWorkspace=dev). When on,
        it lazy-loads the workspace and mirrors the tutor's board output onto
        the new surface beside the old board. Default OFF → zero impact. -->
-  <script defer src="/js/living-workspace/chat-workspace.js?v=20260725a"></script>
+  <script defer src="/js/living-workspace/chat-workspace.js?v=20260725b"></script>
   <!-- Final safety net: strips any inline visual tag no renderer handled -->
   <script defer src="/js/stripVisualTags.js"></script>
   <!-- Non-core libs (lazy-loaded after first interaction) -->

--- a/public/css/living-workspace.css
+++ b/public/css/living-workspace.css
@@ -134,6 +134,10 @@ html[data-theme="dark"] .lws-root {
 .lws-dv-thumb-tex .katex { font-size: 1em; }
 .lws-dv-thumb-tick { flex: 0 0 auto; color: #35c98a; font: 700 12px/1 system-ui, sans-serif; }
 .lws-dv-thumb:not(.is-solved) .lws-dv-thumb-n { background: color-mix(in srgb, var(--lws-card-ink) 14%, transparent); color: var(--lws-card-ink); }
+/* Solved WITHOUT tutor help (§12 ladder ≤4): the number badge goes gold.
+   Quietly aspirational — a student scanning the rail sees which wins were
+   entirely their own. The title/aria-label spells it out in words. */
+.lws-dv-thumb.is-independent .lws-dv-thumb-n { background: color-mix(in srgb, #e8b64c 30%, transparent); color: #e8b64c; }
 
 @media (prefers-reduced-motion: reduce) {
   .lws-dv-thumb { transition: none; }
@@ -170,6 +174,17 @@ html[data-theme="dark"] .lws-root {
 }
 .lws-dv-ov-back:hover { border-color: var(--lws-accent); }
 .lws-dv-ov-back:focus-visible { outline: 2px solid var(--lws-accent); outline-offset: 2px; }
+/* Collapsed-card summary strip (§4.5): outcome + effort at a glance before
+   the full work below. Green-tinted when the problem was solved. */
+.lws-dv-ov-sum {
+  flex: 0 0 auto; display: flex; align-items: baseline; gap: 12px;
+  padding: 8px 12px; border-bottom: 1px solid var(--lws-card-border);
+  background: color-mix(in srgb, var(--lws-card-ink) 5%, transparent);
+  font: 600 13px/1.2 system-ui, sans-serif; color: var(--lws-card-ink);
+}
+.lws-dv-ov-sum.is-solved { background: color-mix(in srgb, #35c98a 10%, transparent); }
+.lws-dv-ov-sum.is-solved .lws-dv-ov-sum-status { color: #35c98a; }
+.lws-dv-ov-sum-steps { font-weight: 400; font-size: 12px; opacity: .75; }
 .lws-dv-ov-body {
   flex: 1 1 auto; min-height: 0; overflow-y: auto; overflow-x: hidden;
   padding: 18px clamp(14px, 5%, 42px) 32px;
@@ -192,6 +207,16 @@ html[data-theme="dark"] .lws-root {
   border: 1px solid var(--lws-card-border); border-left: 3px solid var(--lws-accent);
   border-radius: 12px; padding: 12px 16px; margin-bottom: 10px;
   box-shadow: 0 8px 22px rgba(0, 0, 0, .22);
+}
+/* §4.4 card state, subtle by design: once the derivation in focus reaches its
+   solution the pinned problem shows a quiet "Solved ✓" chip and its accent
+   edge turns green. No layout shift — just the state made visible. */
+.lws-dv-root.is-solved-current .lws-dv-problem { border-left-color: #35c98a; }
+.lws-dv-root.is-solved-current .lws-dv-plabel::after {
+  content: 'Solved ✓';
+  margin-left: 10px; padding: 2px 7px; border-radius: 999px;
+  background: color-mix(in srgb, #35c98a 18%, transparent);
+  color: #35c98a; letter-spacing: .06em;
 }
 .lws-dv-plabel { font: 10px system-ui, sans-serif; font-size: calc(10px * var(--lws-dv-scale)); letter-spacing: .16em; text-transform: uppercase; color: var(--lws-accent); margin-bottom: 6px; }
 .lws-dv-ptex { font-size: calc(21px * var(--lws-dv-scale)); color: var(--lws-card-ink); }

--- a/public/js/living-workspace/chat-workspace.js
+++ b/public/js/living-workspace/chat-workspace.js
@@ -68,7 +68,7 @@
   // public/ with a 7-day cache and no content hashing, so bump this whenever
   // any living-workspace asset changes (and the chat.html <script ?v=> tag to
   // match, so this file itself refreshes). See project_asset_cache_busting.
-  var ASSET_V = '?v=20260725a';
+  var ASSET_V = '?v=20260725b';
   var BASE = '/js/living-workspace/';
   var SCRIPTS = [
     'core/flags.js', 'core/viewport.js', 'core/elementRegistry.js',
@@ -268,6 +268,12 @@
     try { turns = window.LWS.ledgerToTurns(ledger); }
     catch (e) { console.error('[LWS_CHAT] ledger replay failed', e); return; }
     turns.forEach(render);
+    // Commands can't carry per-problem metadata (assistance level etc.) —
+    // zip it onto the rail entries the replay just produced.
+    if (typeof window.LWS.ledgerMeta === 'function') {
+      try { dv.annotateArchive(window.LWS.ledgerMeta(ledger)); }
+      catch (e) { console.error('[LWS_CHAT] archive annotate failed', e); }
+    }
   }
 
   api.hydrate = function (ledger) {

--- a/public/js/living-workspace/core/ledgerReplay.js
+++ b/public/js/living-workspace/core/ledgerReplay.js
@@ -26,7 +26,10 @@
 (function (root, factory) {
   var mod = factory();
   if (typeof module !== 'undefined' && module.exports) module.exports = mod;
-  if (root) (root.LWS = root.LWS || {}).ledgerToTurns = mod.ledgerToTurns;
+  if (root) {
+    (root.LWS = root.LWS || {}).ledgerToTurns = mod.ledgerToTurns;
+    root.LWS.ledgerMeta = mod.ledgerMeta;
+  }
 })(typeof self !== 'undefined' ? self : this, function () {
   'use strict';
 
@@ -36,22 +39,42 @@
     return [{ action: 'pose', tex: entry.problemTex }].concat(steps);
   }
 
+  // The completed entries that will actually replay — ledgerToTurns and
+  // ledgerMeta MUST filter identically, or the metadata (assistance level
+  // etc.) zips onto the wrong rail thumbnails after hydration.
+  function replayableCompleted(ledger) {
+    if (!ledger || typeof ledger !== 'object') return [];
+    return (Array.isArray(ledger.completed) ? ledger.completed : [])
+      .filter(function (entry) { return !!problemTurn(entry); });
+  }
+
   function ledgerToTurns(ledger) {
     var turns = [];
-    if (!ledger || typeof ledger !== 'object') return turns;
 
-    (Array.isArray(ledger.completed) ? ledger.completed : []).forEach(function (entry) {
-      var t = problemTurn(entry);
-      if (!t) return;
-      turns.push(t);
+    replayableCompleted(ledger).forEach(function (entry) {
+      turns.push(problemTurn(entry));
       turns.push([{ action: 'clear' }]);   // park it on the rail
     });
 
-    var cur = problemTurn(ledger.current);
+    var cur = ledger && typeof ledger === 'object' ? problemTurn(ledger.current) : null;
     if (cur) turns.push(cur);              // back in focus, still open
 
     return turns;
   }
 
-  return { ledgerToTurns: ledgerToTurns };
+  // Per-problem metadata the replayed COMMANDS can't carry (recorded by the
+  // server per turn, not per card): the §12 assistance level, plus solved /
+  // completedAt. Ordered oldest-first, aligned 1:1 with the rail entries the
+  // replay produces — DerivationView.annotateArchive zips them together.
+  function ledgerMeta(ledger) {
+    return replayableCompleted(ledger).map(function (entry) {
+      return {
+        assistance: entry.assistance || null,
+        solved: !!entry.solved,
+        completedAt: entry.completedAt || null,
+      };
+    });
+  }
+
+  return { ledgerToTurns: ledgerToTurns, ledgerMeta: ledgerMeta };
 });

--- a/public/js/living-workspace/dom/derivationView.js
+++ b/public/js/living-workspace/dom/derivationView.js
@@ -204,6 +204,18 @@
     });
   }
 
+  // Student-facing summary of a finished card (spec §4.5): completion +
+  // assistance in the student's own terms. Levels 1–4 of the §12 ladder are
+  // independent; 5+ means the tutor's thinking was in the loop. `assistance`
+  // is null for work recorded before the ladder existed (or live-session
+  // archives, where the level is server-side only) — say less, not wrong.
+  // Pure; exported for tests.
+  function assistanceSummary(solved, assistance) {
+    if (!solved) return 'Not finished yet';
+    if (assistance == null) return 'Solved';
+    return assistance <= 4 ? 'Solved it myself' : 'Solved with my tutor';
+  }
+
   function DerivationView(container, opts) {
     opts = opts || {};
     this.doc = container.ownerDocument || document;
@@ -333,6 +345,7 @@
     this.el.problem.style.display = 'none';
     this._problemTex = null;
     this._elements = [];
+    this.el.root.classList.remove('is-solved-current');
     this._refreshEmpty();
   };
 
@@ -356,6 +369,23 @@
     this._renderRail();
   };
 
+  // Zip per-problem metadata from the persisted ledger (assistance level,
+  // completedAt) onto the archive entries a hydration replay just produced.
+  // Alignment is positional — core/ledgerReplay.js guarantees ledgerMeta()
+  // filters the same entries ledgerToTurns() replays. Extra meta is ignored;
+  // entries beyond the meta list (e.g. live-session archives) stay bare.
+  DerivationView.prototype.annotateArchive = function (metaList) {
+    if (!Array.isArray(metaList) || !metaList.length) return;
+    var n = Math.min(this._archive.length, metaList.length);
+    for (var i = 0; i < n; i++) {
+      var m = metaList[i];
+      if (!m || typeof m !== 'object') continue;
+      if (m.assistance != null) this._archive[i].assistance = m.assistance;
+      if (m.completedAt != null) this._archive[i].completedAt = m.completedAt;
+    }
+    this._renderRail();
+  };
+
   DerivationView.prototype._renderRail = function () {
     var self = this;
     var d = this.doc;
@@ -366,10 +396,11 @@
     this._archive.forEach(function (entry, i) {
       var b = d.createElement('button');
       b.type = 'button';
-      b.className = 'lws-dv-thumb' + (entry.solved ? ' is-solved' : '');
+      var independent = entry.solved && entry.assistance != null && entry.assistance <= 4;
+      b.className = 'lws-dv-thumb' + (entry.solved ? ' is-solved' : '') + (independent ? ' is-independent' : '');
       b.setAttribute('role', 'listitem');
       b.setAttribute('data-lws-archive-id', entry.id);
-      var label = 'Problem ' + (i + 1) + (entry.solved ? ', solved' : ', not finished');
+      var label = 'Problem ' + (i + 1) + ' — ' + assistanceSummary(entry.solved, entry.assistance);
       b.setAttribute('aria-label', 'Reopen ' + label);
       b.title = 'Reopen ' + label;
 
@@ -416,6 +447,25 @@
     back.addEventListener('click', function () { self.closeArchived(); });
     bar.appendChild(tag); bar.appendChild(back);
 
+    // Collapsed-card summary (spec §4.5): how it ended and how much work it
+    // took, in the student's terms, before the full derivation below.
+    var stepCount = entry.elements.filter(function (e) {
+      var k = classify(e);
+      return k && k !== 'problem' && k !== 'operation';
+    }).length;
+    var sum = d.createElement('div');
+    sum.className = 'lws-dv-ov-sum' + (entry.solved ? ' is-solved' : '');
+    var sumStatus = d.createElement('span');
+    sumStatus.className = 'lws-dv-ov-sum-status';
+    sumStatus.textContent = assistanceSummary(entry.solved, entry.assistance);
+    sum.appendChild(sumStatus);
+    if (stepCount > 0) {
+      var sumSteps = d.createElement('span');
+      sumSteps.className = 'lws-dv-ov-sum-steps';
+      sumSteps.textContent = stepCount + (stepCount === 1 ? ' step' : ' steps');
+      sum.appendChild(sumSteps);
+    }
+
     var body = d.createElement('div'); body.className = 'lws-dv-ov-body';
     var inner = d.createElement('div'); inner.className = 'lws-dv-inner';
     var problem = d.createElement('div'); problem.className = 'lws-dv-problem';
@@ -436,7 +486,7 @@
       else self._addLine(el, kind, lines);
     });
 
-    ov.appendChild(bar); ov.appendChild(body);
+    ov.appendChild(bar); ov.appendChild(sum); ov.appendChild(body);
     this.el.root.appendChild(ov);
     this._overlay = ov;
     this._escHandler = function (ev) { if (ev.key === 'Escape') self.closeArchived(); };
@@ -641,6 +691,10 @@
     freshNodes(seen, toArray(this.el.lines.childNodes)).forEach(function (n) {
       if (n.classList) n.classList.add('lws-dv-fresh');
     });
+    // §4.4 card state, kept deliberately subtle: once the derivation in focus
+    // reaches its solution, the pinned problem header shows a "Solved ✓" chip
+    // (CSS reads this class). Cleared by _wipeCurrent with everything else.
+    this.el.root.classList.toggle('is-solved-current', hasSolution(this._elements));
     this._refreshEmpty();
     this._scrollToEnd();
   };
@@ -665,9 +719,10 @@
   DerivationView.unwrapText = unwrapText;
   DerivationView.freshNodes = freshNodes;
   DerivationView.hasSolution = hasSolution;
+  DerivationView.assistanceSummary = assistanceSummary;
   DerivationView.MAX_ARCHIVE = MAX_ARCHIVE;
   DerivationView.splitBlanks = splitBlanks;
   DerivationView.hasBlank = hasBlank;
   LWS.DerivationView = DerivationView;
-  if (typeof module !== 'undefined' && module.exports) module.exports = { DerivationView: DerivationView, classify: classify, cleanLatex: cleanLatex, looksLikeProse: looksLikeProse, unwrapText: unwrapText, freshNodes: freshNodes, hasSolution: hasSolution, MAX_ARCHIVE: MAX_ARCHIVE, splitBlanks: splitBlanks, hasBlank: hasBlank };
+  if (typeof module !== 'undefined' && module.exports) module.exports = { DerivationView: DerivationView, classify: classify, cleanLatex: cleanLatex, looksLikeProse: looksLikeProse, unwrapText: unwrapText, freshNodes: freshNodes, hasSolution: hasSolution, assistanceSummary: assistanceSummary, MAX_ARCHIVE: MAX_ARCHIVE, splitBlanks: splitBlanks, hasBlank: hasBlank };
 })(typeof self !== 'undefined' ? self : this);

--- a/tests/unit/workspace/boardHydration.test.js
+++ b/tests/unit/workspace/boardHydration.test.js
@@ -19,7 +19,8 @@
 const { applyTurnToLedger } = require('../../../utils/pipeline/boardLedger');
 const { ledgerToTurns } = require('../../../public/js/living-workspace/core/ledgerReplay.js');
 const { adaptBoardCommands } = require('../../../public/js/living-workspace/dom/legacyBoardAdapter.js');
-const { classify, hasSolution } = require('../../../public/js/living-workspace/dom/derivationView.js');
+const { classify, hasSolution, assistanceSummary } = require('../../../public/js/living-workspace/dom/derivationView.js');
+const { ledgerMeta } = require('../../../public/js/living-workspace/core/ledgerReplay.js');
 
 const NOW = new Date('2026-07-25T12:00:00Z');
 
@@ -84,6 +85,29 @@ describe('board hydration round trip', () => {
     expect(board.focus).toBeNull();
     expect(board.rail).toHaveLength(1);
     expect(hasSolution(board.rail[0].elements)).toBe(true);
+  });
+
+  test('assistance recorded by the pipeline surfaces as the student-facing summary', () => {
+    // Problem 1 solved with heavy help (ladder 8); problem 2 solved unaided.
+    let ledger = null;
+    ledger = applyTurnToLedger(ledger, [{ action: 'pose', tex: 'a=1' }], NOW, 1);
+    ledger = applyTurnToLedger(ledger, [{ action: 'verify', tex: 'a=1' }], NOW, 8);
+    ledger = applyTurnToLedger(ledger, [{ action: 'pose', tex: 'b=2' }], NOW, 1);
+    ledger = applyTurnToLedger(ledger, [{ action: 'verify', tex: 'b=2' }], NOW, 2);
+    ledger = applyTurnToLedger(ledger, [{ action: 'clear' }], NOW, 1);
+
+    const meta = ledgerMeta(JSON.parse(JSON.stringify(ledger)));
+    expect(meta.map(m => assistanceSummary(m.solved, m.assistance))).toEqual([
+      'Solved with my tutor',
+      'Solved it myself',
+    ]);
+  });
+
+  test('assistanceSummary degrades honestly when the level is unknown', () => {
+    expect(assistanceSummary(true, null)).toBe('Solved');       // pre-ladder data
+    expect(assistanceSummary(false, 9)).toBe('Not finished yet');
+    expect(assistanceSummary(true, 4)).toBe('Solved it myself');
+    expect(assistanceSummary(true, 5)).toBe('Solved with my tutor');
   });
 
   test('every replayed step survives the adapter (nothing dropped in transport)', () => {

--- a/tests/unit/workspace/ledgerReplay.test.js
+++ b/tests/unit/workspace/ledgerReplay.test.js
@@ -7,7 +7,7 @@
  * explicit clear (parking them on the rail), and the in-progress problem
  * replays last with no clear, landing back in focus.
  */
-const { ledgerToTurns } = require('../../../public/js/living-workspace/core/ledgerReplay.js');
+const { ledgerToTurns, ledgerMeta } = require('../../../public/js/living-workspace/core/ledgerReplay.js');
 
 describe('ledgerToTurns', () => {
   test('null / malformed ledgers replay to nothing', () => {
@@ -64,5 +64,33 @@ describe('ledgerToTurns', () => {
       completed: [{ steps: [{ action: 'verify' }] }],  // no problemTex
     });
     expect(turns).toEqual([[{ action: 'pose', tex: 'y=x' }]]);
+  });
+});
+
+describe('ledgerMeta', () => {
+  test('aligns 1:1 with the completed entries ledgerToTurns replays — skips the same junk', () => {
+    const ledger = {
+      current: { problemTex: 'z=1', steps: [] },
+      completed: [
+        { problemTex: 'a=1', steps: [{ action: 'verify' }], solved: true, assistance: 3, completedAt: 'T1' },
+        { steps: [{ action: 'verify' }] },                       // no problemTex → replay skips it
+        { problemTex: 'b=2', steps: [{ action: 'resolve' }], solved: false, assistance: 9 },
+      ],
+    };
+    const meta = ledgerMeta(ledger);
+    // 2 replayable completed entries → 2 meta rows (junk skipped identically),
+    // and current is NOT in meta (it never lands on the rail).
+    expect(meta).toEqual([
+      { assistance: 3, solved: true, completedAt: 'T1' },
+      { assistance: 9, solved: false, completedAt: null },
+    ]);
+    // The invariant the rail zip depends on: meta rows == archived replays.
+    const clears = ledgerToTurns(ledger).filter(t => t[0].action === 'clear').length;
+    expect(meta).toHaveLength(clears);
+  });
+
+  test('null / malformed ledgers give empty meta', () => {
+    expect(ledgerMeta(null)).toEqual([]);
+    expect(ledgerMeta({})).toEqual([]);
   });
 });


### PR DESCRIPTION
Third Live Workspace slice: the [spec's](https://github.com/jnappier7/mathmatix-ai/blob/main/docs/LIVE_WORKSPACE_REQUIREMENTS.md) §4.5 collapsed-card summary and §4.4 card states, built on the persisted lifecycle (#1296) and the assistance ladder (#1298).

## What changes for the student

- **Rail thumbnails** now carry a real summary (title + screen reader): *"Solved it myself"*, *"Solved with my tutor"*, or *"Not finished yet"* — and unaided solves get a gold number badge. Quietly aspirational: scanning the rail shows which wins were entirely the student's own.
- **Reopening a finished problem** shows a §4.5 summary strip first — outcome + step count — then the full preserved work.
- **The live card** (§4.4): when the problem in focus reaches its solution, the pinned header gets a subtle "Solved ✓" chip and green accent. Class-driven, no layout shift, cleared on the next problem.

## Mechanics

- `ledgerMeta()` rides per-problem metadata (assistance/solved/completedAt) alongside the command replay; it filters entries **identically** to `ledgerToTurns()`, and a test pins the alignment invariant (meta rows == archived replays), so the zip can't drift onto the wrong thumbnails.
- `annotateArchive()` stamps hydrated metadata onto the rail; live-session archives (where assistance is server-side only) simply stay bare and degrade to the old labels — say less, never wrong.
- Cache-busting: `ASSET_V` + the chat-workspace `?v=` bumped to `20260725b`.

## Verification

- 5 new tests: meta/replay alignment invariant, junk-skipping parity, full pipeline→wire→summary round trip ("solved with heavy help" vs "solved unaided" produce the right labels), honest degradation for pre-ladder data.
- Full suite: 4639 passed; lint clean.
- Visual QA (needs a student login): with `?livingWorkspace=dev`, solve one problem with hints and one without, reload — first thumbnail plain ✓, second gold; reopen each and check the summary strip; watch the "Solved ✓" chip appear live on a verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)