### PR TITLE
feat(lws): problem-region selection + source↔problem linking (spec §5.3–5.4)

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -133,7 +133,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
        LivingWorkspace flag is dev|beta|live (?livingWorkspace=dev). When on,
        it lazy-loads the workspace and mirrors the tutor's board output onto
        the new surface beside the old board. Default OFF → zero impact. -->
-  <script defer src="/js/living-workspace/chat-workspace.js?v=20260725d"></script>
+  <script defer src="/js/living-workspace/chat-workspace.js?v=20260725e"></script>
   <!-- Final safety net: strips any inline visual tag no renderer handled -->
   <script defer src="/js/stripVisualTags.js"></script>
   <!-- Non-core libs (lazy-loaded after first interaction) -->
@@ -2485,7 +2485,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- Player stats card: window-global, loaded before script.js which calls
      window.PlayerStatsCard.init(currentUser) once the user doc is fetched. -->
 <script defer src="/js/modules/playerStatsCard.js?v=20260724b"></script>
-<script src="/js/script.js?v=20260725d" type="module"></script>
+<script src="/js/script.js?v=20260725e" type="module"></script>
   <script src="/js/guidedPath.js" type="module"></script>
   <script src="/dist/js/chat-js9.bc0be9a3.js"></script>
   <!-- Companion HOME screen (phones only; flag-gated OFF by default) -->

--- a/public/css/living-workspace.css
+++ b/public/css/living-workspace.css
@@ -611,3 +611,73 @@ html[data-theme="dark"] .lws-root {
 .lws-sd-ov-body { flex: 1 1 auto; min-height: 0; overflow: auto; padding: 10px; }
 .lws-sd-ov-img { display: block; margin: 0 auto; border-radius: 8px; }
 .lws-sd-ov-frame { width: 100%; height: 100%; border: 0; border-radius: 8px; background: #fff; }
+
+/* ── problem-region selection + source↔problem linking (§5.3–5.4) ── */
+.lws-sd-ov-wrap { position: relative; margin: 0 auto; }
+.lws-sd-ov-wrap .lws-sd-ov-img { width: 100%; }
+.lws-sd-ov-wrap.is-selecting { cursor: crosshair; touch-action: none; }
+.lws-sd-ov-wrap.is-selecting .lws-sd-ov-img { -webkit-user-select: none; user-select: none; -webkit-user-drag: none; }
+
+/* Where a linked problem came from — drawn when the chip reopens the source. */
+.lws-sd-hl {
+  position: absolute; pointer-events: none;
+  border: 2px solid var(--lws-accent); border-radius: 6px;
+  background: color-mix(in srgb, var(--lws-accent) 12%, transparent);
+  box-shadow: 0 0 0 4000px rgba(0, 0, 0, .18);
+}
+
+/* The live drag box. */
+.lws-sd-sel {
+  position: absolute; pointer-events: none;
+  border: 2px dashed var(--lws-accent); border-radius: 4px;
+  background: color-mix(in srgb, var(--lws-accent) 10%, transparent);
+}
+
+.lws-sd-confirm {
+  position: absolute; z-index: 2; display: flex; gap: 6px; margin-top: 6px;
+  transform: translateY(2px);
+}
+.lws-sd-confirm-go {
+  appearance: none; -webkit-appearance: none; cursor: pointer;
+  border: 1px solid var(--lws-accent); border-radius: 999px;
+  background: var(--lws-accent); color: #fff;
+  font: 600 12px/1 system-ui, sans-serif; padding: 8px 14px;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, .3);
+}
+.lws-sd-confirm-no {
+  appearance: none; -webkit-appearance: none; cursor: pointer;
+  width: 30px; border: 1px solid var(--lws-card-border); border-radius: 999px;
+  background: var(--lws-card-bg); color: var(--lws-card-ink);
+  font: 600 12px/1 system-ui, sans-serif;
+}
+.lws-sd-confirm-go:focus-visible, .lws-sd-confirm-no:focus-visible { outline: 2px solid var(--lws-accent); outline-offset: 2px; }
+
+.lws-sd-ov-select {
+  appearance: none; -webkit-appearance: none; cursor: pointer;
+  border: 1px solid var(--lws-accent); border-radius: 999px;
+  background: color-mix(in srgb, var(--lws-accent) 14%, transparent);
+  color: var(--lws-card-ink); font: 600 12px/1 system-ui, sans-serif; padding: 7px 13px;
+}
+.lws-sd-ov-select.is-on { background: var(--lws-accent); color: #fff; }
+.lws-sd-ov-select:focus-visible { outline: 2px solid var(--lws-accent); outline-offset: 2px; }
+
+/* "From my worksheet" chip on the pinned problem header. */
+.lws-dv-srcchip {
+  appearance: none; -webkit-appearance: none; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 4px;
+  margin-top: 7px; padding: 4px 10px;
+  border: 1px solid var(--lws-card-border); border-radius: 999px;
+  background: color-mix(in srgb, var(--lws-accent) 8%, transparent);
+  color: var(--lws-card-ink); font: 600 11px/1 system-ui, sans-serif; opacity: .9;
+}
+.lws-dv-srcchip:hover { border-color: var(--lws-accent); }
+.lws-dv-srcchip:focus-visible { outline: 2px solid var(--lws-accent); outline-offset: 2px; }
+
+/* Same affordance inside a reopened card's summary strip. */
+.lws-dv-ov-sum-src {
+  appearance: none; -webkit-appearance: none; cursor: pointer;
+  border: none; background: transparent; padding: 0;
+  color: var(--lws-accent); font: 600 12px/1.2 system-ui, sans-serif;
+  text-decoration: underline; text-underline-offset: 2px;
+}
+.lws-dv-ov-sum-src:focus-visible { outline: 2px solid var(--lws-accent); outline-offset: 2px; }

--- a/public/js/living-workspace/chat-workspace.js
+++ b/public/js/living-workspace/chat-workspace.js
@@ -64,6 +64,9 @@
     // (history load) or append this turn's uploads (live delta).
     setSourcesFromMessages: function () {},
     addSources: function () {},
+    // Source↔problem link (spec §5.4): paint/clear the in-focus problem's
+    // "from my worksheet" chip. Fed by the response's boardSource field.
+    setProblemSource: function () {},
   };
   window.LWS_CHAT = api;
   if (!ON) return;
@@ -72,7 +75,7 @@
   // public/ with a 7-day cache and no content hashing, so bump this whenever
   // any living-workspace asset changes (and the chat.html <script ?v=> tag to
   // match, so this file itself refreshes). See project_asset_cache_busting.
-  var ASSET_V = '?v=20260725d';
+  var ASSET_V = '?v=20260725e';
   var BASE = '/js/living-workspace/';
   var SCRIPTS = [
     'core/flags.js', 'core/viewport.js', 'core/elementRegistry.js',
@@ -288,6 +291,37 @@
     paintSources();
   };
 
+  api.setProblemSource = function (ref) {
+    if (!ready || !dv) return;
+    try { dv.setProblemSource(ref || null); } catch (e) { console.error('[LWS_CHAT] problem source failed', e); }
+  };
+
+  // The problem header's chip → reopen the docked source with the problem's
+  // region highlighted. Falls back to a bare open when the source has scrolled
+  // off the dock (older than the cap) — the ref still names it servably.
+  function openLinkedSource(ref) {
+    if (!dock || !ref || !ref.uploadId) return;
+    var src = null;
+    for (var i = 0; i < sources.length; i++) {
+      if (sources[i] && sources[i].uploadId === ref.uploadId) { src = sources[i]; break; }
+    }
+    if (!src) src = { uploadId: ref.uploadId, fileType: 'image', mimeType: null };
+    try { dock.openSource(src, 'My worksheet', ref.region || null); }
+    catch (e) { console.error('[LWS_CHAT] open linked source failed', e); }
+  }
+
+  // A confirmed region selection: the crop goes to the tutor as a normal chat
+  // photo turn (OCR, diagnose, the works) tagged with the source ref so the
+  // posed problem links back to the worksheet (spec §5.3–5.4).
+  function askAboutRegion(file, region, src) {
+    if (typeof window.mmAskAboutRegion !== 'function') { console.error('[LWS_CHAT] mmAskAboutRegion unavailable'); return; }
+    window.mmAskAboutRegion(
+      file,
+      "Here's a problem from my worksheet — can we work on this one?",
+      { uploadId: src.uploadId, region: region }
+    );
+  }
+
   // Rebuild the board from a persisted conversation.boardLedger: each finished
   // problem replays and is parked on the rail, the in-progress one lands in
   // focus. Replays run through the SAME adapter/render path as live turns, so
@@ -306,6 +340,11 @@
       try { dv.annotateArchive(window.LWS.ledgerMeta(ledger)); }
       catch (e) { console.error('[LWS_CHAT] archive annotate failed', e); }
     }
+    // The in-focus problem's source link survives the reload too.
+    if (ledger.current && ledger.current.sourceRef) {
+      try { dv.setProblemSource(ledger.current.sourceRef); }
+      catch (e) { console.error('[LWS_CHAT] hydrate problem source failed', e); }
+    }
   }
 
   api.hydrate = function (ledger) {
@@ -319,9 +358,9 @@
     loadNext(0, function () {
       if (!window.LWS || !window.LWS.DerivationView) { console.error('[LWS_CHAT] DerivationView not available after load'); return; }
       var mount = buildPanel();
-      dv = new window.LWS.DerivationView(mount, { renderers: makeRenderers() });
+      dv = new window.LWS.DerivationView(mount, { renderers: makeRenderers(), onOpenSource: openLinkedSource });
       if (window.LWS.SourceDock) {
-        try { dock = new window.LWS.SourceDock(mount); } catch (e) { console.error('[LWS_CHAT] dock mount failed', e); }
+        try { dock = new window.LWS.SourceDock(mount, { onAskRegion: askAboutRegion }); } catch (e) { console.error('[LWS_CHAT] dock mount failed', e); }
       }
       ready = true;
       if (pendingSources !== undefined) { var ps = pendingSources; pendingSources = undefined; api.setSourcesFromMessages(ps); }

--- a/public/js/living-workspace/core/ledgerReplay.js
+++ b/public/js/living-workspace/core/ledgerReplay.js
@@ -72,6 +72,7 @@
         assistance: entry.assistance || null,
         solved: !!entry.solved,
         completedAt: entry.completedAt || null,
+        sourceRef: entry.sourceRef || null,
       };
     });
   }

--- a/public/js/living-workspace/dom/derivationView.js
+++ b/public/js/living-workspace/dom/derivationView.js
@@ -178,8 +178,12 @@
     opts = opts || {};
     this.doc = container.ownerDocument || document;
     this.renderers = opts.renderers || {};
+    // Called with the sourceRef when the student clicks the problem header's
+    // "from my worksheet" chip — the integration opens the docked source.
+    this.onOpenSource = typeof opts.onOpenSource === 'function' ? opts.onOpenSource : null;
     this._blocks = [];        // live block renderers (for destroy on clear)
     this._problemTex = null;
+    this._problemSource = null;   // {uploadId, region} link of the problem in focus
     // The adapted elements making up the CURRENT derivation, kept so a finished
     // problem can be archived as data and re-rendered on demand. Snapshotting
     // data (not detaching live DOM) is what makes reopening safe: block
@@ -299,6 +303,7 @@
     this.el.problem.textContent = '';
     this.el.problem.style.display = 'none';
     this._problemTex = null;
+    this._problemSource = null;
     this._elements = [];
     this.el.root.classList.remove('is-solved-current');
     this._refreshEmpty();
@@ -319,6 +324,7 @@
       problemTex: this._problemTex,
       elements: this._elements.slice(),
       solved: solved,
+      sourceRef: this._problemSource || null,
     });
     while (this._archive.length > MAX_ARCHIVE) this._archive.shift();
     this._renderRail();
@@ -337,8 +343,31 @@
       if (!m || typeof m !== 'object') continue;
       if (m.assistance != null) this._archive[i].assistance = m.assistance;
       if (m.completedAt != null) this._archive[i].completedAt = m.completedAt;
+      if (m.sourceRef != null) this._archive[i].sourceRef = m.sourceRef;
     }
     this._renderRail();
+  };
+
+  // Link (or unlink, with null) the problem in focus to the docked source it
+  // was selected from (spec §5.4). Paints a small "From my worksheet" chip in
+  // the pinned header; clicking it hands the ref to the integration, which
+  // opens the source with the region highlighted. Called on the turn the
+  // server stamps the link, and on hydration from ledger.current.sourceRef.
+  DerivationView.prototype.setProblemSource = function (ref) {
+    this._problemSource = (ref && ref.uploadId) ? ref : null;
+    var old = this.el.problem.querySelector('.lws-dv-srcchip');
+    if (old) old.parentNode.removeChild(old);
+    if (!this._problemSource || this.el.problem.style.display === 'none') return;
+    var self = this;
+    var chip = this.doc.createElement('button');
+    chip.type = 'button';
+    chip.className = 'lws-dv-srcchip';
+    chip.textContent = '📎 From my worksheet';
+    chip.setAttribute('aria-label', 'Open the worksheet this problem came from');
+    chip.addEventListener('click', function () {
+      if (self.onOpenSource) { try { self.onOpenSource(self._problemSource); } catch (e) { console.error('[LWS] open source failed', e); } }
+    });
+    this.el.problem.appendChild(chip);
   };
 
   DerivationView.prototype._renderRail = function () {
@@ -420,6 +449,18 @@
       sumSteps.textContent = stepCount + (stepCount === 1 ? ' step' : ' steps');
       sum.appendChild(sumSteps);
     }
+    if (entry.sourceRef && entry.sourceRef.uploadId) {
+      var sumSrc = d.createElement('button');
+      sumSrc.type = 'button';
+      sumSrc.className = 'lws-dv-ov-sum-src';
+      sumSrc.textContent = '📎 From my worksheet';
+      sumSrc.setAttribute('aria-label', 'Open the worksheet this problem came from');
+      var srcRef = entry.sourceRef;
+      sumSrc.addEventListener('click', function () {
+        if (self.onOpenSource) { try { self.onOpenSource(srcRef); } catch (e) { console.error('[LWS] open source failed', e); } }
+      });
+      sum.appendChild(sumSrc);
+    }
 
     var body = d.createElement('div'); body.className = 'lws-dv-ov-body';
     var inner = d.createElement('div'); inner.className = 'lws-dv-inner';
@@ -492,6 +533,7 @@
       this._destroyBlocks();
       this.el.lines.textContent = '';
       this._elements = [];
+      this._problemSource = null;   // a new problem starts unlinked
     }
     this._problemTex = latex;
     this.el.problem.textContent = '';
@@ -501,6 +543,8 @@
     this.el.problem.appendChild(lab);
     this.el.problem.appendChild(body);
     this.el.problem.style.display = '';
+    // Re-poses rebuild the header from scratch — repaint a surviving link.
+    if (this._problemSource) this.setProblemSource(this._problemSource);
   };
 
   // `target` defaults to the live line stack; the archive overlay passes its

--- a/public/js/living-workspace/dom/sourceDock.js
+++ b/public/js/living-workspace/dom/sourceDock.js
@@ -25,8 +25,13 @@
     return '/api/student/uploads/' + encodeURIComponent(uploadId) + '/file';
   }
 
-  function SourceDock(container) {
+  function SourceDock(container, opts) {
+    opts = opts || {};
     this.doc = container.ownerDocument || document;
+    // Called with (cropFile, region, src) when the student confirms a selected
+    // problem region. The integration owns the send (it goes through chat, the
+    // one path the tutor can see) — the dock never invents its own.
+    this.onAskRegion = typeof opts.onAskRegion === 'function' ? opts.onAskRegion : null;
     this._sources = [];
     this._overlay = null;
     this._escHandler = null;
@@ -110,9 +115,12 @@
     });
   };
 
-  // Full-board read-only viewer, same pattern as the derivation's archive
-  // overlay: it covers the board, never replaces it, Esc or Back returns.
-  SourceDock.prototype.openSource = function (src, name) {
+  // Full-board viewer, same pattern as the derivation's archive overlay: it
+  // covers the board, never replaces it, Esc or Back returns. Images support
+  // problem-region selection (spec §5.3): drag a box around a problem and ask
+  // the tutor about exactly that. An optional `region` ({x,y,w,h}, normalized
+  // 0–1) highlights where a linked problem came from (spec §5.4 back-link).
+  SourceDock.prototype.openSource = function (src, name, region) {
     this.closeSource();
     var self = this;
     var d = this.doc;
@@ -143,17 +151,37 @@
       body.appendChild(frame);
     } else {
       var zoom = 1;
+      // Positioned wrap so the selection box and the region highlight can sit
+      // over the image in normalized (percentage) coordinates — they stay
+      // glued to the right spot at any zoom level.
+      var wrap = d.createElement('div');
+      wrap.className = 'lws-sd-ov-wrap';
       var img = d.createElement('img');
       img.className = 'lws-sd-ov-img';
       img.alt = name;
       img.src = fileUrl(src.uploadId);
+      wrap.appendChild(img);
+
+      if (region && region.w > 0 && region.h > 0) {
+        var hl = d.createElement('div');
+        hl.className = 'lws-sd-hl';
+        hl.style.left = (region.x * 100) + '%';
+        hl.style.top = (region.y * 100) + '%';
+        hl.style.width = (region.w * 100) + '%';
+        hl.style.height = (region.h * 100) + '%';
+        wrap.appendChild(hl);
+        // Bring the highlighted problem into view once the image has size.
+        img.addEventListener('load', function () {
+          try { hl.scrollIntoView({ block: 'center', behavior: 'instant' }); } catch (_) { /* older browsers */ }
+        });
+      }
 
       var ctl = d.createElement('span'); ctl.className = 'lws-sd-ov-zoom';
       var zOut = d.createElement('button'); zOut.type = 'button'; zOut.textContent = '−'; zOut.setAttribute('aria-label', 'Zoom out');
       var zIn = d.createElement('button'); zIn.type = 'button'; zIn.textContent = '+'; zIn.setAttribute('aria-label', 'Zoom in');
       function applyZoom() {
         zoom = Math.max(0.5, Math.min(4, zoom));
-        img.style.width = (zoom * 100) + '%';
+        wrap.style.width = (zoom * 100) + '%';
         zOut.disabled = zoom <= 0.5;
         zIn.disabled = zoom >= 4;
       }
@@ -161,8 +189,15 @@
       zIn.addEventListener('click', function () { zoom += 0.25; applyZoom(); });
       ctl.appendChild(zOut); ctl.appendChild(zIn);
       bar.appendChild(ctl);
+
+      // Problem-region selection: only offered when the integration provided
+      // an ask hook (chat present) — the dock never invents a send path.
+      if (typeof this.onAskRegion === 'function') {
+        bar.appendChild(this._buildSelectControl(wrap, img, src));
+      }
+
       applyZoom();
-      body.appendChild(img);
+      body.appendChild(wrap);
     }
 
     bar.appendChild(back);
@@ -172,6 +207,128 @@
     this._escHandler = function (ev) { if (ev.key === 'Escape') self.closeSource(); };
     d.addEventListener('keydown', this._escHandler);
     try { back.focus(); } catch (_) { /* not focusable yet */ }
+  };
+
+  // "Select a problem" control: toggles a crosshair mode where dragging on
+  // the image draws a box (pointer events — mouse and touch alike). Releasing
+  // shows a confirm chip; confirming crops the region from the image's natural
+  // pixels and hands it to onAskRegion with normalized coordinates.
+  SourceDock.prototype._buildSelectControl = function (wrap, img, src) {
+    var self = this;
+    var d = this.doc;
+    var btn = d.createElement('button');
+    btn.type = 'button';
+    btn.className = 'lws-sd-ov-select';
+    btn.textContent = 'Select a problem';
+    btn.setAttribute('aria-pressed', 'false');
+
+    var selecting = false;
+    var box = null;        // the live selection rect (normalized coords)
+    var confirmEl = null;
+    var start = null;
+
+    function clearSelection() {
+      if (box && box.el.parentNode) box.el.parentNode.removeChild(box.el);
+      if (confirmEl && confirmEl.parentNode) confirmEl.parentNode.removeChild(confirmEl);
+      box = null; confirmEl = null; start = null;
+    }
+    function setMode(on) {
+      selecting = on;
+      wrap.classList.toggle('is-selecting', on);
+      btn.classList.toggle('is-on', on);
+      btn.setAttribute('aria-pressed', on ? 'true' : 'false');
+      btn.textContent = on ? 'Cancel selection' : 'Select a problem';
+      if (!on) clearSelection();
+    }
+    btn.addEventListener('click', function () { setMode(!selecting); });
+
+    function norm(ev) {
+      var r = wrap.getBoundingClientRect();
+      if (!r.width || !r.height) return null;
+      return {
+        x: Math.max(0, Math.min(1, (ev.clientX - r.left) / r.width)),
+        y: Math.max(0, Math.min(1, (ev.clientY - r.top) / r.height)),
+      };
+    }
+    function rectFrom(a, b) {
+      var x = Math.min(a.x, b.x), y = Math.min(a.y, b.y);
+      return { x: x, y: y, w: Math.abs(a.x - b.x), h: Math.abs(a.y - b.y) };
+    }
+    function paintBox(r) {
+      if (!box) {
+        var el = d.createElement('div');
+        el.className = 'lws-sd-sel';
+        wrap.appendChild(el);
+        box = { el: el };
+      }
+      box.el.style.left = (r.x * 100) + '%';
+      box.el.style.top = (r.y * 100) + '%';
+      box.el.style.width = (r.w * 100) + '%';
+      box.el.style.height = (r.h * 100) + '%';
+      box.rect = r;
+    }
+
+    wrap.addEventListener('pointerdown', function (ev) {
+      if (!selecting) return;
+      ev.preventDefault();
+      clearSelection();
+      start = norm(ev);
+      try { wrap.setPointerCapture(ev.pointerId); } catch (_) { /* unsupported */ }
+    });
+    wrap.addEventListener('pointermove', function (ev) {
+      if (!selecting || !start) return;
+      var p = norm(ev);
+      if (p) paintBox(rectFrom(start, p));
+    });
+    wrap.addEventListener('pointerup', function (ev) {
+      if (!selecting || !start) return;
+      start = null;
+      // Too small to be a problem — treat as a mis-tap, not a selection.
+      if (!box || !box.rect || box.rect.w < 0.03 || box.rect.h < 0.02) { clearSelection(); return; }
+      var r = box.rect;
+      confirmEl = d.createElement('div');
+      confirmEl.className = 'lws-sd-confirm';
+      confirmEl.style.left = (r.x * 100) + '%';
+      confirmEl.style.top = (Math.min(0.96, r.y + r.h) * 100) + '%';
+      var go = d.createElement('button');
+      go.type = 'button'; go.className = 'lws-sd-confirm-go';
+      go.textContent = 'Ask my tutor about this';
+      go.addEventListener('click', function () { self._askRegion(img, src, r); setMode(false); });
+      var no = d.createElement('button');
+      no.type = 'button'; no.className = 'lws-sd-confirm-no';
+      no.textContent = '✕';
+      no.setAttribute('aria-label', 'Clear selection');
+      no.addEventListener('click', function () { clearSelection(); });
+      confirmEl.appendChild(go); confirmEl.appendChild(no);
+      wrap.appendChild(confirmEl);
+      try { go.focus(); } catch (_) { /* fine */ }
+    });
+
+    return btn;
+  };
+
+  // Crop the selected region from the image's natural pixels and hand it off.
+  // The crop rides to the tutor as a normal photo upload (OCR and all); the
+  // region ref makes the resulting problem card link back here.
+  SourceDock.prototype._askRegion = function (img, src, region) {
+    var self = this;
+    try {
+      var nw = img.naturalWidth, nh = img.naturalHeight;
+      if (!nw || !nh) throw new Error('image not loaded');
+      var canvas = this.doc.createElement('canvas');
+      canvas.width = Math.max(1, Math.round(region.w * nw));
+      canvas.height = Math.max(1, Math.round(region.h * nh));
+      var ctx2d = canvas.getContext('2d');
+      ctx2d.drawImage(img, region.x * nw, region.y * nh, region.w * nw, region.h * nh, 0, 0, canvas.width, canvas.height);
+      canvas.toBlob(function (blob) {
+        if (!blob) { console.error('[LWS] region crop produced no blob'); return; }
+        var file = new File([blob], 'worksheet-problem.jpg', { type: 'image/jpeg' });
+        try { self.onAskRegion(file, region, src); } catch (e) { console.error('[LWS] onAskRegion failed', e); }
+        self.closeSource();
+      }, 'image/jpeg', 0.92);
+    } catch (e) {
+      console.error('[LWS] region crop failed', e);
+    }
   };
 
   SourceDock.prototype.closeSource = function () {

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -2409,6 +2409,21 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     };
 
+    // Ask the tutor about a problem the student selected off a docked source
+    // (Living Workspace, spec §5.3). The crop rides the NORMAL chat path —
+    // upload, OCR, diagnose, transcript — plus a sourceRef so the posed
+    // problem links back to the worksheet region it came from.
+    window.mmAskAboutRegion = function (file, text, sourceRef) {
+        if (!file) return false;
+        try {
+            queueMessage(String(text || "Can we work on this problem from my worksheet?"), [file], null, { sourceRef: sourceRef || null });
+            return true;
+        } catch (err) {
+            console.error('[chat] region ask failed:', err);
+            return false;
+        }
+    };
+
     function sendMessage() {
         // Seal any active inline equation boxes so their data-latex is set
         if (window.InlineEquationBox) {
@@ -2539,6 +2554,10 @@ document.addEventListener("DOMContentLoaded", () => {
             // (a scaffold the student completes + Checks): the tutor reacts to the
             // card's content without it looking like a typed chat message.
             silent: !!opts.silent,
+            // Problem-region selection: {uploadId, region} naming where on a
+            // docked source this turn's cropped image came from. Rides to the
+            // server so the posed problem links back to the worksheet.
+            sourceRef: opts.sourceRef || null,
             timestamp: Date.now()
         };
 
@@ -2744,6 +2763,10 @@ document.addEventListener("DOMContentLoaded", () => {
 
                 formData.append('message', messageText);
                 formData.append('fileCount', queuedFiles.length);
+
+                if (queuedMsg.sourceRef) {
+                    formData.append('sourceRef', JSON.stringify(queuedMsg.sourceRef));
+                }
 
                 if (responseTime !== null) {
                     formData.append('responseTime', responseTime);
@@ -3212,6 +3235,17 @@ document.addEventListener("DOMContentLoaded", () => {
                     window.LWS_CHAT.addSources(data.sourceUploads);
                 } catch (error) {
                     console.error('[LWS_CHAT] addSources failed:', error);
+                }
+            }
+
+            // Source↔problem link (spec §5.4): the server says whether the
+            // in-focus problem is tied to a worksheet region. Painted every
+            // turn, so it appears when stamped and never lingers stale.
+            if (window.LWS_CHAT && window.LWS_CHAT.isOn() && 'boardSource' in data) {
+                try {
+                    window.LWS_CHAT.setProblemSource(data.boardSource || null);
+                } catch (error) {
+                    console.error('[LWS_CHAT] setProblemSource failed:', error);
                 }
             }
 

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -43,6 +43,7 @@ const { checkReadingLevel, buildSimplificationPrompt } = require('../utils/reada
 
 // Tutoring pipeline (observe → diagnose → decide → generate → verify → persist)
 const { runPipeline, verify: pipelineVerify } = require('../utils/pipeline');
+const { sanitizeSourceRef } = require('../utils/pipeline/boardLedger');
 const { observe: preClassifyMessage, MESSAGE_TYPES: OBSERVE_MSG_TYPES } = require('../utils/pipeline/observe');
 const { initializeLessonPhase, transitionPhase, PHASES } = require('../utils/lessonPhaseManager');
 const { evaluatePhaseAdvancement, updatePhaseTracker } = require('../utils/phaseEvidenceEvaluator');
@@ -534,6 +535,16 @@ async function runStudentTurn(req, res) {
         // so all chat goes through one pipeline with one set of guards.
         const uploadedFiles = req.files || [];
         const hasUploadedFiles = uploadedFiles.length > 0;
+        // Problem-region selection (spec §5.3–5.4): when the student selects a
+        // region of a docked source, the crop arrives as this turn's file and
+        // `sourceRef` names where it came from ({uploadId, region} normalized
+        // 0–1). Only meaningful alongside an upload; sanitized before use and
+        // stamped onto the problem the ledger poses this turn.
+        let regionSourceRef = null;
+        if (hasUploadedFiles && req.body.sourceRef) {
+            try { regionSourceRef = sanitizeSourceRef(JSON.parse(req.body.sourceRef)); }
+            catch (_) { regionSourceRef = null; }
+        }
         let uploadImageContents = [];
         let uploadPdfTexts = [];
         let combinedMessage = effectiveMessage.trim();
@@ -1429,6 +1440,7 @@ async function runStudentTurn(req, res) {
                 stream: useStreaming,
                 res: useStreaming ? res : null,
                 aiProcessingStartTime: aiStartTime,
+                sourceRef: regionSourceRef,
             });
         } catch (pipelineError) {
             // Pipeline failed — fall back to direct LLM call so student always gets a response
@@ -1712,6 +1724,10 @@ async function runStudentTurn(req, res) {
             sourceUploads: attachmentMeta.length > 0
                 ? attachmentMeta.map(a => ({ uploadId: String(a.uploadId), fileType: a.fileType, mimeType: a.mimeType }))
                 : [],
+            // The in-focus problem's source link (spec §5.4), straight from the
+            // ledger the pipeline just updated — the client paints the "from my
+            // worksheet" chip from this. Null when the problem isn't linked.
+            boardSource: activeConversation.boardLedger?.current?.sourceRef || null,
             xpCommands: pipelineResult.xpCommands || [],
             visualTabCommands: pipelineResult.visualTabCommands || [],
             boardContext: pipelineResult.boardContext,

--- a/tests/unit/boardLedger.test.js
+++ b/tests/unit/boardLedger.test.js
@@ -6,7 +6,7 @@
  * completed rail; a re-pose of the same math is a redraw, not a new problem;
  * a problem posed but never worked is dropped, not archived.
  */
-const { applyTurnToLedger, problemAssistance, MAX_COMPLETED, MAX_STEPS } = require('../../utils/pipeline/boardLedger');
+const { applyTurnToLedger, problemAssistance, sanitizeSourceRef, MAX_COMPLETED, MAX_STEPS } = require('../../utils/pipeline/boardLedger');
 
 const NOW = new Date('2026-07-25T12:00:00Z');
 
@@ -138,6 +138,36 @@ describe('applyTurnToLedger', () => {
     expect(l.current.assistance).toBeNull();
     expect(problemAssistance(l)).toBeNull();
     expect(problemAssistance(null)).toBeNull();
+  });
+
+  test('a sourceRef attaches only to a problem POSED that turn, and rides into the archive', () => {
+    const ref = { uploadId: 'abc123', region: { x: 0.1, y: 0.2, w: 0.5, h: 0.25 } };
+    // Ref on a non-pose turn: must NOT stamp the ongoing problem.
+    let l = applyTurnToLedger(null, [{ action: 'pose', tex: 'a=1' }], NOW);
+    l = applyTurnToLedger(l, [{ action: 'resolve', tex: 'a' }], NOW, { sourceRef: ref });
+    expect(l.current.sourceRef).toBeNull();
+    // Ref on the pose turn: stamps the new problem and survives archiving.
+    l = applyTurnToLedger(l, [{ action: 'pose', tex: 'b=2' }], NOW, { sourceRef: ref });
+    expect(l.current.sourceRef).toEqual(ref);
+    l = applyTurnToLedger(l, [{ action: 'verify', tex: 'b=2' }], NOW, 3);   // legacy numeric opts still work
+    l = applyTurnToLedger(l, [{ action: 'clear' }], NOW);
+    expect(l.completed[0].sourceRef).toBeNull();          // problem a, never linked
+    expect(l.completed[1].sourceRef).toEqual(ref);        // problem b keeps its link
+    expect(l.completed[1].assistance).toBe(3);
+  });
+
+  test('sanitizeSourceRef: valid refs normalize, junk dies before the ledger', () => {
+    expect(sanitizeSourceRef({ uploadId: 'abc-123', region: { x: 0.1, y: 0.2, w: 0.5, h: 0.25 } }))
+      .toEqual({ uploadId: 'abc-123', region: { x: 0.1, y: 0.2, w: 0.5, h: 0.25 } });
+    // Coordinates clamp into [0,1]; degenerate regions drop to null.
+    expect(sanitizeSourceRef({ uploadId: 'a', region: { x: -2, y: 5, w: 3, h: 0.5 } }).region)
+      .toEqual({ x: 0, y: 1, w: 1, h: 0.5 });
+    expect(sanitizeSourceRef({ uploadId: 'a', region: { x: 0, y: 0, w: 0, h: 0.5 } }).region).toBeNull();
+    // Bad ids are rejected outright (injection-shaped, oversized, missing).
+    expect(sanitizeSourceRef({ uploadId: 'a b$', region: null })).toBeNull();
+    expect(sanitizeSourceRef({ uploadId: 'x'.repeat(65) })).toBeNull();
+    expect(sanitizeSourceRef(null)).toBeNull();
+    expect(sanitizeSourceRef('junk')).toBeNull();
   });
 
   test('tolerates malformed input: null commands, junk entries, malformed prev', () => {

--- a/tests/unit/workspace/ledgerReplay.test.js
+++ b/tests/unit/workspace/ledgerReplay.test.js
@@ -81,8 +81,8 @@ describe('ledgerMeta', () => {
     // 2 replayable completed entries → 2 meta rows (junk skipped identically),
     // and current is NOT in meta (it never lands on the rail).
     expect(meta).toEqual([
-      { assistance: 3, solved: true, completedAt: 'T1' },
-      { assistance: 9, solved: false, completedAt: null },
+      { assistance: 3, solved: true, completedAt: 'T1', sourceRef: null },
+      { assistance: 9, solved: false, completedAt: null, sourceRef: null },
     ]);
     // The invariant the rail zip depends on: meta rows == archived replays.
     const clears = ledgerToTurns(ledger).filter(t => t[0].action === 'clear').length;

--- a/utils/pipeline/boardLedger.js
+++ b/utils/pipeline/boardLedger.js
@@ -76,9 +76,28 @@ function archiveCurrent(ledger, now) {
     // what the collapsed-card summary and teacher view read. Null when the
     // ladder never reported (e.g. entries written before this field existed).
     assistance: cur.assistance || null,
+    // Where the problem came from (spec §5.4): {uploadId, region} when it was
+    // selected off a docked source; the card keeps its link forever.
+    sourceRef: cur.sourceRef || null,
     completedAt: now,
   });
   while (ledger.completed.length > MAX_COMPLETED) ledger.completed.shift();
+}
+
+// Validate/normalize a client-supplied source reference: an uploadId plus a
+// normalized region ({x,y,w,h} in [0,1]) inside that source. Returns null for
+// anything malformed — a bad ref must never poison the ledger.
+function sanitizeSourceRef(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const id = String(raw.uploadId || '').trim();
+  if (!id || id.length > 64 || !/^[a-zA-Z0-9_-]+$/.test(id)) return null;
+  const r = raw.region;
+  if (!r || typeof r !== 'object') return { uploadId: id, region: null };
+  const clamp = v => Math.max(0, Math.min(1, Number(v)));
+  const x = clamp(r.x); const y = clamp(r.y);
+  const w = clamp(r.w); const h = clamp(r.h);
+  if (!(w > 0) || !(h > 0)) return { uploadId: id, region: null };
+  return { uploadId: id, region: { x, y, w, h } };
 }
 
 /**
@@ -87,11 +106,14 @@ function archiveCurrent(ledger, now) {
  * @param {object|null} prev - conversation.boardLedger (may be null/malformed)
  * @param {Array} commands - the turn's verified board commands, in order
  * @param {Date} [now] - injectable clock for tests
- * @param {number|null} [turnAssistance] - this turn's assistance level
- *   (utils/pipeline/assistanceLadder.js); max-folded onto the problem in focus
+ * @param {number|object|null} [turnOpts] - this turn's context: a bare number
+ *   is the assistance level (back-compat); an object may carry
+ *   { assistance, sourceRef } — sourceRef links a problem POSED this turn to
+ *   the docked source it was selected from (spec §5.4)
  * @returns {object} a new ledger object
  */
-function applyTurnToLedger(prev, commands, now = new Date(), turnAssistance = null) {
+function applyTurnToLedger(prev, commands, now = new Date(), turnOpts = null) {
+  const opts = (turnOpts && typeof turnOpts === 'object') ? turnOpts : { assistance: turnOpts };
   const ledger = {
     current: prev && prev.current && prev.current.problemTex
       ? {
@@ -99,12 +121,15 @@ function applyTurnToLedger(prev, commands, now = new Date(), turnAssistance = nu
           posedAt: prev.current.posedAt || now,
           steps: Array.isArray(prev.current.steps) ? prev.current.steps.slice() : [],
           assistance: prev.current.assistance || null,
+          sourceRef: prev.current.sourceRef || null,
         }
       : null,
     completed: prev && Array.isArray(prev.completed) ? prev.completed.slice() : [],
   };
   if (!Array.isArray(commands)) return ledger;
-  const assist = Number(turnAssistance) > 0 ? Number(turnAssistance) : null;
+  const assist = Number(opts.assistance) > 0 ? Number(opts.assistance) : null;
+  const sourceRef = sanitizeSourceRef(opts.sourceRef);
+  let posedThisTurn = false;
 
   for (const raw of commands) {
     if (!raw || typeof raw !== 'object' || !raw.action) continue;
@@ -116,7 +141,8 @@ function applyTurnToLedger(prev, commands, now = new Date(), turnAssistance = nu
         continue; // same problem re-drawn (board-reference backstop etc.)
       }
       archiveCurrent(ledger, now);
-      ledger.current = { problemTex: cmd.tex, posedAt: now, steps: [], assistance: null };
+      ledger.current = { problemTex: cmd.tex, posedAt: now, steps: [], assistance: null, sourceRef: null };
+      posedThisTurn = true;
       continue;
     }
 
@@ -140,6 +166,13 @@ function applyTurnToLedger(prev, commands, now = new Date(), turnAssistance = nu
     ledger.current.assistance = Math.max(ledger.current.assistance || 0, assist) || null;
   }
 
+  // A source link only attaches to a problem POSED this turn — the turn the
+  // student selected the region and asked. Stamping an ongoing problem would
+  // mislink whatever happened to be in focus when a stray ref arrived.
+  if (ledger.current && sourceRef && posedThisTurn && !ledger.current.sourceRef) {
+    ledger.current.sourceRef = sourceRef;
+  }
+
   return ledger;
 }
 
@@ -161,6 +194,7 @@ function problemAssistance(ledger) {
 module.exports = {
   applyTurnToLedger,
   problemAssistance,
+  sanitizeSourceRef,
   emptyLedger,
   MAX_COMPLETED,
   MAX_STEPS,

--- a/utils/pipeline/index.js
+++ b/utils/pipeline/index.js
@@ -1203,7 +1203,8 @@ async function runPipeline(message, ctx) {
         boardCommands: verified.boardCommands,
       });
       ctx.conversation.boardLedger = applyTurnToLedger(
-        ctx.conversation.boardLedger, verified.boardCommands, new Date(), turnAssistance
+        ctx.conversation.boardLedger, verified.boardCommands, new Date(),
+        { assistance: turnAssistance, sourceRef: ctx.sourceRef || null }
       );
       ctx.conversation.markModified?.('boardLedger');
     } catch (ledgerErr) {


### PR DESCRIPTION
Fifth Live Workspace slice — the payoff of the Source Cards surface: **select one problem from a multi-problem worksheet and it becomes the linked problem in focus.** (Spec [§5.3–5.4](https://github.com/jnappier7/mathmatix-ai/blob/main/docs/LIVE_WORKSPACE_REQUIREMENTS.md), required use cases 3–4.) Builds on #1302 (merged).

## The student flow

1. Open a docked worksheet → **"Select a problem"** → drag a box around one problem (pointer events, so mouse and touch both work).
2. Confirm chip: **"Ask my tutor about this."** The selection is cropped at the image's natural resolution and sent through the *normal* chat path — upload, OCR, diagnose, transcript. No side doors: the tutor sees exactly what a photo upload looks like, plus the link.
3. The posed problem's header gains a **"📎 From my worksheet" chip** — click it and the docked source reopens with the region highlighted and scrolled into view. The link is permanent: it survives archiving to the rail, reloads, and reopening (the collapsed-card summary carries it too).

## Guardrails worth reviewing

- `sanitizeSourceRef()` clamps coordinates to [0,1] and rejects malformed/oversized ids **before** anything touches the ledger; the route only accepts a ref alongside an actual file upload.
- The ledger stamps a ref **only onto a problem POSED that same turn** — a stray ref can never mislink whatever happened to be in focus (test pins this).
- The response's `boardSource` field is painted every turn, so the chip appears when stamped and can't linger stale across problems.
- Selection mode only appears when the chat integration provides the ask-hook — the dock never invents its own send path (lesson of the removed fill-in-the-blanks, #1301).

## Verification

- Full suite **4641 passed**, lint clean. New tests: ref-only-on-pose-turn, archive carry, legacy numeric opts back-compat, sanitizer clamp/reject matrix, meta alignment.
- Manual QA (student login, `?livingWorkspace=dev`): upload a worksheet photo → open from dock → Select a problem → drag + confirm → tutor poses that problem with the 📎 chip → click chip → worksheet reopens with the region boxed → reload → chip and link still there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)