### PR TITLE
fix(tutor): ban the "Sure!" opener and stop repeat explanation-requests

### DIFF
--- a/tests/unit/oneAskGuard.test.js
+++ b/tests/unit/oneAskGuard.test.js
@@ -1,0 +1,73 @@
+/**
+ * The one-ask rule + the "Sure!" opener ban (owner report, 2026-07-26).
+ *
+ * Production pattern: the tutor asked "can you walk me through it?" on
+ * already-confirmed work FOUR times in one stretch, each opening with a
+ * filler "Sure!" — which the owner correctly read as a tell for a canned,
+ * distrustful turn ("sure doesn't read as an affirmation — it's actually
+ * kind of condescending"). The guard is deterministic: if the previous
+ * assistant message asked for an explanation, this turn must not ask again.
+ */
+const { observe } = require('../../utils/pipeline/observe');
+const { decide } = require('../../utils/pipeline/decide');
+
+const noAnswerDiagnosis = { type: 'no_answer', isCorrect: null, answer: null, correctAnswer: null };
+
+function decideAfterAssistant(assistantContent, studentMessage, diagnosis = noAnswerDiagnosis) {
+  const obs = observe(studentMessage, { recentUserMessages: [], recentAssistantMessages: [assistantContent] });
+  return decide(obs, diagnosis, {
+    phaseState: null, activeSkill: null, hasRecentUpload: false,
+    conversation: { messages: [
+      { role: 'user', content: 'x = 100/7' },
+      { role: 'assistant', content: assistantContent },
+      { role: 'user', content: studentMessage },
+    ] },
+  });
+}
+
+const hasOneAsk = d => d.directives.some(x => x.startsWith('ONE-ASK RULE'));
+
+describe('one-ask guard', () => {
+  test('fires after every explanation-request shape the transcript showed', () => {
+    for (const probe of [
+      'Can you walk me through how you arrived at that point?',
+      "I'm curious about your thought process in simplifying those fractions.",
+      'Can you show me how you would simplify that?',
+      'Can you explain how you arrived at your final answer?',
+      'What steps did you take, and where did the 2f come from?',
+    ]) {
+      expect(hasOneAsk(decideAfterAssistant(probe, 'I cross cancelled the 20 and 100 so its 5/7'))).toBe(true);
+    }
+  });
+
+  test('does not fire when the previous tutor message was not a probe', () => {
+    const d = decideAfterAssistant("Nice — that's exactly right. Ready for the next one?", 'yes');
+    expect(hasOneAsk(d)).toBe(false);
+  });
+
+  test('does not fire with no conversation in context (voice, tests, fallbacks)', () => {
+    const obs = observe('sure', { recentUserMessages: [], recentAssistantMessages: [] });
+    const d = decide(obs, noAnswerDiagnosis, { phaseState: null, activeSkill: null });
+    expect(hasOneAsk(d)).toBe(false);
+  });
+
+  test('fires regardless of which action the core logic picked (post-pass)', () => {
+    const correct = { type: 'answer', isCorrect: true, answer: '5/7', correctAnswer: '5/7' };
+    const d = decideAfterAssistant('Can you explain how you arrived at that?', 'its 5/7', correct);
+    expect(hasOneAsk(d)).toBe(true);
+  });
+});
+
+describe('the prompt no longer teaches the "Sure" opener', () => {
+  const fs = require('fs');
+  const src = fs.readFileSync(require.resolve('../../utils/promptCompact.js'), 'utf8');
+
+  test('exemplar dialogues do not open with "Sure"', () => {
+    expect(src).not.toMatch(/You: "Sure/);
+  });
+
+  test('the OPENERS rule bans filler and names the reason', () => {
+    expect(src).toContain('--- OPENERS (MANDATORY) ---');
+    expect(src).toContain('compliance, not affirmation');
+  });
+});

--- a/utils/pipeline/decide.js
+++ b/utils/pipeline/decide.js
@@ -149,7 +149,36 @@ function decide(observation, diagnosis, context = {}) {
   // including a BKT "possible guessing" nudge that would re-inject probing.
   applyBackOffModifiers(decision, observation);
 
+  // One-ask rule runs LAST: whatever branch was chosen, if the tutor's
+  // PREVIOUS message already asked this student to explain their work, this
+  // reply must not ask again (owner-reported: chains of "can you walk me
+  // through it" on already-confirmed work read as distrust and stall the
+  // session — always heralded by a filler "Sure!" opener).
+  applyOneAskGuard(decision, context);
+
   return decision;
+}
+
+// The shapes an explanation-request takes in tutor replies. Deliberately
+// broad: catching an extra affirmation costs nothing (the directive still
+// produces a forward-moving reply); missing a probe chain costs trust.
+const EXPLAIN_PROBE_RX = /walk me through|talk me through|can you (?:show|explain|tell) me|how did you (?:arrive|get|do|handle)|explain (?:how|your|the|it)|show me how you|curious about your (?:thought|thinking|process)|what steps did you take/i;
+
+function applyOneAskGuard(decision, context) {
+  const msgs = context.conversation?.messages;
+  if (!Array.isArray(msgs) || !msgs.length) return;
+  let lastAssistant = null;
+  for (let i = msgs.length - 1; i >= 0; i--) {
+    const m = msgs[i];
+    if (m && m.role !== 'user' && typeof m.content === 'string' && m.content.trim()) { lastAssistant = m; break; }
+    // Stop at the previous user turn boundary only after passing the current
+    // one — the newest message may already be this turn's user message.
+    if (m && m.role === 'user' && lastAssistant) break;
+  }
+  if (!lastAssistant || !EXPLAIN_PROBE_RX.test(lastAssistant.content)) return;
+  decision.directives.push(
+    'ONE-ASK RULE: Your previous message already asked the student to explain or walk through this work — their current message IS that explanation. Do NOT ask them to explain, re-derive, or "walk through" anything again this turn. Accept what they gave, respond to its substance specifically, and MOVE FORWARD: state the result, take the next step, or pose the next problem. Never open with "Sure".'
+  );
 }
 
 /**

--- a/utils/pipeline/index.js
+++ b/utils/pipeline/index.js
@@ -429,6 +429,9 @@ async function runPipeline(message, ctx) {
     modeTransition: modeTransition?.shouldTransition ? modeTransition : null,
     hasRecentUpload: ctx.hasRecentUpload || false,
     user: ctx.user || null,
+    // For the one-ask guard: decide reads the LAST assistant message to know
+    // whether the tutor already asked this student to explain this work.
+    conversation: ctx.conversation || null,
   });
 
   // Test-out: the challenge card is about to render below the tutor's reply, so

--- a/utils/promptCompact.js
+++ b/utils/promptCompact.js
@@ -106,12 +106,12 @@ WORKED EXAMPLE A — equation flow (the canonical dialog):
 
 WORKED EXAMPLE B — student asks for the board on a geometry concept:
   Student: "angles. show me on the board"
-  You: "Sure — here's a labeled reference. Which kind do you want to work with first: acute, right, or obtuse?"
+  You: "Here's a labeled reference — which kind do you want to work with first: acute, right, or obtuse?"
        <BOARD action="image" query="acute right obtuse angles labeled" caption="Angle types — pick one to start" />
 
 WORKED EXAMPLE C — student asks for practice problems:
   Student: "can you give me a few problems to do?"
-  You: "Sure. Let's start with this one — what's your first move?"
+  You: "Let's start with this one — what's your first move?"
        <BOARD action="pose" tex="3x - 7 = 11" />
   (Do NOT list multiple problems in chat without posing the active one on the board. Pose ONE, work it, then pose the next.)
 
@@ -381,6 +381,9 @@ CONVERSATIONAL RHYTHM. The shape of each message should come from what the momen
 CELEBRATE SPECIFICALLY. When you praise, name exactly what they did well — the specific step, the specific reasoning, the specific improvement. If they got a routine problem right, you don't need to celebrate — just move forward. Save real reactions for real moments.
 
 NORMALIZE YOUR OWN PROCESS. Occasionally let the student see that thinking takes time — even for you. Model the messy middle of problem-solving.
+
+--- OPENERS (MANDATORY) ---
+Never open a reply with filler: "Sure!", "Sure,", "Alright,", bare "Great!", "Ooh". "Sure" is compliance, not affirmation — from a tutor it reads condescending, and students learn it signals a canned response. Open with substance: name the specific thing the student just did ("You cancelled the sevens — clean.") or the next move. When their work is right, your FIRST words affirm it specifically.
 
 --- MATH FORMATTING (MANDATORY) ---
 ALL math must use LaTeX delimiters. Never write bare math in plain text.


### PR DESCRIPTION
Owner report: *"the Sure! is getting old fast — every time I see it I know it's gonna be bad"* and *"sure doesn't read as an affirmation. It's actually kind of condescending."* The instinct was exactly right — the consistent tell marked a shared code path, and both halves are now fixed.

## 1. The opener was taught

`promptCompact`'s own exemplar dialogues open with **"Sure —"** and **"Sure."** — so the model learned it as house style, deployed precisely on the turns where it had nothing specific to say. Exemplars rewritten to open with substance, plus a compact **OPENERS rule**: no filler openers ("Sure!", "Alright,", bare "Great!"), with the reason stated in the prompt itself — compliance language reads condescending from a tutor. When work is right, the first words affirm it *specifically*.

## 2. The behavior behind the tell

The production transcript shows four consecutive "can you walk me through it" requests on work the tutor had already confirmed. `decide` gains a deterministic **ONE-ASK post-pass**: if the previous assistant message asked for an explanation, the current student message IS that explanation — the reply must accept it, respond to its substance, and move forward. It runs after every other modifier (mood/evidence/back-off), so nothing can re-inject the probe, and it works on unverifiable turns too — which is exactly where the old directives (which only guard the verified path) never fired.

## Verification

Full suite green, lint clean. New tests pin: every probe shape from the actual transcript triggers the guard; non-probes and missing-conversation contexts don't; the guard survives any core branch (post-pass); and the prompt source no longer contains a `You: "Sure` exemplar.

Manual QA: give a terse correct answer, then answer the follow-up — the next reply should accept and advance, and "Sure!" openers should disappear from new turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)