### PR TITLE
feat(act): bootcamp loop view replaces the scaffold stepper for ACT prep

### DIFF
--- a/public/js/lessonTracker.js
+++ b/public/js/lessonTracker.js
@@ -81,6 +81,19 @@ class LessonTracker {
     // --------------------------------------------------
 
     _render(pu) {
+        // ACT bootcamp: the course is a test→review→re-test loop, not a
+        // gradual-release scaffold, so render the loop view instead of the
+        // Warm-up/Learn/Practice stepper. Only for act-prep with bootcamp state.
+        if (pu && pu.bootcamp && pu.courseId === 'act-prep') {
+            return this._renderBootcamp(pu);
+        }
+        // Not in bootcamp mode — restore the standard tracker chrome if the
+        // bootcamp panel was showing.
+        const bcPanel = document.getElementById('lt-bootcamp');
+        if (bcPanel) bcPanel.style.display = 'none';
+        const ltContainer = document.querySelector('#lesson-tracker-wrapper .lt-container');
+        if (ltContainer) ltContainer.style.display = '';
+
         // Lesson breadcrumb (shows module > lesson context)
         this._renderBreadcrumb(pu);
 
@@ -114,6 +127,107 @@ class LessonTracker {
         if (wrapper && wrapper.style.display === 'none') {
             wrapper.style.display = 'block';
         }
+    }
+
+    // ── ACT bootcamp loop view (replaces the scaffold stepper for act-prep) ──
+    _renderBootcamp(pu) {
+        const wrapper = document.getElementById('lesson-tracker-wrapper');
+        if (!wrapper) return;
+        const ltContainer = wrapper.querySelector('.lt-container');
+        if (ltContainer) ltContainer.style.display = 'none';
+        let panel = document.getElementById('lt-bootcamp');
+        if (!panel) {
+            panel = document.createElement('div');
+            panel.id = 'lt-bootcamp';
+            panel.style.padding = '4px 0';
+            wrapper.appendChild(panel);
+        }
+        panel.innerHTML = this._bootcampHtml(pu.bootcamp, pu.diagnosticPlan);
+        panel.style.display = 'block';
+        wrapper.style.display = 'block';
+        this._wireBootcamp();
+        this._loadBootcampScore();
+    }
+
+    _bootcampHtml(bc, dp) {
+        const CAT = { 'integrating-essential-skills': 'Essential skills', 'number-quantity': 'Number & Quantity', algebra: 'Algebra', functions: 'Functions', geometry: 'Geometry', 'statistics-probability': 'Statistics & Probability' };
+        const label = (c) => CAT[c] || String(c || '').replace(/-/g, ' ');
+        const total = Array.isArray(bc.queue) ? bc.queue.length : 0;
+        const reviewed = Math.min(bc.index || 0, total);
+        const pct = total ? Math.round((100 * reviewed) / total) : 0;
+        const round = bc.round || 1;
+        const isReview = bc.phase === 'review' && total > 0;
+        const cur = isReview && Array.isArray(bc.queue) ? bc.queue[bc.index] : null;
+
+        const step = (icon, name, state) => {
+            const style = state === 'active'
+                ? 'background:rgba(255,255,255,.22);color:#fff;font-weight:600'
+                : state === 'done' ? 'color:rgba(255,255,255,.85)' : 'color:rgba(255,255,255,.5)';
+            return `<div style="flex:1;text-align:center;padding:8px 4px;border-radius:8px;font-size:12px;${style}"><i class="fas ${icon}"></i> ${name}</div>`;
+        };
+        const loop = `<div style="display:flex;gap:6px;margin:10px 0 14px">
+            ${step('fa-flag-checkered', 'Baseline', 'done')}
+            ${step('fa-bullseye', 'Review', isReview ? 'active' : 'done')}
+            ${step('fa-clipboard-list', 'Re-test', bc.phase === 'reassess' ? 'active' : 'todo')}
+            ${step('fa-chart-line', 'Compare', 'todo')}
+          </div>`;
+
+        const phaseCard = isReview ? `
+            <div style="background:rgba(255,255,255,.14);border-radius:12px;padding:12px 14px">
+              <div style="display:flex;justify-content:space-between;align-items:center;color:#fff;font-size:14px;font-weight:600;margin-bottom:8px"><span>Going over what you missed</span><span style="font-weight:500;font-size:12.5px;opacity:.85">${reviewed} of ${total} done</span></div>
+              <div style="height:7px;background:rgba(255,255,255,.22);border-radius:5px;overflow:hidden;margin-bottom:10px"><div style="width:${pct}%;height:100%;background:#fff;border-radius:5px"></div></div>
+              <div style="display:flex;justify-content:space-between;align-items:center;gap:10px;flex-wrap:wrap">
+                <span style="color:rgba(255,255,255,.9);font-size:12.5px">Up next: <strong>${cur ? label(cur.category) : '—'}</strong></span>
+                <button id="lt-bc-continue" style="background:#fff;color:#5b3ea8;border:0;border-radius:8px;padding:6px 14px;font-size:12.5px;font-weight:600;cursor:pointer">Continue in chat</button>
+              </div>
+            </div>` : `
+            <div style="background:rgba(255,255,255,.14);border-radius:12px;padding:12px 14px;display:flex;justify-content:space-between;align-items:center;gap:10px;flex-wrap:wrap">
+              <span style="color:#fff;font-size:13.5px;font-weight:500">You've reviewed your misses — take a fresh test to measure your gains.</span>
+              <button id="lt-bc-retest" style="background:#fff;color:#5b3ea8;border:0;border-radius:8px;padding:6px 14px;font-size:12.5px;font-weight:600;cursor:pointer">Take a fresh test</button>
+            </div>`;
+
+        const chips = (dp && (dp.focusCategories || dp.masteredCategories)) ? `
+            <div style="margin-top:12px;display:flex;flex-wrap:wrap;gap:6px;align-items:center">
+              ${(dp.focusCategories || []).map((c) => `<span style="background:rgba(255,255,255,.2);color:#fff;font-size:11.5px;padding:3px 9px;border-radius:20px">${label(c)}</span>`).join('')}
+              ${(dp.masteredCategories || []).map((c) => `<span style="background:rgba(255,255,255,.1);color:rgba(255,255,255,.75);font-size:11.5px;padding:3px 9px;border-radius:20px"><i class="fas fa-check" style="font-size:10px"></i> ${label(c)}</span>`).join('')}
+            </div>` : '';
+
+        return `
+          <div style="background:linear-gradient(135deg,#667eea,#764ba2);border-radius:14px;padding:14px 16px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif">
+            <div style="display:flex;justify-content:space-between;align-items:center;gap:10px;flex-wrap:wrap">
+              <span style="color:#fff;font-size:15px;font-weight:700">🎯 ACT bootcamp <span style="font-weight:500;font-size:12px;background:rgba(255,255,255,.2);padding:2px 9px;border-radius:20px;margin-left:4px">Round ${round}</span></span>
+              <span id="lt-bc-score" style="color:#fff;font-size:13px;opacity:.9"></span>
+            </div>
+            ${loop}
+            ${phaseCard}
+            ${chips}
+            <div style="margin-top:12px;text-align:right"><a id="lt-bc-progress" href="#" style="color:#fff;font-size:12px;opacity:.9;text-decoration:none"><i class="fas fa-chart-line"></i> See your progress</a></div>
+          </div>`;
+    }
+
+    _wireBootcamp() {
+        const cont = document.getElementById('lt-bc-continue');
+        if (cont) cont.addEventListener('click', () => {
+            const input = document.getElementById('user-input') || document.getElementById('chat-input');
+            if (input) input.focus();
+        });
+        const retest = document.getElementById('lt-bc-retest');
+        if (retest) retest.addEventListener('click', () => { if (window.openActTest) window.openActTest(); });
+        const prog = document.getElementById('lt-bc-progress');
+        if (prog) prog.addEventListener('click', (e) => { e.preventDefault(); if (window.openActProgress) window.openActProgress(); });
+    }
+
+    async _loadBootcampScore() {
+        try {
+            const fetcher = window.csrfFetch || window.fetch;
+            const r = await fetcher('/api/act-test/history').then((x) => x.json()).catch(() => null);
+            const a = ((r && r.attempts) || []).filter((x) => x.scaledScore != null);
+            const el = document.getElementById('lt-bc-score');
+            if (!el || !a.length) return;
+            if (a.length === 1) { el.textContent = `Score ${a[0].scaledScore}`; return; }
+            const first = a[0].scaledScore, latest = a[a.length - 1].scaledScore, d = latest - first;
+            el.innerHTML = `${first} &rarr; ${latest}${d > 0 ? ` <span style="background:rgba(255,255,255,.25);padding:1px 7px;border-radius:20px;font-size:11px">&#9650; +${d}</span>` : ''}`;
+        } catch (e) { /* non-fatal */ }
     }
 
     _renderBreadcrumb(pu) {

--- a/routes/courseSession.js
+++ b/routes/courseSession.js
@@ -524,6 +524,12 @@ router.get('/:id/lesson-progress', async (req, res) => {
       showCheckpoint: false
     });
 
+    // Surface the ACT bootcamp state so the tracker can render the loop view
+    // (test → review misses → re-test → compare) instead of the scaffold stepper.
+    progressUpdate.courseId = session.courseId;
+    progressUpdate.bootcamp = session.bootcamp || null;
+    progressUpdate.diagnosticPlan = session.diagnosticPlan || null;
+
     res.json({ success: true, progressUpdate });
   } catch (err) {
     console.error('[CourseSession] Error fetching lesson progress:', err);


### PR DESCRIPTION
The ACT course is a test→review→re-test→compare loop, but the tracker still showed the gradual-release stepper (Warm-up/Learn/Practice · Step N of 11) — the wrong mental model, and it was frozen anyway. Replace it, for act-prep only, with a loop dashboard driven by the persisted bootcamp state:
- lessonTracker._render short-circuits to _renderBootcamp when pu.bootcamp && courseId === 'act-prep' (other courses keep the scaffold stepper untouched).
- The panel (app purple gradient): "ACT bootcamp · Round N" + score trend (24→27 from /history), a 4-step loop indicator (Baseline·Review·Re-test·Compare) with the current phase lit, a phase card (review: "N of M done" + up-next + Continue; reassess: "take a fresh test" + button), focus/mastered category chips from diagnosticPlan, and a "See your progress" link to the compare view.
- Buttons wire to openActTest / openActProgress / focus-chat.
- /api/course-sessions/:id/progress now surfaces courseId + bootcamp + diagnosticPlan so the client has the state.

Verified in a harness (app styling): review phase renders the loop, progress (3 of 8), up-next, focus chips, and 24→27 trend; reassess phase swaps to the fresh-test CTA and hides the review card.