### PR TITLE
feat(lws): teacher workspace summary — the board at a glance (spec §20)

### DIFF
--- a/public/js/teacher-dashboard.js
+++ b/public/js/teacher-dashboard.js
@@ -1029,6 +1029,77 @@ document.addEventListener("DOMContentLoaded", async () => {
         openStudentProfile(studentId);
     }
 
+    // ── Live Workspace summary (spec §20) ──
+    // Injected into the overview tab: the student's board at a glance —
+    // problem in focus + status, independent-vs-supported solve counts (the
+    // §12 assistance ladder), and recent notebook cards (reminders double as
+    // the recent-misconception signal). Renders nothing for students who
+    // haven't touched the board.
+    const ASSISTANCE_LABELS = { 1: 'independent', 2: 'encouragement', 3: 'directions', 4: 'attention cue', 5: 'strategic question', 6: 'visual scaffold', 7: 'partial setup', 8: 'parallel example', 9: 'explicit instruction' };
+    const CARD_ICONS = { aha: '\u2728', reminder: '\ud83d\udccc', idea: '\ud83d\udca1', strategy: '\ud83e\udded', reflection: '\ud83e\ude9e' };
+
+    async function loadWorkspaceSummary(studentId) {
+        const tab = document.getElementById('profile-overview-tab');
+        if (!tab) return;
+        let section = document.getElementById('detail-workspace-section');
+        if (!section) {
+            section = document.createElement('div');
+            section.id = 'detail-workspace-section';
+            section.className = 'detail-section';
+            tab.appendChild(section);
+        }
+        section.innerHTML = '<h4 style="margin:14px 0 6px;">\ud83d\udcd0 Live Workspace</h4><p style="font-size:.85em;color:#95a5a6;">Loading\u2026</p>';
+
+        try {
+            const res = await fetch(`/api/teacher/students/${studentId}/workspace-summary`);
+            if (!res.ok) throw new Error(`workspace summary ${res.status}`);
+            const data = await res.json();
+            renderWorkspaceSummary(section, data);
+        } catch (err) {
+            console.error('[TeacherDashboard] workspace summary failed:', err);
+            section.innerHTML = '';
+        }
+    }
+
+    function renderWorkspaceSummary(section, data) {
+        const board = data.board || {};
+        const cards = Array.isArray(data.learningCards) ? data.learningCards : [];
+        const hasAnything = board.current || (board.completed && board.completed.length) || cards.length;
+        if (!hasAnything) { section.innerHTML = ''; return; }
+
+        const esc = (t) => { const d = document.createElement('div'); d.textContent = String(t == null ? '' : t); return d.innerHTML; };
+        const assistText = (a) => a == null ? '' : (ASSISTANCE_LABELS[a] || `level ${a}`);
+
+        let html = '<h4 style="margin:14px 0 6px;">\ud83d\udcd0 Live Workspace</h4>';
+
+        if (board.current) {
+            const status = board.current.solved ? '\u2705 solved' : `\u270f\ufe0f in progress \u00b7 ${board.current.stepCount} step${board.current.stepCount === 1 ? '' : 's'}`;
+            const assist = board.current.assistance != null ? ` \u00b7 support: ${esc(assistText(board.current.assistance))}` : '';
+            const src = board.current.fromWorksheet ? ' \u00b7 \ud83d\udcce from worksheet' : '';
+            html += `<p style="margin:4px 0;font-size:.9em;"><strong>Now:</strong> <code>${esc(board.current.problemTex)}</code><br><span style="color:#7f8c8d;font-size:.9em;">${status}${assist}${src}</span></p>`;
+        }
+
+        const solves = (board.independentSolves || 0) + (board.supportedSolves || 0);
+        if (solves > 0) {
+            html += `<p style="margin:4px 0;font-size:.85em;color:#7f8c8d;">Finished this session: ${board.completed.length} \u00b7 <strong>${board.independentSolves}</strong> solved independently, <strong>${board.supportedSolves}</strong> with support</p>`;
+        } else if (board.completed && board.completed.length) {
+            html += `<p style="margin:4px 0;font-size:.85em;color:#7f8c8d;">Finished this session: ${board.completed.length}</p>`;
+        }
+
+        if (cards.length) {
+            html += '<p style="margin:8px 0 2px;font-size:.85em;"><strong>Recent notebook cards</strong></p><ul style="margin:2px 0 0;padding-left:18px;font-size:.85em;">';
+            cards.slice(0, 5).forEach((c) => {
+                const icon = CARD_ICONS[c.type] || '\ud83d\udcd3';
+                const seen = c.type === 'reminder' && c.seenCount >= 2 ? ` <span style="color:#e0a23c;">(\u00d7${c.seenCount})</span>` : '';
+                const when = c.createdAt ? ` <span style="color:#95a5a6;">\u00b7 ${new Date(c.createdAt).toLocaleDateString()}</span>` : '';
+                html += `<li>${icon} ${esc(c.title)}${seen}${when}</li>`;
+            });
+            html += '</ul>';
+        }
+
+        section.innerHTML = html;
+    }
+
     async function openStudentProfile(studentId) {
         const student = currentStudentsData.find(s => s._id === studentId);
         if (!student) return;
@@ -1070,6 +1141,9 @@ document.addEventListener("DOMContentLoaded", async () => {
 
         // Render sparkline (weekly activity trend)
         renderSparkline(student);
+
+        // Live Workspace summary (spec §20): the student's board at a glance.
+        loadWorkspaceSummary(studentId);
 
         // Load recent conversations (preview, 3 most recent)
         const conversationsDiv = document.getElementById('detail-conversations');

--- a/public/teacher-dashboard.html
+++ b/public/teacher-dashboard.html
@@ -6030,7 +6030,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <script src="/js/auto-logout.js"></script>
   <script src="/js/teacher-live-feed.js"></script>
   <script src="/js/teacher-live-monitor.js"></script>
-  <script src="/js/teacher-dashboard.js?v=2.2"></script>
+  <script src="/js/teacher-dashboard.js?v=2.3"></script>
   <script src="/js/teacher-transcripts.js"></script>
   <script src="/js/teacher-curriculum.js"></script>
   <script src="/js/teacher-resources.js"></script>

--- a/routes/teacher.js
+++ b/routes/teacher.js
@@ -14,6 +14,8 @@ const ScreenerSession = require('../models/screenerSession');
 const EnrollmentCode = require('../models/enrollmentCode');
 const Skill = require('../models/skill');
 const { resolveSkillDisplayNames } = require('../utils/skillDisplayNames');
+const { summarizeLedger } = require('../utils/pipeline/boardLedger');
+const LearningCard = require('../models/learningCard');
 const { callLLMStream } = require('../utils/openaiClient');
 const { getStudentIdsForTeacher } = require('../services/userService');
 const { logRecordAccess } = require('../middleware/ferpaAccessLog');
@@ -1919,6 +1921,53 @@ router.post('/intervention-alerts/:studentId/acknowledge', isTeacher, async (req
   } catch (err) {
     console.error('Error acknowledging intervention alert:', err);
     res.status(500).json({ message: 'Error acknowledging alert.' });
+  }
+});
+
+// ── Live Workspace summary (spec §20) ────────────────────────────────
+// What the student's board says: the problem in focus and its status, how
+// much support each finished problem took (the §12 assistance ladder), and
+// their recent notebook cards — reminders double as the "recent
+// misconception" signal. A progress read, not a transcript feed: no step
+// contents, no chat, no student quotes beyond card titles.
+router.get('/students/:studentId/workspace-summary', isTeacher, requireActiveConsent(), logRecordAccess('workspace_summary', 'academic_progress'), async (req, res) => {
+  try {
+    const { studentId } = req.params;
+    const teacherId = req.user._id;
+
+    const authorizedStudentIds = await getStudentIdsForTeacher(teacherId);
+    if (!authorizedStudentIds.includes(studentId)) {
+      return res.status(404).json({ message: 'Student not found or not assigned to this teacher.' });
+    }
+
+    const student = await User.findOne(
+      { _id: studentId, $or: [{ roles: 'student' }, { role: 'student' }] },
+      'activeConversationId'
+    ).lean();
+    if (!student) {
+      return res.status(404).json({ message: 'Student not found or not assigned to this teacher.' });
+    }
+
+    const [conversation, cards] = await Promise.all([
+      student.activeConversationId
+        ? Conversation.findById(student.activeConversationId).select('boardLedger lastActivity currentTopic').lean()
+        : Promise.resolve(null),
+      LearningCard.find({ userId: studentId, archived: false })
+        .sort({ createdAt: -1 })
+        .limit(10)
+        .select('type title seenCount skillId createdAt')
+        .lean(),
+    ]);
+
+    res.json({
+      board: summarizeLedger(conversation?.boardLedger),
+      lastActivity: conversation?.lastActivity || null,
+      currentTopic: conversation?.currentTopic || null,
+      learningCards: cards,
+    });
+  } catch (err) {
+    console.error('Error fetching workspace summary:', err);
+    res.status(500).json({ message: 'Server error fetching workspace summary.' });
   }
 });
 

--- a/tests/unit/boardLedger.test.js
+++ b/tests/unit/boardLedger.test.js
@@ -177,3 +177,41 @@ describe('applyTurnToLedger', () => {
     expect(l.current).toBeNull();
   });
 });
+
+describe('summarizeLedger (teacher view, spec §20)', () => {
+  const { summarizeLedger } = require('../../utils/pipeline/boardLedger');
+
+  test('null/empty ledgers summarize to an empty read', () => {
+    expect(summarizeLedger(null)).toEqual({ current: null, completed: [], independentSolves: 0, supportedSolves: 0 });
+    expect(summarizeLedger({}).current).toBeNull();
+  });
+
+  test('summarizes focus + support split WITHOUT step contents', () => {
+    let l = applyTurnToLedger(null, [{ action: 'pose', tex: 'a=1' }], NOW, 2);
+    l = applyTurnToLedger(l, [{ action: 'verify', tex: 'a=1' }], NOW, 2);      // independent (≤4)
+    l = applyTurnToLedger(l, [{ action: 'pose', tex: 'b=2' }], NOW, 1);
+    l = applyTurnToLedger(l, [{ action: 'verify', tex: 'b=2' }], NOW, 8);      // supported (≥5)
+    l = applyTurnToLedger(l, [{ action: 'pose', tex: 'c=3' }], NOW, 1);
+    l = applyTurnToLedger(l, [{ action: 'resolve', tex: 'c' }], NOW, 5);
+
+    const s = summarizeLedger(JSON.parse(JSON.stringify(l)));
+    expect(s.current).toMatchObject({ problemTex: 'c=3', stepCount: 1, solved: false, assistance: 5 });
+    expect(s.current.steps).toBeUndefined();               // a progress read, not a feed
+    expect(s.completed).toHaveLength(2);
+    expect(s.completed[0].steps).toBeUndefined();
+    expect(s.independentSolves).toBe(1);
+    expect(s.supportedSolves).toBe(1);
+  });
+
+  test('unsolved and unrated problems never count toward the solve split', () => {
+    let l = applyTurnToLedger(null, [{ action: 'pose', tex: 'x=1' }], NOW);
+    l = applyTurnToLedger(l, [{ action: 'verify', tex: 'x=1' }], NOW);          // solved, assistance unknown
+    l = applyTurnToLedger(l, [{ action: 'pose', tex: 'y=2' }], NOW);
+    l = applyTurnToLedger(l, [{ action: 'resolve', tex: 'y' }], NOW, 9);
+    l = applyTurnToLedger(l, [{ action: 'clear' }], NOW);                       // abandoned
+    const s = summarizeLedger(l);
+    expect(s.independentSolves).toBe(0);
+    expect(s.supportedSolves).toBe(0);
+    expect(s.completed).toHaveLength(2);
+  });
+});

--- a/utils/pipeline/boardLedger.js
+++ b/utils/pipeline/boardLedger.js
@@ -195,10 +195,51 @@ function problemAssistance(ledger) {
   return null;
 }
 
+/**
+ * Teacher-facing summary of a student's board (Live Workspace spec §20):
+ * what they're working on, how it's going, and how much support each
+ * finished problem took — WITHOUT the step-by-step contents (that lives in
+ * the student's own board; the teacher view is a progress read, not a feed).
+ * Pure; null-safe for students who have never touched the board.
+ */
+function summarizeLedger(ledger) {
+  const empty = { current: null, completed: [], independentSolves: 0, supportedSolves: 0 };
+  if (!ledger || typeof ledger !== 'object') return empty;
+
+  const cur = ledger.current && ledger.current.problemTex ? {
+    problemTex: String(ledger.current.problemTex).slice(0, 200),
+    stepCount: Array.isArray(ledger.current.steps) ? ledger.current.steps.length : 0,
+    solved: Array.isArray(ledger.current.steps) && ledger.current.steps.some(c => c && c.action === 'verify'),
+    assistance: ledger.current.assistance || null,
+    fromWorksheet: !!ledger.current.sourceRef,
+  } : null;
+
+  const completed = (Array.isArray(ledger.completed) ? ledger.completed : [])
+    .filter(e => e && e.problemTex)
+    .map(e => ({
+      problemTex: String(e.problemTex).slice(0, 200),
+      solved: !!e.solved,
+      assistance: e.assistance || null,
+      fromWorksheet: !!e.sourceRef,
+      completedAt: e.completedAt || null,
+    }));
+
+  let independentSolves = 0;
+  let supportedSolves = 0;
+  for (const e of completed) {
+    if (!e.solved) continue;
+    if (e.assistance != null && e.assistance <= 4) independentSolves += 1;
+    else if (e.assistance != null) supportedSolves += 1;
+  }
+
+  return { current: cur, completed, independentSolves, supportedSolves };
+}
+
 module.exports = {
   applyTurnToLedger,
   problemAssistance,
   sanitizeSourceRef,
+  summarizeLedger,
   emptyLedger,
   MAX_COMPLETED,
   MAX_STEPS,


### PR DESCRIPTION
Eleventh Live Workspace slice: the first read surface on top of everything the pipeline now records. **Stacked on #1315** (→ #1314); retargets as the stack merges.

## What the teacher sees

Opening a student in the dashboard now shows a **📐 Live Workspace** section on the overview tab:

- **Now:** the problem in focus, its status (✏️ in progress · N steps / ✅ solved), the support level it's taken so far, and whether it came from a worksheet.
- **Finished this session:** N — **X solved independently, Y with support** (the §12 assistance ladder doing its job for the person who needs it most).
- **Recent notebook cards:** AHA moments and reminders — a recurring reminder shows its ×count, which IS the "recent misconception" signal §20 asks for.

## Boundaries (deliberate)

- Roster-authorized via `getStudentIdsForTeacher` (direct + enrollment-code assignment), consent-gated, **FERPA access-logged** — same middleware stack as the IEP routes.
- `summarizeLedger()` strips step contents and chat: this is a progress read, not a transcript feed. Card titles are the only student language that crosses.
- Students who've never touched the board get nothing injected — no empty scaffolding.

## Verification

Full suite **4720 passed**, lint clean, dashboard JS syntax-checked. New tests: empty-ledger read, focus + support-split summarization (asserting steps are absent), unsolved/unrated problems excluded from the solve split.

Manual QA: open a student who's worked on the board → section appears with live data; a student with no board history → no section at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)