### PR TITLE
feat(lws): concept models render on the Living Workspace board (spec §6.8)

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -133,7 +133,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
        LivingWorkspace flag is dev|beta|live (?livingWorkspace=dev). When on,
        it lazy-loads the workspace and mirrors the tutor's board output onto
        the new surface beside the old board. Default OFF → zero impact. -->
-  <script defer src="/js/living-workspace/chat-workspace.js?v=20260725f"></script>
+  <script defer src="/js/living-workspace/chat-workspace.js?v=20260725g"></script>
   <!-- Final safety net: strips any inline visual tag no renderer handled -->
   <script defer src="/js/stripVisualTags.js"></script>
   <!-- Non-core libs (lazy-loaded after first interaction) -->

--- a/public/css/living-workspace.css
+++ b/public/css/living-workspace.css
@@ -758,3 +758,10 @@ html[data-theme="dark"] .lws-root {
 .lws-nb-card-body { margin: 4px 0 0; white-space: pre-line; }
 .lws-nb-card-prob { margin: 6px 0 0; font-size: 12px; opacity: .7; overflow-wrap: anywhere; }
 .lws-nb-card-seen { margin: 6px 0 0; font: 600 11px/1 system-ui, sans-serif; color: #e0a23c; }
+
+/* ── interactive concept models embedded in the derivation (§6.8) ── */
+.lws-model { width: 100%; max-width: 560px; }
+.lws-model-unavailable {
+  padding: 10px 12px; border: 1px dashed var(--lws-card-border); border-radius: 10px;
+  color: var(--lws-card-ink); opacity: .7; font: 400 13px/1.4 system-ui, sans-serif;
+}

--- a/public/js/living-workspace/chat-workspace.js
+++ b/public/js/living-workspace/chat-workspace.js
@@ -75,12 +75,12 @@
   // public/ with a 7-day cache and no content hashing, so bump this whenever
   // any living-workspace asset changes (and the chat.html <script ?v=> tag to
   // match, so this file itself refreshes). See project_asset_cache_busting.
-  var ASSET_V = '?v=20260725f';
+  var ASSET_V = '?v=20260725g';
   var BASE = '/js/living-workspace/';
   var SCRIPTS = [
     'core/flags.js', 'core/viewport.js', 'core/elementRegistry.js',
     'core/snapshotManager.js', 'core/a11yCommands.js', 'core/ledgerReplay.js',
-    'core/sourceList.js', 'dom/sourceDock.js', 'dom/notebookPanel.js',
+    'core/sourceList.js', 'dom/sourceDock.js', 'dom/notebookPanel.js', 'dom/modelElement.js',
     'dom/gridRenderer.js', 'dom/overlayManager.js', 'dom/equationElement.js',
     'dom/tileElement.js', 'dom/numberLineElement.js', 'dom/graphElement.js',
     'dom/noteElement.js', 'dom/imageElement.js', 'dom/studentMoveClient.js',
@@ -216,6 +216,9 @@
     else if (window.LWS.NoteElement) r.image = window.LWS.NoteElement.makeRenderer();
     // Geometry (P17): titled note card until a real figure renderer lands.
     if (window.LWS.NoteElement) r.geometry = window.LWS.NoteElement.makeRenderer();
+    // Interactive concept models (§6.8) — bridges to the page's
+    // ConceptModelRenderer engine (JSXGraph/tokens, linked representations).
+    if (window.LWS.ModelElement) r.model = window.LWS.ModelElement.makeRenderer();
     return r;
   }
 

--- a/public/js/living-workspace/dom/legacyBoardAdapter.js
+++ b/public/js/living-workspace/dom/legacyBoardAdapter.js
@@ -22,7 +22,7 @@
   // not load the shared constants module).
   const ELEMENT_TYPES = {
     EQUATION: 'equation', ALGEBRA_TILES: 'algebra_tiles', NUMBER_LINE: 'number_line',
-    GRAPH: 'graph', GEOMETRY: 'geometry', IMAGE: 'image',
+    GRAPH: 'graph', GEOMETRY: 'geometry', IMAGE: 'image', MODEL: 'model',
   };
 
   const COL_X = 60, START_Y = 40, STEP_Y = 120;
@@ -47,6 +47,9 @@
       case 'graph':    return cmd.fn  ? { type: ELEMENT_TYPES.GRAPH, semantic: Object.assign({ fn: cmd.fn }, cmd.caption ? { caption: cmd.caption } : null) } : null;
       case 'image':    return cmd.query ? { type: ELEMENT_TYPES.IMAGE, semantic: Object.assign({ query: cmd.query }, cmd.caption ? { caption: cmd.caption } : null) } : null;
       case 'diagram':  return (cmd.diagram_type || cmd.diagram_params) ? { type: ELEMENT_TYPES.GEOMETRY, semantic: { diagramType: cmd.diagram_type || null, params: cmd.diagram_params || null } } : null;
+      // Interactive concept model (CONCEPT_MODELS): a curated name OR a full
+      // spec (JSON string, validated client-side before it can render).
+      case 'model':    return (cmd.model || cmd.spec) ? { type: ELEMENT_TYPES.MODEL, semantic: { model: cmd.model || null, spec: cmd.spec || null, prompt: cmd.prompt || cmd.caption || null } } : null;
       default:         return null;
     }
   }
@@ -65,7 +68,7 @@
       if (!mapped) {
         result.unmapped.push({
           action: cmd.action,
-          reason: (cmd.action === 'model' || cmd.action === 'spec') ? 'no-workspace-element-yet' : 'empty-or-unsupported',
+          reason: 'empty-or-unsupported',
         });
         continue;
       }

--- a/public/js/living-workspace/dom/modelElement.js
+++ b/public/js/living-workspace/dom/modelElement.js
@@ -1,0 +1,65 @@
+/* ============================================================
+   modelElement.js — interactive concept models on the Living Workspace
+   board (spec §6.8: linked representations are mandatory, not optional).
+
+   The `model` board verb (CONCEPT_MODELS) carries either a curated model
+   name ("slope_intercept_line") or a full spec (JSON string, validated
+   before it may render). The engine already lives on the chat page —
+   window.ConceptModelRenderer (JSXGraph substrate, lazy-loaded) +
+   window.ConceptModelTokenRenderer (discrete chips) — and does the real
+   work: sliders, draggable points, equation readouts, all reading and
+   writing one shared parameter state. This element is the thin bridge
+   that lets the DerivationView embed it as a block.
+
+   Until this file, the P5 adapter DROPPED model commands with
+   'no-workspace-element-yet' — the interactives died at the door of the
+   new board even with the flag on. Browser-only view; parseSpec is pure
+   and exported for tests.
+   ============================================================ */
+(function (root) {
+  'use strict';
+  var LWS = (root.LWS = root.LWS || {});
+
+  // The structured path ships specs as JSON STRINGS (schema constraint);
+  // tolerate an already-parsed object so both paths land here safely.
+  function parseSpec(raw) {
+    if (!raw) return null;
+    if (typeof raw === 'object') return raw;
+    try { return JSON.parse(raw); } catch (_) { return null; }
+  }
+
+  function makeRenderer() {
+    return function (element, ctx) {
+      var host = ctx && ctx.host;
+      var d = (host && host.ownerDocument) || document;
+      var node = d.createElement('div');
+      node.className = 'lws-model';
+      node.setAttribute('role', 'group');
+      node.setAttribute('aria-label', 'Interactive math model');
+
+      var sem = (element && element.semantic) || {};
+      var subject = sem.model || parseSpec(sem.spec);
+      var CMR = root.ConceptModelRenderer;
+
+      if (!subject || !CMR || typeof CMR.renderModel !== 'function') {
+        // Engine not on this page or nothing renderable — degrade to a quiet
+        // placeholder rather than a broken block.
+        node.className += ' lws-model-unavailable';
+        node.textContent = sem.prompt || 'Interactive model unavailable here.';
+      } else {
+        // renderModel validates the spec itself and paints its own error
+        // states; it lazy-loads JSXGraph only when a model actually draws.
+        try { CMR.renderModel(node, subject, { prompt: sem.prompt || null }); }
+        catch (e) { console.error('[LWS] concept model render failed', e); node.textContent = 'Interactive model error.'; }
+      }
+
+      return {
+        node: node,
+        destroy: function () { try { node.innerHTML = ''; } catch (_) { /* detached */ } },
+      };
+    };
+  }
+
+  LWS.ModelElement = { makeRenderer: makeRenderer, parseSpec: parseSpec };
+  if (typeof module !== 'undefined' && module.exports) module.exports = { makeRenderer: makeRenderer, parseSpec: parseSpec };
+})(typeof self !== 'undefined' ? self : this);

--- a/shared/workspace/constants/elementTypes.js
+++ b/shared/workspace/constants/elementTypes.js
@@ -14,6 +14,8 @@ const ELEMENT_TYPES = Object.freeze({
   GRAPH:         'graph',          // draggable handles — P14 (AFTER visual-gate extension)
   GEOMETRY:      'geometry',       // narrow models only — P17
   IMAGE:         'image',          // pinned upload — P15
+  MODEL:         'model',          // interactive concept model (JSXGraph/tokens,
+                                   // CONCEPT_MODELS catalog) — linked representations, §6.8
 });
 
 const ELEMENT_TYPE_LIST = Object.freeze(Object.values(ELEMENT_TYPES));

--- a/shared/workspace/legacyBoardAdapter.js
+++ b/shared/workspace/legacyBoardAdapter.js
@@ -14,9 +14,10 @@
      - It does NOT re-run the safety gauntlet. Guards / visual-gate /
        mirror-rule already ran UPSTREAM on the board_commands before they
        reached here; this only re-expresses already-approved content.
-     - It NEVER silently drops a command it can't map (e.g. concept
-       `model` cards, which have no workspace element yet) — those are
+     - It NEVER silently drops a command it can't map — those are
        reported in `unmapped` so coverage gaps are visible, not hidden.
+       (Concept `model` cards map to ELEMENT_TYPES.MODEL as of §6.8;
+       dom/modelElement.js renders them via ConceptModelRenderer.)
      - Elements are `provisional:false`: legacy content is tutor-authored
        and already verified; the provisional/"?" state is reserved for
        unverified STUDENT moves (spec §3.4).
@@ -85,8 +86,14 @@ function mapCommand(cmd) {
       return (cmd.diagram_type || cmd.diagram_params)
         ? { type: ELEMENT_TYPES.GEOMETRY, semantic: { diagramType: cmd.diagram_type || null, params: cmd.diagram_params || null } }
         : null;
+    case 'model':
+      // Interactive concept model (CONCEPT_MODELS): a curated name OR a full
+      // spec (JSON string, validated client-side before it can render).
+      return (cmd.model || cmd.spec)
+        ? { type: ELEMENT_TYPES.MODEL, semantic: { model: cmd.model || null, spec: cmd.spec || null, prompt: cmd.prompt || cmd.caption || null } }
+        : null;
     default:
-      return null; // 'clear' is a directive (handled by caller); 'model'/'spec' have no element yet
+      return null; // 'clear' is a directive (handled by caller)
   }
 }
 
@@ -119,9 +126,7 @@ function adaptBoardCommands(commands, opts) {
     if (!mapped) {
       result.unmapped.push({
         action: cmd.action,
-        reason: (cmd.action === 'model' || cmd.action === 'spec')
-          ? 'no-workspace-element-yet'
-          : 'empty-or-unsupported',
+        reason: 'empty-or-unsupported',
       });
       continue;
     }

--- a/tests/unit/workspace/legacyBoardAdapter.test.js
+++ b/tests/unit/workspace/legacyBoardAdapter.test.js
@@ -62,10 +62,12 @@ describe('adaptBoardCommands — directives & coverage gaps', () => {
     expect(elements).toHaveLength(0);
   });
 
-  test('concept model has no workspace element yet → reported in unmapped (not dropped)', () => {
+  test('concept model maps to a workspace element (§6.8 — was unmapped before dom/modelElement.js)', () => {
     const { elements, unmapped } = adaptBoardCommands([{ action: 'model', model: 'slope_intercept_line' }]);
-    expect(elements).toHaveLength(0);
-    expect(unmapped).toEqual([{ action: 'model', reason: 'no-workspace-element-yet' }]);
+    expect(unmapped).toHaveLength(0);
+    expect(elements).toHaveLength(1);
+    expect(elements[0].type).toBe('model');
+    expect(elements[0].semantic.model).toBe('slope_intercept_line');
   });
 
   test('a command missing its required payload is skipped and reported', () => {

--- a/tests/unit/workspace/modelElement.test.js
+++ b/tests/unit/workspace/modelElement.test.js
@@ -1,0 +1,71 @@
+/**
+ * Concept-model bridge into the Living Workspace (spec §6.8).
+ *
+ * Until dom/modelElement.js, the P5 adapter dropped `model` commands with
+ * 'no-workspace-element-yet' — interactives died at the door of the new
+ * board even with CONCEPT_MODELS on. These tests pin the pipeline seams:
+ * adapter mapping, spec parsing, and ledger replay fidelity for every
+ * visual card type (graphs once silently lost their `fn` in the ledger's
+ * field whitelist — that class of bug is what the round trip here catches).
+ */
+const { adaptBoardCommands } = require('../../../public/js/living-workspace/dom/legacyBoardAdapter.js');
+const { parseSpec } = require('../../../public/js/living-workspace/dom/modelElement.js');
+const { applyTurnToLedger } = require('../../../utils/pipeline/boardLedger');
+const { ledgerToTurns } = require('../../../public/js/living-workspace/core/ledgerReplay.js');
+
+const NOW = new Date('2026-07-25T12:00:00Z');
+
+describe('adapter maps model commands', () => {
+  test('curated model name → a model element with prompt', () => {
+    const out = adaptBoardCommands([
+      { action: 'model', model: 'slope_intercept_line', prompt: 'Slide m — what happens?' },
+    ]);
+    expect(out.unmapped).toEqual([]);
+    expect(out.elements).toHaveLength(1);
+    expect(out.elements[0].type).toBe('model');
+    expect(out.elements[0].semantic).toEqual({ model: 'slope_intercept_line', spec: null, prompt: 'Slide m — what happens?' });
+  });
+
+  test('generated spec (JSON string) also maps; empty model card does not', () => {
+    const spec = JSON.stringify({ model: 'custom', engine: 'jsxgraph' });
+    expect(adaptBoardCommands([{ action: 'model', spec }]).elements[0].semantic.spec).toBe(spec);
+    const out = adaptBoardCommands([{ action: 'model' }]);
+    expect(out.elements).toEqual([]);
+    expect(out.unmapped[0].reason).toBe('empty-or-unsupported');
+  });
+});
+
+describe('parseSpec', () => {
+  test('JSON strings parse, objects pass through, junk dies quietly', () => {
+    expect(parseSpec('{"model":"m"}')).toEqual({ model: 'm' });
+    const obj = { model: 'm' };
+    expect(parseSpec(obj)).toBe(obj);
+    expect(parseSpec('not json')).toBeNull();
+    expect(parseSpec(null)).toBeNull();
+  });
+});
+
+describe('every visual card type survives ledger → wire → replay → adapter', () => {
+  test('graph fn, image query, diagram params, and model spec all round-trip', () => {
+    let ledger = applyTurnToLedger(null, [{ action: 'pose', tex: 'y=mx+b' }], NOW);
+    ledger = applyTurnToLedger(ledger, [
+      { action: 'graph', fn: '2*x+1', caption: 'the line' },
+      { action: 'image', query: 'balance scale' },
+      { action: 'diagram', diagram_type: 'triangle', diagram_params: { a: 3, b: 4 } },
+      { action: 'model', model: 'slope_intercept_line', prompt: 'Slide m' },
+    ], NOW);
+
+    const wire = JSON.parse(JSON.stringify(ledger));
+    const turns = ledgerToTurns(wire);
+    const out = adaptBoardCommands(turns[0], { idPrefix: 'rt' });
+
+    expect(out.unmapped).toEqual([]);
+    const byType = {};
+    out.elements.forEach(e => { byType[e.type] = e.semantic; });
+    expect(byType.graph.fn).toBe('2*x+1');
+    expect(byType.image.query).toBe('balance scale');
+    expect(byType.geometry.diagramType).toBe('triangle');
+    expect(byType.model.model).toBe('slope_intercept_line');
+    expect(byType.model.prompt).toBe('Slide m');
+  });
+});

--- a/utils/pipeline/boardLedger.js
+++ b/utils/pipeline/boardLedger.js
@@ -46,14 +46,18 @@ function emptyLedger() {
   return { current: null, completed: [] };
 }
 
-// Keep only the fields the client replay needs. Board commands are already
-// schema-checked upstream; this is belt-and-braces against oversized payloads
-// riding into Mongo (e.g. an unexpected extra field on a graph card).
+// Keep only the fields the client replay needs — the EXACT field names the
+// board schema emits (utils/boardResponseSchema.js) and the P5 adapter reads
+// (legacyBoardAdapter.mapCommand). Board commands are already schema-checked
+// upstream; this is belt-and-braces against oversized payloads riding into
+// Mongo. A field missing here silently breaks replay fidelity for its card
+// type (graphs once lost their `fn` this way), so keep the two lists in sync.
 const COMMAND_FIELDS = [
-  'action', 'tex', 'op', 'caption', 'label', 'plain',
-  // visual/block cards
-  'graphType', 'expression', 'expressions', 'points', 'window', 'imageQuery',
-  'shape', 'params', 'highlight', 'steps',
+  'action', 'tex', 'op', 'check', 'caption',
+  'fn',                              // graph
+  'query',                           // image
+  'diagram_type', 'diagram_params',  // diagram
+  'model', 'spec', 'prompt',         // interactive concept model
 ];
 function sanitizeCommand(cmd) {
   const out = {};

--- a/utils/pipeline/boardStateBlock.js
+++ b/utils/pipeline/boardStateBlock.js
@@ -36,10 +36,12 @@ function describeStep(cmd) {
     case 'verify': return 'SOLUTION shown: ' + trunc(cmd.tex);
     case 'scaffold': return 'scaffold with blanks for the student: ' + trunc(cmd.tex);
     case 'example': return 'worked example (different problem): ' + trunc(cmd.tex);
-    case 'graph': return 'graph: ' + trunc(cmd.expression || cmd.tex || 'plotted');
-    case 'image': return 'picture: ' + trunc(cmd.imageQuery || cmd.caption || '');
-    case 'diagram':
-    case 'model': return cmd.action + ': ' + trunc(cmd.tex || cmd.caption || 'shown');
+    case 'graph': return 'graph: ' + trunc(cmd.fn || cmd.tex || 'plotted');
+    case 'image': return 'picture: ' + trunc(cmd.query || cmd.caption || '');
+    case 'diagram': return 'diagram: ' + trunc(cmd.diagram_type || cmd.caption || 'shown');
+    case 'model': return 'INTERACTIVE model the student can manipulate: '
+      + trunc(cmd.model || 'custom')
+      + (cmd.prompt ? ' — “' + trunc(cmd.prompt) + '”' : '');
     default: return null;
   }
 }


### PR DESCRIPTION
Eighth Live Workspace slice: waking up the dormant interactives. ([Spec §6](https://github.com/jnappier7/mathmatix-ai/blob/main/docs/LIVE_WORKSPACE_REQUIREMENTS.md): *"Interactive mathematical tools are a core requirement… Representations must not function as isolated tools."*)

## What was actually blocking it

The linked-representation engine already exists and is genuinely good — `ConceptModelRenderer` drives JSXGraph + token substrates where sliders, draggable points, and equation readouts all read/write **one shared parameter state**. It shipped dark behind the `CONCEPT_MODELS` env flag with the prompt wiring ready in `generate.js`. But even flag-on, interactives could never reach the new board: **the P5 adapter dropped every `model` command** with `no-workspace-element-yet`.

## What this does

- Registers `ELEMENT_TYPES.MODEL` (shared registry + client mirror — the parity suite guards the twin adapters) and maps `model` commands → a model element carrying `{model|spec, prompt}`.
- `dom/modelElement.js` (new): the thin bridge into the page's renderer, which validates specs itself and lazy-loads JSXGraph only when a model actually draws. Engine absent → quiet placeholder, never a broken block.
- **Fixes a latent replay-fidelity bug found on the way**: the board ledger's field whitelist guessed wrong names (`expression`/`imageQuery`) versus the schema's actual `fn`/`query`/`diagram_*` — graphs and images silently lost their payload on reload replay. A round-trip test now pins **every** visual card type through ledger → wire JSON → replay → adapter.
- The tutor's board-state ghost now names the interactive — *"INTERACTIVE model the student can manipulate: slope_intercept_line — Slide m…"* — so the board-aware tutor (#1304) can talk about what the student is touching.

## Turning it on

Code is ready on both boards; **prod enablement is one Render env var: `CONCEPT_MODELS=1`** (default stays off — your call on timing/token cost; the prompt block only appends when the flag is on). Worth a `dev` soak first.

## Verification

Full suite **4688 passed** (parity suite extended to the model verb; obsolete "no element yet" assertion updated to pin the new contract), lint clean. Manual QA once flagged on: ask about slope → tutor summons `slope_intercept_line` → slider on the board moves the line AND the equation readout together; reload → the model re-renders from the ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)