### PR TITLE
fix(latex): normalizeLatex was splitting \dfrac into \d\frac (prod hotfix)

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -134,7 +134,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
        LivingWorkspace flag is dev|beta|live (?livingWorkspace=dev). When on,
        it lazy-loads the workspace and mirrors the tutor's board output onto
        the new surface beside the old board. Default OFF → zero impact. -->
-  <script defer src="/js/living-workspace/chat-workspace.js?v=20260725k"></script>
+  <script defer src="/js/living-workspace/chat-workspace.js?v=20260726a"></script>
   <!-- Final safety net: strips any inline visual tag no renderer handled -->
   <script defer src="/js/stripVisualTags.js"></script>
   <!-- Non-core libs (lazy-loaded after first interaction) -->
@@ -2487,7 +2487,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
      window.PlayerStatsCard.init(currentUser) once the user doc is fetched. -->
 <script defer src="/js/modules/playerStatsCard.js?v=20260724b"></script>
 <script src="/js/challengeCard.js?v=20260725f"></script>
-<script src="/js/script.js?v=20260725i" type="module"></script>
+<script src="/js/script.js?v=20260726a" type="module"></script>
   <script src="/js/guidedPath.js" type="module"></script>
   <script src="/dist/js/chat-js9.bc0be9a3.js"></script>
   <!-- Companion HOME screen (phones only; flag-gated OFF by default) -->

--- a/public/js/living-workspace/chat-workspace.js
+++ b/public/js/living-workspace/chat-workspace.js
@@ -77,7 +77,7 @@
   // public/ with a 7-day cache and no content hashing, so bump this whenever
   // any living-workspace asset changes (and the chat.html <script ?v=> tag to
   // match, so this file itself refreshes). See project_asset_cache_busting.
-  var ASSET_V = '?v=20260725k';
+  var ASSET_V = '?v=20260726a';
   var BASE = '/js/living-workspace/';
   var SCRIPTS = [
     'core/flags.js', 'core/viewport.js', 'core/elementRegistry.js',

--- a/public/js/living-workspace/dom/derivationView.js
+++ b/public/js/living-workspace/dom/derivationView.js
@@ -53,6 +53,9 @@
     var t = String(s == null ? '' : s).trim();
     t = t.replace(/\\[()[\]]/g, ' ');        // \( \) \[ \] delimiters -> space
     t = t.replace(/^\$\$?/, '').replace(/\$\$?$/, ''); // $ … $ or $$ … $$
+    // Tolerate the tutor model's split \dfrac ("\d\frac{5}{7}") in tex that
+    // was ledgered before the server-side normalization existed.
+    t = t.replace(/\\([dt])\s*\\(frac)\b/g, '\\$1$2').replace(/\\displaystyle\s*/g, '');
     return t.trim();
   }
 

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -828,6 +828,9 @@ document.addEventListener("DOMContentLoaded", () => {
      */
     function renderKatex(math, displayMode) {
         if (!window.katex) return (displayMode ? '\\[' : '\\(') + math + (displayMode ? '\\]' : '\\)');
+        // Tolerate the tutor model's split \dfrac ("\d\frac{5}{7}") in
+        // already-stored history — new turns are normalized server-side.
+        math = String(math).replace(/\\([dt])\s*\\(frac)\b/g, '\\$1$2').replace(/\\displaystyle\s*/g, '');
         try {
             return window.katex.renderToString(math, { displayMode, throwOnError: false, strict: false, trust: true, errorColor: '#888888' });
         } catch (e) {

--- a/tests/unit/latexSplitDfrac.test.js
+++ b/tests/unit/latexSplitDfrac.test.js
@@ -1,0 +1,58 @@
+/**
+ * The split-\dfrac production bug (owner screenshot, 2026-07-26).
+ *
+ * Ground truth from the live DB: the tutor model emitted
+ * "\\( \\d\\frac{5}{7} = \\d\\frac{x}{20} \\)" — \dfrac with a backslash
+ * spliced in. KaTeX renders the unknown \d macro in red, and because the
+ * board synthesizer poses verbatim from tutor text and history teaches the
+ * model its own habits, one bad turn contaminated every surface. These pin
+ * the repair at both server choke points.
+ */
+const { verify } = require('../../utils/pipeline/verify');
+const { normalizeBoardCommand } = require('../../utils/boardResponseSchema');
+const { cleanLatex } = require('../../public/js/living-workspace/dom/derivationView.js');
+
+describe('verify rejoins split LaTeX commands in tutor text', () => {
+  test('the exact production string comes out clean', async () => {
+    const v = await verify("Try this one: \\( \\d\\frac{5}{7} = \\d\\frac{x}{20} \\)", {});
+    expect(v.text).toContain('\\dfrac{5}{7}');
+    expect(v.text).not.toMatch(/\\d\s*\\frac/);
+  });
+
+  test('\\t\\frac and \\displaystyle variants are handled; legit commands untouched', async () => {
+    const v = await verify('\\( \\t\\frac{1}{2} \\) and \\( \\displaystyle \\frac{3}{4} \\) and \\( \\frac{a}{b} \\)', {});
+    expect(v.text).toContain('\\tfrac{1}{2}');
+    expect(v.text).toContain('\\frac{3}{4}');
+    expect(v.text).toContain('\\frac{a}{b}');
+    expect(v.text).not.toContain('\\displaystyle');
+  });
+});
+
+describe('board tex sanitizer applies the same repair', () => {
+  test('pose tex with split \\dfrac normalizes', () => {
+    const cmd = normalizeBoardCommand({ action: 'pose', tex: '\\d\\frac{5}{7} = \\d\\frac{x}{20}' });
+    expect(cmd.tex).toBe('\\dfrac{5}{7} = \\dfrac{x}{20}');
+  });
+});
+
+describe('client cleanLatex tolerates ledgered pre-fix tex', () => {
+  test('stored mangled tex renders as \\dfrac after cleaning', () => {
+    expect(cleanLatex('\\d\\frac{5}{7} = \\d\\frac{x}{20}')).toBe('\\dfrac{5}{7} = \\dfrac{x}{20}');
+    expect(cleanLatex('\\displaystyle \\frac{3}{4}')).toBe('\\frac{3}{4}');
+  });
+});
+
+describe('normalizeLatex root cause: the backslash-restorer must not split \\dfrac', () => {
+  const { normalizeLatex } = require('../../utils/pipeline/verify');
+
+  test('\\dfrac / \\tfrac / \\arcsin survive normalization intact', () => {
+    expect(normalizeLatex('\\( \\dfrac{5}{7} = \\dfrac{x}{20} \\)')).toContain('\\dfrac{5}{7}');
+    expect(normalizeLatex('\\( \\tfrac{1}{2} \\)')).toContain('\\tfrac{1}{2}');
+    expect(normalizeLatex('\\( \\arcsin{x} \\)')).toContain('\\arcsin{x}');
+  });
+
+  test('genuinely bare commands STILL get their backslash restored', () => {
+    expect(normalizeLatex('\\( frac{3}{4} \\)')).toContain('\\frac{3}{4}');
+    expect(normalizeLatex('\\( 2sqrt{7} \\)')).toContain('2\\sqrt{7}');
+  });
+});

--- a/utils/boardResponseSchema.js
+++ b/utils/boardResponseSchema.js
@@ -194,7 +194,13 @@ const TEX_FIELDS = new Set(['tex', 'check']);
  */
 function sanitizeBoardTex(tex) {
   if (typeof tex !== 'string') return tex;
-  return tex.trim().replace(/\\+\s*$/g, '').trim();
+  return tex.trim()
+    .replace(/\\+\s*$/g, '')
+    // Rejoin the model's split \dfrac/\tfrac ("\d\frac{5}{7}") and drop
+    // \displaystyle — both render as red junk on the card otherwise.
+    .replace(/\\([dt])\s*\\(frac)\b/g, '\\$1$2')
+    .replace(/\\displaystyle\s*/g, '')
+    .trim();
 }
 
 function normalizeBoardCommand(cmd) {

--- a/utils/pipeline/verify.js
+++ b/utils/pipeline/verify.js
@@ -351,6 +351,15 @@ async function verify(responseText, context = {}) {
   let text = responseText;
   const flags = [];
 
+  // LaTeX repair (production, 2026-07-26): the tutor model sometimes writes
+  // \dfrac with a backslash spliced in — "\d\frac{5}{7}" — which KaTeX
+  // renders as a red unknown-macro \d before the fraction. Once one turn
+  // does it, history teaches every later turn to copy it. Rejoin the split
+  // command at the shared choke point so chat text, the board synthesizer
+  // (which poses verbatim from this text), and the ledger all stay clean.
+  text = text.replace(/\\([dt])\s*\\(frac)\b/g, '\\$1$2');
+  text = text.replace(/\\displaystyle\s*/g, '');
+
   // ── 1. Extract system tags (structured sidecar data) ──
   const { text: tagStrippedText, extracted } = extractSystemTags(text);
   text = tagStrippedText;
@@ -1181,8 +1190,14 @@ function normalizeLatex(text) {
     'sin', 'cos', 'tan', 'log', 'ln',
   ];
   // Match command names NOT preceded by a backslash, followed by { or a space-then-{
+  // The lookbehind must exclude LETTERS as well as the backslash: `frac`
+  // preceded by `d` is the tail of \dfrac, not a bare command — the old
+  // backslash-only lookbehind "repaired" \dfrac{5}{7} into \d\frac{5}{7}
+  // (a red unknown-macro \d on every card; production, 2026-07-26). Same
+  // class of bug for \tfrac/\cfrac/\arcsin/\arccos via their embedded
+  // command-word tails.
   const cmdPattern = new RegExp(
-    `(?<!\\\\)(${LATEX_COMMANDS.join('|')})(?=\\s*\\{)`, 'g'
+    `(?<![\\\\a-zA-Z])(${LATEX_COMMANDS.join('|')})(?=\\s*\\{)`, 'g'
   );
   result = result.replace(cmdPattern, '\\$1');
 

--- a/utils/promptCompact.js
+++ b/utils/promptCompact.js
@@ -385,6 +385,7 @@ NORMALIZE YOUR OWN PROCESS. Occasionally let the student see that thinking takes
 --- MATH FORMATTING (MANDATORY) ---
 ALL math must use LaTeX delimiters. Never write bare math in plain text.
 Inline: \\( x^2 - 4 \\)   Display: \\[ x^2 + 3x - 5 = 0 \\]
+Fractions: always plain \\frac{a}{b} — NEVER \\dfrac, \\tfrac, or \\displaystyle.
 
 Examples of CORRECT formatting:
 - "So we get \\( x = -1 \\) or \\( x = 1 \\)."


### PR DESCRIPTION
Fixes the red `\d` in front of every fraction in today's production screenshots.

## Root cause — it was us, not the model

Ground truth from the live DB (read-only query): stored tutor messages contain `\d\frac{5}{7}`. The model writes `\dfrac{5}{7}` **correctly** — `normalizeLatex`'s missing-backslash restorer (the one that repairs `frac{3}{4}` → `\frac{3}{4}`) matched command words with `(?<!\\)` — a lookbehind excluding only a backslash. Inside `\dfrac{`, the `frac` is preceded by the letter `d`, so it got a backslash "restored": `\dfrac` → `\d\frac`. KaTeX renders the unknown `\d` macro in red; the board synthesizer poses verbatim from tutor text so it spread to the board and ledger; and the model's own history taught it to repeat the pattern every turn.

## Fix

- **Root cause:** the lookbehind now excludes letters too — `(?<![\\a-zA-Z])` — because a command name can't start mid-word. `\dfrac`/`\tfrac`/`\arcsin` survive intact; genuinely bare `frac{3}{4}` and `2sqrt{7}` still get repaired. Both directions regression-pinned.
- **Defense in depth:** `verify` rejoins any `\d\frac` the model now echoes from poisoned history; `sanitizeBoardTex` applies the same repair on board tex; both renderers tolerate already-ledgered mangled tex, so **stored history heals on display** without a data migration.
- **Prompt:** one line steering to plain `\frac` (cheaper, and KaTeX sizes it fine).

## Verification

Full suite **4729 passed**, lint clean. The new suite pins: the exact production string end-to-end through `verify`, board-tex sanitization, client tolerance, and the normalizeLatex both-directions contract. Diagnosis trail: standalone regex ✓ → jest still failing → direct `verify()` call showed `\(` being inserted mid-command → the restorer's lookbehind.

Post-deploy: the next tutor turn with a fraction should render clean, and old mangled cards clean up on reload (display-side healing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)