### PR TITLE
fix(lws): empty "My materials" dock painted its pill and did nothing

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -134,7 +134,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
        LivingWorkspace flag is dev|beta|live (?livingWorkspace=dev). When on,
        it lazy-loads the workspace and mirrors the tutor's board output onto
        the new surface beside the old board. Default OFF → zero impact. -->
-  <script defer src="/js/living-workspace/chat-workspace.js?v=20260726a"></script>
+  <script defer src="/js/living-workspace/chat-workspace.js?v=20260726b"></script>
   <!-- Final safety net: strips any inline visual tag no renderer handled -->
   <script defer src="/js/stripVisualTags.js"></script>
   <!-- Non-core libs (lazy-loaded after first interaction) -->

--- a/public/css/living-workspace.css
+++ b/public/css/living-workspace.css
@@ -533,6 +533,11 @@ html[data-theme="dark"] .lws-root {
   max-width: min(62%, 420px);
   display: flex; flex-direction: column; gap: 6px;
 }
+/* display:flex above would defeat the `hidden` attribute (UA display:none
+   loses to any authored display) — the same guard the rail and caption have.
+   Without it an EMPTY dock painted its pill and clicking it did nothing. */
+.lws-sd[hidden] { display: none; }
+
 .lws-sd-head {
   appearance: none; -webkit-appearance: none; cursor: pointer;
   align-self: flex-start; display: inline-flex; align-items: center; gap: 6px;

--- a/public/js/living-workspace/chat-workspace.js
+++ b/public/js/living-workspace/chat-workspace.js
@@ -77,7 +77,7 @@
   // public/ with a 7-day cache and no content hashing, so bump this whenever
   // any living-workspace asset changes (and the chat.html <script ?v=> tag to
   // match, so this file itself refreshes). See project_asset_cache_busting.
-  var ASSET_V = '?v=20260726a';
+  var ASSET_V = '?v=20260726b';
   var BASE = '/js/living-workspace/';
   var SCRIPTS = [
     'core/flags.js', 'core/viewport.js', 'core/elementRegistry.js',


### PR DESCRIPTION
Answers the owner report: *"what is my materials supposed to do. currently nothing happens."*

**What it's for:** "📎 My materials" is the Source Cards dock (spec §5.1) — upload a worksheet photo/PDF in chat and it docks there; click a card to view it full-board; drag **Select a problem** to ask the tutor about one region.

**The bug:** with zero uploads the dock is hidden via the `hidden` attribute — but `.lws-sd` sets `display:flex`, and any authored `display` beats the UA's `[hidden] { display:none }`. So an empty dock painted its pill anyway, and clicking toggled an empty, invisible strip. The rail and the caption strip already carry the `[hidden]` guard; the dock missed it.

**Fix:** one guard rule + cache-bust. The pill now appears only once materials exist — and then clicking it collapses/expands the card strip as designed.

CSS-only; no test surface beyond the existing suite (green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)