### PR TITLE
feat(lws): learning notebook (AHA + Reminder cards) + board-aware tutor

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -119,6 +119,7 @@ const supportRoutes = require('../routes/support');
 const imageSearchRoutes = require('../routes/imageSearch');
 const browserLockRoutes = require('../routes/browserLock');
 const practicePackRoutes = require('../routes/practicePack');
+const notebookRoutes = require('../routes/notebook');
 const { desktopRouter: phoneLinkRoutes, phoneRouter: phoneUploadRoutes } = require('../routes/phoneLink');
 const transcriptFlagsRoutes = require('../routes/transcriptFlags');
 const notificationsRoutes = require('../routes/notifications');
@@ -272,6 +273,7 @@ function registerRoutes(app, { authLimiter, signupLimiter }) {
   app.use('/api/iep-templates', isAuthenticated, isTeacher, iepTemplatesRoutes);
   app.use('/api/browser-lock', isAuthenticated, browserLockRoutes);
   app.use('/api/practice-pack', isAuthenticated, practicePackRoutes);
+  app.use('/api/notebook', isAuthenticated, notebookRoutes);
   // "Scan with your phone" desktop endpoints (session-authed). The public
   // phone-upload counterpart is registered earlier, before the /api auth
   // catch-alls (see the Public API routes block above).

--- a/models/learningCard.js
+++ b/models/learningCard.js
@@ -1,0 +1,50 @@
+// LEARNING CARDS — the Live Workspace's persistent learning notebook
+// (docs/LIVE_WORKSPACE_REQUIREMENTS.md §7, §15).
+//
+// A card preserves something worth keeping beyond the conversation it
+// happened in: an AHA moment in the student's own words, a recurring
+// mistake to watch for, a reusable idea or strategy. Cards live in their
+// own collection — the notebook is CROSS-session by definition, while
+// conversations archive and roll over.
+//
+// Writers today: utils/pipeline/learningCards.js (deterministic capture in
+// the persist stage — AHA and Reminder). The idea/strategy/reflection types
+// are part of the schema so the API and notebook UI are ready for them, but
+// nothing auto-creates them yet.
+
+const mongoose = require('mongoose');
+const { Schema } = mongoose;
+
+const learningCardSchema = new Schema({
+    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true, index: true },
+    type: {
+        type: String,
+        required: true,
+        enum: ['aha', 'reminder', 'idea', 'strategy', 'reflection'],
+    },
+    // Short student-facing headline ("You figured out two-step equations!",
+    // "Watch for This: losing a negative sign").
+    title: { type: String, required: true, maxlength: 160 },
+    // The substance. For AHA cards this leads with the student's own words —
+    // spec §7.2: "prioritize the student's own wording."
+    body: { type: String, default: '', maxlength: 2000 },
+    // Verbatim student quote behind an AHA card.
+    quote: { type: String, default: null, maxlength: 400 },
+    skillId: { type: String, default: null, index: true },
+    // Stable dedupe key for reminder cards (one card per misconception per
+    // student — recurrences bump seenCount instead of stacking duplicates).
+    misconceptionKey: { type: String, default: null },
+    conversationId: { type: Schema.Types.ObjectId, ref: 'Conversation', default: null },
+    // The problem on the board when the card was born, when known.
+    problemTex: { type: String, default: null, maxlength: 500 },
+    seenCount: { type: Number, default: 1 },
+    lastSeenAt: { type: Date, default: Date.now },
+    // Soft delete — students may clear cards from their notebook without the
+    // evidence trail vanishing.
+    archived: { type: Boolean, default: false },
+}, { timestamps: true });
+
+learningCardSchema.index({ userId: 1, type: 1, createdAt: -1 });
+learningCardSchema.index({ userId: 1, misconceptionKey: 1 }, { sparse: true });
+
+module.exports = mongoose.model('LearningCard', learningCardSchema);

--- a/public/chat.html
+++ b/public/chat.html
@@ -2485,7 +2485,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- Player stats card: window-global, loaded before script.js which calls
      window.PlayerStatsCard.init(currentUser) once the user doc is fetched. -->
 <script defer src="/js/modules/playerStatsCard.js?v=20260724b"></script>
-<script src="/js/script.js?v=20260725e" type="module"></script>
+<script src="/js/script.js?v=20260725f" type="module"></script>
   <script src="/js/guidedPath.js" type="module"></script>
   <script src="/dist/js/chat-js9.bc0be9a3.js"></script>
   <!-- Companion HOME screen (phones only; flag-gated OFF by default) -->

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -3249,6 +3249,19 @@ document.addEventListener("DOMContentLoaded", () => {
                 }
             }
 
+            // Notebook cards minted this turn (spec §7): a captured AHA moment
+            // or an activated "Watch for This" reminder. Celebrate briefly —
+            // the cards themselves live in the notebook, not the chat.
+            if (Array.isArray(data.learningCards) && data.learningCards.length > 0 && typeof showToast === 'function') {
+                data.learningCards.forEach((card, i) => {
+                    const icon = card.type === 'aha' ? '✨' : '📌';
+                    setTimeout(() => {
+                        try { showToast(`${icon} Saved to your notebook — ${card.title}`, 5000); }
+                        catch (err) { console.error('[notebook] toast failed:', err); }
+                    }, i * 1200);
+                });
+            }
+
             // Phase C: execute server-emitted <XP> ceremony commands
             // (confetti + optional gold caption). Pipeline caps the batch
             // at 3 so a runaway model can't confetti-bomb the chat.

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -1728,6 +1728,9 @@ async function runStudentTurn(req, res) {
             // ledger the pipeline just updated — the client paints the "from my
             // worksheet" chip from this. Null when the problem isn't linked.
             boardSource: activeConversation.boardLedger?.current?.sourceRef || null,
+            // Notebook cards minted this turn (AHA moments, activated
+            // reminders) — the client celebrates them (spec §7).
+            learningCards: pipelineResult.learningCards || [],
             xpCommands: pipelineResult.xpCommands || [],
             visualTabCommands: pipelineResult.visualTabCommands || [],
             boardContext: pipelineResult.boardContext,

--- a/routes/notebook.js
+++ b/routes/notebook.js
@@ -1,0 +1,56 @@
+/**
+ * THE LEARNING NOTEBOOK (Live Workspace spec §15)
+ *
+ * Read/manage the student's persistent learning cards — AHA moments,
+ * reminders, ideas — captured by the tutoring pipeline across sessions.
+ *
+ * GET    /api/notebook           — list my cards (?type=aha|reminder|idea|strategy|reflection, ?limit=)
+ * PATCH  /api/notebook/:id/archive — soft-remove a card from my notebook
+ *
+ * Students only see their own cards. Natural-language search and the
+ * teacher's cross-student view (spec §15/§20) build on this later.
+ */
+
+const express = require('express');
+const router = express.Router();
+const { isAuthenticated } = require('../middleware/auth');
+const LearningCard = require('../models/learningCard');
+const logger = require('../utils/logger').child({ route: 'notebook' });
+
+const TYPES = ['aha', 'reminder', 'idea', 'strategy', 'reflection'];
+
+router.get('/', isAuthenticated, async (req, res) => {
+  try {
+    const query = { userId: req.user._id, archived: false };
+    if (req.query.type && TYPES.includes(req.query.type)) query.type = req.query.type;
+    const limit = Math.min(100, Math.max(1, parseInt(req.query.limit, 10) || 50));
+
+    const cards = await LearningCard.find(query)
+      .sort({ createdAt: -1 })
+      .limit(limit)
+      .select('type title body quote skillId problemTex seenCount createdAt lastSeenAt')
+      .lean();
+
+    res.json({ cards });
+  } catch (err) {
+    logger.error('Failed to list notebook cards', { error: err.message });
+    res.status(500).json({ message: 'Failed to load notebook' });
+  }
+});
+
+router.patch('/:id/archive', isAuthenticated, async (req, res) => {
+  try {
+    const card = await LearningCard.findOneAndUpdate(
+      { _id: req.params.id, userId: req.user._id },
+      { $set: { archived: true } },
+      { new: true }
+    ).select('_id').lean();
+    if (!card) return res.status(404).json({ message: 'Card not found' });
+    res.json({ ok: true });
+  } catch (err) {
+    logger.error('Failed to archive notebook card', { error: err.message });
+    res.status(500).json({ message: 'Failed to archive card' });
+  }
+});
+
+module.exports = router;

--- a/tests/unit/boardStateBlock.test.js
+++ b/tests/unit/boardStateBlock.test.js
@@ -1,0 +1,79 @@
+/**
+ * The tutor's eyes on its own board (utils/pipeline/boardStateBlock.js).
+ *
+ * The block is rebuilt into the system prompt every turn from the board
+ * ledger, so the tutor knows exactly what the student is looking at — and
+ * an empty board must contribute zero tokens.
+ */
+const { buildBoardStateBlock, MAX_STEPS_SHOWN } = require('../../utils/pipeline/boardStateBlock');
+const { applyTurnToLedger } = require('../../utils/pipeline/boardLedger');
+
+const NOW = new Date('2026-07-25T12:00:00Z');
+
+describe('buildBoardStateBlock', () => {
+  test('empty / null boards contribute nothing', () => {
+    expect(buildBoardStateBlock(null)).toBe('');
+    expect(buildBoardStateBlock({})).toBe('');
+    expect(buildBoardStateBlock({ current: null, completed: [] })).toBe('');
+  });
+
+  test('describes the in-progress problem exactly as the ledger recorded it', () => {
+    let l = applyTurnToLedger(null, [{ action: 'pose', tex: '2x+5=13' }], NOW);
+    l = applyTurnToLedger(l, [
+      { action: 'apply', op: 'subtract 5 from both sides' },
+      { action: 'resolve', tex: '2x=8' },
+    ], NOW);
+    const block = buildBoardStateBlock(l);
+    expect(block).toContain('Problem in focus: 2x+5=13');
+    expect(block).toContain('operation: subtract 5 from both sides');
+    expect(block).toContain('line: 2x=8');
+    expect(block).toContain('Status: in progress');
+    expect(block).toContain('Never re-derive');
+  });
+
+  test('a solved problem says SOLVED so the tutor stops working it', () => {
+    let l = applyTurnToLedger(null, [{ action: 'pose', tex: '2x+5=13' }], NOW);
+    l = applyTurnToLedger(l, [{ action: 'verify', tex: 'x=4' }], NOW);
+    const block = buildBoardStateBlock(l);
+    expect(block).toContain('SOLUTION shown: x=4');
+    expect(block).toContain('Status: SOLVED');
+    expect(block).toContain('do not keep');
+  });
+
+  test('worksheet-linked problems and the rail are mentioned', () => {
+    let l = applyTurnToLedger(null, [{ action: 'pose', tex: 'a=1' }], NOW);
+    l = applyTurnToLedger(l, [{ action: 'verify', tex: 'a=1' }], NOW);
+    l = applyTurnToLedger(l, [{ action: 'clear' }], NOW);
+    l = applyTurnToLedger(l, [{ action: 'pose', tex: '3y-1=8' }], NOW,
+      { sourceRef: { uploadId: 'u1', region: { x: 0.1, y: 0.1, w: 0.4, h: 0.2 } } });
+    const block = buildBoardStateBlock(l);
+    expect(block).toContain('selected from their uploaded worksheet');
+    expect(block).toContain('Finished-problems rail: 1 earlier problem');
+  });
+
+  test('a posed-but-unworked problem reads as such', () => {
+    const l = applyTurnToLedger(null, [{ action: 'pose', tex: 'y=2x' }], NOW);
+    expect(buildBoardStateBlock(l)).toContain('only the problem is posed');
+  });
+
+  test('long derivations cap at the newest steps with honest numbering', () => {
+    let l = applyTurnToLedger(null, [{ action: 'pose', tex: 'big' }], NOW);
+    const steps = [];
+    for (let i = 1; i <= MAX_STEPS_SHOWN + 4; i++) steps.push({ action: 'resolve', tex: 'step' + i });
+    l = applyTurnToLedger(l, steps, NOW);
+    const block = buildBoardStateBlock(l);
+    expect(block).toContain('newest ' + MAX_STEPS_SHOWN + ' of ' + (MAX_STEPS_SHOWN + 4));
+    expect(block).not.toContain('line: step1\n');              // oldest dropped
+    expect(block).not.toContain('line: step4');                // …through the cap boundary
+    expect(block).toContain('step' + (MAX_STEPS_SHOWN + 4));   // newest kept
+    // Numbering continues from the true position, not from 1.
+    expect(block).toContain('  5. line: step5');
+  });
+
+  test('long tex truncates instead of flooding the prompt', () => {
+    const l = applyTurnToLedger(null, [{ action: 'pose', tex: 'x+'.repeat(200) }], NOW);
+    const line = buildBoardStateBlock(l).split('\n').find(s => s.startsWith('Problem in focus'));
+    expect(line.length).toBeLessThan(130);
+    expect(line).toContain('…');
+  });
+});

--- a/tests/unit/learningCards.test.js
+++ b/tests/unit/learningCards.test.js
@@ -1,0 +1,97 @@
+/**
+ * Deterministic AHA + Reminder capture (utils/pipeline/learningCards.js, spec §7).
+ *
+ * The contract: an AHA card requires ALL THREE signals at once — verified
+ * correct, prior struggle on the problem, realization language in the
+ * student's own message. Anything less saves nothing (skipping beats false
+ * epiphanies). Reminders dedupe by misconception and stay supportive.
+ */
+const {
+  detectAha,
+  reminderKey,
+  shapeReminder,
+  shapeAha,
+  toClientCard,
+  REMINDER_ACTIVATION_COUNT,
+} = require('../../utils/pipeline/learningCards');
+
+const STRUGGLE = { attemptCount: 2, misconception: null };
+
+describe('detectAha', () => {
+  test('correct + prior struggle + realization language → AHA with the student quote', () => {
+    const r = detectAha({
+      message: "ohhh I get it, the 5 doesn't jump across — you subtract it from both sides. x=4",
+      wasCorrect: true,
+      priorProblemState: STRUGGLE,
+    });
+    expect(r.isAha).toBe(true);
+    expect(r.quote).toContain("the 5 doesn't jump across");
+  });
+
+  test('a prior misconception counts as struggle even with zero failed attempts', () => {
+    expect(detectAha({
+      message: 'wait, so that makes sense now — x=4',
+      wasCorrect: true,
+      priorProblemState: { attemptCount: 0, misconception: 'one-sided-operation' },
+    }).isAha).toBe(true);
+  });
+
+  test('any missing leg kills the card', () => {
+    // No struggle (first try) — being right immediately is not an epiphany.
+    expect(detectAha({ message: 'oh I get it! x=4', wasCorrect: true, priorProblemState: null }).isAha).toBe(false);
+    // Not correct — saying "I get it" without the answer proving it.
+    expect(detectAha({ message: 'oh I get it now', wasCorrect: false, priorProblemState: STRUGGLE }).isAha).toBe(false);
+    // No realization language — a bare correct retry is progress, not an AHA.
+    expect(detectAha({ message: 'x=4', wasCorrect: true, priorProblemState: STRUGGLE }).isAha).toBe(false);
+  });
+
+  test('weak acknowledgements do not mint cards', () => {
+    for (const msg of ['ok', 'yes', 'sure x=4', 'oh', 'I see the problem says 12']) {
+      expect(detectAha({ message: msg, wasCorrect: true, priorProblemState: STRUGGLE }).isAha).toBe(false);
+    }
+  });
+
+  test('realization phrase variants that must hit', () => {
+    for (const msg of [
+      'that makes sense! so x=4',
+      'now I see why we flip it, x=4',
+      "wait, so it's the slope? then y=2",
+      'i understand now, x=4',
+    ]) {
+      expect(detectAha({ message: msg, wasCorrect: true, priorProblemState: STRUGGLE }).isAha).toBe(true);
+    }
+  });
+
+  test('quote caps at 400 chars and junk input never throws', () => {
+    const long = 'oh i get it ' + 'x'.repeat(600);
+    expect(detectAha({ message: long, wasCorrect: true, priorProblemState: STRUGGLE }).quote.length).toBe(400);
+    expect(detectAha(null).isAha).toBe(false);
+    expect(detectAha({}).isAha).toBe(false);
+  });
+});
+
+describe('reminder shaping', () => {
+  test('reminderKey slugs stably and rejects empties', () => {
+    expect(reminderKey('Losing a Negative Sign')).toBe('losing-a-negative-sign');
+    expect(reminderKey('  Partial Distribution!! ')).toBe('partial-distribution');
+    expect(reminderKey('')).toBeNull();
+    expect(reminderKey(null)).toBeNull();
+  });
+
+  test('shapeReminder is supportive and carries the fix', () => {
+    const s = shapeReminder({ name: 'losing a negative sign', description: 'The minus sign got dropped.', fix: 'Circle every negative before you move terms.' });
+    expect(s.title).toBe('Watch for This: losing a negative sign');
+    expect(s.body).toContain('Next time: Circle every negative');
+  });
+
+  test('shapeAha leads with the student quote', () => {
+    const s = shapeAha('the 5 does not jump across', 'two-step-equations');
+    expect(s.title).toContain('Two Step Equations');
+    expect(s.body).toBe('“the 5 does not jump across”');
+  });
+
+  test('activation threshold: a reminder is a RECURRING mistake', () => {
+    expect(REMINDER_ACTIVATION_COUNT).toBeGreaterThanOrEqual(2);
+    expect(toClientCard({ type: 'reminder', title: 'T', seenCount: 3 })).toEqual({ type: 'reminder', title: 'T', seenCount: 3 });
+  });
+});

--- a/utils/pipeline/boardStateBlock.js
+++ b/utils/pipeline/boardStateBlock.js
@@ -1,0 +1,97 @@
+/**
+ * boardStateBlock.js — the tutor's eyes on its own board.
+ *
+ * The pipeline EMITS board commands every turn but never read them back:
+ * generate/decide had zero awareness of what the student is looking at, so
+ * the tutor would re-derive steps already displayed, re-narrate a solved
+ * problem, or say "let's start with…" about a line that's been sitting on
+ * the board for five turns.
+ *
+ * This builds a compact "ghost" description of the live board — what the
+ * student currently SEES — from conversation.boardLedger, rebuilt fresh
+ * every turn and appended to the system prompt. A system-prompt block
+ * (rather than a message injected into history) is deliberate: the
+ * anthropicClient adapter hoists system-role messages out of history, and
+ * conversation summarization would eat an in-history ghost; the prompt
+ * block is provider-safe, always current, and can never go stale.
+ *
+ * Token-sensitive: steps cap at the newest MAX_STEPS_SHOWN, tex is
+ * truncated, and an empty board contributes nothing at all.
+ */
+'use strict';
+
+const MAX_STEPS_SHOWN = 6;
+const MAX_TEX = 90;
+
+function trunc(s) {
+  const t = String(s == null ? '' : s).replace(/\s+/g, ' ').trim();
+  return t.length > MAX_TEX ? t.slice(0, MAX_TEX - 1) + '…' : t;
+}
+
+function describeStep(cmd) {
+  if (!cmd || !cmd.action) return null;
+  switch (cmd.action) {
+    case 'apply': return 'operation: ' + trunc(cmd.op || cmd.tex || '');
+    case 'resolve': return 'line: ' + trunc(cmd.tex);
+    case 'verify': return 'SOLUTION shown: ' + trunc(cmd.tex);
+    case 'scaffold': return 'scaffold with blanks for the student: ' + trunc(cmd.tex);
+    case 'example': return 'worked example (different problem): ' + trunc(cmd.tex);
+    case 'graph': return 'graph: ' + trunc(cmd.expression || cmd.tex || 'plotted');
+    case 'image': return 'picture: ' + trunc(cmd.imageQuery || cmd.caption || '');
+    case 'diagram':
+    case 'model': return cmd.action + ': ' + trunc(cmd.tex || cmd.caption || 'shown');
+    default: return null;
+  }
+}
+
+/**
+ * @param {object|null} ledger - conversation.boardLedger
+ * @returns {string} the prompt block, or '' when the board is empty
+ */
+function buildBoardStateBlock(ledger) {
+  if (!ledger || typeof ledger !== 'object') return '';
+  const cur = ledger.current;
+  const railCount = Array.isArray(ledger.completed) ? ledger.completed.length : 0;
+  if (!cur && railCount === 0) return '';
+
+  const lines = ['== THE STUDENT\'S BOARD (visible to them RIGHT NOW) =='];
+
+  if (cur && cur.problemTex) {
+    lines.push('Problem in focus: ' + trunc(cur.problemTex)
+      + (cur.sourceRef ? ' (selected from their uploaded worksheet)' : ''));
+    const steps = Array.isArray(cur.steps) ? cur.steps : [];
+    const shown = steps.map(describeStep).filter(Boolean);
+    const tail = shown.slice(-MAX_STEPS_SHOWN);
+    if (tail.length) {
+      if (shown.length > tail.length) {
+        lines.push('Steps on the board (newest ' + tail.length + ' of ' + shown.length + '):');
+      } else {
+        lines.push('Steps on the board:');
+      }
+      tail.forEach((s, i) => lines.push('  ' + (shown.length - tail.length + i + 1) + '. ' + s));
+      const solved = steps.some(c => c && c.action === 'verify');
+      lines.push(solved
+        ? 'Status: SOLVED — the final answer is displayed.'
+        : 'Status: in progress — no solution line yet.');
+    } else {
+      lines.push('Steps on the board: none yet — only the problem is posed.');
+    }
+  } else {
+    lines.push('No problem is in focus (board is between problems).');
+  }
+
+  if (railCount > 0) {
+    lines.push('Finished-problems rail: ' + railCount + ' earlier problem' + (railCount === 1 ? '' : 's')
+      + ' the student can reopen.');
+  }
+
+  lines.push('RULES: This board is shared — the student sees every line above. '
+    + 'Never re-derive or re-narrate steps already displayed; refer to them instead '
+    + '("look at the last line on your board"). If the problem is SOLVED, do not keep '
+    + 'working it — celebrate briefly and move forward. When the student says "what\'s next", '
+    + 'advance from the newest board line, not from the beginning.');
+
+  return lines.join('\n');
+}
+
+module.exports = { buildBoardStateBlock, MAX_STEPS_SHOWN };

--- a/utils/pipeline/index.js
+++ b/utils/pipeline/index.js
@@ -33,6 +33,7 @@ const { generateSuggestions } = require('./suggestions');
 const { assembleEvidence } = require('./evidenceAccumulator');
 const { applyTurnToLedger } = require('./boardLedger');
 const { assistanceLevelForTurn } = require('./assistanceLadder');
+const { buildBoardStateBlock } = require('./boardStateBlock');
 
 // New data-driven engines
 const { updateBKT, initializeBKT } = require('../knowledgeTracer');
@@ -491,6 +492,17 @@ async function runPipeline(message, ctx) {
     if (planLayer) {
       enrichedSystemPrompt += '\n\n' + planLayer;
     }
+  }
+
+  // Board awareness: describe what the student's board displays RIGHT NOW
+  // (from the ledger the previous turns built), so the tutor references the
+  // shared surface instead of re-deriving lines already on it. Rebuilt every
+  // turn — it can't go stale and survives conversation summarization.
+  try {
+    const boardBlock = buildBoardStateBlock(ctx.conversation?.boardLedger);
+    if (boardBlock) enrichedSystemPrompt += '\n\n' + boardBlock;
+  } catch (boardBlockErr) {
+    console.error('[Pipeline] board-state block failed (non-fatal):', boardBlockErr.message);
   }
 
   const assembled = assemblePrompt(decision, {
@@ -1284,6 +1296,7 @@ async function runPipeline(message, ctx) {
       masterySuccess: false,
       badgeAwarded: null,
       iepGoalUpdates: [],
+      learningCards: [],
       courseProgressUpdate: null,
       aiTimeUsed: 0,
       freeWeeklySecondsRemaining: null,
@@ -1345,6 +1358,7 @@ async function runPipeline(message, ctx) {
         masterySuccess: false,
         badgeAwarded: null,
         iepGoalUpdates: [],
+      learningCards: [],
         courseProgressUpdate: null,
         aiTimeUsed: 0,
         freeWeeklySecondsRemaining: null,
@@ -1671,6 +1685,9 @@ async function runPipeline(message, ctx) {
     masterySuccess: persistResults.masterySuccess || false,
     badgeAwarded: persistResults.badgeAwarded || null,
     iepGoalUpdates: persistResults.iepGoalUpdates,
+    // Notebook cards minted this turn (AHA / activated reminders) — the
+    // client celebrates them (Live Workspace spec §7).
+    learningCards: persistResults.learningCards || [],
     courseProgressUpdate: persistResults.courseProgressUpdate,
     aiTimeUsed: persistResults.aiTimeUsed,
     freeWeeklySecondsRemaining: persistResults.freeWeeklySecondsRemaining,

--- a/utils/pipeline/learningCards.js
+++ b/utils/pipeline/learningCards.js
@@ -1,0 +1,121 @@
+/**
+ * learningCards.js — deterministic AHA + Reminder capture (spec §7.2–7.3).
+ *
+ * The notebook must fill itself from real signals, not another LLM call:
+ *
+ *   • AHA (spec §7.2): the student was struggling on a problem (a failed
+ *     attempt or a diagnosed misconception), then got it right ON a turn
+ *     whose own message carries realization language ("ohh I get it",
+ *     "that makes sense", "wait so…"). All three at once is a strong
+ *     signal; anything less and we save nothing — the spec says ask when
+ *     confidence is low, and until the tutor can ask, skipping beats
+ *     polluting the notebook with false epiphanies.
+ *
+ *   • Reminder (spec §7.3): the SAME diagnosed misconception recurring for
+ *     a student. One card per misconception, upserted — the second
+ *     occurrence activates it ("Watch for This"), later ones bump its
+ *     count. Supportive framing, never punitive.
+ *
+ * Detection here is pure; the persist stage owns the database writes.
+ */
+'use strict';
+
+// Realization language. Deliberately explicit phrases — a bare "ok" or
+// "yes" must not mint an AHA card.
+const REALIZATION_RX = new RegExp(
+  [
+    '\\boh+h*\\b[!.\\s]*(?:i\\s+(?:get|see)|now|that)',   // "ohh I get it", "oh now…", "oh that's…"
+    '\\bi\\s+(?:get|got)\\s+it\\b',
+    '\\bi\\s+see\\s+(?:it|now|why|what)\\b',
+    '\\bthat\\s+makes\\s+sense\\b',
+    '\\bmakes\\s+so\\s+much\\s+sense\\b',
+    '\\bi\\s+understand\\s+(?:it\\s+)?now\\b',
+    '\\bnow\\s+i\\s+(?:get|see|understand)\\b',
+    '\\bwait[,!\\s]+so\\b',
+    '\\bso\\s+that\'?s\\s+(?:why|how)\\b',
+  ].join('|'),
+  'i'
+);
+
+/**
+ * Should this turn mint an AHA card?
+ *
+ * @param {object} signals
+ * @param {string}  signals.message - the student's message this turn
+ * @param {boolean} signals.wasCorrect - verified-correct answer this turn
+ * @param {object|null} signals.priorProblemState - conversation.lastProblemState
+ *   BEFORE this turn's update ({attemptCount, misconception, problemText})
+ * @returns {{isAha: boolean, quote: string|null}}
+ */
+function detectAha(signals) {
+  const s = signals || {};
+  const msg = String(s.message == null ? '' : s.message).trim();
+  if (!msg || s.wasCorrect !== true) return { isAha: false, quote: null };
+
+  const prior = s.priorProblemState;
+  const struggled = !!(prior && ((prior.attemptCount || 0) >= 1 || prior.misconception));
+  if (!struggled) return { isAha: false, quote: null };
+
+  if (!REALIZATION_RX.test(msg)) return { isAha: false, quote: null };
+  return { isAha: true, quote: msg.slice(0, 400) };
+}
+
+/** Stable per-misconception dedupe key ("losing-a-negative-sign"). */
+function reminderKey(misconceptionName) {
+  const k = String(misconceptionName == null ? '' : misconceptionName)
+    .toLowerCase().trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
+  return k || null;
+}
+
+/** Student-facing reminder content — supportive, never punitive (§7.3). */
+function shapeReminder(misconception) {
+  const m = misconception || {};
+  const name = String(m.name || 'this step').trim();
+  return {
+    title: ('Watch for This: ' + name).slice(0, 160),
+    body: [
+      m.description ? String(m.description).trim() : '',
+      m.fix ? ('Next time: ' + String(m.fix).trim()) : '',
+    ].filter(Boolean).join('\n').slice(0, 2000) || 'You’ve hit this snag more than once — slow down here next time.',
+  };
+}
+
+/** AHA card content — the student's own words lead (§7.2). */
+function shapeAha(quote, skillId) {
+  const label = skillId
+    ? String(skillId).replace(/[-_.]+/g, ' ').replace(/\b\w/g, c => c.toUpperCase()).trim()
+    : null;
+  return {
+    title: (label ? ('AHA! ' + label) : 'AHA! It clicked').slice(0, 160),
+    body: '“' + String(quote || '').trim() + '”',
+  };
+}
+
+/** Compact client shape — what rides the chat response for the celebration. */
+function toClientCard(doc) {
+  return {
+    type: doc.type,
+    title: doc.title,
+    // Only reminders past their activation threshold surface to the client;
+    // seenCount lets the UI say "3rd time" if it wants to.
+    seenCount: doc.seenCount || 1,
+  };
+}
+
+// A reminder only surfaces once the mistake has RECURRED — the first
+// occurrence is just learning, the second is a pattern (spec: "recurring
+// mistakes"). The card exists from occurrence one so the count is honest.
+const REMINDER_ACTIVATION_COUNT = 2;
+
+module.exports = {
+  detectAha,
+  reminderKey,
+  shapeReminder,
+  shapeAha,
+  toClientCard,
+  REMINDER_ACTIVATION_COUNT,
+  REALIZATION_RX,
+};

--- a/utils/pipeline/persist.js
+++ b/utils/pipeline/persist.js
@@ -28,6 +28,8 @@ const { canonicalSkillId } = require('../skillCanonicalizer');
 const { updateSkillMastery: engineUpdateSkillMastery, initializeSkillMastery } = require('../masteryEngine');
 const { problemAssistance } = require('./boardLedger');
 const { isIndependent } = require('./assistanceLadder');
+const LearningCard = require('../../models/learningCard');
+const { detectAha, reminderKey, shapeReminder, shapeAha, toClientCard, REMINDER_ACTIVATION_COUNT } = require('./learningCards');
 const { advanceRung, currentRung, clearsPrerequisites } = require('../skillRung');
 const { getSkillMasteryEntry, setSkillMasteryEntry, decodedMasteryMap } = require('../masteryGuard');
 
@@ -341,6 +343,19 @@ async function persist(params) {
   // Mark scaffold advance point
   if (extracted.scaffoldAdvance && conversation.messages.length > 0) {
     conversation.messages[conversation.messages.length - 1].scaffoldAdvanced = true;
+  }
+
+  // ── 7a-cards. Learning-card capture (Live Workspace spec §7.2–7.3) ──
+  // MUST run before 7b: conversation.lastProblemState still holds the PRIOR
+  // turn's state here, and "was struggling, now correct" is the AHA signal.
+  // Cross-session notebook writes; never allowed to cost the student a turn.
+  results.learningCards = [];
+  try {
+    results.learningCards = await captureLearningCards({
+      user, conversation, diagnosis, originalMessage, results, masteryAttempt,
+    });
+  } catch (cardErr) {
+    console.error('[Persist] learning-card capture failed (non-fatal):', cardErr.message);
   }
 
   // ── 7b. Persist last problem state for session continuity ──
@@ -875,6 +890,69 @@ function updateBadgeProgress(user, wasCorrect) {
       totalBadges: user.badges.length,
     },
   };
+}
+
+/**
+ * Learning-card capture (Live Workspace spec §7.2–7.3) — the notebook fills
+ * itself from the turn's verified signals; no extra LLM call.
+ *
+ * Reminder: a diagnosed misconception on a wrong answer upserts ONE card per
+ * misconception per student; the card only surfaces to the client once the
+ * mistake has recurred (REMINDER_ACTIVATION_COUNT) — first time is learning,
+ * second is a pattern. AHA: verified-correct after struggle, with realization
+ * language in the student's own message; their words become the card.
+ * Detection is pure (utils/pipeline/learningCards.js); this owns the writes.
+ */
+async function captureLearningCards({ user, conversation, diagnosis, originalMessage, results, masteryAttempt }) {
+  const out = [];
+  const skillId = masteryAttempt?.skillId || null;
+  const problemTex = conversation.boardLedger?.current?.problemTex
+    || (diagnosis?.problemInfo?.content ? String(diagnosis.problemInfo.content).slice(0, 500) : null);
+
+  if (diagnosis?.misconception?.name && diagnosis.isCorrect === false) {
+    const key = reminderKey(diagnosis.misconception.name);
+    if (key) {
+      const shaped = shapeReminder(diagnosis.misconception);
+      const card = await LearningCard.findOneAndUpdate(
+        { userId: user._id, type: 'reminder', misconceptionKey: key },
+        {
+          $setOnInsert: {
+            title: shaped.title, body: shaped.body, skillId,
+            conversationId: conversation._id, problemTex,
+          },
+          $inc: { seenCount: 1 },
+          $set: { lastSeenAt: new Date(), archived: false },
+        },
+        { upsert: true, new: true }
+      );
+      if (card.seenCount >= REMINDER_ACTIVATION_COUNT) out.push(toClientCard(card));
+    }
+  }
+
+  const aha = detectAha({
+    message: originalMessage,
+    wasCorrect: results.wasCorrect,
+    priorProblemState: conversation.lastProblemState,
+  });
+  if (aha.isAha) {
+    // One AHA per conversation per 10 minutes — a hot streak is one moment,
+    // not a card-printing machine (rewards must not track message volume).
+    const recent = await LearningCard.findOne({
+      userId: user._id, type: 'aha', conversationId: conversation._id,
+      createdAt: { $gte: new Date(Date.now() - 10 * 60 * 1000) },
+    }).select('_id').lean();
+    if (!recent) {
+      const shaped = shapeAha(aha.quote, skillId);
+      const card = await LearningCard.create({
+        userId: user._id, type: 'aha',
+        title: shaped.title, body: shaped.body, quote: aha.quote,
+        skillId, conversationId: conversation._id, problemTex,
+      });
+      out.push(toClientCard(card));
+    }
+  }
+
+  return out;
 }
 
 module.exports = {


### PR DESCRIPTION
Sixth Live Workspace slice — two halves of the same idea: **the workspace remembers, and the tutor sees.** (Spec §7.2–7.3, §15, §8 — plus the owner ask: *"make sure the tutor is aware of the board, and what is being displayed."*)

## 1. The learning notebook (MVP items 16–17)

**AHA cards** capture the student's own realization, deterministically — no extra LLM call. A card requires **all three** signals on one turn: a verified-correct answer + prior struggle on that problem (failed attempt or diagnosed misconception) + realization language in the student's own message ("ohh I get it…", "that makes sense", "wait, so…"). Their words become the card: *AHA! Two Step Equations — "the 5 doesn't jump across — you subtract it from both sides."* Anything less than all three saves nothing; the spec says ask when unsure, and until the tutor can ask, skipping beats false epiphanies. Rate-limited to one per conversation per 10 minutes.

**Reminder cards** ("Watch for This") upsert one card per diagnosed misconception per student; the card only *surfaces* when the mistake recurs — the first time is learning, the second is a pattern. Supportive framing, carries the fix.

Cards live in a new cross-session `LearningCard` collection (idea/strategy/reflection types are schema-ready for later capture). `GET /api/notebook` lists them (own cards only); responses carry `learningCards` and the client toasts "✨ Saved to your notebook."

## 2. The board-aware tutor

The pipeline **emitted** board commands every turn but never read them back — generate had zero awareness of what the student is looking at (the root of re-derived steps and "great work, what's next?" loops). Now `boardStateBlock.js` builds a ghost description of the live board from the ledger — problem in focus, newest steps with honest numbering, **SOLVED** status, rail count, worksheet link — rebuilt into the system prompt **every turn**, with explicit rules: never re-derive displayed steps, never keep working a solved problem, advance from the newest line.

Why a prompt block and not an in-history ghost message: the `anthropicClient` adapter hoists system-role messages out of position, and conversation summarization eats history — the block is provider-safe, always current, and costs zero tokens on an empty board.

## Verification

- Full suite **4658 passed**, lint clean. 17 new tests: the three-legged AHA gate (each missing leg kills the card), weak-acknowledgement rejections, phrase matrix, reminder slugging/threshold, board-block rendering built from REAL ledger folds (solved status, caps with honest numbering, truncation, empty→zero tokens).
- Manual QA: miss a two-step equation, get the misconception explained, then reply "ohh I get it — subtract from both sides, x=4" → toast + card in `GET /api/notebook`. Ask "what's next?" after solving → tutor should now reference the board instead of re-walking it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)