### PR TITLE
fix(mastery): credit a verified solve even when currentTarget is transiently null

### DIFF
--- a/tests/unit/recentPracticeSkill.test.js
+++ b/tests/unit/recentPracticeSkill.test.js
@@ -1,0 +1,40 @@
+const { recentPracticeSkillId } = require('../../utils/tutorPlanManager');
+
+// Attribution fallback: when currentTarget is transiently null, a verified solve
+// should still credit the skill the student is plainly working on — the most
+// recently worked in-progress focus entry.
+describe('recentPracticeSkillId', () => {
+  it('returns the most-recently-worked in-progress skill', () => {
+    const plan = {
+      skillFocus: [
+        { skillId: 'MS.QNT.8', status: 'in-progress', lastWorkedOn: '2026-07-23T15:00:00Z' },
+        { skillId: 'ALG1.EQV.1', status: 'in-progress', lastWorkedOn: '2026-07-20T10:00:00Z' },
+        { skillId: 'GEO.CON.2', status: 'active', lastWorkedOn: '2026-07-10T10:00:00Z' },
+      ],
+    };
+    expect(recentPracticeSkillId(plan)).toBe('MS.QNT.8');
+  });
+
+  it('ignores resolved / deferred entries', () => {
+    const plan = {
+      skillFocus: [
+        { skillId: 'MASTERED.1', status: 'resolved', lastWorkedOn: '2026-07-25T00:00:00Z' },
+        { skillId: 'DEFERRED.1', status: 'deferred', lastWorkedOn: '2026-07-25T00:00:00Z' },
+        { skillId: 'MS.QNT.8', status: 'in-progress', lastWorkedOn: '2026-07-01T00:00:00Z' },
+      ],
+    };
+    expect(recentPracticeSkillId(plan)).toBe('MS.QNT.8');
+  });
+
+  it('returns null when nothing is in progress', () => {
+    expect(recentPracticeSkillId({ skillFocus: [{ skillId: 'X', status: 'resolved' }] })).toBeNull();
+    expect(recentPracticeSkillId({ skillFocus: [] })).toBeNull();
+    expect(recentPracticeSkillId({})).toBeNull();
+    expect(recentPracticeSkillId(null)).toBeNull();
+  });
+
+  it('falls back to an entry with no lastWorkedOn when it is the only candidate', () => {
+    const plan = { skillFocus: [{ skillId: 'MS.QNT.8', status: 'in-progress' }] };
+    expect(recentPracticeSkillId(plan)).toBe('MS.QNT.8');
+  });
+});

--- a/utils/pipeline/index.js
+++ b/utils/pipeline/index.js
@@ -42,7 +42,7 @@ const { updateCard, initializeCard, rateAttempt, RATINGS } = require('../fsrsSch
 const { recordAttempt: recordConsistencyAttempt, initializeScore, categorizeDifficulty } = require('../consistencyScorer');
 
 // Backbone: Tutor Plan + Skill Familiarity
-const { loadOrCreatePlan, resolveCurrentTarget, updatePlanAfterInteraction, advanceInstructionPhase } = require('../tutorPlanManager');
+const { loadOrCreatePlan, resolveCurrentTarget, updatePlanAfterInteraction, advanceInstructionPhase, recentPracticeSkillId } = require('../tutorPlanManager');
 const { buildPlanLayer, shouldSuppressSocratic } = require('../promptPlanLayer');
 const { reassessFamiliarity } = require('../phaseEvidenceEvaluator');
 const { detectModeTransition } = require('../modeTransitionDetector');
@@ -1310,7 +1310,18 @@ async function runPipeline(message, ctx) {
     // directly keyed BKT/FSRS/SmartScore state under "undefined" whenever activeSkill
     // lacked a skillId but a target existed — so a whole session's mastery evidence
     // pooled into one bogus bucket instead of the skill being taught.
-    const engineSkillId = ctx.activeSkill?.skillId || tutorPlan?.currentTarget?.skillId;
+    const resolvedSkillId = ctx.activeSkill?.skillId || tutorPlan?.currentTarget?.skillId || null;
+    // Resilience (mode-A attribution): currentTarget goes transiently null — it's
+    // cleared when a skill reads as mastered (tutorPlanManager) and isn't re-set on
+    // a turn that resolves no skill. On such a turn a clean, verified solve would
+    // credit NOTHING and the progress bar wouldn't move. So fall back to the skill
+    // the student is plainly working on: the most-recently-worked in-progress skill
+    // in the plan. The verified-attempt gate below is unchanged, so this only ever
+    // routes a real completed problem to a real in-progress skill — never invents one.
+    const engineSkillId = resolvedSkillId || recentPracticeSkillId(tutorPlan);
+    if (!resolvedSkillId && engineSkillId) {
+      console.log(`[Pipeline] Attribution fallback: crediting to in-progress skill "${engineSkillId}" (no active target this turn)`);
+    }
     // The verified answer feeds skillMastery's pillars/rung too, not just BKT.
     // This replaces the disabled <SKILL_MASTERED> tag path — without it, chat
     // practice never advanced skillMastery and the progress card sat frozen.

--- a/utils/tutorPlanManager.js
+++ b/utils/tutorPlanManager.js
@@ -197,6 +197,26 @@ function getHighestPrioritySkill(plan) {
 }
 
 /**
+ * The skill the student is most likely working on RIGHT NOW: the active/in-progress
+ * focus entry with the most recent lastWorkedOn. Used as an attribution fallback
+ * when currentTarget is transiently null so a verified completed problem still
+ * credits the right skill instead of silently crediting nothing. Priority-order
+ * (getHighestPrioritySkill) answers "what's next"; this answers "what's now".
+ */
+function recentPracticeSkillId(plan) {
+  const focus = plan?.skillFocus;
+  if (!Array.isArray(focus)) return null;
+  let bestId = null;
+  let bestT = -1;
+  for (const sf of focus) {
+    if (!sf?.skillId || (sf.status !== 'in-progress' && sf.status !== 'active')) continue;
+    const t = sf.lastWorkedOn ? new Date(sf.lastWorkedOn).getTime() : 0;
+    if (t > bestT) { bestT = t; bestId = sf.skillId; }
+  }
+  return bestId;
+}
+
+/**
  * Determine the instruction phase for INSTRUCT mode.
  *
  * If the target hasn't changed and we were already in an instruction sequence,
@@ -400,4 +420,5 @@ module.exports = {
   advanceInstructionPhase,
   updatePlanAfterInteraction,
   addSkillToFocus,
+  recentPracticeSkillId,
 };


### PR DESCRIPTION
## Problem (mode-A attribution)
Free-chat crediting has a single skill signal — `tutorPlan.currentTarget.skillId` (`ctx.activeSkill` is null without an active badge). `currentTarget` is cleared when a skill reads as mastered and isn't re-set on a turn that resolves no skill, so a **clean, verified solve on such a turn credits nothing** and the progress bar doesn't move. This is the second half of the "8 sessions → 2 attempts" gap (the first half — unverifiable multi-step work — is #1307).

## Fix
- `tutorPlanManager.recentPracticeSkillId(plan)`: the active/in-progress focus entry with the most recent `lastWorkedOn` — "what the student is on right now."
- Use it as the fallback in the pipeline's `engineSkillId` resolution (`activeSkill → currentTarget → recentPractice`). The verified-attempt gate is unchanged, so this only routes a **real completed problem** to a **real in-progress skill** — it never invents attribution.

## Tests
`recentPracticeSkill.test.js` (most-recent wins; ignores resolved/deferred; null when nothing in progress). Pipeline suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)