### PR TITLE
refactor(lws): remove board fill-in-the-blank inputs

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -133,7 +133,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
        LivingWorkspace flag is dev|beta|live (?livingWorkspace=dev). When on,
        it lazy-loads the workspace and mirrors the tutor's board output onto
        the new surface beside the old board. Default OFF → zero impact. -->
-  <script defer src="/js/living-workspace/chat-workspace.js?v=20260725b"></script>
+  <script defer src="/js/living-workspace/chat-workspace.js?v=20260725c"></script>
   <!-- Final safety net: strips any inline visual tag no renderer handled -->
   <script defer src="/js/stripVisualTags.js"></script>
   <!-- Non-core libs (lazy-loaded after first interaction) -->

--- a/public/css/living-workspace.css
+++ b/public/css/living-workspace.css
@@ -246,47 +246,6 @@ html[data-theme="dark"] .lws-root {
 .lws-dv-block { padding: 10px 0; }
 .lws-dv-block > * { max-width: 100%; }
 
-/* ── fill-in-the-blank scaffolds ────────────────────────────────
-   A scaffold card is defined by its empty \boxed{} slots (the server guard
-   rejects one without them), so the blanks are the student's turn — they
-   render as real inputs, not painted boxes. Submitting sends the value
-   through the ordinary chat path, so it is graded like anything typed. */
-/* The question that names what belongs in the blank. */
-.lws-dv-ask {
-  font-size: calc(13px * var(--lws-dv-scale)); line-height: 1.4;
-  color: var(--lws-accent); opacity: .95; margin-bottom: 5px;
-}
-.lws-dv-fill { display: flex; flex-wrap: wrap; align-items: center; gap: 5px; }
-.lws-dv-fill-tex { display: inline-flex; align-items: center; }
-.lws-dv-blank {
-  appearance: none; -webkit-appearance: none;
-  min-width: 2.6em; padding: 2px 7px;
-  font: inherit; font-size: calc(19px * var(--lws-dv-scale));
-  text-align: center; color: var(--lws-card-ink);
-  background: color-mix(in srgb, var(--lws-accent) 10%, transparent);
-  border: 1.5px dashed var(--lws-accent); border-radius: 8px;
-  transition: background-color .15s ease, border-color .15s ease;
-}
-.lws-dv-blank:hover:not(:disabled) { background: color-mix(in srgb, var(--lws-accent) 18%, transparent); }
-.lws-dv-blank:focus { outline: none; border-style: solid; background: color-mix(in srgb, var(--lws-accent) 20%, transparent); }
-.lws-dv-blank:focus-visible { outline: 2px solid var(--lws-accent); outline-offset: 2px; }
-.lws-dv-blank:disabled { border-style: solid; opacity: .8; cursor: default; }
-.lws-dv-fill-go {
-  appearance: none; -webkit-appearance: none; cursor: pointer;
-  margin-left: 4px; padding: 5px 12px;
-  border: 1px solid var(--lws-accent); border-radius: 999px;
-  background: color-mix(in srgb, var(--lws-accent) 16%, transparent);
-  color: var(--lws-card-ink); font: 600 12px/1 system-ui, sans-serif;
-}
-.lws-dv-fill-go:hover:not(:disabled) { background: color-mix(in srgb, var(--lws-accent) 30%, transparent); }
-.lws-dv-fill-go:focus-visible { outline: 2px solid var(--lws-accent); outline-offset: 2px; }
-.lws-dv-fill-go:disabled { opacity: .5; cursor: default; }
-/* Pressing Check with a blank still empty points at what is missing. */
-.lws-dv-fill.is-incomplete .lws-dv-blank:placeholder-shown,
-.lws-dv-fill.is-incomplete .lws-dv-blank:not(:disabled) { border-color: #e0a23c; }
-.lws-dv-fill.is-sent .lws-dv-blank { border-color: color-mix(in srgb, var(--lws-card-ink) 40%, transparent); background: transparent; }
-@media (prefers-reduced-motion: reduce) { .lws-dv-blank { transition: none; } }
-
 /* Spoken-step spotlight. Voice ships the board cumulatively, so the step that
    arrived this turn IS the step being talked about — it lights up while the
    tutor speaks and settles into the stack when they stop. Attention direction

--- a/public/js/living-workspace/chat-workspace.js
+++ b/public/js/living-workspace/chat-workspace.js
@@ -68,7 +68,7 @@
   // public/ with a 7-day cache and no content hashing, so bump this whenever
   // any living-workspace asset changes (and the chat.html <script ?v=> tag to
   // match, so this file itself refreshes). See project_asset_cache_busting.
-  var ASSET_V = '?v=20260725b';
+  var ASSET_V = '?v=20260725c';
   var BASE = '/js/living-workspace/';
   var SCRIPTS = [
     'core/flags.js', 'core/viewport.js', 'core/elementRegistry.js',
@@ -282,20 +282,12 @@
     doHydrate(ledger);
   };
 
-  // A student filling a scaffold's blanks is answering the tutor — send it as a
-  // chat message so it is graded by the same pipeline as anything they type.
-  // Returning false leaves the inputs editable (chat engine not ready yet).
-  function submitBlanks(text) {
-    if (typeof window.mmSendChatMessage !== 'function') return false;
-    return window.mmSendChatMessage(text) !== false;
-  }
-
   function boot() {
     injectCss();
     loadNext(0, function () {
       if (!window.LWS || !window.LWS.DerivationView) { console.error('[LWS_CHAT] DerivationView not available after load'); return; }
       var mount = buildPanel();
-      dv = new window.LWS.DerivationView(mount, { renderers: makeRenderers(), onBlankSubmit: submitBlanks });
+      dv = new window.LWS.DerivationView(mount, { renderers: makeRenderers() });
       ready = true;
       // Queued work replays in arrival order: hydrate() clears any turn queued
       // before it, so a `pending` that is still set alongside a pendingLedger

--- a/public/js/living-workspace/dom/derivationView.js
+++ b/public/js/living-workspace/dom/derivationView.js
@@ -118,48 +118,6 @@
     if (!found) target.textContent = unwrapText(tex);   // pure prose, no math
   }
 
-  // The blank tokens a scaffold card may use, mirroring texHasBlank() in
-  // utils/boardCommandGuard.js — that guard REJECTS a scaffold with no blank,
-  // so these are a contract between server and board, not a guess.
-  var BLANK_TOKEN = /\\boxed\s*\{\s*(?:\\(?:[;,:!\s]|quad|qquad|phantom\s*\{[^{}]*\}|hspace\s*\{[^{}]*\})\s*)*\}|\\square\b|(?:\\_){3,}|_{3,}/g;
-
-  // Split tex into alternating rendered math and student-fillable holes.
-  // Pure; exported for tests.
-  function splitBlanks(latex) {
-    var t = String(latex == null ? '' : latex);
-    var out = [];
-    var last = 0;
-    var m;
-    BLANK_TOKEN.lastIndex = 0;
-    while ((m = BLANK_TOKEN.exec(t)) !== null) {
-      if (m.index > last) out.push({ type: 'tex', value: t.slice(last, m.index) });
-      out.push({ type: 'blank', value: m[0] });
-      last = m.index + m[0].length;
-    }
-    if (last < t.length) out.push({ type: 'tex', value: t.slice(last) });
-    return out;
-  }
-
-  function hasBlank(latex) {
-    BLANK_TOKEN.lastIndex = 0;
-    return BLANK_TOKEN.test(String(latex == null ? '' : latex));
-  }
-
-  // Render one tex fragment. Splitting at blanks can leave a fragment that is
-  // not standalone-valid ("x^2 + 4x +"); KaTeX would paint that as red error
-  // source, so throwOnError is ON here and a failure degrades to plain text.
-  function typesetFragment(span, frag) {
-    var katex = root.katex;
-    var tex = cleanLatex(frag);
-    if (!tex) return false;
-    if (katex && typeof katex.render === 'function') {
-      try { katex.render(tex, span, { throwOnError: true, displayMode: false }); return true; }
-      catch (_) { /* not standalone-valid — show it as text */ }
-    }
-    span.textContent = tex;
-    return true;
-  }
-
   function typeset(target, latex) {
     var katex = root.katex;
     var tex = cleanLatex(latex);
@@ -220,9 +178,6 @@
     opts = opts || {};
     this.doc = container.ownerDocument || document;
     this.renderers = opts.renderers || {};
-    // Called with (text, latex) when a student fills a scaffold's blanks.
-    // Returning false means "not sent" and leaves the line editable.
-    this.onBlankSubmit = typeof opts.onBlankSubmit === 'function' ? opts.onBlankSubmit : null;
     this._blocks = [];        // live block renderers (for destroy on clear)
     this._problemTex = null;
     // The adapted elements making up the CURRENT derivation, kept so a finished
@@ -563,97 +518,15 @@
       var tag = d.createElement('span'); tag.className = 'lws-dv-op'; tag.textContent = op;
       row.appendChild(tag);
     } else {
-      var latex = element.semantic && element.semantic.latex;
-      // A scaffold's empty \boxed{} slots are the student's to fill — the whole
-      // point of the card. Render them as real inputs on the live board; a
-      // reopened archive is a look-back, so it stays static.
-      var live = !target || target === this.el.lines;
-      if (live && this.onBlankSubmit && hasBlank(latex)) {
-        // The tutor's question for this blank ("What does 20 − 4 leave you
-        // with?"). A box with no question is a guessing game, so fall back to
-        // a generic prompt when the model omits one.
-        var ask = (element.semantic && element.semantic.caption) || 'Your turn — fill in the blank.';
-        var askEl = d.createElement('div');
-        askEl.className = 'lws-dv-ask';
-        askEl.textContent = ask;
-        row.appendChild(askEl);
-        row.appendChild(this._buildFillLine(latex));
-      } else {
-        var tex = d.createElement('div'); tex.className = 'lws-dv-tex';
-        typeset(tex, latex);
-        row.appendChild(tex);
-      }
+      // Scaffold blanks (\boxed{}) render as KaTeX's empty box — a visual
+      // "your turn" cue the student answers IN CHAT, where the pipeline can
+      // see it. (Board-side inputs were removed: they submitted through a
+      // side door the tutor had no concept of.)
+      var tex = d.createElement('div'); tex.className = 'lws-dv-tex';
+      typeset(tex, element.semantic && element.semantic.latex);
+      row.appendChild(tex);
     }
     (target || this.el.lines).appendChild(row);
-  };
-
-  // Build a fill-in-the-blank line: the fixed math renders, each blank becomes
-  // a focusable input, and submitting sends the student's value through the
-  // ordinary chat path so the existing diagnose/verify pipeline grades it.
-  DerivationView.prototype._buildFillLine = function (latex) {
-    var self = this;
-    var d = this.doc;
-    var wrap = d.createElement('div');
-    wrap.className = 'lws-dv-tex lws-dv-fill';
-
-    var inputs = [];
-    splitBlanks(latex).forEach(function (seg) {
-      if (seg.type === 'tex') {
-        var span = d.createElement('span');
-        span.className = 'lws-dv-fill-tex';
-        if (typesetFragment(span, seg.value)) wrap.appendChild(span);
-        return;
-      }
-      var inp = d.createElement('input');
-      inp.type = 'text';
-      inp.className = 'lws-dv-blank';
-      inp.setAttribute('inputmode', 'text');
-      inp.setAttribute('autocomplete', 'off');
-      inp.setAttribute('autocapitalize', 'off');
-      inp.spellcheck = false;
-      inp.size = 3;
-      inp.setAttribute('aria-label', 'Fill in the blank');
-      inp.addEventListener('keydown', function (ev) {
-        if (ev.key === 'Enter') { ev.preventDefault(); submit(); }
-      });
-      // Grow with the answer so long values stay readable.
-      inp.addEventListener('input', function () {
-        inp.size = Math.max(3, Math.min(18, inp.value.length + 1));
-        wrap.classList.remove('is-incomplete');
-      });
-      inputs.push(inp);
-      wrap.appendChild(inp);
-    });
-
-    var btn = d.createElement('button');
-    btn.type = 'button';
-    btn.className = 'lws-dv-fill-go';
-    btn.textContent = 'Check';
-    btn.setAttribute('aria-label', 'Check my answer');
-    btn.addEventListener('click', submit);
-    wrap.appendChild(btn);
-
-    function submit() {
-      var values = inputs.map(function (i) { return i.value.trim(); });
-      var firstEmpty = values.indexOf('');
-      if (firstEmpty !== -1) {
-        wrap.classList.add('is-incomplete');
-        try { inputs[firstEmpty].focus(); } catch (_) { /* detached */ }
-        return;
-      }
-      var sent = false;
-      try { sent = self.onBlankSubmit(values.join(', '), latex) !== false; }
-      catch (e) { console.error('[LWS] blank submit failed', e); sent = false; }
-      if (!sent) return;
-      // Lock the line: it is now part of the transcript, and the tutor's reply
-      // will redraw the board anyway.
-      wrap.classList.add('is-sent');
-      inputs.forEach(function (i) { i.disabled = true; });
-      btn.disabled = true;
-      btn.textContent = 'Sent';
-    }
-
-    return wrap;
   };
 
   DerivationView.prototype._addBlock = function (element, target, blockSink) {
@@ -721,8 +594,6 @@
   DerivationView.hasSolution = hasSolution;
   DerivationView.assistanceSummary = assistanceSummary;
   DerivationView.MAX_ARCHIVE = MAX_ARCHIVE;
-  DerivationView.splitBlanks = splitBlanks;
-  DerivationView.hasBlank = hasBlank;
   LWS.DerivationView = DerivationView;
-  if (typeof module !== 'undefined' && module.exports) module.exports = { DerivationView: DerivationView, classify: classify, cleanLatex: cleanLatex, looksLikeProse: looksLikeProse, unwrapText: unwrapText, freshNodes: freshNodes, hasSolution: hasSolution, assistanceSummary: assistanceSummary, MAX_ARCHIVE: MAX_ARCHIVE, splitBlanks: splitBlanks, hasBlank: hasBlank };
+  if (typeof module !== 'undefined' && module.exports) module.exports = { DerivationView: DerivationView, classify: classify, cleanLatex: cleanLatex, looksLikeProse: looksLikeProse, unwrapText: unwrapText, freshNodes: freshNodes, hasSolution: hasSolution, assistanceSummary: assistanceSummary, MAX_ARCHIVE: MAX_ARCHIVE };
 })(typeof self !== 'undefined' ? self : this);

--- a/tests/unit/workspace/derivationView.test.js
+++ b/tests/unit/workspace/derivationView.test.js
@@ -62,51 +62,6 @@ describe('derivationView.classify', () => {
   });
 });
 
-// A scaffold card is DEFINED by its empty slots — utils/boardCommandGuard.js
-// rejects one without a blank (`scaffold_has_no_blank`). The board never
-// implemented the other half of that contract, so the blanks rendered as dead
-// boxes. splitBlanks is what turns them into real inputs.
-describe('derivationView.splitBlanks / hasBlank', () => {
-  const { splitBlanks, hasBlank } = require('../../../public/js/living-workspace/dom/derivationView.js');
-
-  it('splits the schema\'s own scaffold example into fixed math and holes', () => {
-    // From boardResponseSchema.js: "x^2 + 4x + \boxed{} = 12 + \boxed{}"
-    const segs = splitBlanks('x^2 + 4x + \\boxed{} = 12 + \\boxed{}');
-    expect(segs.map((s) => s.type)).toEqual(['tex', 'blank', 'tex', 'blank']);
-    expect(segs[0].value).toBe('x^2 + 4x + ');
-    expect(segs[2].value).toBe(' = 12 + ');
-  });
-
-  it('recognises every blank form the guard accepts', () => {
-    expect(hasBlank('\\boxed{}')).toBe(true);
-    expect(hasBlank('\\boxed{\\;\\;}')).toBe(true);   // spacing-only counts as empty
-    expect(hasBlank('\\square = 6 \\div 2')).toBe(true);
-    expect(hasBlank('x = ___')).toBe(true);
-    expect(hasBlank('x = \\_\\_\\_')).toBe(true);
-  });
-
-  it('a blank can lead the line', () => {
-    const segs = splitBlanks('\\square = 6 \\div 2');
-    expect(segs[0]).toEqual({ type: 'blank', value: '\\square' });
-    expect(segs[1].value).toBe(' = 6 \\div 2');
-  });
-
-  it('a FILLED box is not a blank — that would be an answer, not a scaffold', () => {
-    expect(hasBlank('\\boxed{5} = 5')).toBe(false);
-  });
-
-  it('leaves ordinary math (and subscripts) alone', () => {
-    expect(hasBlank('x^2 - 4x + 3')).toBe(false);
-    expect(hasBlank('a_{ij} + b_{12}')).toBe(false);
-    expect(splitBlanks('x^2 - 4x + 3')).toEqual([{ type: 'tex', value: 'x^2 - 4x + 3' }]);
-  });
-
-  it('handles junk', () => {
-    expect(hasBlank(null)).toBe(false);
-    expect(splitBlanks(null)).toEqual([]);
-  });
-});
-
 // A finished problem shrinks to a thumbnail rather than being deleted, and the
 // ✓ on it means the derivation actually reached an answer.
 describe('derivationView.hasSolution', () => {


### PR DESCRIPTION
Owner call: the board fill-in-the-blanks were half-baked and ran as a separate entity — chat had no concept they existed.

## What was wrong

Scaffold cards rendered their `\boxed{}` slots as live inputs with a Check button. Submitting pushed the values into chat via `window.mmSendChatMessage` — a side door: the pipeline received a bare `"7, 3"` user message with **no signal** it came from a board scaffold, no link to which blanks were filled, and no board-state awareness in the reply. Two input surfaces, one conversation, zero shared state.

## What this does

- Removes the whole input apparatus: `onBlankSubmit` plumbing, `_buildFillLine`, `splitBlanks`/`hasBlank`/`BLANK_TOKEN`/`typesetFragment`, the `.lws-dv-fill`/`.lws-dv-blank`/`.lws-dv-ask` CSS family, and their tests. Verified zero stale references across `public/`, `tests/`, `utils/`.
- Scaffold cards **still render** — the server guard still requires blanks, and the empty `\boxed{}` slots paint as KaTeX boxes: a visual "your turn" cue the student answers **in chat**, where diagnose/verify actually sees it.
- Cache-bust: `ASSET_V` + chat-workspace tag → `?v=20260725c`.

If board-side input returns, it should come back as StudentMoves the pipeline understands (the algebra-tile loop is the working pattern), not as a parallel submit path.

**Stacked on #1300** (same files); merges cleanly after it and retargets to `main` automatically.

## Verification

Full suite: 4633 passed; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)