### PR TITLE
feat(lws): Source Cards v1 — uploads live on the board (spec §5.1)

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -133,7 +133,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
        LivingWorkspace flag is dev|beta|live (?livingWorkspace=dev). When on,
        it lazy-loads the workspace and mirrors the tutor's board output onto
        the new surface beside the old board. Default OFF → zero impact. -->
-  <script defer src="/js/living-workspace/chat-workspace.js?v=20260725c"></script>
+  <script defer src="/js/living-workspace/chat-workspace.js?v=20260725d"></script>
   <!-- Final safety net: strips any inline visual tag no renderer handled -->
   <script defer src="/js/stripVisualTags.js"></script>
   <!-- Non-core libs (lazy-loaded after first interaction) -->
@@ -2485,7 +2485,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- Player stats card: window-global, loaded before script.js which calls
      window.PlayerStatsCard.init(currentUser) once the user doc is fetched. -->
 <script defer src="/js/modules/playerStatsCard.js?v=20260724b"></script>
-<script src="/js/script.js?v=20260725b" type="module"></script>
+<script src="/js/script.js?v=20260725d" type="module"></script>
   <script src="/js/guidedPath.js" type="module"></script>
   <script src="/dist/js/chat-js9.bc0be9a3.js"></script>
   <!-- Companion HOME screen (phones only; flag-gated OFF by default) -->

--- a/public/css/living-workspace.css
+++ b/public/css/living-workspace.css
@@ -522,3 +522,92 @@ html[data-theme="dark"] .lws-root {
 .lws-empty-state .lws-empty-sub {
   font: 13px/1.45 Inter, system-ui, sans-serif; opacity: 0.82; max-width: 280px;
 }
+
+/* ── Source Cards dock (spec §5.1) ──────────────────────────────
+   Uploads live ON the board: a slim dock pinned to the board's bottom-left
+   (the supporting zone of the §14 layout) with one card per source. Cards
+   open full-board in a read-only overlay — the student's work underneath is
+   never disturbed. */
+.lws-sd {
+  position: absolute; left: 10px; bottom: 10px; z-index: 5;
+  max-width: min(62%, 420px);
+  display: flex; flex-direction: column; gap: 6px;
+}
+.lws-sd-head {
+  appearance: none; -webkit-appearance: none; cursor: pointer;
+  align-self: flex-start; display: inline-flex; align-items: center; gap: 6px;
+  padding: 5px 11px; border: 1px solid var(--lws-card-border); border-radius: 999px;
+  background: color-mix(in srgb, var(--lws-card-bg) 88%, transparent);
+  color: var(--lws-card-ink); font: 600 11px/1 system-ui, sans-serif;
+  -webkit-backdrop-filter: blur(6px); backdrop-filter: blur(6px);
+}
+.lws-sd-head:hover { border-color: var(--lws-accent); }
+.lws-sd-head:focus-visible { outline: 2px solid var(--lws-accent); outline-offset: 2px; }
+.lws-sd-strip {
+  display: flex; gap: 8px; overflow-x: auto; padding: 2px;
+  scrollbar-width: thin;
+}
+.lws-sd.is-collapsed .lws-sd-strip { display: none; }
+.lws-sd-card {
+  appearance: none; -webkit-appearance: none; cursor: pointer;
+  flex: 0 0 auto; display: flex; flex-direction: column; align-items: center; gap: 3px;
+  width: 74px; padding: 5px;
+  border: 1px solid var(--lws-card-border); border-radius: 10px;
+  background: var(--lws-card-bg); color: var(--lws-card-ink);
+}
+.lws-sd-card:hover { border-color: var(--lws-accent); }
+.lws-sd-card:focus-visible { outline: 2px solid var(--lws-accent); outline-offset: 2px; }
+.lws-sd-card-img {
+  width: 62px; height: 44px; object-fit: cover; border-radius: 6px;
+  background: color-mix(in srgb, var(--lws-card-ink) 8%, transparent);
+}
+.lws-sd-card-pdf {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 62px; height: 44px; border-radius: 6px;
+  background: color-mix(in srgb, #d0453e 16%, transparent);
+  color: #d0453e; font: 700 12px/1 system-ui, sans-serif; letter-spacing: .08em;
+}
+.lws-sd-card-lab {
+  max-width: 100%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis;
+  font: 500 10px/1.2 system-ui, sans-serif; opacity: .85;
+}
+
+/* Source viewer overlay — same contract as the archive overlay. */
+.lws-sd-ov {
+  position: absolute; inset: 0; z-index: 8;
+  display: flex; flex-direction: column;
+  background: var(--lws-grid-bg);
+  animation: lws-dv-ov-in .18s ease-out both;
+}
+@media (prefers-reduced-motion: reduce) { .lws-sd-ov { animation: none; } }
+.lws-sd-ov-bar {
+  flex: 0 0 auto; display: flex; align-items: center; justify-content: space-between;
+  gap: 10px; padding: 9px 12px;
+  border-bottom: 1px solid var(--lws-card-border);
+  background: color-mix(in srgb, var(--lws-card-bg) 70%, transparent);
+}
+.lws-sd-ov-tag {
+  font: 600 10px/1 system-ui, sans-serif; letter-spacing: .16em; text-transform: uppercase;
+  color: var(--lws-accent);
+}
+.lws-sd-ov-back {
+  appearance: none; -webkit-appearance: none; cursor: pointer;
+  border: 1px solid var(--lws-card-border); border-radius: 999px;
+  background: var(--lws-card-bg); color: var(--lws-card-ink);
+  font: 600 12px/1 system-ui, sans-serif; padding: 7px 13px;
+}
+.lws-sd-ov-back:hover { border-color: var(--lws-accent); }
+.lws-sd-ov-back:focus-visible { outline: 2px solid var(--lws-accent); outline-offset: 2px; }
+.lws-sd-ov-zoom { display: inline-flex; gap: 6px; }
+.lws-sd-ov-zoom button {
+  appearance: none; -webkit-appearance: none; cursor: pointer;
+  width: 28px; height: 28px; border-radius: 8px;
+  border: 1px solid var(--lws-card-border);
+  background: var(--lws-card-bg); color: var(--lws-card-ink);
+  font: 700 15px/1 system-ui, sans-serif;
+}
+.lws-sd-ov-zoom button:disabled { opacity: .4; cursor: default; }
+.lws-sd-ov-zoom button:focus-visible { outline: 2px solid var(--lws-accent); outline-offset: 2px; }
+.lws-sd-ov-body { flex: 1 1 auto; min-height: 0; overflow: auto; padding: 10px; }
+.lws-sd-ov-img { display: block; margin: 0 auto; border-radius: 8px; }
+.lws-sd-ov-frame { width: 100%; height: 100%; border: 0; border-radius: 8px; background: #fff; }

--- a/public/js/living-workspace/chat-workspace.js
+++ b/public/js/living-workspace/chat-workspace.js
@@ -60,6 +60,10 @@
     // Rebuild the board from a persisted conversation.boardLedger (session
     // switch / page re-mount). No-op when the workspace is off.
     hydrate: function () {},
+    // Source Cards (spec §5.1): set the dock from a conversation's messages
+    // (history load) or append this turn's uploads (live delta).
+    setSourcesFromMessages: function () {},
+    addSources: function () {},
   };
   window.LWS_CHAT = api;
   if (!ON) return;
@@ -68,11 +72,12 @@
   // public/ with a 7-day cache and no content hashing, so bump this whenever
   // any living-workspace asset changes (and the chat.html <script ?v=> tag to
   // match, so this file itself refreshes). See project_asset_cache_busting.
-  var ASSET_V = '?v=20260725c';
+  var ASSET_V = '?v=20260725d';
   var BASE = '/js/living-workspace/';
   var SCRIPTS = [
     'core/flags.js', 'core/viewport.js', 'core/elementRegistry.js',
     'core/snapshotManager.js', 'core/a11yCommands.js', 'core/ledgerReplay.js',
+    'core/sourceList.js', 'dom/sourceDock.js',
     'dom/gridRenderer.js', 'dom/overlayManager.js', 'dom/equationElement.js',
     'dom/tileElement.js', 'dom/numberLineElement.js', 'dom/graphElement.js',
     'dom/noteElement.js', 'dom/imageElement.js', 'dom/studentMoveClient.js',
@@ -83,9 +88,11 @@
   // Build brick #1: the chat board renders as a FOCUSED DERIVATION
   // (dom/derivationView.js), not free-floating canvas cards. `dv` is that view.
   var dv = null;
+  var dock = null;           // SourceDock — uploads living on the board
   var ready = false;
   var pending = null;        // latest board_commands received before ready
   var pendingLedger;         // ledger passed to hydrate() before ready (undefined = none)
+  var pendingSources;        // source list set before ready (undefined = none)
   var turn = 0;
 
   function injectCss() {
@@ -252,8 +259,33 @@
   api.reset = function () {
     pending = null;                 // don't let a queued turn repaint the old session
     pendingLedger = undefined;
+    pendingSources = undefined;
+    if (dock) { try { dock.clear(); } catch (e) { console.error('[LWS_CHAT] dock clear failed', e); } }
     if (!dv) return;
     try { dv.resetAll(); } catch (e) { console.error('[LWS_CHAT] reset failed', e); }
+  };
+
+  var sources = [];
+  function paintSources() {
+    if (!dock) return;
+    try { dock.setSources(sources); } catch (e) { console.error('[LWS_CHAT] dock render failed', e); }
+  }
+
+  // History load: the full source list derives from messages[].attachments.
+  // Replaces whatever the dock held — a switch means a different conversation.
+  api.setSourcesFromMessages = function (messages) {
+    if (!window.LWS || typeof window.LWS.sourcesFromMessages !== 'function') { pendingSources = messages || []; return; }
+    sources = window.LWS.sourcesFromMessages(messages);
+    if (!ready) { pendingSources = messages || []; return; }
+    paintSources();
+  };
+
+  // Live turn: the response's sourceUploads delta appends to the dock.
+  api.addSources = function (delta) {
+    if (!Array.isArray(delta) || !delta.length) return;
+    if (!window.LWS || typeof window.LWS.mergeSources !== 'function' || !ready) return;
+    sources = window.LWS.mergeSources(sources, delta);
+    paintSources();
   };
 
   // Rebuild the board from a persisted conversation.boardLedger: each finished
@@ -288,7 +320,11 @@
       if (!window.LWS || !window.LWS.DerivationView) { console.error('[LWS_CHAT] DerivationView not available after load'); return; }
       var mount = buildPanel();
       dv = new window.LWS.DerivationView(mount, { renderers: makeRenderers() });
+      if (window.LWS.SourceDock) {
+        try { dock = new window.LWS.SourceDock(mount); } catch (e) { console.error('[LWS_CHAT] dock mount failed', e); }
+      }
       ready = true;
+      if (pendingSources !== undefined) { var ps = pendingSources; pendingSources = undefined; api.setSourcesFromMessages(ps); }
       // Queued work replays in arrival order: hydrate() clears any turn queued
       // before it, so a `pending` that is still set alongside a pendingLedger
       // arrived AFTER the hydrate and renders on top of the rebuilt board.

--- a/public/js/living-workspace/core/sourceList.js
+++ b/public/js/living-workspace/core/sourceList.js
@@ -1,0 +1,66 @@
+/* ============================================================
+   sourceList.js — derive the board's Source Cards from conversation data.
+
+   Spec §5.1: uploaded materials must appear on the workspace board, not
+   vanish into an attachment tray. The server already persists every upload
+   as a servable reference on its message ({uploadId, fileType, mimeType},
+   bytes at /api/student/uploads/:id/file), so the source list is DERIVED:
+
+     • on history load, from messages[].attachments (user messages only —
+       the student's uploads are the sources; tutor-side images are not),
+     • on a live turn, from the response's `sourceUploads` delta.
+
+   Dedupes by uploadId, keeps arrival order (oldest first, so the newest
+   source lands nearest the student), caps the dock at MAX_SOURCES — the
+   board shows a session's working set, the transcript remains the archive.
+
+   Pure; UMD-lite like the rest of core/. The DOM lives in dom/sourceDock.js.
+   ============================================================ */
+(function (root, factory) {
+  var mod = factory();
+  if (typeof module !== 'undefined' && module.exports) module.exports = mod;
+  if (root) {
+    (root.LWS = root.LWS || {}).sourcesFromMessages = mod.sourcesFromMessages;
+    root.LWS.mergeSources = mod.mergeSources;
+  }
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  var MAX_SOURCES = 6;
+
+  function normalize(att) {
+    if (!att || att.uploadId == null) return null;
+    return {
+      uploadId: String(att.uploadId),
+      fileType: att.fileType === 'pdf' ? 'pdf' : 'image',
+      mimeType: att.mimeType || null,
+    };
+  }
+
+  // Append `incoming` to `existing`, dropping uploadIds already present and
+  // trimming from the FRONT (oldest) past the cap. Both inputs untouched.
+  function mergeSources(existing, incoming) {
+    var out = (Array.isArray(existing) ? existing : []).slice();
+    var seen = {};
+    out.forEach(function (s) { if (s && s.uploadId != null) seen[String(s.uploadId)] = true; });
+    (Array.isArray(incoming) ? incoming : []).forEach(function (att) {
+      var s = normalize(att);
+      if (!s || seen[s.uploadId]) return;
+      seen[s.uploadId] = true;
+      out.push(s);
+    });
+    while (out.length > MAX_SOURCES) out.shift();
+    return out;
+  }
+
+  function sourcesFromMessages(messages) {
+    var atts = [];
+    (Array.isArray(messages) ? messages : []).forEach(function (m) {
+      if (!m || m.role !== 'user' || !Array.isArray(m.attachments)) return;
+      atts = atts.concat(m.attachments);
+    });
+    return mergeSources([], atts);
+  }
+
+  return { sourcesFromMessages: sourcesFromMessages, mergeSources: mergeSources, MAX_SOURCES: MAX_SOURCES };
+});

--- a/public/js/living-workspace/dom/sourceDock.js
+++ b/public/js/living-workspace/dom/sourceDock.js
@@ -1,0 +1,188 @@
+/* ============================================================
+   sourceDock.js — Source Cards v1: uploads live ON the board.
+
+   Spec §5.1: uploaded materials must appear directly on the workspace,
+   not disappear into an attachment menu or a separate tab. This dock is
+   the supporting zone of the ratified zones layout (spec §14): a slim
+   strip pinned to the bottom edge of the board holding one card per
+   uploaded source. Clicking a card opens it full-board in a read-only
+   overlay — images with zoom controls, PDFs through the browser's
+   native viewer (page turns and zoom included) — beside, never instead
+   of, the student's work.
+
+   Bytes are served by /api/student/uploads/:id/file (auth + ownership
+   enforced server-side); this module only ever handles {uploadId,
+   fileType} references. Region selection and source↔problem linking
+   (spec §5.3–5.4) build on top of this surface in a later slice.
+
+   Browser-only view; the pure list logic lives in core/sourceList.js.
+   ============================================================ */
+(function (root) {
+  'use strict';
+  var LWS = (root.LWS = root.LWS || {});
+
+  function fileUrl(uploadId) {
+    return '/api/student/uploads/' + encodeURIComponent(uploadId) + '/file';
+  }
+
+  function SourceDock(container) {
+    this.doc = container.ownerDocument || document;
+    this._sources = [];
+    this._overlay = null;
+    this._escHandler = null;
+
+    var d = this.doc;
+    var dock = d.createElement('div');
+    dock.className = 'lws-sd';
+    dock.hidden = true;
+
+    var head = d.createElement('button');
+    head.type = 'button';
+    head.className = 'lws-sd-head';
+    head.setAttribute('aria-expanded', 'true');
+    head.innerHTML = '<span class="lws-sd-head-ic" aria-hidden="true">📎</span><span class="lws-sd-head-t">My materials</span>';
+    var self = this;
+    head.addEventListener('click', function () {
+      var collapsed = dock.classList.toggle('is-collapsed');
+      head.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+    });
+
+    var strip = d.createElement('div');
+    strip.className = 'lws-sd-strip';
+    strip.setAttribute('role', 'list');
+    strip.setAttribute('aria-label', 'Uploaded materials');
+
+    dock.appendChild(head);
+    dock.appendChild(strip);
+    container.appendChild(dock);
+    this.el = { root: dock, strip: strip, container: container };
+    void self; // bound handlers only
+  }
+
+  SourceDock.prototype.setSources = function (sources) {
+    this._sources = Array.isArray(sources) ? sources : [];
+    this._render();
+  };
+
+  SourceDock.prototype.clear = function () {
+    this.closeSource();
+    this._sources = [];
+    this._render();
+  };
+
+  SourceDock.prototype._render = function () {
+    var self = this;
+    var d = this.doc;
+    var strip = this.el.strip;
+    strip.textContent = '';
+    this.el.root.hidden = this._sources.length === 0;
+
+    this._sources.forEach(function (src, i) {
+      if (!src || !src.uploadId) return;
+      var b = d.createElement('button');
+      b.type = 'button';
+      b.className = 'lws-sd-card';
+      b.setAttribute('role', 'listitem');
+      var name = (src.fileType === 'pdf' ? 'Worksheet PDF ' : 'Photo ') + (i + 1);
+      b.setAttribute('aria-label', 'Open ' + name + ' on the board');
+      b.title = 'Open ' + name;
+
+      if (src.fileType === 'pdf') {
+        var ic = d.createElement('span');
+        ic.className = 'lws-sd-card-pdf';
+        ic.textContent = 'PDF';
+        b.appendChild(ic);
+      } else {
+        var img = d.createElement('img');
+        img.className = 'lws-sd-card-img';
+        img.alt = '';
+        img.loading = 'lazy';
+        img.src = fileUrl(src.uploadId);
+        b.appendChild(img);
+      }
+      var lab = d.createElement('span');
+      lab.className = 'lws-sd-card-lab';
+      lab.textContent = name;
+      b.appendChild(lab);
+
+      b.addEventListener('click', function () { self.openSource(src, name); });
+      strip.appendChild(b);
+    });
+  };
+
+  // Full-board read-only viewer, same pattern as the derivation's archive
+  // overlay: it covers the board, never replaces it, Esc or Back returns.
+  SourceDock.prototype.openSource = function (src, name) {
+    this.closeSource();
+    var self = this;
+    var d = this.doc;
+
+    var ov = d.createElement('div');
+    ov.className = 'lws-sd-ov';
+    ov.setAttribute('role', 'dialog');
+    ov.setAttribute('aria-modal', 'false');
+    ov.setAttribute('aria-label', name);
+
+    var bar = d.createElement('div'); bar.className = 'lws-sd-ov-bar';
+    var tag = d.createElement('span'); tag.className = 'lws-sd-ov-tag'; tag.textContent = name;
+    var back = d.createElement('button');
+    back.type = 'button'; back.className = 'lws-sd-ov-back';
+    back.textContent = 'Back to my work';
+    back.addEventListener('click', function () { self.closeSource(); });
+    bar.appendChild(tag);
+
+    var body = d.createElement('div'); body.className = 'lws-sd-ov-body';
+
+    if (src.fileType === 'pdf') {
+      // The browser's own PDF viewer supplies paging, zoom and search —
+      // native capabilities the spec asks Source Cards to have (§5.2).
+      var frame = d.createElement('iframe');
+      frame.className = 'lws-sd-ov-frame';
+      frame.title = name;
+      frame.src = fileUrl(src.uploadId);
+      body.appendChild(frame);
+    } else {
+      var zoom = 1;
+      var img = d.createElement('img');
+      img.className = 'lws-sd-ov-img';
+      img.alt = name;
+      img.src = fileUrl(src.uploadId);
+
+      var ctl = d.createElement('span'); ctl.className = 'lws-sd-ov-zoom';
+      var zOut = d.createElement('button'); zOut.type = 'button'; zOut.textContent = '−'; zOut.setAttribute('aria-label', 'Zoom out');
+      var zIn = d.createElement('button'); zIn.type = 'button'; zIn.textContent = '+'; zIn.setAttribute('aria-label', 'Zoom in');
+      function applyZoom() {
+        zoom = Math.max(0.5, Math.min(4, zoom));
+        img.style.width = (zoom * 100) + '%';
+        zOut.disabled = zoom <= 0.5;
+        zIn.disabled = zoom >= 4;
+      }
+      zOut.addEventListener('click', function () { zoom -= 0.25; applyZoom(); });
+      zIn.addEventListener('click', function () { zoom += 0.25; applyZoom(); });
+      ctl.appendChild(zOut); ctl.appendChild(zIn);
+      bar.appendChild(ctl);
+      applyZoom();
+      body.appendChild(img);
+    }
+
+    bar.appendChild(back);
+    ov.appendChild(bar); ov.appendChild(body);
+    this.el.container.appendChild(ov);
+    this._overlay = ov;
+    this._escHandler = function (ev) { if (ev.key === 'Escape') self.closeSource(); };
+    d.addEventListener('keydown', this._escHandler);
+    try { back.focus(); } catch (_) { /* not focusable yet */ }
+  };
+
+  SourceDock.prototype.closeSource = function () {
+    if (this._escHandler) {
+      this.doc.removeEventListener('keydown', this._escHandler);
+      this._escHandler = null;
+    }
+    if (this._overlay && this._overlay.parentNode) this._overlay.parentNode.removeChild(this._overlay);
+    this._overlay = null;
+  };
+
+  LWS.SourceDock = SourceDock;
+  if (typeof module !== 'undefined' && module.exports) module.exports = { SourceDock: SourceDock };
+})(typeof self !== 'undefined' ? self : this);

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -3205,6 +3205,16 @@ document.addEventListener("DOMContentLoaded", () => {
                 }
             }
 
+            // Source Cards (spec §5.1): uploads that arrived on this turn dock
+            // onto the board instead of living only in the transcript.
+            if (window.LWS_CHAT && window.LWS_CHAT.isOn() && Array.isArray(data.sourceUploads) && data.sourceUploads.length > 0) {
+                try {
+                    window.LWS_CHAT.addSources(data.sourceUploads);
+                } catch (error) {
+                    console.error('[LWS_CHAT] addSources failed:', error);
+                }
+            }
+
             // Phase C: execute server-emitted <XP> ceremony commands
             // (confetti + optional gold caption). Pipeline caps the batch
             // at 3 so a runaway model can't confetti-bomb the chat.
@@ -5492,6 +5502,12 @@ document.addEventListener("DOMContentLoaded", () => {
         if (window.LWS_CHAT && typeof window.LWS_CHAT.hydrate === 'function') {
             try { window.LWS_CHAT.hydrate(conversation.boardLedger || null); }
             catch (err) { console.error('[updateChatForSession] board hydrate failed:', err); }
+        }
+        // Source Cards: this conversation's uploads dock onto the board,
+        // derived from the messages' attachment refs (spec §5.1).
+        if (window.LWS_CHAT && typeof window.LWS_CHAT.setSourcesFromMessages === 'function') {
+            try { window.LWS_CHAT.setSourcesFromMessages(messages || []); }
+            catch (err) { console.error('[updateChatForSession] source dock failed:', err); }
         }
 
         console.log('[updateChatForSession] Loaded', messages?.length || 0, 'messages');

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -1704,6 +1704,14 @@ async function runStudentTurn(req, res) {
             drawingSequence: pipelineResult.drawingSequence,
             visualCommands: pipelineResult.visualCommands,
             boardCommands: pipelineResult.boardCommands || [],
+            // Uploads that arrived on THIS turn, in servable form. The Living
+            // Workspace docks them as Source Cards (spec §5.1: files live on
+            // the board, not in a buried attachment tray). The full source list
+            // for a conversation is derived from messages[].attachments on
+            // history load; this is the live-turn delta.
+            sourceUploads: attachmentMeta.length > 0
+                ? attachmentMeta.map(a => ({ uploadId: String(a.uploadId), fileType: a.fileType, mimeType: a.mimeType }))
+                : [],
             xpCommands: pipelineResult.xpCommands || [],
             visualTabCommands: pipelineResult.visualTabCommands || [],
             boardContext: pipelineResult.boardContext,
@@ -2372,6 +2380,11 @@ async function handleGreetingRequest(req, res, userId) {
                         role: m.role,
                         content: m.content,
                         workCheckId: m.workCheckId || null,
+                        // Servable refs only — the server-side continuity payload
+                        // (extractedText/imageData) must never reach the client.
+                        ...(Array.isArray(m.attachments) && m.attachments.length > 0
+                            ? { attachments: m.attachments.map(a => ({ uploadId: a.uploadId, fileType: a.fileType, mimeType: a.mimeType })) }
+                            : {}),
                     }));
 
                 const useStreaming = req.query.stream === 'true';
@@ -2426,7 +2439,15 @@ async function handleGreetingRequest(req, res, userId) {
                     && typeof m.content === 'string'
                     && m.content.startsWith('[Voice session')
                 ))
-                .map(m => ({ role: m.role, content: m.content, workCheckId: m.workCheckId || null }));
+                .map(m => ({
+                    role: m.role,
+                    content: m.content,
+                    workCheckId: m.workCheckId || null,
+                    // Servable refs only — continuity payload stays server-side.
+                    ...(Array.isArray(m.attachments) && m.attachments.length > 0
+                        ? { attachments: m.attachments.map(a => ({ uploadId: a.uploadId, fileType: a.fileType, mimeType: a.mimeType })) }
+                        : {}),
+                }));
 
             const useStreaming = req.query.stream === 'true';
             if (useStreaming) {

--- a/tests/unit/workspace/sourceList.test.js
+++ b/tests/unit/workspace/sourceList.test.js
@@ -1,0 +1,70 @@
+/**
+ * Source Cards list derivation (core/sourceList.js, spec §5.1).
+ *
+ * The dock's contract: sources come from USER messages' attachment refs,
+ * dedupe by uploadId, keep arrival order, cap at MAX_SOURCES with the oldest
+ * falling off — the board holds a working set, the transcript is the archive.
+ */
+const { sourcesFromMessages, mergeSources, MAX_SOURCES } =
+  require('../../../public/js/living-workspace/core/sourceList.js');
+
+describe('sourcesFromMessages', () => {
+  test('collects user-message attachments in order, normalized to servable refs', () => {
+    const messages = [
+      { role: 'user', content: 'here is my worksheet', attachments: [{ uploadId: 'u1', fileType: 'image', mimeType: 'image/jpeg' }] },
+      { role: 'assistant', content: 'got it' },
+      { role: 'user', content: 'and the pdf', attachments: [{ uploadId: 'u2', fileType: 'pdf', mimeType: 'application/pdf' }] },
+    ];
+    expect(sourcesFromMessages(messages)).toEqual([
+      { uploadId: 'u1', fileType: 'image', mimeType: 'image/jpeg' },
+      { uploadId: 'u2', fileType: 'pdf', mimeType: 'application/pdf' },
+    ]);
+  });
+
+  test('ignores assistant attachments, junk entries, and messages without attachments', () => {
+    const messages = [
+      { role: 'assistant', attachments: [{ uploadId: 'tutor-img', fileType: 'image' }] },
+      { role: 'user', content: 'plain' },
+      { role: 'user', attachments: [null, {}, { uploadId: 'u1' }] },
+      null,
+    ];
+    // Unknown fileType defaults to image (only two servable types exist).
+    expect(sourcesFromMessages(messages)).toEqual([{ uploadId: 'u1', fileType: 'image', mimeType: null }]);
+  });
+
+  test('dedupes by uploadId across messages', () => {
+    const messages = [
+      { role: 'user', attachments: [{ uploadId: 'u1', fileType: 'image' }] },
+      { role: 'user', attachments: [{ uploadId: 'u1', fileType: 'image' }, { uploadId: 'u2', fileType: 'pdf' }] },
+    ];
+    expect(sourcesFromMessages(messages).map(s => s.uploadId)).toEqual(['u1', 'u2']);
+  });
+
+  test('caps at MAX_SOURCES, oldest falling off', () => {
+    const messages = Array.from({ length: MAX_SOURCES + 3 }, (_, i) => ({
+      role: 'user', attachments: [{ uploadId: 'u' + i, fileType: 'image' }],
+    }));
+    const out = sourcesFromMessages(messages);
+    expect(out).toHaveLength(MAX_SOURCES);
+    expect(out[0].uploadId).toBe('u3');
+    expect(out[out.length - 1].uploadId).toBe('u' + (MAX_SOURCES + 2));
+  });
+});
+
+describe('mergeSources', () => {
+  test('appends a live-turn delta without duplicating and without mutating inputs', () => {
+    const existing = [{ uploadId: 'u1', fileType: 'image', mimeType: null }];
+    const frozen = JSON.parse(JSON.stringify(existing));
+    const out = mergeSources(existing, [
+      { uploadId: 'u1', fileType: 'image' },              // already docked
+      { uploadId: 'u2', fileType: 'pdf', mimeType: 'application/pdf' },
+    ]);
+    expect(out.map(s => s.uploadId)).toEqual(['u1', 'u2']);
+    expect(existing).toEqual(frozen);
+  });
+
+  test('tolerates junk on both sides', () => {
+    expect(mergeSources(null, null)).toEqual([]);
+    expect(mergeSources('junk', [{ uploadId: 'u1' }])).toEqual([{ uploadId: 'u1', fileType: 'image', mimeType: null }]);
+  });
+});


### PR DESCRIPTION
Fourth Live Workspace slice, under the ratified **zones-around-the-column** layout: uploads now dock ON the board instead of vanishing into the transcript. ([Spec §5.1](https://github.com/jnappier7/mathmatix-ai/blob/main/docs/LIVE_WORKSPACE_REQUIREMENTS.md): *"Uploaded materials must appear directly on the workspace board."*)

**Stacked on #1301** (same files); retargets to `main` when it merges.

## What the student gets

- A **"📎 My materials" dock** pinned to the board's bottom-left (§14 supporting zone): one card per uploaded source — photo thumbnails, PDF chips. Collapsible; cleared on session switch.
- Clicking a card opens it **full-board in a read-only overlay** (same pattern as reopening a finished problem): images get zoom controls; PDFs open in the browser's native viewer, which supplies §5.2's page-turning/zoom for free. The work underneath is never disturbed.
- Sources **survive reloads and session switches** — the dock rebuilds from the conversation on every history load.

## Mechanics — no new storage

Every upload already persists on its message as a servable ref (`{uploadId, fileType}`, bytes at `/api/student/uploads/:id/file`, auth + ownership enforced). So the dock is *derived*:

- History load: `sourcesFromMessages()` (new, pure) collects user-message attachment refs — deduped, arrival order, capped at 6.
- Live turn: `/api/chat` responses now carry a `sourceUploads` delta; continued-greeting replays include stripped attachment refs (the server-side OCR/continuity payload never reaches the client).
- `dom/sourceDock.js` renders it; wired into `updateChatForSession` + the SSE handler. Cache-bust `?v=20260725d`.

## Next on this surface

Problem-region selection (§5.3) and source↔problem linking (§5.4) — the student picks a problem on the docked worksheet and it becomes the linked derivation in focus.

## Verification

- 6 new pure tests (derivation, dedupe, cap, junk tolerance, non-mutation); full suite **4639 passed**; lint clean.
- Manual QA (needs a student login): upload a worksheet photo in chat with `?livingWorkspace=dev` → dock appears with the photo; click → full-board viewer; reload → dock persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)