### PR TITLE
fix(mastery): unfreeze the progress bar — merge split skill records + catalog names

### DIFF
--- a/routes/parent.js
+++ b/routes/parent.js
@@ -12,6 +12,7 @@ const { cleanupStaleSessions } = require('../services/sessionService');
 const ScreenerSession = require('../models/screenerSession');
 const { logRecordAccess } = require('../middleware/ferpaAccessLog');
 const { calculateRetrievability } = require('../utils/fsrsScheduler');
+const { resolveSkillDisplayNames } = require('../utils/skillDisplayNames');
 
 // Helper: verify parent has access to child
 async function verifyParentChildAccess(parentId, childId) {
@@ -529,6 +530,7 @@ router.get('/child/:childId/learning-curve', isAuthenticated, isParent, async (r
         if (!child) return res.status(403).json({ message: 'Not authorized to view this child.' });
 
         const skillsOverview = [];
+        const skillNames = await resolveSkillDisplayNames(Object.keys(child.skillMastery || {}));
         for (const [skillId, skillData] of Object.entries(child.skillMastery || {})) {
             const practiceCount = (skillData.practiceHistory || []).length;
             if (practiceCount === 0) continue;
@@ -538,7 +540,7 @@ router.get('/child/:childId/learning-curve', isAuthenticated, isParent, async (r
 
             skillsOverview.push({
                 skillId,
-                displayName: skillId.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' '),
+                displayName: skillNames[skillId],
                 currentTheta,
                 growth: currentTheta - firstTheta,
                 practiceCount,

--- a/routes/student.js
+++ b/routes/student.js
@@ -12,6 +12,7 @@ const { isAuthenticated, isStudent } = require('../middleware/auth'); // Import 
 const crypto = require('crypto'); // Node.js built-in module for cryptography
 const mongoose = require('mongoose');
 const { computeWeeklyAccuracy } = require('../utils/weeklyAccuracy');
+const { resolveSkillDisplayNames } = require('../utils/skillDisplayNames');
 const { deriveProgressCardState } = require('../utils/progressCardState');
 const { getReviewSummary } = require('../utils/smartReviewQueue');
 const { resolveMasteryKey, getSkillMasteryEntry, setSkillMasteryEntry } = require('../utils/masteryGuard');
@@ -307,9 +308,12 @@ router.get('/progress', isAuthenticated, isStudent, async (req, res) => {
         const ready = [];
 
         const skillEntries = student.skillMastery ? Object.entries(student.skillMastery) : [];
+        // Resolve names from the Skill catalog by canonical id, NOT from the storage
+        // key — canonical keys are dot-encoded ("MS_QNT_8") and would render "Ms Qnt 8".
+        const skillNames = await resolveSkillDisplayNames(skillEntries.map(([k]) => k));
         if (skillEntries.length > 0) {
             for (const [skillId, data] of skillEntries) {
-                const displayName = skillId.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+                const displayName = skillNames[skillId];
 
                 const skillData = {
                     skillId,
@@ -384,8 +388,9 @@ router.get('/progress/summary', isAuthenticated, isStudent, async (req, res) => 
             const learning = [];
             const ready = [];
 
+            const skillNames = await resolveSkillDisplayNames(skillEntries.map(([k]) => k));
             for (const [skillId, data] of skillEntries) {
-                const displayName = skillId.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+                const displayName = skillNames[skillId];
 
                 if (data.status === 'mastered' && data.masteredDate) {
                     mastered.push({ skillId, displayName, date: data.masteredDate });

--- a/routes/teacher.js
+++ b/routes/teacher.js
@@ -13,6 +13,7 @@ const { computeRiskScore, getInterventionTier, generateRecommendation } = requir
 const ScreenerSession = require('../models/screenerSession');
 const EnrollmentCode = require('../models/enrollmentCode');
 const Skill = require('../models/skill');
+const { resolveSkillDisplayNames } = require('../utils/skillDisplayNames');
 const { callLLMStream } = require('../utils/openaiClient');
 const { getStudentIdsForTeacher } = require('../services/userService');
 const { logRecordAccess } = require('../middleware/ferpaAccessLog');
@@ -917,6 +918,7 @@ router.get('/students/:studentId/learning-curve', isTeacher, requireActiveConsen
     if (!student) return res.status(403).json({ message: 'Not authorized.' });
 
     const skillsOverview = [];
+    const skillNames = await resolveSkillDisplayNames(Object.keys(student.skillMastery || {}));
     for (const [skillId, skillData] of Object.entries(student.skillMastery || {})) {
       const practiceHistory = skillData.practiceHistory || [];
       const practiceCount = practiceHistory.length;
@@ -927,7 +929,7 @@ router.get('/students/:studentId/learning-curve', isTeacher, requireActiveConsen
 
       skillsOverview.push({
         skillId,
-        displayName: skillId.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' '),
+        displayName: skillNames[skillId],
         currentTheta,
         growth: currentTheta - firstTheta,
         practiceCount,
@@ -1520,6 +1522,12 @@ async function buildClassSnapshot(teacherId) {
   const oneWeekAgo = new Date(now - 7 * 24 * 60 * 60 * 1000);
   const twoDaysAgo = new Date(now - 2 * 24 * 60 * 60 * 1000);
 
+  // Names come from the Skill catalog by canonical id, resolved once for all
+  // students up front (the .map below is synchronous), never from the raw key.
+  const allSkillNames = await resolveSkillDisplayNames(
+    students.flatMap(s => (s.skillMastery ? Object.keys(s.skillMastery) : []))
+  );
+
   // Build individual student profiles
   const profiles = students.map(s => {
     const name = `${s.firstName || ''}`.trim() || 'Unknown';
@@ -1528,7 +1536,7 @@ async function buildClassSnapshot(teacherId) {
     const learningCount = mastery.filter(([, d]) => ['learning', 'practicing', 're-fragile', 'needs-review'].includes(d.status)).length;
     const strugglingSkills = mastery
       .filter(([, d]) => d.status === 'learning' && d.masteryScore !== undefined && d.masteryScore < 40)
-      .map(([id]) => id.replace(/-/g, ' '))
+      .map(([id]) => allSkillNames[id] || id)
       .slice(0, 3);
 
     // IEP info

--- a/scripts/backfillUnifiedMasteryKeys.js
+++ b/scripts/backfillUnifiedMasteryKeys.js
@@ -4,11 +4,13 @@
 // kebab skill ids to canonical unified "Map of Mathmatix" ids, so historical
 // data matches what the canonicalized read/write boundary now stores.
 //
-// Runtime code already canonicalizes at the mastery boundary (utils/skillCanonicalizer
-// via masteryGuard / persist / pipeline), so this backfill is OPTIONAL — reads
-// fall back to legacy keys, so nothing is broken without it. Running it just makes
-// stored keys uniform (one node per concept) and collapses any legacy+unified
-// duplicates a user accumulated across the transition.
+// Runtime code canonicalizes at the mastery WRITE boundary, but a user seeded
+// under a legacy key before that boundary existed ends up with TWO records for one
+// concept: the legacy "order-of-operations" (e.g. a screener seed, masteryScore
+// 0.5) and the canonical "MS_QNT_8" that practice accumulates into. Progress cards
+// pick the legacy one, so the bar sits frozen at the seed value no matter how much
+// the student practices. This backfill collapses those duplicates onto the single
+// canonical key — it is NOT cosmetic; it is what unfreezes those bars.
 //
 // Rewrites, per user:
 //   - skillMastery                (Map<skillId, entry>)
@@ -28,28 +30,41 @@
 require('dotenv').config();
 const mongoose = require('mongoose');
 const { canonicalSkillId } = require('../utils/skillCanonicalizer');
+const { encodeMasteryKey, decodeMasteryKey } = require('../utils/masteryGuard');
 
 const APPLY = process.argv.includes('--apply');
 
 function stronger(a, b) {
-  // return the mastery entry to keep when two collide
+  // return the mastery entry to keep when two collide. masteryScore is dual-scale
+  // (placement seeds it 0-1, the pillar engine writes 0-100), so a real practice
+  // record always outranks a 0.5 placement seed — which is exactly what we want.
   const rank = (e) => (e?.status === 'mastered' ? 1e9 : 0) + (Number(e?.masteryScore) || 0);
   return rank(a) >= rank(b) ? a : b;
 }
 
-// Rewrite a Map's keys to canonical ids. Returns { next: Map, remapped, merged }.
+// Rewrite a skillMastery Map's keys to the canonical ENCODED storage key.
+//
+// This must operate in ENCODED key-space, not logical space. Mongoose Maps store
+// dotted ids with dots swapped for "_" (masteryGuard.encodeMasteryKey), so the
+// canonical record for "order-of-operations" lives under the key "MS_QNT_8", not
+// "MS.QNT.8". An earlier version keyed the rebuilt map by canonicalSkillId(key)
+// alone — which yields the DOTTED "MS.QNT.8". That (a) never collides with the
+// runtime-written "MS_QNT_8", so legacy+unified duplicates were never merged (the
+// whole point), and (b) is an invalid Mongoose Map key. Decoding the stored key
+// first, then canonicalizing, then re-encoding, makes both the legacy kebab entry
+// and the runtime canonical entry land on the same valid "MS_QNT_8" and merge.
 function remapMap(map, mergeFn) {
   const next = new Map();
   let remapped = 0;
   let merged = 0;
   for (const [key, val] of map) {
-    const canon = canonicalSkillId(key);
-    if (canon !== key) remapped += 1;
-    if (next.has(canon)) {
+    const canonEncoded = encodeMasteryKey(canonicalSkillId(decodeMasteryKey(key)));
+    if (canonEncoded !== key) remapped += 1;
+    if (next.has(canonEncoded)) {
       merged += 1;
-      next.set(canon, mergeFn(next.get(canon), val));
+      next.set(canonEncoded, mergeFn(next.get(canonEncoded), val));
     } else {
-      next.set(canon, val);
+      next.set(canonEncoded, val);
     }
   }
   return { next, remapped, merged };

--- a/utils/pipeline/persist.js
+++ b/utils/pipeline/persist.js
@@ -25,6 +25,7 @@ const { getNextActions } = require('../nextActionSuggestions');
 const { checkForInterventionAlert } = require('../interventionAlerts');
 const { getReviewSummary } = require('../smartReviewQueue');
 const { canonicalSkillId } = require('../skillCanonicalizer');
+const { prettifyLabel } = require('../skillDisplayNames');
 const { updateSkillMastery: engineUpdateSkillMastery, initializeSkillMastery } = require('../masteryEngine');
 const { problemAssistance } = require('./boardLedger');
 const { isIndependent } = require('./assistanceLadder');
@@ -758,8 +759,10 @@ function updateSkillMastery(user, rawSkillId, observation, conversation, correct
   // Add to recent wins the first time the skill is genuinely owned.
   if (justProved && !wasOwned) {
     if (!user.learningProfile.recentWins) user.learningProfile.recentWins = [];
-    // derive the label from the original (kebab) id — nicer than a dotted unified id
-    const displayName = rawSkillId.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+    // Normalize both kebab and dot-encoded unified ids to a readable label
+    // (sync path — no catalog lookup; the display readers resolve the formal
+    // catalog name at read time).
+    const displayName = prettifyLabel(rawSkillId);
     user.learningProfile.recentWins.unshift({ skill: skillId, description: `Mastered ${displayName}`, date: new Date() });
     user.learningProfile.recentWins = user.learningProfile.recentWins.slice(0, 10);
     user.markModified('learningProfile');

--- a/utils/skillDisplayNames.js
+++ b/utils/skillDisplayNames.js
@@ -1,0 +1,78 @@
+// Resolve skillMastery STORAGE KEYS to human display names via the Skill catalog.
+//
+// Why this exists: several readers used to derive a skill's display name straight
+// from its Map key — `skillId.replace(/-/g, ' ')`. That worked only for legacy
+// kebab ids ("order-of-operations" -> "Order Of Operations"). The canonical
+// unified ids are stored dot-encoded ("MS.QNT.8" -> "MS_QNT_8"), so the same
+// trick renders "Ms Qnt 8". Once records are migrated onto canonical keys, EVERY
+// key-derived name would read like that — so every such reader must resolve the
+// name through the catalog instead. This is the single place that does it.
+//
+// Input keys may be either form (encoded canonical or legacy kebab); we decode →
+// canonicalize → look up Skill.displayName, and fall back to a prettified logical
+// id (never the encoded underscore form) when the catalog has no match.
+
+const Skill = require('../models/skill');
+const { decodeMasteryKey } = require('./masteryGuard');
+const { canonicalSkillId } = require('./skillCanonicalizer');
+
+// Last-resort label when the catalog has no entry: turn "MS.QNT.8" / "order-of-
+// operations" into something readable rather than "MS_QNT_8".
+function prettify(logicalId) {
+  return String(logicalId)
+    .replace(/[-_.]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (l) => l.toUpperCase());
+}
+
+/**
+ * @param {Iterable<string>} storageKeys - keys as stored in user.skillMastery
+ * @returns {Promise<Object>} map of ORIGINAL key -> display name
+ */
+async function resolveSkillDisplayNames(storageKeys) {
+  const keys = Array.from(storageKeys || []);
+  if (keys.length === 0) return {};
+
+  // key -> { logical, canonical }
+  const meta = {};
+  const canonicalIds = new Set();
+  for (const key of keys) {
+    const logical = decodeMasteryKey(key);
+    const canonical = canonicalSkillId(logical);
+    meta[key] = { logical, canonical };
+    canonicalIds.add(canonical);
+  }
+
+  let catalog = {};
+  try {
+    const skills = await Skill.find({ skillId: { $in: Array.from(canonicalIds) } })
+      .select('skillId displayName')
+      .lean();
+    for (const s of skills) {
+      if (s.displayName) catalog[s.skillId] = s.displayName;
+    }
+  } catch (_) {
+    // Catalog unavailable → fall back to prettified ids below. Never throw: a
+    // name lookup must not take down a progress endpoint.
+  }
+
+  const out = {};
+  for (const key of keys) {
+    const { logical, canonical } = meta[key];
+    out[key] = catalog[canonical] || prettify(logical);
+  }
+  return out;
+}
+
+// Synchronous label prettifier for hot write paths with no catalog access (e.g.
+// the recentWins "Mastered X" toast). Deliberately does NOT canonicalize: a
+// legacy kebab id reads best as-is ("order-of-operations" -> "Order Of
+// Operations"); canonicalizing it first would yield "MS QNT 8". Unified ids
+// still degrade to "MS QNT 8" here, which is why user-facing READ paths use the
+// async catalog resolver above instead.
+function prettifyLabel(id) {
+  return prettify(id);
+}
+
+module.exports = { resolveSkillDisplayNames, prettifyLabel };


### PR DESCRIPTION
## Problem
A student seeded under a legacy kebab key (e.g. `order-of-operations`, `masteryScore: 0.5`) before the write boundary canonicalized keys ends up with **two** `skillMastery` records for one concept: the legacy seed, and the canonical `MS_QNT_8` that practice accumulates into. Progress cards read the **legacy** one via `learning[0]`, so the bar sits frozen at the seed (an exact, unchanging 50%) no matter how much the student practices. Confirmed on a real record: `order-of-operations → 0.5` next to `MS_QNT_8 → 67`.

## Fix
- **`scripts/backfillUnifiedMasteryKeys.js`**: remap in **encoded key-space** (`encodeMasteryKey ∘ canonicalSkillId ∘ decodeMasteryKey`) so legacy and canonical keys actually collide and merge onto the valid `MS_QNT_8`. The previous version produced a **dotted** `MS.QNT.8` key that never collided (so nothing merged) and that Mongoose Maps reject on save (the `(type Map) at path "skillMastery"` crash).
- **`utils/skillDisplayNames.js`** (new): resolve display names from the `Skill` catalog by canonical id, never from the storage key — otherwise a canonical key renders "Ms Qnt 8". Required *with* the migration, since converting everyone to canonical keys would otherwise make every name-from-key reader ugly.
- Route the six key-as-name readers (student/parent/teacher progress + the `recentWins` label) through the resolver.

## Migration
Dry-run first, then `--apply` (targets Atlas — run from Render Shell or an allowlisted host):
```
node scripts/backfillUnifiedMasteryKeys.js          # dry run
node scripts/backfillUnifiedMasteryKeys.js --apply
```

## Tests
`masteryKeyEncoding` + full diagnose/pipeline suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)