### PR TITLE
feat(lws): tutor-offered Idea cards with student consent (spec §7.6)

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -90,7 +90,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- Design tokens (single source of truth) — must precede chat-redesign.css -->
   <link rel="stylesheet" href="/css/design-system.css" />
   <!-- Redesigned chat shell (opt-in via body.cr-mode) -->
-  <link rel="stylesheet" href="/css/chat-redesign.css?v=20260715" />
+  <link rel="stylesheet" href="/css/chat-redesign.css?v=20260725h" />
   <!-- Gamification surfacing: combo meter + identity chip -->
   <link rel="stylesheet" href="/css/gamification-surfacing.css" />
   <!-- Personal status card modal (Progress button) -->
@@ -2487,7 +2487,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
      window.PlayerStatsCard.init(currentUser) once the user doc is fetched. -->
 <script defer src="/js/modules/playerStatsCard.js?v=20260724b"></script>
 <script src="/js/challengeCard.js?v=20260725f"></script>
-<script src="/js/script.js?v=20260725f" type="module"></script>
+<script src="/js/script.js?v=20260725h" type="module"></script>
   <script src="/js/guidedPath.js" type="module"></script>
   <script src="/dist/js/chat-js9.bc0be9a3.js"></script>
   <!-- Companion HOME screen (phones only; flag-gated OFF by default) -->

--- a/public/chat.html
+++ b/public/chat.html
@@ -134,7 +134,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
        LivingWorkspace flag is dev|beta|live (?livingWorkspace=dev). When on,
        it lazy-loads the workspace and mirrors the tutor's board output onto
        the new surface beside the old board. Default OFF → zero impact. -->
-  <script defer src="/js/living-workspace/chat-workspace.js?v=20260725g"></script>
+  <script defer src="/js/living-workspace/chat-workspace.js?v=20260725i"></script>
   <!-- Final safety net: strips any inline visual tag no renderer handled -->
   <script defer src="/js/stripVisualTags.js"></script>
   <!-- Non-core libs (lazy-loaded after first interaction) -->
@@ -2487,7 +2487,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
      window.PlayerStatsCard.init(currentUser) once the user doc is fetched. -->
 <script defer src="/js/modules/playerStatsCard.js?v=20260724b"></script>
 <script src="/js/challengeCard.js?v=20260725f"></script>
-<script src="/js/script.js?v=20260725h" type="module"></script>
+<script src="/js/script.js?v=20260725i" type="module"></script>
   <script src="/js/guidedPath.js" type="module"></script>
   <script src="/dist/js/chat-js9.bc0be9a3.js"></script>
   <!-- Companion HOME screen (phones only; flag-gated OFF by default) -->

--- a/public/css/chat-redesign.css
+++ b/public/css/chat-redesign.css
@@ -864,3 +864,15 @@ body.cr-mode .inline-equation-palette {
 }
 .cr-encourage-title { color: #18202B; }
 .cr-encourage-body  { color: #5B6876; }
+
+/* ── notebook idea offer (Live Workspace §7.6) ──
+   Consent chip under a tutor message: save the offered idea, or wave it off. */
+.idea-offer { display: flex; align-items: center; gap: 8px; margin-top: 8px; flex-wrap: wrap; }
+.idea-offer-dismiss {
+  appearance: none; -webkit-appearance: none; cursor: pointer;
+  border: none; background: transparent; padding: 4px 6px;
+  color: var(--cr-text-secondary, #5B6876); font: 500 12px/1 Inter, system-ui, sans-serif;
+  text-decoration: underline; text-underline-offset: 2px;
+}
+.idea-offer-dismiss:hover { color: var(--cr-text-primary, #14202b); }
+.idea-offer-dismiss:focus-visible { outline: 2px solid var(--cr-accent, #4a7dff); outline-offset: 2px; }

--- a/public/css/living-workspace.css
+++ b/public/css/living-workspace.css
@@ -765,3 +765,17 @@ html[data-theme="dark"] .lws-root {
   padding: 10px 12px; border: 1px dashed var(--lws-card-border); border-radius: 10px;
   color: var(--lws-card-ink); opacity: .7; font: 400 13px/1.4 system-ui, sans-serif;
 }
+
+/* ── tutor pointing (§8): the line being discussed glows ── */
+.lws-dv-pointed {
+  animation: lws-point-pulse 1.4s ease-in-out 3;
+  border-radius: 10px;
+  box-shadow: 0 0 0 2px var(--lws-accent), 0 0 18px color-mix(in srgb, var(--lws-accent) 55%, transparent);
+}
+@keyframes lws-point-pulse {
+  0%, 100% { box-shadow: 0 0 0 2px var(--lws-accent), 0 0 18px color-mix(in srgb, var(--lws-accent) 55%, transparent); }
+  50% { box-shadow: 0 0 0 3px var(--lws-accent), 0 0 30px color-mix(in srgb, var(--lws-accent) 80%, transparent); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .lws-dv-pointed { animation: none; }
+}

--- a/public/js/living-workspace/chat-workspace.js
+++ b/public/js/living-workspace/chat-workspace.js
@@ -67,6 +67,8 @@
     // Source↔problem link (spec §5.4): paint/clear the in-focus problem's
     // "from my worksheet" chip. Fed by the response's boardSource field.
     setProblemSource: function () {},
+    // Tutor pointing (spec §8): highlight the board line the tutor named.
+    pointAt: function () {},
   };
   window.LWS_CHAT = api;
   if (!ON) return;
@@ -75,7 +77,7 @@
   // public/ with a 7-day cache and no content hashing, so bump this whenever
   // any living-workspace asset changes (and the chat.html <script ?v=> tag to
   // match, so this file itself refreshes). See project_asset_cache_busting.
-  var ASSET_V = '?v=20260725g';
+  var ASSET_V = '?v=20260725i';
   var BASE = '/js/living-workspace/';
   var SCRIPTS = [
     'core/flags.js', 'core/viewport.js', 'core/elementRegistry.js',
@@ -297,6 +299,11 @@
   api.setProblemSource = function (ref) {
     if (!ready || !dv) return;
     try { dv.setProblemSource(ref || null); } catch (e) { console.error('[LWS_CHAT] problem source failed', e); }
+  };
+
+  api.pointAt = function (ref) {
+    if (!ready || !dv) return;
+    try { dv.pointAt(ref); } catch (e) { console.error('[LWS_CHAT] pointAt failed', e); }
   };
 
   // The problem header's chip → reopen the docked source with the problem's

--- a/public/js/living-workspace/dom/derivationView.js
+++ b/public/js/living-workspace/dom/derivationView.js
@@ -616,6 +616,32 @@
     this._scrollToEnd();
   };
 
+  // Tutor pointing (spec §8): make the exact line the tutor is discussing
+  // glow. `ref` is {step: N} (1-based, the board-state block's numbering —
+  // both count the same rendered rows in the same order) or {target:
+  // 'problem'|'solution'|'last'}. Out-of-range steps fall back to the newest
+  // line rather than pointing at nothing. The glow self-clears.
+  DerivationView.prototype.pointAt = function (ref) {
+    if (!ref || typeof ref !== 'object') return;
+    var rows = this.el.lines.children;
+    var node = null;
+    if (ref.target === 'problem') node = this.el.problem.style.display === 'none' ? null : this.el.problem;
+    else if (ref.target === 'solution') {
+      var sols = this.el.lines.querySelectorAll('.lws-dv-solution');
+      node = sols.length ? sols[sols.length - 1] : null;
+    } else if (ref.target === 'last') node = rows.length ? rows[rows.length - 1] : null;
+    else if (ref.step >= 1) node = rows[ref.step - 1] || (rows.length ? rows[rows.length - 1] : null);
+    if (!node) return;
+
+    var prev = this.el.root.querySelectorAll('.lws-dv-pointed');
+    for (var i = 0; i < prev.length; i++) prev[i].classList.remove('lws-dv-pointed');
+    if (this._pointTimer) { clearTimeout(this._pointTimer); this._pointTimer = null; }
+
+    node.classList.add('lws-dv-pointed');
+    try { node.scrollIntoView({ block: 'center', behavior: 'smooth' }); } catch (_) { /* older browsers */ }
+    this._pointTimer = setTimeout(function () { node.classList.remove('lws-dv-pointed'); }, 7000);
+  };
+
   // Caption strip API — text only; the karaoke pointer lives in the caption
   // layer, this just paints what it's told and hides when empty.
   DerivationView.prototype.setCaption = function (text) {

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -3302,6 +3302,16 @@ document.addEventListener("DOMContentLoaded", () => {
                 }
             }
 
+            // Tutor pointing (§8): make the named board line glow. AFTER
+            // applyBoardCommands so a point at a line drawn THIS turn lands.
+            if (window.LWS_CHAT && window.LWS_CHAT.isOn() && data.boardPoint) {
+                try {
+                    window.LWS_CHAT.pointAt(data.boardPoint);
+                } catch (error) {
+                    console.error('[LWS_CHAT] pointAt failed:', error);
+                }
+            }
+
             // Tutor-offered notebook idea (§7.6): promotion is consented — the
             // student clicks to save, nothing is stored silently.
             if (data.ideaSuggestion && data.ideaSuggestion.body) {

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -770,6 +770,52 @@ document.addEventListener("DOMContentLoaded", () => {
     // Expose for other modules that append AI messages (e.g. streaming finalizer).
     window.attachInlineCtaToLatestMessage = attachInlineCtaToLatestMessage;
 
+    // ── Notebook idea offer (Live Workspace §7.6) ──
+    // The tutor proposed saving an idea; render a small consent chip under its
+    // message. Saving POSTs to the notebook; dismissing just removes the chip.
+    function appendIdeaSaveOffer(idea, skillId) {
+        const messages = document.querySelectorAll('.message.ai');
+        const latest = messages[messages.length - 1];
+        if (!latest || latest.querySelector('.idea-offer')) return;
+
+        const wrap = document.createElement('div');
+        wrap.className = 'idea-offer';
+
+        const save = document.createElement('button');
+        save.type = 'button';
+        save.className = 'message-cta idea-offer-save';
+        save.textContent = `💡 Save to my notebook: “${idea.title}”`;
+        save.addEventListener('click', async () => {
+            save.disabled = true;
+            try {
+                const res = await csrfFetch('/api/notebook', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    credentials: 'include',
+                    body: JSON.stringify({ type: 'idea', title: idea.title, body: idea.body, skillId }),
+                });
+                if (!res.ok) throw new Error(`save failed (${res.status})`);
+                save.textContent = '💡 Saved to your notebook!';
+                dismiss.remove();
+            } catch (err) {
+                console.error('[notebook] idea save failed:', err);
+                save.disabled = false;
+                if (typeof showToast === 'function') showToast('Could not save that — try again.', 3000);
+            }
+        });
+
+        const dismiss = document.createElement('button');
+        dismiss.type = 'button';
+        dismiss.className = 'idea-offer-dismiss';
+        dismiss.textContent = 'No thanks';
+        dismiss.setAttribute('aria-label', 'Don’t save this idea');
+        dismiss.addEventListener('click', () => wrap.remove());
+
+        wrap.appendChild(save);
+        wrap.appendChild(dismiss);
+        latest.appendChild(wrap);
+    }
+
     // ── Unified Markdown + Math renderer (marked + KaTeX) ──
     // Pipeline: protect LaTeX → marked.parse → restore with katex.renderToString
     // KaTeX renders synchronously — no FOUC, no debounce, no post-processing.
@@ -3254,6 +3300,13 @@ document.addEventListener("DOMContentLoaded", () => {
                 } catch (error) {
                     console.error('[LWS_CHAT] setProblemSource failed:', error);
                 }
+            }
+
+            // Tutor-offered notebook idea (§7.6): promotion is consented — the
+            // student clicks to save, nothing is stored silently.
+            if (data.ideaSuggestion && data.ideaSuggestion.body) {
+                try { appendIdeaSaveOffer(data.ideaSuggestion, data.currentSkillId || null); }
+                catch (error) { console.error('[notebook] idea offer failed:', error); }
             }
 
             // Notebook cards minted this turn (spec §7): a captured AHA moment

--- a/public/js/teacher-dashboard.js
+++ b/public/js/teacher-dashboard.js
@@ -1029,6 +1029,77 @@ document.addEventListener("DOMContentLoaded", async () => {
         openStudentProfile(studentId);
     }
 
+    // ── Live Workspace summary (spec §20) ──
+    // Injected into the overview tab: the student's board at a glance —
+    // problem in focus + status, independent-vs-supported solve counts (the
+    // §12 assistance ladder), and recent notebook cards (reminders double as
+    // the recent-misconception signal). Renders nothing for students who
+    // haven't touched the board.
+    const ASSISTANCE_LABELS = { 1: 'independent', 2: 'encouragement', 3: 'directions', 4: 'attention cue', 5: 'strategic question', 6: 'visual scaffold', 7: 'partial setup', 8: 'parallel example', 9: 'explicit instruction' };
+    const CARD_ICONS = { aha: '\u2728', reminder: '\ud83d\udccc', idea: '\ud83d\udca1', strategy: '\ud83e\udded', reflection: '\ud83e\ude9e' };
+
+    async function loadWorkspaceSummary(studentId) {
+        const tab = document.getElementById('profile-overview-tab');
+        if (!tab) return;
+        let section = document.getElementById('detail-workspace-section');
+        if (!section) {
+            section = document.createElement('div');
+            section.id = 'detail-workspace-section';
+            section.className = 'detail-section';
+            tab.appendChild(section);
+        }
+        section.innerHTML = '<h4 style="margin:14px 0 6px;">\ud83d\udcd0 Live Workspace</h4><p style="font-size:.85em;color:#95a5a6;">Loading\u2026</p>';
+
+        try {
+            const res = await fetch(`/api/teacher/students/${studentId}/workspace-summary`);
+            if (!res.ok) throw new Error(`workspace summary ${res.status}`);
+            const data = await res.json();
+            renderWorkspaceSummary(section, data);
+        } catch (err) {
+            console.error('[TeacherDashboard] workspace summary failed:', err);
+            section.innerHTML = '';
+        }
+    }
+
+    function renderWorkspaceSummary(section, data) {
+        const board = data.board || {};
+        const cards = Array.isArray(data.learningCards) ? data.learningCards : [];
+        const hasAnything = board.current || (board.completed && board.completed.length) || cards.length;
+        if (!hasAnything) { section.innerHTML = ''; return; }
+
+        const esc = (t) => { const d = document.createElement('div'); d.textContent = String(t == null ? '' : t); return d.innerHTML; };
+        const assistText = (a) => a == null ? '' : (ASSISTANCE_LABELS[a] || `level ${a}`);
+
+        let html = '<h4 style="margin:14px 0 6px;">\ud83d\udcd0 Live Workspace</h4>';
+
+        if (board.current) {
+            const status = board.current.solved ? '\u2705 solved' : `\u270f\ufe0f in progress \u00b7 ${board.current.stepCount} step${board.current.stepCount === 1 ? '' : 's'}`;
+            const assist = board.current.assistance != null ? ` \u00b7 support: ${esc(assistText(board.current.assistance))}` : '';
+            const src = board.current.fromWorksheet ? ' \u00b7 \ud83d\udcce from worksheet' : '';
+            html += `<p style="margin:4px 0;font-size:.9em;"><strong>Now:</strong> <code>${esc(board.current.problemTex)}</code><br><span style="color:#7f8c8d;font-size:.9em;">${status}${assist}${src}</span></p>`;
+        }
+
+        const solves = (board.independentSolves || 0) + (board.supportedSolves || 0);
+        if (solves > 0) {
+            html += `<p style="margin:4px 0;font-size:.85em;color:#7f8c8d;">Finished this session: ${board.completed.length} \u00b7 <strong>${board.independentSolves}</strong> solved independently, <strong>${board.supportedSolves}</strong> with support</p>`;
+        } else if (board.completed && board.completed.length) {
+            html += `<p style="margin:4px 0;font-size:.85em;color:#7f8c8d;">Finished this session: ${board.completed.length}</p>`;
+        }
+
+        if (cards.length) {
+            html += '<p style="margin:8px 0 2px;font-size:.85em;"><strong>Recent notebook cards</strong></p><ul style="margin:2px 0 0;padding-left:18px;font-size:.85em;">';
+            cards.slice(0, 5).forEach((c) => {
+                const icon = CARD_ICONS[c.type] || '\ud83d\udcd3';
+                const seen = c.type === 'reminder' && c.seenCount >= 2 ? ` <span style="color:#e0a23c;">(\u00d7${c.seenCount})</span>` : '';
+                const when = c.createdAt ? ` <span style="color:#95a5a6;">\u00b7 ${new Date(c.createdAt).toLocaleDateString()}</span>` : '';
+                html += `<li>${icon} ${esc(c.title)}${seen}${when}</li>`;
+            });
+            html += '</ul>';
+        }
+
+        section.innerHTML = html;
+    }
+
     async function openStudentProfile(studentId) {
         const student = currentStudentsData.find(s => s._id === studentId);
         if (!student) return;
@@ -1070,6 +1141,9 @@ document.addEventListener("DOMContentLoaded", async () => {
 
         // Render sparkline (weekly activity trend)
         renderSparkline(student);
+
+        // Live Workspace summary (spec §20): the student's board at a glance.
+        loadWorkspaceSummary(studentId);
 
         // Load recent conversations (preview, 3 most recent)
         const conversationsDiv = document.getElementById('detail-conversations');

--- a/public/teacher-dashboard.html
+++ b/public/teacher-dashboard.html
@@ -6030,7 +6030,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <script src="/js/auto-logout.js"></script>
   <script src="/js/teacher-live-feed.js"></script>
   <script src="/js/teacher-live-monitor.js"></script>
-  <script src="/js/teacher-dashboard.js?v=2.2"></script>
+  <script src="/js/teacher-dashboard.js?v=2.3"></script>
   <script src="/js/teacher-transcripts.js"></script>
   <script src="/js/teacher-curriculum.js"></script>
   <script src="/js/teacher-resources.js"></script>

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -1789,6 +1789,8 @@ async function runStudentTurn(req, res) {
             // Notebook cards minted this turn (AHA moments, activated
             // reminders) — the client celebrates them (spec §7).
             learningCards: pipelineResult.learningCards || [],
+            // Tutor-proposed idea for the notebook (§7.6) — student confirms.
+            ideaSuggestion: pipelineResult.ideaSuggestion || null,
             xpCommands: pipelineResult.xpCommands || [],
             visualTabCommands: pipelineResult.visualTabCommands || [],
             boardContext: pipelineResult.boardContext,

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -1791,6 +1791,8 @@ async function runStudentTurn(req, res) {
             learningCards: pipelineResult.learningCards || [],
             // Tutor-proposed idea for the notebook (§7.6) — student confirms.
             ideaSuggestion: pipelineResult.ideaSuggestion || null,
+            // Tutor pointing at a board line (§8) — client highlights it.
+            boardPoint: pipelineResult.boardPoint || null,
             xpCommands: pipelineResult.xpCommands || [],
             visualTabCommands: pipelineResult.visualTabCommands || [],
             boardContext: pipelineResult.boardContext,

--- a/routes/notebook.js
+++ b/routes/notebook.js
@@ -53,6 +53,40 @@ router.get('/', isAuthenticated, async (req, res) => {
   }
 });
 
+// Student-confirmed card creation (spec §7.6 promotion): the tutor OFFERS an
+// idea (<NOTEBOOK_IDEA> → ideaSuggestion on the chat response) and the student
+// clicks save — this is that click. Restricted to the student-initiated kinds;
+// aha/reminder stay pipeline-only so their evidence semantics stay honest.
+const CREATABLE_TYPES = ['idea', 'strategy', 'reflection'];
+function sanitizeCardInput(body) {
+  const b = body || {};
+  const type = CREATABLE_TYPES.includes(b.type) ? b.type : 'idea';
+  const title = String(b.title == null ? '' : b.title).trim().slice(0, 160);
+  const text = String(b.body == null ? '' : b.body).trim().slice(0, 2000);
+  if (!title && !text) return null;
+  const skillId = b.skillId ? String(b.skillId).trim().slice(0, 80) : null;
+  return { type, title: title || text.slice(0, 60), body: text, skillId };
+}
+
+router.post('/', isAuthenticated, async (req, res) => {
+  try {
+    const input = sanitizeCardInput(req.body);
+    if (!input) return res.status(400).json({ message: 'Card needs a title or body' });
+    const card = await LearningCard.create({
+      userId: req.user._id,
+      type: input.type,
+      title: input.title,
+      body: input.body,
+      skillId: input.skillId,
+      conversationId: null,
+    });
+    res.status(201).json({ card: { _id: card._id, type: card.type, title: card.title } });
+  } catch (err) {
+    logger.error('Failed to create notebook card', { error: err.message });
+    res.status(500).json({ message: 'Failed to save card' });
+  }
+});
+
 router.patch('/:id/archive', isAuthenticated, async (req, res) => {
   try {
     const card = await LearningCard.findOneAndUpdate(
@@ -69,6 +103,6 @@ router.patch('/:id/archive', isAuthenticated, async (req, res) => {
 });
 
 // Pure helpers reachable from unit tests (same pattern as practicePack).
-router.__helpers = { escapeRegex, buildSearchClause };
+router.__helpers = { escapeRegex, buildSearchClause, sanitizeCardInput };
 
 module.exports = router;

--- a/routes/teacher.js
+++ b/routes/teacher.js
@@ -14,6 +14,8 @@ const ScreenerSession = require('../models/screenerSession');
 const EnrollmentCode = require('../models/enrollmentCode');
 const Skill = require('../models/skill');
 const { resolveSkillDisplayNames } = require('../utils/skillDisplayNames');
+const { summarizeLedger } = require('../utils/pipeline/boardLedger');
+const LearningCard = require('../models/learningCard');
 const { callLLMStream } = require('../utils/openaiClient');
 const { getStudentIdsForTeacher } = require('../services/userService');
 const { logRecordAccess } = require('../middleware/ferpaAccessLog');
@@ -1919,6 +1921,53 @@ router.post('/intervention-alerts/:studentId/acknowledge', isTeacher, async (req
   } catch (err) {
     console.error('Error acknowledging intervention alert:', err);
     res.status(500).json({ message: 'Error acknowledging alert.' });
+  }
+});
+
+// ── Live Workspace summary (spec §20) ────────────────────────────────
+// What the student's board says: the problem in focus and its status, how
+// much support each finished problem took (the §12 assistance ladder), and
+// their recent notebook cards — reminders double as the "recent
+// misconception" signal. A progress read, not a transcript feed: no step
+// contents, no chat, no student quotes beyond card titles.
+router.get('/students/:studentId/workspace-summary', isTeacher, requireActiveConsent(), logRecordAccess('workspace_summary', 'academic_progress'), async (req, res) => {
+  try {
+    const { studentId } = req.params;
+    const teacherId = req.user._id;
+
+    const authorizedStudentIds = await getStudentIdsForTeacher(teacherId);
+    if (!authorizedStudentIds.includes(studentId)) {
+      return res.status(404).json({ message: 'Student not found or not assigned to this teacher.' });
+    }
+
+    const student = await User.findOne(
+      { _id: studentId, $or: [{ roles: 'student' }, { role: 'student' }] },
+      'activeConversationId'
+    ).lean();
+    if (!student) {
+      return res.status(404).json({ message: 'Student not found or not assigned to this teacher.' });
+    }
+
+    const [conversation, cards] = await Promise.all([
+      student.activeConversationId
+        ? Conversation.findById(student.activeConversationId).select('boardLedger lastActivity currentTopic').lean()
+        : Promise.resolve(null),
+      LearningCard.find({ userId: studentId, archived: false })
+        .sort({ createdAt: -1 })
+        .limit(10)
+        .select('type title seenCount skillId createdAt')
+        .lean(),
+    ]);
+
+    res.json({
+      board: summarizeLedger(conversation?.boardLedger),
+      lastActivity: conversation?.lastActivity || null,
+      currentTopic: conversation?.currentTopic || null,
+      learningCards: cards,
+    });
+  } catch (err) {
+    console.error('Error fetching workspace summary:', err);
+    res.status(500).json({ message: 'Server error fetching workspace summary.' });
   }
 });
 

--- a/tests/unit/boardLedger.test.js
+++ b/tests/unit/boardLedger.test.js
@@ -177,3 +177,41 @@ describe('applyTurnToLedger', () => {
     expect(l.current).toBeNull();
   });
 });
+
+describe('summarizeLedger (teacher view, spec §20)', () => {
+  const { summarizeLedger } = require('../../utils/pipeline/boardLedger');
+
+  test('null/empty ledgers summarize to an empty read', () => {
+    expect(summarizeLedger(null)).toEqual({ current: null, completed: [], independentSolves: 0, supportedSolves: 0 });
+    expect(summarizeLedger({}).current).toBeNull();
+  });
+
+  test('summarizes focus + support split WITHOUT step contents', () => {
+    let l = applyTurnToLedger(null, [{ action: 'pose', tex: 'a=1' }], NOW, 2);
+    l = applyTurnToLedger(l, [{ action: 'verify', tex: 'a=1' }], NOW, 2);      // independent (≤4)
+    l = applyTurnToLedger(l, [{ action: 'pose', tex: 'b=2' }], NOW, 1);
+    l = applyTurnToLedger(l, [{ action: 'verify', tex: 'b=2' }], NOW, 8);      // supported (≥5)
+    l = applyTurnToLedger(l, [{ action: 'pose', tex: 'c=3' }], NOW, 1);
+    l = applyTurnToLedger(l, [{ action: 'resolve', tex: 'c' }], NOW, 5);
+
+    const s = summarizeLedger(JSON.parse(JSON.stringify(l)));
+    expect(s.current).toMatchObject({ problemTex: 'c=3', stepCount: 1, solved: false, assistance: 5 });
+    expect(s.current.steps).toBeUndefined();               // a progress read, not a feed
+    expect(s.completed).toHaveLength(2);
+    expect(s.completed[0].steps).toBeUndefined();
+    expect(s.independentSolves).toBe(1);
+    expect(s.supportedSolves).toBe(1);
+  });
+
+  test('unsolved and unrated problems never count toward the solve split', () => {
+    let l = applyTurnToLedger(null, [{ action: 'pose', tex: 'x=1' }], NOW);
+    l = applyTurnToLedger(l, [{ action: 'verify', tex: 'x=1' }], NOW);          // solved, assistance unknown
+    l = applyTurnToLedger(l, [{ action: 'pose', tex: 'y=2' }], NOW);
+    l = applyTurnToLedger(l, [{ action: 'resolve', tex: 'y' }], NOW, 9);
+    l = applyTurnToLedger(l, [{ action: 'clear' }], NOW);                       // abandoned
+    const s = summarizeLedger(l);
+    expect(s.independentSolves).toBe(0);
+    expect(s.supportedSolves).toBe(0);
+    expect(s.completed).toHaveLength(2);
+  });
+});

--- a/tests/unit/boardPoint.test.js
+++ b/tests/unit/boardPoint.test.js
@@ -1,0 +1,53 @@
+/**
+ * Tutor board-pointing (spec §8): tag extraction + prompt instruction.
+ *
+ * The numbering contract: <BOARD_POINT step="N"/> uses the board-state
+ * block's step numbers, which are the ledger's rendered-row order — the same
+ * order the DerivationView paints. One point per turn; tags never leak.
+ */
+const { verify } = require('../../utils/pipeline/verify');
+const { buildBoardStateBlock } = require('../../utils/pipeline/boardStateBlock');
+const { applyTurnToLedger } = require('../../utils/pipeline/boardLedger');
+
+const NOW = new Date('2026-07-25T12:00:00Z');
+
+describe('BOARD_POINT extraction', () => {
+  test('step form extracts and strips', async () => {
+    const v = await verify('Look at this line. <BOARD_POINT step="2"/> See the sign?', {});
+    expect(v.extracted.boardPoint).toEqual({ step: 2 });
+    expect(v.text).not.toContain('BOARD_POINT');
+    expect(v.text).toContain('Look at this line.');
+    expect(v.text).toContain('See the sign?');
+  });
+
+  test('target forms extract; first of many wins; junk targets ignored', async () => {
+    const v = await verify('<BOARD_POINT target="solution"/> and <BOARD_POINT step="1"/>', {});
+    expect(v.extracted.boardPoint).toEqual({ target: 'solution' });
+    expect(v.text).not.toContain('BOARD_POINT');
+    const junk = await verify('<BOARD_POINT target="banana"/>', {});
+    expect(junk.extracted.boardPoint).toBeNull();
+    expect(junk.text).toContain('BOARD_POINT'); // unrecognized shape left alone (harmless text, model error)
+  });
+
+  test('no tag → null', async () => {
+    const v = await verify('plain reply', {});
+    expect(v.extracted.boardPoint).toBeNull();
+  });
+});
+
+describe('board-state block teaches pointing only when a problem is up', () => {
+  test('with a problem in focus, the POINTING instruction appears', () => {
+    let l = applyTurnToLedger(null, [{ action: 'pose', tex: '2x+5=13' }], NOW);
+    l = applyTurnToLedger(l, [{ action: 'resolve', tex: '2x=8' }], NOW);
+    const block = buildBoardStateBlock(l);
+    expect(block).toContain('POINTING:');
+    expect(block).toContain('<BOARD_POINT step="N"/>');
+  });
+
+  test('no problem in focus → no pointing instruction (nothing to point at)', () => {
+    let l = applyTurnToLedger(null, [{ action: 'pose', tex: 'a=1' }], NOW);
+    l = applyTurnToLedger(l, [{ action: 'verify', tex: 'a=1' }, { action: 'clear' }], NOW);
+    const block = buildBoardStateBlock(l);
+    expect(block).not.toContain('POINTING:');
+  });
+});

--- a/tests/unit/ideaSuggestion.test.js
+++ b/tests/unit/ideaSuggestion.test.js
@@ -1,0 +1,70 @@
+/**
+ * Tutor-offered notebook ideas (spec §7.6): tag extraction + save validation.
+ *
+ * The contract: the tutor OFFERS via <NOTEBOOK_IDEA>, the student consents via
+ * POST /api/notebook. One offer per turn; every tag is stripped from the
+ * student-visible text; the create endpoint only mints student-initiated kinds.
+ */
+const { verify } = require('../../utils/pipeline/verify');
+const notebookRouter = require('../../routes/notebook');
+const { sanitizeCardInput } = notebookRouter.__helpers;
+
+// verify() is the pipeline stage; extractSystemTags is internal, so exercise
+// it through verify's public surface: verify(responseText, context).
+async function runVerify(text) {
+  return verify(text, {});
+}
+
+describe('NOTEBOOK_IDEA extraction', () => {
+  test('a titled offer extracts and strips clean', async () => {
+    const v = await runVerify('Nice work! <NOTEBOOK_IDEA title="Balance rule">Whatever you do to one side, do to the other.</NOTEBOOK_IDEA> Ready for the next one?');
+    expect(v.extracted.ideaSuggestion).toEqual({
+      title: 'Balance rule',
+      body: 'Whatever you do to one side, do to the other.',
+    });
+    expect(v.text).not.toContain('NOTEBOOK_IDEA');
+    expect(v.text).toContain('Nice work!');
+    expect(v.text).toContain('Ready for the next one?');
+  });
+
+  test('missing title falls back to the body head; empty body yields nothing', async () => {
+    const v = await runVerify('<NOTEBOOK_IDEA>Parallel lines have equal slopes.</NOTEBOOK_IDEA>');
+    expect(v.extracted.ideaSuggestion.title).toBe('Parallel lines have equal slopes.');
+    const empty = await runVerify('plain reply, no tags');
+    expect(empty.extracted.ideaSuggestion).toBeNull();
+  });
+
+  test('only the FIRST offer counts; all tags are stripped regardless', async () => {
+    const v = await runVerify(
+      '<NOTEBOOK_IDEA title="One">first</NOTEBOOK_IDEA> and <NOTEBOOK_IDEA title="Two">second</NOTEBOOK_IDEA>'
+    );
+    expect(v.extracted.ideaSuggestion.title).toBe('One');
+    expect(v.text).not.toContain('NOTEBOOK_IDEA');
+    expect(v.text).not.toContain('second');
+  });
+});
+
+describe('sanitizeCardInput (POST /api/notebook)', () => {
+  test('valid idea passes through with caps applied', () => {
+    const input = sanitizeCardInput({ type: 'idea', title: 'Balance rule', body: 'Do it to both sides.', skillId: 'two-step-equations' });
+    expect(input).toEqual({ type: 'idea', title: 'Balance rule', body: 'Do it to both sides.', skillId: 'two-step-equations' });
+  });
+
+  test('pipeline-only kinds are coerced to idea — clients cannot mint AHA/reminder evidence', () => {
+    expect(sanitizeCardInput({ type: 'aha', title: 'fake', body: 'x' }).type).toBe('idea');
+    expect(sanitizeCardInput({ type: 'reminder', title: 'fake', body: 'x' }).type).toBe('idea');
+    expect(sanitizeCardInput({ type: 'reflection', title: 't', body: 'x' }).type).toBe('reflection');
+  });
+
+  test('empty submissions are rejected; missing title derives from body', () => {
+    expect(sanitizeCardInput({})).toBeNull();
+    expect(sanitizeCardInput({ body: '   ' })).toBeNull();
+    expect(sanitizeCardInput({ body: 'Estimate before calculating.' }).title).toBe('Estimate before calculating.');
+  });
+
+  test('oversized fields are truncated, not rejected', () => {
+    const input = sanitizeCardInput({ title: 'T'.repeat(500), body: 'B'.repeat(5000) });
+    expect(input.title.length).toBe(160);
+    expect(input.body.length).toBe(2000);
+  });
+});

--- a/utils/pipeline/boardLedger.js
+++ b/utils/pipeline/boardLedger.js
@@ -195,10 +195,51 @@ function problemAssistance(ledger) {
   return null;
 }
 
+/**
+ * Teacher-facing summary of a student's board (Live Workspace spec §20):
+ * what they're working on, how it's going, and how much support each
+ * finished problem took — WITHOUT the step-by-step contents (that lives in
+ * the student's own board; the teacher view is a progress read, not a feed).
+ * Pure; null-safe for students who have never touched the board.
+ */
+function summarizeLedger(ledger) {
+  const empty = { current: null, completed: [], independentSolves: 0, supportedSolves: 0 };
+  if (!ledger || typeof ledger !== 'object') return empty;
+
+  const cur = ledger.current && ledger.current.problemTex ? {
+    problemTex: String(ledger.current.problemTex).slice(0, 200),
+    stepCount: Array.isArray(ledger.current.steps) ? ledger.current.steps.length : 0,
+    solved: Array.isArray(ledger.current.steps) && ledger.current.steps.some(c => c && c.action === 'verify'),
+    assistance: ledger.current.assistance || null,
+    fromWorksheet: !!ledger.current.sourceRef,
+  } : null;
+
+  const completed = (Array.isArray(ledger.completed) ? ledger.completed : [])
+    .filter(e => e && e.problemTex)
+    .map(e => ({
+      problemTex: String(e.problemTex).slice(0, 200),
+      solved: !!e.solved,
+      assistance: e.assistance || null,
+      fromWorksheet: !!e.sourceRef,
+      completedAt: e.completedAt || null,
+    }));
+
+  let independentSolves = 0;
+  let supportedSolves = 0;
+  for (const e of completed) {
+    if (!e.solved) continue;
+    if (e.assistance != null && e.assistance <= 4) independentSolves += 1;
+    else if (e.assistance != null) supportedSolves += 1;
+  }
+
+  return { current: cur, completed, independentSolves, supportedSolves };
+}
+
 module.exports = {
   applyTurnToLedger,
   problemAssistance,
   sanitizeSourceRef,
+  summarizeLedger,
   emptyLedger,
   MAX_COMPLETED,
   MAX_STEPS,

--- a/utils/pipeline/boardStateBlock.js
+++ b/utils/pipeline/boardStateBlock.js
@@ -92,6 +92,12 @@ function buildBoardStateBlock(ledger) {
     + '("look at the last line on your board"). If the problem is SOLVED, do not keep '
     + 'working it — celebrate briefly and move forward. When the student says "what\'s next", '
     + 'advance from the newest board line, not from the beginning.');
+  if (cur && cur.problemTex) {
+    lines.push('POINTING: To make the exact line you are discussing glow on the student\'s '
+      + 'board, append <BOARD_POINT step="N"/> (N from the numbering above) or '
+      + '<BOARD_POINT target="problem"/> / target="solution" / target="last". At most one '
+      + 'per turn, and only when you are referring to that specific line.');
+  }
 
   return lines.join('\n');
 }

--- a/utils/pipeline/generate.js
+++ b/utils/pipeline/generate.js
@@ -432,6 +432,17 @@ function assemblePrompt(decision, promptContext) {
     );
   }
 
+  // ── Notebook idea offers (Live Workspace §7.6) ──
+  // Compact and always-on: the tutor may OFFER a reusable idea for the
+  // student's notebook; the student confirms client-side. Deliberately rare —
+  // the instruction sets a high bar so the notebook stays meaningful.
+  fullSystemPrompt += '\n\n--- NOTEBOOK ---\n'
+    + 'When a turn lands a genuinely reusable idea the student just grasped (a rule or '
+    + 'pattern worth keeping, e.g. "whatever you do to one side, do to the other"), you may '
+    + 'offer it for their notebook by appending: <NOTEBOOK_IDEA title="Short name">One sentence, '
+    + 'in the student\'s language.</NOTEBOOK_IDEA> — at most one per turn, only at real moments, '
+    + 'never for routine steps. The student chooses whether to save it.';
+
   // Inject phase-specific prompt if available
   if (decision.phasePrompt) {
     fullSystemPrompt += '\n\n' + decision.phasePrompt;

--- a/utils/pipeline/index.js
+++ b/utils/pipeline/index.js
@@ -1690,6 +1690,8 @@ async function runPipeline(message, ctx) {
     // Signals the client to open the timed practice-ACT runner. Extracted in
     // verify (shared choke point) so it fires on both /api/chat and course-chat.
     launchPracticeAct: verified.extracted?.launchPracticeAct || false,
+    // Tutor-proposed notebook idea (§7.6) — the client asks the student.
+    ideaSuggestion: verified.extracted?.ideaSuggestion || null,
     // Tutor finished coaching the current missed question → advance the ACT
     // bootcamp review queue (handled in routes/chat.js after the pipeline).
     reviewNext: verified.extracted?.reviewNext || false,

--- a/utils/pipeline/index.js
+++ b/utils/pipeline/index.js
@@ -1692,6 +1692,8 @@ async function runPipeline(message, ctx) {
     launchPracticeAct: verified.extracted?.launchPracticeAct || false,
     // Tutor-proposed notebook idea (§7.6) — the client asks the student.
     ideaSuggestion: verified.extracted?.ideaSuggestion || null,
+    // Tutor pointing at a specific board line (§8) — the client makes it glow.
+    boardPoint: verified.extracted?.boardPoint || null,
     // Tutor finished coaching the current missed question → advance the ACT
     // bootcamp review queue (handled in routes/chat.js after the pipeline).
     reviewNext: verified.extracted?.reviewNext || false,

--- a/utils/pipeline/verify.js
+++ b/utils/pipeline/verify.js
@@ -195,6 +195,7 @@ function extractSystemTags(responseText) {
     moduleComplete: false,
     launchPracticeAct: false,
     reviewNext: false,
+    ideaSuggestion: null,
   };
 
   let text = responseText;
@@ -287,6 +288,24 @@ function extractSystemTags(responseText) {
     extracted.launchPracticeAct = true;
     text = text.replace(/<\s*LAUNCH_PRACTICE_ACT\s*>/gi, '').trim();
     console.log('[Verify] AI emitted <LAUNCH_PRACTICE_ACT> — signalling client to open the practice ACT runner');
+  }
+
+  // Notebook idea offer (Live Workspace §7.6). The tutor may propose saving a
+  // reusable idea; the STUDENT confirms client-side — promotion is consented,
+  // never silent. One offer per turn; extras are stripped without effect.
+  const ideaRegex = /<\s*NOTEBOOK_IDEA(?:\s+title="([^"]{0,160})")?\s*>([\s\S]{1,600}?)<\/\s*NOTEBOOK_IDEA\s*>/gi;
+  let ideaMatch;
+  while ((ideaMatch = ideaRegex.exec(responseText)) !== null) {
+    if (!extracted.ideaSuggestion) {
+      const body = ideaMatch[2].trim();
+      if (body) {
+        extracted.ideaSuggestion = {
+          title: (ideaMatch[1] || '').trim() || body.slice(0, 60),
+          body,
+        };
+      }
+    }
+    text = text.replace(ideaMatch[0], '').trim();
   }
 
   // ACT bootcamp: tutor finished coaching the current missed question → advance.

--- a/utils/pipeline/verify.js
+++ b/utils/pipeline/verify.js
@@ -196,6 +196,7 @@ function extractSystemTags(responseText) {
     launchPracticeAct: false,
     reviewNext: false,
     ideaSuggestion: null,
+    boardPoint: null,
   };
 
   let text = responseText;
@@ -306,6 +307,21 @@ function extractSystemTags(responseText) {
       }
     }
     text = text.replace(ideaMatch[0], '').trim();
+  }
+
+  // Board pointing (Live Workspace §8): the tutor names the exact line it is
+  // talking about; the client makes that line glow. Step numbers match the
+  // board-state block's numbering (the ledger's step order). One point per
+  // turn — a laser pointer, not a light show; extras are stripped inert.
+  const pointRegex = /<\s*BOARD_POINT\s+(?:step="(\d{1,2})"|target="(problem|solution|last)")\s*\/?\s*>/gi;
+  let pointMatch;
+  while ((pointMatch = pointRegex.exec(responseText)) !== null) {
+    if (!extracted.boardPoint) {
+      extracted.boardPoint = pointMatch[1]
+        ? { step: parseInt(pointMatch[1], 10) }
+        : { target: pointMatch[2].toLowerCase() };
+    }
+    text = text.replace(pointMatch[0], '').trim();
   }
 
   // ACT bootcamp: tutor finished coaching the current missed question → advance.


### PR DESCRIPTION
Ninth Live Workspace slice: the §7.6 promotion workflow — **the tutor offers, the student decides.**

## Flow

1. A compact always-on prompt block (deliberately high bar: "only at real moments, never for routine steps, at most one per turn") teaches the tutor it may append `<NOTEBOOK_IDEA title="…">one sentence in the student's language</NOTEBOOK_IDEA>` when a turn lands a genuinely reusable idea.
2. `verify` extracts **one** offer per turn and strips every tag from the student-visible reply (same choke point as `<LAUNCH_PRACTICE_ACT>`, so it works on both chat routes).
3. The client renders a consent chip under the tutor's message — **"💡 Save to my notebook: “Balance rule”"** / *No thanks*. Nothing is stored silently.
4. Saving hits the new `POST /api/notebook`, which only mints student-initiated kinds (`idea`/`strategy`/`reflection`) — `aha`/`reminder` are **coerced away server-side** so no client can manufacture pipeline evidence. Title/body capped and truncated.

This also gives the AHA detector its ask-when-unsure path: weak realization signals can now become tutor offers instead of silent skips.

## Verification

Full suite green, lint clean. New tests: extraction through `verify`'s public surface (titled offer, title-from-body fallback, first-of-many wins, all tags stripped), and the create-endpoint sanitizer (kind coercion, empty rejection, truncation).

Manual QA: reach a real teaching moment → tutor appends the offer → chip appears → Save → card in 📓 under Ideas; the raw tag never shows in chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)