### PR TITLE
feat(mastery): test out of a skill from chat via an in-chat challenge card (Fix B)

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -106,6 +106,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <!-- Enriched right-rail player card (stats band + expand-up progress panel).
        Loads AFTER workspace.css/avatar-fullbody.css so .psc-* rules win. -->
   <link rel="stylesheet" href="/css/player-stats-card.css?v=20260724b" />
+  <link rel="stylesheet" href="/css/challenge-card.css?v=20260725f" />
   <!-- Adjustable panels: resizable work board + minimizable tutor hero -->
   <link rel="stylesheet" href="/css/adjustable-panels.css?v=20260721" />
   <!-- Voice mode (layout mode of the chat stage) -->
@@ -2485,6 +2486,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- Player stats card: window-global, loaded before script.js which calls
      window.PlayerStatsCard.init(currentUser) once the user doc is fetched. -->
 <script defer src="/js/modules/playerStatsCard.js?v=20260724b"></script>
+<script src="/js/challengeCard.js?v=20260725f"></script>
 <script src="/js/script.js?v=20260725f" type="module"></script>
   <script src="/js/guidedPath.js" type="module"></script>
   <script src="/dist/js/chat-js9.bc0be9a3.js"></script>

--- a/public/css/challenge-card.css
+++ b/public/css/challenge-card.css
@@ -1,0 +1,71 @@
+/* In-chat challenge card (test-out / Fix B). Self-contained; reads a couple of
+   app tokens with fallbacks so it sits on the chat surface in light or dark. */
+.mm-challenge-card {
+  --mm-ch-accent: var(--cr-accent, #6c5ce7);
+  margin: 12px 0;
+  padding: 16px 18px;
+  border-radius: 16px;
+  border: 1px solid color-mix(in srgb, var(--mm-ch-accent) 35%, transparent);
+  background:
+    linear-gradient(180deg,
+      color-mix(in srgb, var(--mm-ch-accent) 10%, var(--cr-surface, #fff)),
+      var(--cr-surface, #fff));
+  box-shadow: 0 10px 28px rgba(0, 0, 0, .12);
+  color: var(--cr-ink, #1c1c28);
+  animation: mm-ch-in .28s cubic-bezier(.2, 1, .3, 1) both;
+}
+@keyframes mm-ch-in { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
+@media (prefers-reduced-motion: reduce) { .mm-challenge-card { animation: none; } }
+
+.mm-ch-head { display: flex; align-items: center; gap: 10px; margin-bottom: 4px; }
+.mm-ch-badge {
+  font: 700 11px/1 system-ui, sans-serif; letter-spacing: .06em; text-transform: uppercase;
+  color: #fff; background: var(--mm-ch-accent);
+  padding: 5px 9px; border-radius: 999px; flex: 0 0 auto;
+}
+.mm-ch-title { font: 700 16px/1.3 system-ui, sans-serif; }
+.mm-ch-sub { font: 13px/1.45 system-ui, sans-serif; opacity: .72; margin: 4px 0 12px; }
+
+.mm-ch-list { list-style: decimal; margin: 0; padding-left: 22px; display: flex; flex-direction: column; gap: 14px; }
+.mm-ch-q { padding-left: 4px; }
+.mm-ch-prompt { font-size: 15px; margin-bottom: 8px; overflow-x: auto; }
+
+.mm-ch-input {
+  width: 100%; max-width: 260px; padding: 8px 11px;
+  font: 15px system-ui, sans-serif;
+  border: 1.5px solid color-mix(in srgb, var(--cr-ink, #1c1c28) 22%, transparent);
+  border-radius: 9px; background: var(--cr-surface, #fff); color: inherit;
+}
+.mm-ch-input:focus { outline: none; border-color: var(--mm-ch-accent); }
+
+.mm-ch-options { display: flex; flex-direction: column; gap: 6px; }
+.mm-ch-option {
+  display: flex; align-items: center; gap: 8px; cursor: pointer;
+  padding: 7px 10px; border-radius: 9px;
+  border: 1px solid color-mix(in srgb, var(--cr-ink, #1c1c28) 14%, transparent);
+}
+.mm-ch-option:hover { border-color: var(--mm-ch-accent); }
+
+.mm-ch-footer { display: flex; align-items: center; gap: 10px; margin-top: 16px; flex-wrap: wrap; }
+.mm-ch-submit {
+  appearance: none; cursor: pointer; border: 0;
+  padding: 10px 18px; border-radius: 999px;
+  font: 700 14px/1 system-ui, sans-serif; color: #fff;
+  background: var(--mm-ch-accent);
+}
+.mm-ch-submit:disabled { opacity: .6; cursor: default; }
+.mm-ch-cancel {
+  appearance: none; cursor: pointer;
+  padding: 10px 16px; border-radius: 999px;
+  font: 600 14px/1 system-ui, sans-serif; color: inherit;
+  background: transparent;
+  border: 1px solid color-mix(in srgb, var(--cr-ink, #1c1c28) 22%, transparent);
+}
+.mm-ch-cancel:hover { border-color: var(--mm-ch-accent); }
+
+.mm-ch-result { text-align: center; padding: 8px 0 2px; }
+.mm-ch-result-big { font: 800 22px/1.2 system-ui, sans-serif; }
+.mm-ch-result-sub { font: 14px/1.45 system-ui, sans-serif; opacity: .8; margin-top: 4px; }
+.mm-challenge-card.is-pass { border-color: #35c98a; }
+.mm-challenge-card.is-pass .mm-ch-result-big { color: #1f9d6b; }
+.mm-challenge-card.is-miss { border-color: color-mix(in srgb, #e0a23c 60%, transparent); }

--- a/public/js/challengeCard.js
+++ b/public/js/challengeCard.js
@@ -1,0 +1,184 @@
+/**
+ * In-chat CHALLENGE CARD (test-out / Fix B).
+ *
+ * When the student asks to prove they already know a skill, the pipeline sends
+ * { launchChallenge: { skillId } } on the chat `complete` event and script.js
+ * calls MMChallengeCard.launch(skillId). This renders a self-contained card in
+ * the conversation: 5 problems, no hints, one submit. Grading + the rung proof
+ * happen server-side (GET/POST /api/mastery/challenge/:skillId, proves
+ * via:'challenge'); this file is only DOM + fetch. On a pass the skill is proved
+ * and the cascade clears everything beneath it — we celebrate and nudge a refresh
+ * of the progress surfaces. On a miss nothing is lost — we name the gap.
+ */
+(function () {
+  'use strict';
+
+  function csrf(options) {
+    return (typeof addCsrfToken === 'function') ? addCsrfToken(options) : options;
+  }
+
+  function api(url, options) {
+    var opts = Object.assign({ credentials: 'include' }, options || {});
+    return fetch(url, opts).then(function (res) {
+      return res.json().then(function (body) {
+        if (!res.ok) throw Object.assign(new Error(body.error || 'Request failed'), { body: body, status: res.status });
+        return body;
+      });
+    });
+  }
+
+  function el(tag, cls, text) {
+    var e = document.createElement(tag);
+    if (cls) e.className = cls;
+    if (text != null) e.textContent = text;
+    return e;
+  }
+
+  // Render math if KaTeX auto-render is on the page; otherwise the text stands on
+  // its own (prompts are plain enough to read either way).
+  function typeset(node) {
+    try { if (typeof window.renderMathInElement === 'function') window.renderMathInElement(node, { throwOnError: false }); } catch (_) {}
+  }
+
+  function answerField(problem) {
+    if (Array.isArray(problem.options) && problem.options.length) {
+      var wrap = el('div', 'mm-ch-options');
+      problem.options.forEach(function (opt, i) {
+        var id = 'mmch-' + problem.problemId + '-' + i;
+        var label = el('label', 'mm-ch-option');
+        label.htmlFor = id;
+        var radio = document.createElement('input');
+        radio.type = 'radio';
+        radio.id = id;
+        radio.name = 'mmch-' + problem.problemId;
+        radio.value = opt;
+        radio.dataset.problemId = problem.problemId;
+        label.appendChild(radio);
+        label.appendChild(document.createTextNode(' ' + opt));
+        wrap.appendChild(label);
+      });
+      return wrap;
+    }
+    var input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'mm-ch-input';
+    input.autocomplete = 'off';
+    input.dataset.problemId = problem.problemId;
+    input.setAttribute('aria-label', 'Your answer');
+    return input;
+  }
+
+  function collect(card, problems) {
+    return problems.map(function (p) {
+      var sel = card.querySelector('input[name="mmch-' + p.problemId + '"]:checked');
+      if (sel) return { problemId: p.problemId, answer: sel.value };
+      var txt = card.querySelector('.mm-ch-input[data-problem-id="' + p.problemId + '"]');
+      return { problemId: p.problemId, answer: txt ? txt.value.trim() : '' };
+    });
+  }
+
+  function launch(skillId) {
+    if (!skillId) return;
+    var mount = document.getElementById('chat-messages-container') || document.getElementById('chat-messages');
+    if (!mount) return;
+
+    var card = el('div', 'mm-challenge-card');
+    card.setAttribute('role', 'group');
+    card.setAttribute('aria-label', 'Skill challenge');
+    var head = el('div', 'mm-ch-head');
+    head.appendChild(el('span', 'mm-ch-badge', '⚡ Challenge'));
+    var title = el('div', 'mm-ch-title', 'Loading your challenge…');
+    head.appendChild(title);
+    card.appendChild(head);
+    var sub = el('div', 'mm-ch-sub');
+    card.appendChild(sub);
+    var list = el('ol', 'mm-ch-list');
+    card.appendChild(list);
+    var footer = el('div', 'mm-ch-footer');
+    card.appendChild(footer);
+    mount.appendChild(card);
+    card.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+
+    api('/api/mastery/challenge/' + encodeURIComponent(skillId)).then(function (data) {
+      title.textContent = 'Prove it: ' + (data.label || 'this skill');
+      sub.textContent = data.instructions || 'Five problems, no hints, one shot.';
+      var problems = data.problems || [];
+      problems.forEach(function (p) {
+        var li = el('li', 'mm-ch-q');
+        var prompt = el('div', 'mm-ch-prompt', p.prompt);
+        li.appendChild(prompt);
+        li.appendChild(answerField(p));
+        list.appendChild(li);
+      });
+      typeset(card);
+
+      var submit = el('button', 'mm-ch-submit', 'Submit challenge');
+      submit.type = 'button';
+      var cancel = el('button', 'mm-ch-cancel', 'Not now');
+      cancel.type = 'button';
+      cancel.addEventListener('click', function () { card.remove(); });
+      footer.appendChild(submit);
+      footer.appendChild(cancel);
+
+      submit.addEventListener('click', function () {
+        var submissions = collect(card, problems);
+        if (submissions.some(function (s) { return !s.answer; })) {
+          sub.textContent = 'Answer all five, then submit — no hints, but you get to finish it.';
+          return;
+        }
+        submit.disabled = true;
+        submit.textContent = 'Grading…';
+        api('/api/mastery/challenge/' + encodeURIComponent(skillId), csrf({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ submissions: submissions })
+        })).then(function (result) {
+          renderResult(card, list, footer, result, skillId);
+        }).catch(function (err) {
+          submit.disabled = false;
+          submit.textContent = 'Submit challenge';
+          sub.textContent = (err && err.body && (err.body.error || err.body.message)) || 'Could not grade that — try again.';
+        });
+      });
+    }).catch(function (err) {
+      var body = (err && err.body) || {};
+      // 409 = already proved, or too few problems in the bank for this skill.
+      title.textContent = 'Challenge';
+      sub.textContent = body.reason || body.error || 'Could not start a challenge for this skill right now.';
+      var ok = el('button', 'mm-ch-cancel', 'Got it');
+      ok.type = 'button';
+      ok.addEventListener('click', function () { card.remove(); });
+      footer.appendChild(ok);
+    });
+  }
+
+  function renderResult(card, list, footer, result, skillId) {
+    list.innerHTML = '';
+    footer.innerHTML = '';
+    card.classList.add(result.passed ? 'is-pass' : 'is-miss');
+    var res = el('div', 'mm-ch-result');
+    if (result.passed) {
+      res.appendChild(el('div', 'mm-ch-result-big', '🎉 Proved it!'));
+      res.appendChild(el('div', 'mm-ch-result-sub',
+        (result.correct != null ? result.correct + ' of ' + result.total + ' — ' : '') +
+        'this skill is yours. Nice.'));
+      // Nudge the progress surfaces to re-read (the bar just moved to mastered).
+      try { if (typeof window.refreshResumeCard === 'function') window.refreshResumeCard(); } catch (_) {}
+      try { if (window.MM_XP && typeof window.MM_XP.celebrate === 'function') window.MM_XP.celebrate(); } catch (_) {}
+      document.dispatchEvent(new CustomEvent('mm:skill-proved', { detail: { skillId: skillId } }));
+    } else {
+      res.appendChild(el('div', 'mm-ch-result-big', 'Found the gap'));
+      res.appendChild(el('div', 'mm-ch-result-sub',
+        (result.correct != null ? result.correct + ' of ' + result.total + '. ' : '') +
+        (result.message || "Let's close it together — nothing lost.")));
+    }
+    card.appendChild(res);
+    var done = el('button', 'mm-ch-cancel', result.passed ? 'Keep going' : 'Let’s work on it');
+    done.type = 'button';
+    done.addEventListener('click', function () { card.remove(); });
+    footer.appendChild(done);
+    card.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }
+
+  window.MMChallengeCard = { launch: launch };
+})();

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -3122,6 +3122,13 @@ document.addEventListener("DOMContentLoaded", () => {
                 setTimeout(() => window.openActTest(), 400); // let the tutor's confirming reply render first
             }
 
+            // Test-out (Fix B): the student asked to prove they know this skill.
+            // Drop an in-chat challenge card under the tutor's set-up reply.
+            if (data.launchChallenge && data.launchChallenge.skillId && window.MMChallengeCard) {
+                const _sid = data.launchChallenge.skillId;
+                setTimeout(() => window.MMChallengeCard.launch(_sid), 400);
+            }
+
             // Server withheld course teaching because a REQUIRED baseline (e.g. the
             // ACT practice test) isn't done — surface the baseline card under the
             // tutor's message so the student can start it. We do NOT auto-open the

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -1771,6 +1771,9 @@ async function runStudentTurn(req, res) {
             drawingSequence: pipelineResult.drawingSequence,
             visualCommands: pipelineResult.visualCommands,
             boardCommands: pipelineResult.boardCommands || [],
+            // Fix B: signals the client to open an in-chat challenge card so the
+            // student can prove out of the skill they're working on.
+            launchChallenge: pipelineResult.launchChallenge || null,
             // Uploads that arrived on THIS turn, in servable form. The Living
             // Workspace docks them as Source Cards (spec §5.1: files live on
             // the board, not in a buried attachment tray). The full source list

--- a/routes/courseChat.js
+++ b/routes/courseChat.js
@@ -322,6 +322,8 @@ router.post('/', async (req, res) => {
                 graphTool: graphToolConfig,
                 // Launch the real practice-ACT runner when the tutor signalled it
                 launchPracticeAct: courseResult.launchPracticeAct || false,
+                // Fix B: open an in-chat challenge card so the student can test out
+                launchChallenge: pipelineResult.launchChallenge || null,
                 // Course-specific fields
                 courseContext: courseResult.courseContext,
                 courseProgress: courseProgressUpdate,

--- a/tests/unit/testOutIntent.test.js
+++ b/tests/unit/testOutIntent.test.js
@@ -1,0 +1,30 @@
+const { detectTestOutIntent } = require('../../utils/testOutIntent');
+
+describe('detectTestOutIntent', () => {
+  it.each([
+    'I KNOW order of operations how do I test out of this skill?',
+    'let me test out',
+    'can I test out now',
+    'quiz me',
+    'challenge me',
+    'prove that I know this',
+    'skip the lesson',
+    'let me prove it',
+    "I'm ready to test",
+  ])('fires on test-out phrasing: %s', (t) => {
+    expect(detectTestOutIntent(t)).toBe(true);
+  });
+
+  it.each([
+    'this is a test',
+    'let me test my answer 3x=9',
+    'I know this is hard',
+    'what is the protest about',
+    'testing 1 2 3',
+    'can I test my code',
+    '',
+    null,
+  ])('does NOT fire on: %s', (t) => {
+    expect(detectTestOutIntent(t)).toBe(false);
+  });
+});

--- a/utils/pipeline/index.js
+++ b/utils/pipeline/index.js
@@ -43,6 +43,7 @@ const { recordAttempt: recordConsistencyAttempt, initializeScore, categorizeDiff
 
 // Backbone: Tutor Plan + Skill Familiarity
 const { loadOrCreatePlan, resolveCurrentTarget, updatePlanAfterInteraction, advanceInstructionPhase, recentPracticeSkillId } = require('../tutorPlanManager');
+const { detectTestOutIntent } = require('../testOutIntent');
 const { buildPlanLayer, shouldSuppressSocratic } = require('../promptPlanLayer');
 const { reassessFamiliarity } = require('../phaseEvidenceEvaluator');
 const { detectModeTransition } = require('../modeTransitionDetector');
@@ -308,6 +309,22 @@ async function runPipeline(message, ctx) {
     // TutorPlan is optional — pipeline continues without it
   }
 
+  // ── Test-out (Fix B): launch an in-chat challenge run ──
+  // When the student asks to prove they already know this, hand the client the
+  // skill to challenge on. The challenge (5 problems, no hints) proves the skill
+  // via the challenge rung — the one proof path with no 3-context requirement,
+  // so ambient practice and a test-out both have a real road to 100%.
+  let launchChallenge = null;
+  if (detectTestOutIntent(message)) {
+    const challengeSkillId = ctx.activeSkill?.skillId
+      || tutorPlan?.currentTarget?.skillId
+      || recentPracticeSkillId(tutorPlan);
+    if (challengeSkillId) {
+      launchChallenge = { skillId: challengeSkillId };
+      console.log(`[Pipeline] Test-out intent → launching challenge for ${challengeSkillId}`);
+    }
+  }
+
   // ── Evidence Assembly (NEW: data-driven intelligence layer) ──
   // Gathers signals from BKT, FSRS, cognitive load, consistency scoring,
   // and misconception history into a unified evidence object for decide.js
@@ -413,6 +430,14 @@ async function runPipeline(message, ctx) {
     hasRecentUpload: ctx.hasRecentUpload || false,
     user: ctx.user || null,
   });
+
+  // Test-out: the challenge card is about to render below the tutor's reply, so
+  // the reply should tee it up — not teach or pose a problem of its own.
+  if (launchChallenge) {
+    decision.directives.push(
+      'TEST-OUT: The student wants to prove they already know this skill, and a 5-problem challenge is being launched right in the chat immediately after your message. In ONE or two upbeat sentences, set it up: 5 problems, no hints, one shot — miss it and we just find the gap, nothing lost. Do NOT pose a problem yourself and do NOT start teaching; the challenge card handles the problems.'
+    );
+  }
 
   // Inject mode transition directives into the decision
   if (modeTransition?.shouldTransition && modeTransition.suggestedDirectives) {
@@ -1670,6 +1695,8 @@ async function runPipeline(message, ctx) {
     reviewNext: verified.extracted?.reviewNext || false,
     visualCommands: verified.visualCommands,
     boardCommands: verified.boardCommands || [],
+    // Fix B: when set, the client opens an in-chat challenge card for this skill.
+    launchChallenge: launchChallenge || null,
     xpCommands: verified.xpCommands || [],
     visualTabCommands: verified.visualTabCommands || [],
     drawingSequence: verified.drawingSequence,

--- a/utils/testOutIntent.js
+++ b/utils/testOutIntent.js
@@ -1,0 +1,30 @@
+// Detect a student asking to TEST OUT of / prove a skill from chat, so the
+// pipeline can launch an in-chat challenge run (5 problems, no hints, proves the
+// skill via the challenge rung — utils/skillRung).
+//
+// Deliberately SPECIFIC. A loose /test/ match would fire on "this is a test",
+// "let me test my answer", or "i know this is hard". We require an explicit
+// test-out / challenge / skip-the-lesson phrasing so the card only appears when
+// the student actually asked to prove out.
+const TEST_OUT = new RegExp(
+  [
+    'test(?:ing)?\\s*out',          // "test out", "testing out" ("test my answer" won't match)
+    'test me\\b',
+    'quiz me\\b',
+    'challenge me\\b',
+    'let me prove\\b',
+    'ready to test\\b',
+    'can i test out\\b',
+    'skip (?:the )?lesson\\b',
+    'prove (?:that )?i know\\b',
+    'i can pass (?:the )?(?:test|challenge)\\b',
+  ].join('|'),
+  'i'
+);
+
+function detectTestOutIntent(text) {
+  if (!text || typeof text !== 'string') return false;
+  return TEST_OUT.test(text);
+}
+
+module.exports = { detectTestOutIntent };


### PR DESCRIPTION
## Why
A student who already knows a skill had **no way to prove it from chat**. The graded challenge — 5 problems, proves the skill `via:'challenge'` (the one rung path with **no** 3-context requirement) + cascade — existed only on the skill-map page. So after #1306/#1307/#1310 the bar can *climb* with practice but still can't reach 100% from the conversation. This is the last piece.

## What
- **`utils/testOutIntent.js`**: detects an explicit test-out ask ("test out", "quiz me", "let me prove it", "challenge me", "prove that I know", "skip the lesson"). Deliberately tight — does **not** fire on "test my answer", "this is a test", "I know this is hard".
- **Pipeline** (`index.js`): on that intent, resolves the skill in focus (`activeSkill → currentTarget → recentPracticeSkillId`) and emits `launchChallenge:{skillId}`. A `decide` directive makes the tutor's reply *tee up the card* (5 problems, no hints, one shot — miss it and we find the gap) instead of teaching or posing its own problem.
- **Routes**: `chat.js` + `courseChat.js` relay `launchChallenge` on the `complete` event — works in **free chat and the ACT/course flow**.
- **Frontend**: `public/js/challengeCard.js` + `challenge-card.css` — a self-contained in-chat card. GETs the 5 problems (answers stripped server-side), collects answers, POSTs for server-side grading. On a pass: "🎉 Proved it!" + fires `mm:skill-proved` and nudges the progress surfaces to re-read (the skill just went mastered + cascade). On a miss: names the gap, nothing lost. `script.js` opens it right after the tutor's set-up reply.

## Reuses, doesn't reinvent
The server engine is the existing `GET/POST /api/mastery/challenge/:skillId` (same one skill-map drives) — this PR only adds the *launch-from-chat* direction and the in-chat card UI.

## Verification
- `testOutIntent.test.js` (17 cases: fires on real test-out phrasing, ignores look-alikes); full pipeline/diagnose suites green (213).
- **Needs a live smoke test**: running server + a signed-in student on a skill with ≥5 bank problems → say "let me test out" → card renders → submit → pass proves the skill. (Can't fully exercise the runtime flow in CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)