### PR TITLE
feat(act): no re-test ever repeats an item (seen-ledger + assembler e…

### DIFF
--- a/routes/actTest.js
+++ b/routes/actTest.js
@@ -51,6 +51,25 @@ const ACT_SKILL_NAMES = (() => {
   return map;
 })();
 
+// Every problemId this student has ever been served, across ALL their ACT test
+// sessions (any status — an item shown in an abandoned test still "burns" it).
+// This is the seen-ledger the assembler excludes so no re-test ever repeats an
+// item. Computed on the fly from the sessions themselves — no separate store to
+// drift out of sync.
+async function seenProblemIdsForUser(userId) {
+  try {
+    const sessions = await ActTestSession.find({ userId }).select('items.problemId').lean();
+    const seen = new Set();
+    for (const s of sessions) {
+      for (const it of (s.items || [])) if (it && it.problemId) seen.add(it.problemId);
+    }
+    return [...seen];
+  } catch (err) {
+    console.error('[actTest] seen-ledger lookup failed (non-fatal, no exclusion):', err.message);
+    return [];   // fail open: better a possible repeat than a blocked test
+  }
+}
+
 // ── POST /start ─────────────────────────────────────────────
 router.post('/', async (req, res) => {
   return res.status(404).json({ message: 'Use POST /api/act-test/start' });
@@ -83,9 +102,25 @@ router.post('/start', async (req, res) => {
 
     const blueprint = getBlueprint();
     const seed = `${userId}-${Date.now()}`;
-    const form = await assembleForm({ seed });
+    // Every re-test must be FRESH — no item this student has already been served
+    // (any prior session) may reappear, or the re-test measures memory of the
+    // question, not the skill. Exclude their whole seen-history.
+    const excludeIds = await seenProblemIdsForUser(userId);
+    const form = await assembleForm({ seed, excludeIds });
 
     if (form.coverage.filled === 0) {
+      if (excludeIds.length > 0) {
+        // Not empty — EXHAUSTED. This student has now seen every item the bank
+        // can offer for the blueprint. Honest signal, distinct from "unseeded",
+        // so the UI can say "you've worked through everything" and content gen
+        // can be prioritized. Never silently re-serve seen items.
+        return res.status(409).json({
+          message: "You've worked through every ACT practice question we have — nice. Fresh questions are being added.",
+          exhausted: true,
+          seenCount: excludeIds.length,
+          coverage: form.coverage,
+        });
+      }
       // Honest failure: the ACT item bank isn't populated yet. The gaps array
       // is the generation worklist (skill + difficulty per missing slot).
       return res.status(503).json({

--- a/tests/integration/actNoRepeat.test.js
+++ b/tests/integration/actNoRepeat.test.js
@@ -1,0 +1,87 @@
+/**
+ * No re-test ever repeats an item the student has already seen.
+ *
+ * Repeating an item measures memory of the question, not the skill — it inflates
+ * the round-over-round comparison the whole ACT bootcamp loop rests on. This
+ * drives the REAL assembler against a real (in-memory) Problem collection with a
+ * tiny blueprint, plays several rounds feeding each round's items back as the
+ * seen-ledger, and asserts: zero overlap ever, and graceful exhaustion (not a
+ * silent repeat) once the bank is used up.
+ */
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const Problem = require('../../models/problem');
+const { assembleForm } = require('../../utils/actTestAssembler');
+
+// 3 slots per form, one skill, N distinct items -> exhausts after N/3 rounds.
+const BLUEPRINT = {
+  testId: 'test-act', title: 'T', totalItems: 3, timeLimitMinutes: 5,
+  categoryWeights: { 'cat-a': 3 },
+  skillsByCategory: { 'cat-a': ['skill-1'] },
+  difficultyRamp: [{ fromPosition: 1, toPosition: 45, targetDifficulty: 3 }],
+};
+
+let mem;
+
+beforeAll(async () => {
+  mem = await MongoMemoryServer.create();
+  await mongoose.connect(mem.getUri());
+  const docs = [];
+  for (let i = 1; i <= 9; i++) {
+    docs.push({
+      problemId: `p${i}`,
+      skillId: 'skill-1',
+      prompt: `Distinct question number ${i}?`,
+      answer: { value: `${i}` },
+      answerType: 'multiple-choice',
+      options: [{ label: 'A', text: `${i}` }, { label: 'B', text: `${i + 1}` }, { label: 'C', text: `${i + 2}` }, { label: 'D', text: `${i + 3}` }],
+      correctOption: 'A',
+      difficulty: 3,
+      isActive: true,
+      source: 'test',
+    });
+  }
+  await Problem.insertMany(docs);
+}, 60000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  if (mem) await mem.stop();
+});
+
+test('across rounds, no item is ever served twice; exhaustion is graceful', async () => {
+  const seen = new Set();
+  let round = 0;
+  let lastCoverage = null;
+
+  // Play until the assembler can no longer fill any slot with a fresh item.
+  while (round < 10) {
+    const form = await assembleForm({ blueprint: BLUEPRINT, seed: `u-${round}`, excludeIds: [...seen] });
+    lastCoverage = form.coverage;
+    const ids = form.items.map((it) => it.problemId);
+
+    // (1) No item in this form was seen in ANY prior round.
+    ids.forEach((id) => expect(seen.has(id)).toBe(false));
+    // (2) No item repeats WITHIN the form either.
+    expect(new Set(ids).size).toBe(ids.length);
+
+    if (form.coverage.filled === 0) break;   // bank exhausted for this student
+    ids.forEach((id) => seen.add(id));
+    round++;
+  }
+
+  // 9 items / 3 per form = exactly 3 fresh rounds, then a 4th that fills nothing.
+  expect(seen.size).toBe(9);
+  expect(round).toBe(3);
+  // The empty round reports it as EXHAUSTED (excluded>0), not "unseeded" (excluded=0).
+  expect(lastCoverage.filled).toBe(0);
+  expect(lastCoverage.excluded).toBe(9);
+});
+
+test('excludeIds defaults to none (unchanged behavior when omitted)', async () => {
+  const form = await assembleForm({ blueprint: BLUEPRINT, seed: 'plain' });
+  expect(form.coverage.excluded).toBe(0);
+  expect(form.items.length).toBe(3);
+});

--- a/utils/actTestAssembler.js
+++ b/utils/actTestAssembler.js
@@ -151,6 +151,12 @@ function toGenerationSpec(slot) {
  * @param {Object} [opts.blueprint] - Override blueprint (defaults to seeds file)
  * @param {string|number} [opts.seed] - Reproducibility seed (string hashed)
  * @param {number} [opts.difficultyRange=1] - ± band passed to findNearDifficulty
+ * @param {string[]} [opts.excludeIds] - problemIds the student has already been
+ *   served (any prior session). Seeded into the exclusion set so no item ever
+ *   repeats across re-tests — repeats measure memory, not skill. As these deplete
+ *   a skill, the same-category fallback keeps drawing fresh items; when a whole
+ *   category is exhausted those slots become gaps (coverage drops), which the
+ *   caller surfaces honestly instead of silently repeating.
  * @returns {Promise<{items, gaps, coverage, meta}>}
  */
 async function assembleForm(opts = {}) {
@@ -162,7 +168,11 @@ async function assembleForm(opts = {}) {
   const Problem = require('../models/problem');
   const byCat = blueprint.skillsByCategory || {};
   const slots = buildSlots(blueprint, rng);
-  const usedProblemIds = [];
+  // Never re-serve an item the student has already seen (cross-session), on top
+  // of the within-form dedup this array already provides.
+  const excludeIds = Array.isArray(opts.excludeIds) ? opts.excludeIds : [];
+  const usedProblemIds = excludeIds.slice();
+  const excludedCount = usedProblemIds.length;
   const usedSignatures = new Map();   // prompt-shape -> count, to avoid look-alikes
   const items = [];
   const gaps = [];
@@ -226,6 +236,7 @@ async function assembleForm(opts = {}) {
       filled: items.length,
       missing: gaps.length,
       pct: slots.length ? Math.round((items.length / slots.length) * 100) : 0,
+      excluded: excludedCount,   // items withheld as already-seen (re-test freshness)
     },
     meta: {
       testId: blueprint.testId,


### PR DESCRIPTION
…xclude)

Foundation for the ACT bootcamp loop (test → work misses → re-test → compare → repeat). A re-test that reuses items measures memory of the question, not the skill, and inflates the round-over-round comparison the whole loop rests on.

Today the assembler only dedups WITHIN one form — usedProblemIds starts empty every call — so re-tests would repeat freely. Now:
- assembleForm accepts opts.excludeIds and seeds the exclusion set with it, so no item the student has already seen can reappear. As a skill's fresh stock depletes, the existing same-category fallback keeps drawing fresh items; when a whole category is spent those slots become gaps (coverage.filled drops).
- routes/actTest.js: seenProblemIdsForUser() unions problemIds across ALL the student's sessions (any status) and passes them as excludeIds on /start. Computed from the sessions themselves — no separate ledger to drift.
- Exhaustion is HONEST and distinct: filled===0 with excluded>0 returns 409 "you've worked through every question we have" (fresh gen needed), vs the existing 503 "bank not populated" (excluded===0). Never silently re-serves.
- fail-open: a ledger lookup error skips exclusion rather than blocking a test.

Verified (real in-memory DB, tiny blueprint): 9 items / 3-slot form = exactly 3 fresh rounds with zero overlap across AND within forms, then a graceful empty round (filled 0, excluded 9). excludeIds omitted -> unchanged.