### PR TITLE
feat(lws): notebook on the board — browse and search learning cards (spec §15)

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -133,7 +133,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
        LivingWorkspace flag is dev|beta|live (?livingWorkspace=dev). When on,
        it lazy-loads the workspace and mirrors the tutor's board output onto
        the new surface beside the old board. Default OFF → zero impact. -->
-  <script defer src="/js/living-workspace/chat-workspace.js?v=20260725e"></script>
+  <script defer src="/js/living-workspace/chat-workspace.js?v=20260725f"></script>
   <!-- Final safety net: strips any inline visual tag no renderer handled -->
   <script defer src="/js/stripVisualTags.js"></script>
   <!-- Non-core libs (lazy-loaded after first interaction) -->

--- a/public/css/living-workspace.css
+++ b/public/css/living-workspace.css
@@ -681,3 +681,80 @@ html[data-theme="dark"] .lws-root {
   text-decoration: underline; text-underline-offset: 2px;
 }
 .lws-dv-ov-sum-src:focus-visible { outline: 2px solid var(--lws-accent); outline-offset: 2px; }
+
+/* ── learning notebook on the board (spec §15) ─────────────────
+   The 📓 pill sits bottom-right (materials dock is bottom-left); the
+   overlay follows the same covers-never-replaces contract as the rest. */
+.lws-nb-btn {
+  position: absolute; right: 10px; bottom: 10px; z-index: 5;
+  appearance: none; -webkit-appearance: none; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 5px 11px; border: 1px solid var(--lws-card-border); border-radius: 999px;
+  background: color-mix(in srgb, var(--lws-card-bg) 88%, transparent);
+  color: var(--lws-card-ink); font: 600 11px/1 system-ui, sans-serif;
+  -webkit-backdrop-filter: blur(6px); backdrop-filter: blur(6px);
+}
+.lws-nb-btn:hover { border-color: var(--lws-accent); }
+.lws-nb-btn:focus-visible { outline: 2px solid var(--lws-accent); outline-offset: 2px; }
+
+.lws-nb-ov {
+  position: absolute; inset: 0; z-index: 8;
+  display: flex; flex-direction: column;
+  background: var(--lws-grid-bg);
+  animation: lws-dv-ov-in .18s ease-out both;
+}
+@media (prefers-reduced-motion: reduce) { .lws-nb-ov { animation: none; } }
+
+.lws-nb-tools {
+  flex: 0 0 auto; display: flex; flex-wrap: wrap; align-items: center; gap: 8px;
+  padding: 10px 12px; border-bottom: 1px solid var(--lws-card-border);
+}
+.lws-nb-search {
+  flex: 1 1 220px; min-width: 160px;
+  padding: 8px 12px; border: 1px solid var(--lws-card-border); border-radius: 10px;
+  background: var(--lws-card-bg); color: var(--lws-card-ink);
+  font: 400 13px/1.2 system-ui, sans-serif;
+}
+.lws-nb-search:focus-visible { outline: 2px solid var(--lws-accent); outline-offset: 1px; }
+.lws-nb-chips { display: flex; gap: 6px; }
+.lws-nb-chip {
+  appearance: none; -webkit-appearance: none; cursor: pointer;
+  padding: 6px 11px; border: 1px solid var(--lws-card-border); border-radius: 999px;
+  background: var(--lws-card-bg); color: var(--lws-card-ink);
+  font: 600 11px/1 system-ui, sans-serif;
+}
+.lws-nb-chip.is-on { border-color: var(--lws-accent); background: color-mix(in srgb, var(--lws-accent) 16%, var(--lws-card-bg)); }
+.lws-nb-chip:focus-visible { outline: 2px solid var(--lws-accent); outline-offset: 2px; }
+
+.lws-nb-body {
+  flex: 1 1 auto; min-height: 0; overflow-y: auto;
+  padding: 12px; display: grid; gap: 10px;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  align-content: start;
+  font: 400 13px/1.45 system-ui, sans-serif;
+}
+.lws-nb-empty {
+  grid-column: 1 / -1; text-align: center; padding: 34px 16px;
+  color: var(--lws-card-ink); opacity: .7;
+}
+.lws-nb-card {
+  border: 1px solid var(--lws-card-border); border-left: 3px solid var(--lws-accent);
+  border-radius: 12px; padding: 10px 12px;
+  background: var(--lws-card-bg); color: var(--lws-card-ink);
+}
+.lws-nb-card.is-aha { border-left-color: #e8b64c; }
+.lws-nb-card.is-reminder { border-left-color: #e0a23c; }
+.lws-nb-card-head { display: flex; align-items: baseline; gap: 8px; }
+.lws-nb-card-kind { font: 600 10px/1 system-ui, sans-serif; letter-spacing: .1em; text-transform: uppercase; opacity: .75; }
+.lws-nb-card-when { margin-left: auto; font-size: 10px; opacity: .55; }
+.lws-nb-card-del {
+  appearance: none; -webkit-appearance: none; cursor: pointer;
+  border: none; background: transparent; color: var(--lws-card-ink);
+  font: 600 12px/1 system-ui, sans-serif; opacity: .45; padding: 2px 4px;
+}
+.lws-nb-card-del:hover { opacity: 1; }
+.lws-nb-card-del:focus-visible { outline: 2px solid var(--lws-accent); outline-offset: 2px; opacity: 1; }
+.lws-nb-card-title { margin: 6px 0 2px; font: 700 14px/1.3 system-ui, sans-serif; }
+.lws-nb-card-body { margin: 4px 0 0; white-space: pre-line; }
+.lws-nb-card-prob { margin: 6px 0 0; font-size: 12px; opacity: .7; overflow-wrap: anywhere; }
+.lws-nb-card-seen { margin: 6px 0 0; font: 600 11px/1 system-ui, sans-serif; color: #e0a23c; }

--- a/public/js/living-workspace/chat-workspace.js
+++ b/public/js/living-workspace/chat-workspace.js
@@ -75,12 +75,12 @@
   // public/ with a 7-day cache and no content hashing, so bump this whenever
   // any living-workspace asset changes (and the chat.html <script ?v=> tag to
   // match, so this file itself refreshes). See project_asset_cache_busting.
-  var ASSET_V = '?v=20260725e';
+  var ASSET_V = '?v=20260725f';
   var BASE = '/js/living-workspace/';
   var SCRIPTS = [
     'core/flags.js', 'core/viewport.js', 'core/elementRegistry.js',
     'core/snapshotManager.js', 'core/a11yCommands.js', 'core/ledgerReplay.js',
-    'core/sourceList.js', 'dom/sourceDock.js',
+    'core/sourceList.js', 'dom/sourceDock.js', 'dom/notebookPanel.js',
     'dom/gridRenderer.js', 'dom/overlayManager.js', 'dom/equationElement.js',
     'dom/tileElement.js', 'dom/numberLineElement.js', 'dom/graphElement.js',
     'dom/noteElement.js', 'dom/imageElement.js', 'dom/studentMoveClient.js',
@@ -361,6 +361,9 @@
       dv = new window.LWS.DerivationView(mount, { renderers: makeRenderers(), onOpenSource: openLinkedSource });
       if (window.LWS.SourceDock) {
         try { dock = new window.LWS.SourceDock(mount, { onAskRegion: askAboutRegion }); } catch (e) { console.error('[LWS_CHAT] dock mount failed', e); }
+      }
+      if (window.LWS.NotebookPanel) {
+        try { new window.LWS.NotebookPanel(mount); } catch (e) { console.error('[LWS_CHAT] notebook mount failed', e); }
       }
       ready = true;
       if (pendingSources !== undefined) { var ps = pendingSources; pendingSources = undefined; api.setSourcesFromMessages(ps); }

--- a/public/js/living-workspace/dom/notebookPanel.js
+++ b/public/js/living-workspace/dom/notebookPanel.js
@@ -1,0 +1,214 @@
+/* ============================================================
+   notebookPanel.js — the learning notebook ON the board (spec §15).
+
+   A "📓 Notebook" pill pinned to the board's bottom-right (opposite the
+   materials dock) opens a full-board overlay of the student's learning
+   cards — AHA moments in their own words, "Watch for This" reminders,
+   and, as capture grows, ideas/strategies/reflections. Searchable
+   ("negative sign", "slope") and filterable by kind; cards can be
+   removed (soft archive) without touching the evidence trail.
+
+   Reads GET /api/notebook (own cards only; auth server-side). Same
+   overlay contract as the source viewer and the archive rail: it covers
+   the board, never replaces it; Esc or Back returns to the work.
+   Browser-only view.
+   ============================================================ */
+(function (root) {
+  'use strict';
+  var LWS = (root.LWS = root.LWS || {});
+
+  var TYPE_META = {
+    aha: { icon: '✨', label: 'AHA moments' },
+    reminder: { icon: '📌', label: 'Watch for This' },
+    idea: { icon: '💡', label: 'Ideas' },
+    strategy: { icon: '🧭', label: 'Strategies' },
+    reflection: { icon: '🪞', label: 'Reflections' },
+  };
+  var FILTERS = [
+    { key: '', icon: '📓', label: 'Everything' },
+    { key: 'aha', icon: '✨', label: 'AHA' },
+    { key: 'reminder', icon: '📌', label: 'Reminders' },
+  ];
+
+  function NotebookPanel(container) {
+    this.doc = container.ownerDocument || document;
+    this._overlay = null;
+    this._escHandler = null;
+    this._type = '';
+    this._q = '';
+
+    var d = this.doc;
+    var btn = d.createElement('button');
+    btn.type = 'button';
+    btn.className = 'lws-nb-btn';
+    btn.innerHTML = '<span aria-hidden="true">📓</span><span>Notebook</span>';
+    btn.setAttribute('aria-label', 'Open my learning notebook');
+    var self = this;
+    btn.addEventListener('click', function () { self.open(); });
+    container.appendChild(btn);
+    this.el = { container: container, btn: btn };
+  }
+
+  NotebookPanel.prototype._fetch = function (cb) {
+    var params = new URLSearchParams();
+    if (this._type) params.set('type', this._type);
+    if (this._q) params.set('q', this._q);
+    var url = '/api/notebook' + (params.toString() ? '?' + params.toString() : '');
+    fetch(url, { credentials: 'include' })
+      .then(function (r) { return r.ok ? r.json() : { cards: [] }; })
+      .then(function (data) { cb(Array.isArray(data.cards) ? data.cards : []); })
+      .catch(function (err) { console.error('[LWS] notebook fetch failed', err); cb([]); });
+  };
+
+  NotebookPanel.prototype.open = function () {
+    this.close();
+    var self = this;
+    var d = this.doc;
+
+    var ov = d.createElement('div');
+    ov.className = 'lws-nb-ov';
+    ov.setAttribute('role', 'dialog');
+    ov.setAttribute('aria-modal', 'false');
+    ov.setAttribute('aria-label', 'My learning notebook');
+
+    var bar = d.createElement('div'); bar.className = 'lws-sd-ov-bar';
+    var tag = d.createElement('span'); tag.className = 'lws-sd-ov-tag'; tag.textContent = 'My notebook';
+    var back = d.createElement('button');
+    back.type = 'button'; back.className = 'lws-sd-ov-back';
+    back.textContent = 'Back to my work';
+    back.addEventListener('click', function () { self.close(); });
+    bar.appendChild(tag); bar.appendChild(back);
+
+    var tools = d.createElement('div'); tools.className = 'lws-nb-tools';
+    var search = d.createElement('input');
+    search.type = 'search';
+    search.className = 'lws-nb-search';
+    search.placeholder = 'Search… ("negative sign", "slope")';
+    search.setAttribute('aria-label', 'Search my notebook');
+    var debounce = null;
+    search.addEventListener('input', function () {
+      if (debounce) clearTimeout(debounce);
+      debounce = setTimeout(function () { self._q = search.value.trim(); self._reload(); }, 250);
+    });
+    tools.appendChild(search);
+
+    var chips = d.createElement('div'); chips.className = 'lws-nb-chips';
+    chips.setAttribute('role', 'group'); chips.setAttribute('aria-label', 'Filter by kind');
+    FILTERS.forEach(function (f) {
+      var c = d.createElement('button');
+      c.type = 'button';
+      c.className = 'lws-nb-chip' + (self._type === f.key ? ' is-on' : '');
+      c.textContent = f.icon + ' ' + f.label;
+      c.setAttribute('aria-pressed', self._type === f.key ? 'true' : 'false');
+      c.addEventListener('click', function () {
+        self._type = f.key;
+        var all = chips.querySelectorAll('.lws-nb-chip');
+        for (var i = 0; i < all.length; i++) { all[i].classList.remove('is-on'); all[i].setAttribute('aria-pressed', 'false'); }
+        c.classList.add('is-on'); c.setAttribute('aria-pressed', 'true');
+        self._reload();
+      });
+      chips.appendChild(c);
+    });
+    tools.appendChild(chips);
+
+    var body = d.createElement('div'); body.className = 'lws-nb-body';
+    body.setAttribute('aria-live', 'polite');
+
+    ov.appendChild(bar); ov.appendChild(tools); ov.appendChild(body);
+    this.el.container.appendChild(ov);
+    this._overlay = ov;
+    this._body = body;
+    this._escHandler = function (ev) { if (ev.key === 'Escape') self.close(); };
+    d.addEventListener('keydown', this._escHandler);
+    try { search.focus(); } catch (_) { /* fine */ }
+
+    this._reload();
+  };
+
+  NotebookPanel.prototype._reload = function () {
+    var self = this;
+    var body = this._body;
+    if (!body) return;
+    body.textContent = 'Loading…';
+    this._fetch(function (cards) {
+      if (!self._body) return;   // closed mid-flight
+      self._renderCards(cards);
+    });
+  };
+
+  NotebookPanel.prototype._renderCards = function (cards) {
+    var self = this;
+    var d = this.doc;
+    var body = this._body;
+    body.textContent = '';
+
+    if (!cards.length) {
+      var empty = d.createElement('div');
+      empty.className = 'lws-nb-empty';
+      empty.textContent = this._q || this._type
+        ? 'Nothing here matches — try a different search.'
+        : 'Your AHA moments and reminders will collect here as you work.';
+      body.appendChild(empty);
+      return;
+    }
+
+    cards.forEach(function (card) {
+      var meta = TYPE_META[card.type] || { icon: '📓', label: card.type };
+      var el = d.createElement('article');
+      el.className = 'lws-nb-card is-' + card.type;
+
+      var head = d.createElement('div'); head.className = 'lws-nb-card-head';
+      var kind = d.createElement('span'); kind.className = 'lws-nb-card-kind';
+      kind.textContent = meta.icon + ' ' + meta.label;
+      var when = d.createElement('span'); when.className = 'lws-nb-card-when';
+      try { when.textContent = new Date(card.createdAt).toLocaleDateString(); } catch (_) { /* fine */ }
+      var del = d.createElement('button');
+      del.type = 'button'; del.className = 'lws-nb-card-del';
+      del.textContent = '✕';
+      del.setAttribute('aria-label', 'Remove this card from my notebook');
+      del.addEventListener('click', function () {
+        var csrfFetchFn = root.csrfFetch || fetch;
+        csrfFetchFn('/api/notebook/' + encodeURIComponent(card._id) + '/archive', { method: 'PATCH', credentials: 'include' })
+          .then(function () { if (el.parentNode) el.parentNode.removeChild(el); })
+          .catch(function (err) { console.error('[LWS] archive card failed', err); });
+      });
+      head.appendChild(kind); head.appendChild(when); head.appendChild(del);
+
+      var title = d.createElement('h3'); title.className = 'lws-nb-card-title';
+      title.textContent = card.title || '';
+
+      el.appendChild(head);
+      el.appendChild(title);
+      if (card.body) {
+        var bodyEl = d.createElement('p'); bodyEl.className = 'lws-nb-card-body';
+        bodyEl.textContent = card.body;
+        el.appendChild(bodyEl);
+      }
+      if (card.problemTex) {
+        var prob = d.createElement('p'); prob.className = 'lws-nb-card-prob';
+        prob.textContent = 'Problem: ' + card.problemTex;
+        el.appendChild(prob);
+      }
+      if (card.type === 'reminder' && (card.seenCount || 0) >= 2) {
+        var seen = d.createElement('p'); seen.className = 'lws-nb-card-seen';
+        seen.textContent = 'Spotted ' + card.seenCount + ' times';
+        el.appendChild(seen);
+      }
+      body.appendChild(el);
+    });
+    void self;
+  };
+
+  NotebookPanel.prototype.close = function () {
+    if (this._escHandler) {
+      this.doc.removeEventListener('keydown', this._escHandler);
+      this._escHandler = null;
+    }
+    if (this._overlay && this._overlay.parentNode) this._overlay.parentNode.removeChild(this._overlay);
+    this._overlay = null;
+    this._body = null;
+  };
+
+  LWS.NotebookPanel = NotebookPanel;
+  if (typeof module !== 'undefined' && module.exports) module.exports = { NotebookPanel: NotebookPanel };
+})(typeof self !== 'undefined' ? self : this);

--- a/routes/notebook.js
+++ b/routes/notebook.js
@@ -19,10 +19,25 @@ const logger = require('../utils/logger').child({ route: 'notebook' });
 
 const TYPES = ['aha', 'reminder', 'idea', 'strategy', 'reflection'];
 
+// Text search over a student's own cards (spec §15: "Show me where I learned
+// slope", "find a problem where I lost a negative sign"). Plain escaped-regex
+// matching for now — semantic search can swap in behind the same param.
+function escapeRegex(s) {
+  return String(s == null ? '' : s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+function buildSearchClause(q) {
+  const term = String(q == null ? '' : q).trim().slice(0, 120);
+  if (!term) return null;
+  const rx = new RegExp(escapeRegex(term), 'i');
+  return { $or: [{ title: rx }, { body: rx }, { quote: rx }, { skillId: rx }, { problemTex: rx }] };
+}
+
 router.get('/', isAuthenticated, async (req, res) => {
   try {
     const query = { userId: req.user._id, archived: false };
     if (req.query.type && TYPES.includes(req.query.type)) query.type = req.query.type;
+    const search = buildSearchClause(req.query.q);
+    if (search) Object.assign(query, search);
     const limit = Math.min(100, Math.max(1, parseInt(req.query.limit, 10) || 50));
 
     const cards = await LearningCard.find(query)
@@ -52,5 +67,8 @@ router.patch('/:id/archive', isAuthenticated, async (req, res) => {
     res.status(500).json({ message: 'Failed to archive card' });
   }
 });
+
+// Pure helpers reachable from unit tests (same pattern as practicePack).
+router.__helpers = { escapeRegex, buildSearchClause };
 
 module.exports = router;

--- a/tests/unit/notebookSearch.test.js
+++ b/tests/unit/notebookSearch.test.js
@@ -1,0 +1,35 @@
+/**
+ * Notebook search clause (routes/notebook.js, spec §15).
+ *
+ * Student-typed queries become escaped regexes over their own cards —
+ * regex metacharacters must be literals, and an empty query means no clause.
+ */
+const router = require('../../routes/notebook');
+const { escapeRegex, buildSearchClause } = router.__helpers;
+
+describe('escapeRegex', () => {
+  test('regex metacharacters become literals', () => {
+    expect(new RegExp(escapeRegex('2x+5=13 (step?)'), 'i').test('does 2x+5=13 (step?) work')).toBe(true);
+    expect(escapeRegex('a.b*c')).toBe('a\\.b\\*c');
+  });
+});
+
+describe('buildSearchClause', () => {
+  test('empty / whitespace queries produce no clause', () => {
+    expect(buildSearchClause('')).toBeNull();
+    expect(buildSearchClause('   ')).toBeNull();
+    expect(buildSearchClause(null)).toBeNull();
+  });
+
+  test('a real query ORs across the student-visible fields', () => {
+    const clause = buildSearchClause('negative sign');
+    const fields = clause.$or.map(o => Object.keys(o)[0]);
+    expect(fields).toEqual(['title', 'body', 'quote', 'skillId', 'problemTex']);
+    expect(clause.$or[0].title.test('Watch for This: losing a NEGATIVE SIGN')).toBe(true);
+  });
+
+  test('queries cap at 120 chars (no regex DoS via huge input)', () => {
+    const clause = buildSearchClause('x'.repeat(500));
+    expect(clause.$or[0].title.source.length).toBeLessThanOrEqual(120);
+  });
+});


### PR DESCRIPTION
Seventh Live Workspace slice: the notebook's student-facing front. #1304 made the pipeline *fill* the notebook; this makes it a place students actually visit. ([Spec §15](https://github.com/jnappier7/mathmatix-ai/blob/main/docs/LIVE_WORKSPACE_REQUIREMENTS.md).)

## What the student gets

- A **"📓 Notebook" pill** pinned to the board's bottom-right (the materials dock owns bottom-left). Opens a full-board overlay — same covers-never-replaces contract as every other Live Workspace surface; Esc or "Back to my work" returns.
- **Their cards, in their words**: ✨ AHA moments lead with the student's own quote; 📌 reminders show the supportive "Watch for This" framing plus an honest "Spotted 3 times" count. Card grid, color-coded by kind, dated.
- **Search that matches the spec's examples**: type "negative sign" or "slope" and matching cards surface — escaped-regex over title/body/quote/skill/problem (capped input, so no regex-DoS), debounced as they type. Type filters: Everything / AHA / Reminders.
- **Soft remove** (✕): archives the card server-side — gone from the notebook, evidence trail intact.

## Notes

- The `?q=` param is the seam for semantic search later — the UI won't change when the backend gets smarter.
- Idea/Strategy/Reflection kinds already render if cards exist (schema-ready since #1304); filters stay minimal until capture exists.

## Verification

- Full suite **4662 passed**, lint clean. New tests: regex escaping (metacharacters as literals), search clause field coverage, empty-query null, input cap.
- Manual QA: after earning an AHA (see #1304's QA loop), open 📓 → card is there with the quote → search a word from it → filters down → ✕ removes it → `GET /api/notebook` no longer returns it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)