### PR TITLE
fix(lws): transparent notebook overlay + raw \frac on the rail (prod hotfix)

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -134,7 +134,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
        LivingWorkspace flag is dev|beta|live (?livingWorkspace=dev). When on,
        it lazy-loads the workspace and mirrors the tutor's board output onto
        the new surface beside the old board. Default OFF → zero impact. -->
-  <script defer src="/js/living-workspace/chat-workspace.js?v=20260725g"></script>
+  <script defer src="/js/living-workspace/chat-workspace.js?v=20260725j"></script>
   <!-- Final safety net: strips any inline visual tag no renderer handled -->
   <script defer src="/js/stripVisualTags.js"></script>
   <!-- Non-core libs (lazy-loaded after first interaction) -->

--- a/public/css/living-workspace.css
+++ b/public/css/living-workspace.css
@@ -576,7 +576,7 @@ html[data-theme="dark"] .lws-root {
 .lws-sd-ov {
   position: absolute; inset: 0; z-index: 8;
   display: flex; flex-direction: column;
-  background: var(--lws-grid-bg);
+  background: var(--lws-grid-bg, #0f1422);
   animation: lws-dv-ov-in .18s ease-out both;
 }
 @media (prefers-reduced-motion: reduce) { .lws-sd-ov { animation: none; } }
@@ -700,7 +700,7 @@ html[data-theme="dark"] .lws-root {
 .lws-nb-ov {
   position: absolute; inset: 0; z-index: 8;
   display: flex; flex-direction: column;
-  background: var(--lws-grid-bg);
+  background: var(--lws-grid-bg, #0f1422);
   animation: lws-dv-ov-in .18s ease-out both;
 }
 @media (prefers-reduced-motion: reduce) { .lws-nb-ov { animation: none; } }

--- a/public/js/living-workspace/chat-workspace.js
+++ b/public/js/living-workspace/chat-workspace.js
@@ -75,7 +75,7 @@
   // public/ with a 7-day cache and no content hashing, so bump this whenever
   // any living-workspace asset changes (and the chat.html <script ?v=> tag to
   // match, so this file itself refreshes). See project_asset_cache_busting.
-  var ASSET_V = '?v=20260725g';
+  var ASSET_V = '?v=20260725j';
   var BASE = '/js/living-workspace/';
   var SCRIPTS = [
     'core/flags.js', 'core/viewport.js', 'core/elementRegistry.js',
@@ -362,11 +362,16 @@
       if (!window.LWS || !window.LWS.DerivationView) { console.error('[LWS_CHAT] DerivationView not available after load'); return; }
       var mount = buildPanel();
       dv = new window.LWS.DerivationView(mount, { renderers: makeRenderers(), onOpenSource: openLinkedSource });
+      // Docked widgets mount INSIDE the view's root, not beside it: every
+      // --lws-* token (colors, the overlays' opaque background) is defined ON
+      // .lws-root, so a sibling widget resolves them to nothing — which
+      // shipped as a transparent notebook overlay bleeding over the board.
+      var widgetHost = (dv.el && dv.el.root) || mount;
       if (window.LWS.SourceDock) {
-        try { dock = new window.LWS.SourceDock(mount, { onAskRegion: askAboutRegion }); } catch (e) { console.error('[LWS_CHAT] dock mount failed', e); }
+        try { dock = new window.LWS.SourceDock(widgetHost, { onAskRegion: askAboutRegion }); } catch (e) { console.error('[LWS_CHAT] dock mount failed', e); }
       }
       if (window.LWS.NotebookPanel) {
-        try { new window.LWS.NotebookPanel(mount); } catch (e) { console.error('[LWS_CHAT] notebook mount failed', e); }
+        try { new window.LWS.NotebookPanel(widgetHost); } catch (e) { console.error('[LWS_CHAT] notebook mount failed', e); }
       }
       ready = true;
       if (pendingSources !== undefined) { var ps = pendingSources; pendingSources = undefined; api.setSourcesFromMessages(ps); }

--- a/public/js/living-workspace/dom/derivationView.js
+++ b/public/js/living-workspace/dom/derivationView.js
@@ -64,11 +64,18 @@
     var t = String(s == null ? '' : s).trim();
     if (!t) return false;
     if (/^\\text\s*\{[\s\S]*\}$/.test(t)) return true;             // whole thing is \text{…}
-    // Strip LaTeX commands (\frac, \quad, \Rightarrow, \text …) and braces first
-    // so command names aren't mistaken for words — then count the genuine words
-    // left. Math is single-letter variables, digits and operators (none 3+ letter
-    // runs), so 3+ real words means prose, not an equation.
-    var stripped = t.replace(/\\[a-zA-Z]+/g, ' ').replace(/[{}]/g, ' ');
+    // Words inside \text{…} are math-mode LABELS ("cups", "batches"), not
+    // prose — KaTeX renders them fine, and counting them here mis-routed
+    // ratios like \frac{3 \text{ cups}}{2 \text{ batches}} down the
+    // prose-with-inline-math path, whose splitter can't handle the nested
+    // braces and shipped raw "\frac3 cups2 batches" to production. Drop the
+    // whole \text groups BEFORE counting words.
+    var stripped = t.replace(/\\text\s*\{[^{}]*\}/g, ' ');
+    // Strip remaining LaTeX commands (\frac, \quad, \Rightarrow …) and braces
+    // so command names aren't mistaken for words — then count the genuine
+    // words left. Math is single-letter variables, digits and operators (no
+    // 3+ letter runs), so 3+ real words means prose, not an equation.
+    stripped = stripped.replace(/\\[a-zA-Z]+/g, ' ').replace(/[{}]/g, ' ');
     return (stripped.match(/[A-Za-z]{3,}/g) || []).length >= 3;
   }
 

--- a/tests/unit/derivationProse.test.js
+++ b/tests/unit/derivationProse.test.js
@@ -42,3 +42,25 @@ describe('unwrapText', () => {
     expect(unwrapText('Find the height of the screen')).toBe('Find the height of the screen');
   });
 });
+
+// Production regression (owner screenshot, 2026-07-25): ratio poses like
+// \frac{3 \text{ cups}}{2 \text{ batches}} were mis-detected as prose (the
+// \text labels counted as words), routed down the inline-math splitter that
+// can't handle their nested braces, and shipped raw "\frac3 cups2 batches"
+// onto the rail. \text contents are math-mode labels — KaTeX's job.
+describe('looksLikeProse × \\text labels', () => {
+  const { looksLikeProse } = require('../../public/js/living-workspace/dom/derivationView.js');
+
+  it('a ratio with \\text unit labels is MATH, not prose', () => {
+    expect(looksLikeProse('\\frac{3 \\text{ cups}}{2 \\text{ batches}} = \\frac{x \\text{ cups}}{5 \\text{ batches}}')).toBe(false);
+    expect(looksLikeProse('2 \\text{ batches of cookies}')).toBe(false);
+  });
+
+  it('a whole-sentence \\text{…} wrapper is still prose', () => {
+    expect(looksLikeProse('\\text{Sarah bakes 3 batches of cookies every morning}')).toBe(true);
+  });
+
+  it('bare word-problem sentences (no \\text) are still prose', () => {
+    expect(looksLikeProse('Sarah has 3 cups of flour and needs enough for 5 batches')).toBe(true);
+  });
+});


### PR DESCRIPTION
Hotfix for the two live rendering bugs in the owner's production screenshot.

## 1. Transparent overlays (the mess in the top-right)

The notebook overlay (and latently the source viewer) rendered transparent — search bar, chips, and "Back to my work" bleeding over the board and rail. Root cause: every `--lws-*` token, including the overlays' opaque background, is defined **on `.lws-root`** — but the dock/notebook widgets were appended to the mount as **siblings** of `.lws-root`, so `var(--lws-grid-bg)` resolved to nothing.

Fix: widgets now mount **inside** `dv.el.root` (the same place the archive overlay already lives — one consistent pattern), plus opaque fallback values on both overlay backgrounds so this class of bug can never render see-through again.

## 2. Raw `\frac3 cups2 batches` on the rail

Ratio poses with unit labels — `\frac{3 \text{ cups}}{2 \text{ batches}}` — were mis-detected as prose because the words *inside* `\text{…}` counted toward the word threshold. That routed them down the prose-with-inline-math splitter, which can't handle the nested braces, shipping mangled raw LaTeX to the rail. Fix: `\text` groups are dropped before word-counting, so these go straight to KaTeX (which renders `\text` labels correctly). Whole-sentence `\text` wrappers and bare word problems still detect as prose — all three cases regression-tested.

Cache-bust `?v=20260725j`.

## Verification

Full suite **4708 passed**, lint clean, three new regression tests pinned to the exact production tex. Post-deploy check: open 📓 → opaque overlay; re-pose a ratio word problem → clean fraction on the rail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)