### PR TITLE
feat(voice): voice joins the Live Workspace loop (spec §17)

### DIFF
--- a/tests/unit/voiceBoardLedger.test.js
+++ b/tests/unit/voiceBoardLedger.test.js
@@ -1,0 +1,135 @@
+/**
+ * Voice joins the Live Workspace loop (spec §17): a voice turn's board
+ * output folds into the SAME ledger chat writes, so it persists, earns
+ * assistance evidence, and feeds the board ghost — end to end.
+ *
+ *   voice payload → voiceToBoardCommands → promoteLeadingResolveToPose
+ *     → applyTurnToLedger → buildBoardStateBlock / ledgerToTurns
+ */
+const { voiceToBoardCommands } = require('../../public/js/living-workspace/dom/voiceBoardTranslate');
+const { applyTurnToLedger, promoteLeadingResolveToPose } = require('../../utils/pipeline/boardLedger');
+const { assistanceLevelForTurn } = require('../../utils/pipeline/assistanceLadder');
+const { buildBoardStateBlock } = require('../../utils/pipeline/boardStateBlock');
+const { ledgerToTurns } = require('../../public/js/living-workspace/core/ledgerReplay.js');
+
+const NOW = new Date('2026-07-26T12:00:00Z');
+
+function foldVoiceTurn(ledger, payload) {
+  let cmds = voiceToBoardCommands(payload);
+  cmds = promoteLeadingResolveToPose(ledger, cmds);
+  if (!cmds.length) return ledger;
+  return applyTurnToLedger(ledger, cmds, NOW, {
+    assistance: assistanceLevelForTurn({ boardCommands: cmds }),
+  });
+}
+
+describe('promoteLeadingResolveToPose', () => {
+  test('empty board: the first voice math line becomes the problem', () => {
+    const out = promoteLeadingResolveToPose(null, [
+      { action: 'resolve', tex: '2x - 4 = 0' },
+      { action: 'resolve', tex: '2x = 4' },
+    ]);
+    expect(out[0]).toEqual({ action: 'pose', tex: '2x - 4 = 0' });
+    expect(out[1].action).toBe('resolve');
+  });
+
+  test('a problem already in focus is never re-posed over', () => {
+    const ledger = applyTurnToLedger(null, [{ action: 'pose', tex: '2x - 4 = 0' }], NOW);
+    const out = promoteLeadingResolveToPose(ledger, [{ action: 'resolve', tex: '2x = 4' }]);
+    expect(out[0].action).toBe('resolve');
+  });
+
+  test('non-resolve heads and junk pass through untouched', () => {
+    expect(promoteLeadingResolveToPose(null, [{ action: 'clear' }])).toEqual([{ action: 'clear' }]);
+    expect(promoteLeadingResolveToPose(null, [])).toEqual([]);
+    expect(promoteLeadingResolveToPose(null, null)).toEqual([]);
+  });
+});
+
+describe('a voice-first session persists like a typed one', () => {
+  test('cumulative mathSteps turns build one problem with steps, ghost included', () => {
+    // Turn 1: problem posed by voice ("solve 2x minus 4 equals 0").
+    let ledger = foldVoiceTurn(null, { mathSteps: [{ label: 'Given', latex: '2x - 4 = 0' }] });
+    expect(ledger.current.problemTex).toBe('2x - 4 = 0');
+
+    // Turn 2: voice re-sends the board CUMULATIVELY (its protocol) + new step.
+    ledger = foldVoiceTurn(ledger, {
+      mathSteps: [
+        { label: 'Given', latex: '2x - 4 = 0' },
+        { label: 'Add 4', latex: '2x = 4' },
+      ],
+    });
+    // The cumulative re-send must not duplicate the problem into the steps…
+    expect(ledger.current.problemTex).toBe('2x - 4 = 0');
+    const stepTex = ledger.current.steps.map(c => c.tex);
+    expect(stepTex).toContain('2x = 4');
+
+    // …and the ghost the voice tutor reads matches what the student sees.
+    const ghost = buildBoardStateBlock(ledger);
+    expect(ghost).toContain('Problem in focus: 2x - 4 = 0');
+    expect(ghost).toContain('2x = 4');
+
+    // A later chat reload replays it like any typed problem.
+    const turns = ledgerToTurns(JSON.parse(JSON.stringify(ledger)));
+    expect(turns[turns.length - 1][0]).toEqual({ action: 'pose', tex: '2x - 4 = 0' });
+  });
+
+  test('graph steps from voice visuals survive the fold', () => {
+    let ledger = foldVoiceTurn(null, {
+      mathSteps: [
+        { label: 'Given', latex: 'y = x^2' },
+        { visual: { fn: 'x^2', caption: 'the parabola' } },
+      ],
+    });
+    expect(ledger.current.steps.some(c => c.action === 'graph' && c.fn === 'x^2')).toBe(true);
+  });
+
+  test('board-actions mode: WRITE lines fold; narration and annotations do not', () => {
+    const ledger = foldVoiceTurn(null, {
+      boardActions: [
+        { type: 'write', text: '3x + 1 = 10' },
+        { type: 'write', text: 'nice work today' },   // prose — not board math
+        { type: 'circle', objectId: 'obj1' },          // annotation — dropped
+      ],
+    });
+    expect(ledger.current.problemTex).toBe('3x + 1 = 10');
+    expect(ledger.current.steps).toHaveLength(0);
+  });
+});
+
+describe('cumulative re-sends never duplicate ledger lines', () => {
+  const { dedupeCumulativeResolves } = require('../../utils/pipeline/boardLedger');
+
+  function foldVoiceTurnDeduped(ledger, payload) {
+    let cmds = voiceToBoardCommands(payload);
+    cmds = promoteLeadingResolveToPose(ledger, cmds);
+    cmds = dedupeCumulativeResolves(ledger, cmds);
+    if (!cmds.length) return ledger;
+    return applyTurnToLedger(ledger, cmds, NOW, {});
+  }
+
+  test('three cumulative turns → one problem, each step exactly once', () => {
+    const t1 = [{ label: 'Given', latex: '2x - 4 = 0' }];
+    const t2 = t1.concat([{ label: 'Add 4', latex: '2x = 4' }]);
+    const t3 = t2.concat([{ label: 'Divide', latex: 'x = 2' }]);
+
+    let ledger = null;
+    for (const steps of [t1, t2, t3]) ledger = foldVoiceTurnDeduped(ledger, { mathSteps: steps });
+
+    expect(ledger.current.problemTex).toBe('2x - 4 = 0');
+    expect(ledger.current.steps.map(c => c.tex)).toEqual(['2x = 4', 'x = 2']);
+  });
+
+  test('a small-talk turn (prior board re-sent unchanged) folds nothing', () => {
+    let ledger = foldVoiceTurnDeduped(null, { mathSteps: [{ latex: '2x - 4 = 0' }, { latex: '2x = 4' }] });
+    const before = JSON.parse(JSON.stringify(ledger));
+    ledger = foldVoiceTurnDeduped(ledger, { mathSteps: [{ latex: '2x - 4 = 0' }, { latex: '2x = 4' }] });
+    expect(ledger.current.steps).toEqual(before.current.steps);
+  });
+
+  test('graph/clear commands pass through the dedupe untouched', () => {
+    const ledger = { current: { problemTex: 'y=x^2', steps: [] }, completed: [] };
+    const out = dedupeCumulativeResolves(ledger, [{ action: 'graph', fn: 'x^2' }, { action: 'clear' }]);
+    expect(out).toHaveLength(2);
+  });
+});

--- a/utils/activeConversation.js
+++ b/utils/activeConversation.js
@@ -87,7 +87,7 @@ async function loadActiveHistory(user, depth = VOICE_HISTORY_DEPTH) {
  * @param {Array<{role: string, content: string}>} turns
  * @returns {Promise<import('mongoose').Types.ObjectId|null>} conversationId written to, or null if nothing to write
  */
-async function appendToActiveConversation(user, turns) {
+async function appendToActiveConversation(user, turns, opts = {}) {
     const clean = (turns || [])
         .filter(t => t && t.content && String(t.content).trim().length > 0)
         .map(t => ({
@@ -98,16 +98,34 @@ async function appendToActiveConversation(user, turns) {
     if (!clean.length) return null;
 
     const { conversationId } = await resolveActiveConversationId(user);
+    const set = { lastActivity: new Date() };
+    // Voice turns fold their board output into the same ledger chat writes
+    // (Live Workspace): pass the updated ledger with the turn so a voice
+    // session's board survives reloads exactly like a typed one.
+    if (opts.boardLedger !== undefined) set.boardLedger = opts.boardLedger;
     await Conversation.updateOne(
         { _id: conversationId },
-        { $push: { messages: { $each: clean } }, $set: { lastActivity: new Date() } }
+        { $push: { messages: { $each: clean } }, $set: set }
     );
     return conversationId;
+}
+
+/**
+ * Read-only: the active conversation's board ledger (Live Workspace state),
+ * or null when there is none. Voice sessions seed from this at start so the
+ * board ghost and the ledger fold continue from whatever chat already built.
+ */
+async function loadActiveBoardLedger(user) {
+    const convId = user && user.activeConversationId;
+    if (!convId) return null;
+    const conv = await Conversation.findById(convId).select('boardLedger').lean();
+    return conv?.boardLedger || null;
 }
 
 module.exports = {
     VOICE_HISTORY_DEPTH,
     resolveActiveConversationId,
+    loadActiveBoardLedger,
     loadActiveHistory,
     appendToActiveConversation,
 };

--- a/utils/pipeline/boardLedger.js
+++ b/utils/pipeline/boardLedger.js
@@ -235,8 +235,49 @@ function summarizeLedger(ledger) {
   return { current: cur, completed, independentSolves, supportedSolves };
 }
 
+/**
+ * Voice-turn preamble (Live Workspace): voice speaks only derivation lines —
+ * it has no pose concept. With no problem in focus the ledger drops every
+ * line as a stray, so a voice-FIRST session would persist nothing. When the
+ * board is empty, the first math line IS the problem being worked: promote
+ * it to a pose. No-op when a problem is already in focus (chat posed it, or
+ * an earlier voice turn did). Pure; returns a new array.
+ */
+function promoteLeadingResolveToPose(ledger, commands) {
+  const cmds = Array.isArray(commands) ? commands : [];
+  if (!cmds.length || !cmds[0] || cmds[0].action !== 'resolve' || !cmds[0].tex) return cmds;
+  if (ledger && ledger.current && ledger.current.problemTex) return cmds;
+  return [{ action: 'pose', tex: cmds[0].tex }].concat(cmds.slice(1));
+}
+
+/**
+ * Voice re-sends its board CUMULATIVELY every turn (its protocol: the full
+ * step list, typically one new line at the end). Folding that raw into the
+ * ledger would re-append the problem and every prior step each turn. Drop
+ * resolves that match the problem in focus or a step already ledgered;
+ * everything genuinely new passes through. Pure; returns a new array.
+ */
+function dedupeCumulativeResolves(ledger, commands) {
+  const cmds = Array.isArray(commands) ? commands : [];
+  const cur = ledger && ledger.current;
+  if (!cur || !cur.problemTex) return cmds;
+  const seen = new Set([normTex(cur.problemTex)]);
+  for (const st of Array.isArray(cur.steps) ? cur.steps : []) {
+    if (st && st.action === 'resolve' && st.tex) seen.add(normTex(st.tex));
+  }
+  return cmds.filter(c => {
+    if (!c || c.action !== 'resolve' || !c.tex) return true;
+    const k = normTex(c.tex);
+    if (seen.has(k)) return false;
+    seen.add(k);           // also collapses dupes within one turn
+    return true;
+  });
+}
+
 module.exports = {
   applyTurnToLedger,
+  promoteLeadingResolveToPose,
+  dedupeCumulativeResolves,
   problemAssistance,
   sanitizeSourceRef,
   summarizeLedger,

--- a/utils/voiceSession.js
+++ b/utils/voiceSession.js
@@ -12,6 +12,14 @@ const { verify: pipelineVerify } = require('./pipeline');
 const { checkReadingLevel } = require('./readability');
 const { replaceDashes } = require('./dashNormalizer');
 const { ensureBoardCarriesSpokenMath } = require('./voiceBoardGuard');
+// Voice board work joins the Live Workspace loop: the same translator the
+// client renders with (UMD, requireable in node), folded into the same
+// ledger chat writes, described to the model by the same board ghost.
+const { voiceToBoardCommands } = require('../public/js/living-workspace/dom/voiceBoardTranslate');
+const { applyTurnToLedger, promoteLeadingResolveToPose, dedupeCumulativeResolves } = require('./pipeline/boardLedger');
+const { assistanceLevelForTurn } = require('./pipeline/assistanceLadder');
+const { buildBoardStateBlock } = require('./pipeline/boardStateBlock');
+const { loadActiveBoardLedger } = require('./activeConversation');
 const sttStream = require('./sttStream');
 const ttsStream = require('./ttsStream');
 const ttsProvider = require('./ttsProvider');
@@ -181,6 +189,12 @@ class VoiceSession {
         // chat uses (user.activeConversationId), so a student who was just typing
         // continues seamlessly into voice.
         this.history = await loadActiveHistory(this.user, HISTORY_DEPTH);
+
+        // Seed the board ledger from the active conversation so voice continues
+        // the SAME board chat built (and vice versa). Never fatal — a voice
+        // session must start even if the ledger read hiccups.
+        try { this.boardLedger = await loadActiveBoardLedger(this.user); }
+        catch (err) { this.boardLedger = null; logger.warn('board ledger seed failed', { error: err.message }); }
 
         // Persistent Cartesia pool — one WS per session, context_id per turn.
         // Saves ~50–100ms handshake on every turn vs opening a fresh WS.
@@ -424,6 +438,14 @@ class VoiceSession {
 
         let systemContent = this.systemPrompt + modeInstructions;
 
+        // Board awareness (same ghost chat uses): what the student's board
+        // shows RIGHT NOW, so the voice tutor references lines instead of
+        // re-deriving them. Empty board contributes zero tokens.
+        try {
+            const boardBlock = buildBoardStateBlock(this.boardLedger);
+            if (boardBlock) systemContent += '\n\n' + boardBlock;
+        } catch (_) { /* non-fatal */ }
+
         // board-actions mode: enrich prompt with current whiteboard state
         if (this.mode === 'board-actions' && this.boardContext) {
             const ctx = this.boardContext;
@@ -592,6 +614,24 @@ class VoiceSession {
         if (this.history.length > HISTORY_DEPTH * 2) {
             this.history = this.history.slice(-HISTORY_DEPTH * 2);
         }
+        // Fold this turn's board output into the shared ledger (Live Workspace):
+        // the same translation the client renders is what gets remembered, so a
+        // voice session's board survives reloads exactly like a typed one.
+        try {
+            let cmds = voiceToBoardCommands({ mathSteps: mathStepsForBoard, boardActions: boardActionsForFinal });
+            cmds = promoteLeadingResolveToPose(this.boardLedger, cmds);
+            // Voice's protocol is cumulative (full board re-sent each turn) —
+            // only genuinely new lines may fold, or steps duplicate every turn.
+            cmds = dedupeCumulativeResolves(this.boardLedger, cmds);
+            if (cmds.length) {
+                this.boardLedger = applyTurnToLedger(this.boardLedger, cmds, new Date(), {
+                    assistance: assistanceLevelForTurn({ boardCommands: cmds }),
+                });
+            }
+        } catch (err) {
+            logger.warn('voice board ledger fold failed (non-fatal)', { error: err.message });
+        }
+
         this._persistTurn(turn.userMessage, assistantContent).catch(err => {
             logger.warn('persist failed', { error: err.message });
         });
@@ -639,7 +679,7 @@ not on the board is lost the moment it's said.
 Never speak math notation. Never include system tags. Always valid JSON.`;
 
         const messages = [
-            { role: 'system', content: this.systemPrompt + ORCH_VOICE_INSTRUCTIONS },
+            { role: 'system', content: this.systemPrompt + ORCH_VOICE_INSTRUCTIONS + this._boardGhost() },
             ...this.history,
             { role: 'user', content: turn.userMessage },
         ];
@@ -1151,10 +1191,20 @@ Never speak math notation. Never include system tags. Always valid JSON.`;
         // when the student switches back to text. resolveActiveConversationId
         // (inside the helper) also updates this.user.activeConversationId in
         // place, so a long-lived session keeps targeting the right document.
+        // The board ledger rides along so the voice session's board persists.
         await appendToActiveConversation(this.user, [
             { role: 'user', content: userMessage },
             { role: 'assistant', content: aiContent },
-        ]);
+        ], this.boardLedger ? { boardLedger: this.boardLedger } : {});
+    }
+
+    // The board ghost for prompt assembly — one guarded call site for the
+    // orchestrated path (the streaming path inlines the same block).
+    _boardGhost() {
+        try {
+            const block = buildBoardStateBlock(this.boardLedger);
+            return block ? '\n\n' + block : '';
+        } catch (_) { return ''; }
     }
 
     shutdown(reason = 'shutdown') {


### PR DESCRIPTION
The last big architectural hole from the friction list: voice tutoring ran outside everything the Live Workspace records. A voice session's board vanished on reload, earned no assistance evidence, fed nothing to the teacher view, and the voice tutor was board-blind.

## What changes

Voice now uses the same three pieces chat does:

- **Ledger.** Each finalized voice turn translates its board payload with `voiceToBoardCommands` — deliberately the *same* translator the client renders with, so what's remembered is exactly what was seen — and folds it into `conversation.boardLedger`, persisted with the turn. Voice work now survives reloads (the chat board hydrates it), records assistance levels, and appears in the teacher workspace summary.
- **Ghost.** `buildBoardStateBlock` rides the voice system prompt in all three modes (math-steps, board-actions, orchestrated), so the voice tutor references what's on the board instead of re-deriving it aloud. Sessions seed the ledger from the active conversation — a student who was typing continues seamlessly into voice with the tutor knowing the board, and vice versa.
- **Two voice-protocol adapters** (pure, in `boardLedger.js`, both pinned by tests):
  - `promoteLeadingResolveToPose` — voice speaks only derivation lines, no pose concept. On an empty board the first math line IS the problem; without this, voice-first sessions would persist nothing.
  - `dedupeCumulativeResolves` — voice re-sends its full board every turn (its protocol). Only genuinely new lines fold; without this, steps would duplicate turn after turn.

Every fold/read is guarded non-fatal — a ledger hiccup never costs a student a voice turn.

## Verification

Full suite **4732 passed**, lint clean. 9 new tests, including the full round trip: voice payload → translate → promote → dedupe → ledger → board ghost → chat-reload replay; three cumulative turns yielding one problem with each step exactly once; graph visuals surviving; prose/annotations correctly excluded.

Manual QA: start a voice session on an empty board, work a problem aloud, end the session, reload chat → the problem and steps should be on the board; ask the voice tutor "what's next?" mid-problem → it should reference the last line, not re-derive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)