### PR TITLE
fix(verify): canned-phrase scrub was decapitating sentences (prod 2026-07-26)

### DIFF
--- a/tests/unit/mangledSentenceHeads.test.js
+++ b/tests/unit/mangledSentenceHeads.test.js
@@ -1,0 +1,116 @@
+/**
+ * Mangled sentence-head production bug (owner transcript, 2026-07-26).
+ *
+ * Two verbatim shapes shipped to a student:
+ *   ", Jason! You're suggesting we multiply…"   (head eaten before the comma)
+ *   "Alright, together. You've got…"            (middle of the sentence eaten)
+ *
+ * Root cause: verify()'s canned-phrase scrub deleted banned transition
+ * phrases ("let's work through this", "let's tackle this", …) wherever they
+ * appeared, leaving the sentence's trimmings behind. The anchored opener
+ * strips (false-affirmation, CANNED_OPENERS) could orphan a comma the same
+ * way ("Exactly, Jason!" → ", Jason!").
+ *
+ * These tests pin: phrase removal is sentence-aware, stripping never orphans
+ * punctuation or ships a decapitated sentence, and clean text is untouched.
+ */
+const { verify, stripCannedTransitions, repairStrippedHead } = require('../../utils/pipeline/verify');
+const { ACTIONS } = require('../../utils/pipeline/decide');
+const { MESSAGE_TYPES } = require('../../utils/pipeline/observe');
+
+describe('production shape 1: ", Jason! You\'re suggesting…"', () => {
+  test('transition phrase heading the sentence drops the whole filler sentence', async () => {
+    const v = await verify(
+      "Let's work through this, Jason! You're suggesting we multiply both sides by 4.",
+      { firstName: 'Jason' }
+    );
+    expect(v.text).toBe("You're suggesting we multiply both sides by 4.");
+    expect(v.flags).toContain('canned_transitions_stripped');
+  });
+
+  test('false-affirmation strip does not orphan the vocative comma', async () => {
+    const v = await verify(
+      "Exactly, Jason! Which number should we look at first?",
+      { action: ACTIONS.HINT, messageType: MESSAGE_TYPES.IDK, firstName: 'Jason' }
+    );
+    expect(v.text).not.toMatch(/^[,;]/);
+    expect(v.text).toMatch(/^Jason! Which number/);
+    expect(v.flags).toContain('false_affirmation_stripped');
+  });
+});
+
+describe('production shape 2: "Alright, together. You\'ve got…"', () => {
+  test('mid-sentence transition drops the whole filler sentence, not just the phrase', async () => {
+    const v = await verify(
+      "Alright, let's work through this together. You've got \\(3x + 5 = 20\\).",
+      {}
+    );
+    expect(v.text).toBe("You've got \\(3x + 5 = 20\\).");
+    expect(v.text).not.toMatch(/Alright,\s*together/);
+    expect(v.flags).toContain('canned_transitions_stripped');
+  });
+
+  test('"let\'s tackle this" variant with a vocative', async () => {
+    const v = await verify(
+      "Now let's tackle this, Jason! What does the 5 tell you?",
+      { firstName: 'Jason' }
+    );
+    expect(v.text).toBe('What does the 5 tell you?');
+  });
+});
+
+describe('sentence-aware scrub keeps real content', () => {
+  test('substantive remainder survives with repaired seams', () => {
+    const { text, changed } = stripCannedTransitions(
+      "Now let's break this down: first, find the GCF of 12 and 18.",
+      'Jason'
+    );
+    expect(changed).toBe(true);
+    expect(text).toBe('First, find the GCF of 12 and 18.');
+  });
+
+  test('phrase embedded in a content-bearing sentence never leaves a lowercase orphan head', () => {
+    const { text } = stripCannedTransitions(
+      'Moving on to quadratics, remember the vertex form.',
+      null
+    );
+    expect(text).toBe('Quadratics, remember the vertex form.');
+  });
+
+  test('surrounding sentences are untouched when the filler sentence drops', () => {
+    const { text } = stripCannedTransitions(
+      "Nice work on that step. Let's tackle this together. What is 12 divided by 3?",
+      null
+    );
+    expect(text).toBe('Nice work on that step. What is 12 divided by 3?');
+  });
+
+  test('decimals do not split a sentence', () => {
+    const { text } = stripCannedTransitions(
+      "Let's work through this with 3.5 as the rate. What is 3.5 times 4?",
+      null
+    );
+    expect(text).not.toMatch(/^\s*[,.]/);
+    expect(text).toContain('What is 3.5 times 4?');
+  });
+});
+
+describe('the orphaned-head safety net (§8e)', () => {
+  test('a system tag heading the reply cannot leave its comma behind', async () => {
+    const v = await verify('<AWARD_XP:5,effort>, nice work on setting that up. What comes next?', {});
+    expect(v.text).toBe('Nice work on setting that up. What comes next?');
+  });
+
+  test('repairStrippedHead never capitalizes a math variable', () => {
+    expect(repairStrippedHead(', x = 2 is what you found. Why?')).toBe('x = 2 is what you found. Why?');
+    expect(repairStrippedHead(', so the slope is 3.')).toBe('So the slope is 3.');
+  });
+});
+
+describe('clean text passes through unmangled', () => {
+  test('a normal affirmation with a vocative is untouched', async () => {
+    const v = await verify("Great thinking, Jason! You're suggesting we multiply both sides by 4.", {});
+    expect(v.text).toBe("Great thinking, Jason! You're suggesting we multiply both sides by 4.");
+    expect(v.flags).toEqual([]);
+  });
+});

--- a/utils/pipeline/verify.js
+++ b/utils/pipeline/verify.js
@@ -334,6 +334,124 @@ function extractSystemTags(responseText) {
   return { text, extracted };
 }
 
+// ── Canned phrase patterns (§2f) ──
+// The system prompt bans these, but the model slips them in regularly.
+// Stripped instead of regenerated (cheaper, faster).
+const CANNED_OPENERS = /^(great\s+question[.!]*\s*|that'?s\s+a\s+great\s+question[.!]*\s*|let'?s\s+dive\s+(right\s+)?in[.!]*\s*|i(?:'?d|\s+would)\s+(?:be\s+)?(?:happy|love)\s+to\s+help(?:\s+(?:you\s+)?with\s+that)?[.!]*\s*|i\s+can\s+(?:definitely|certainly)\s+help\s+(?:you\s+)?with\s+that[.!]*\s*|absolutely[.!]*\s+(?=\w)|certainly[.!]*\s+(?=\w)|of\s+course[.!]*\s+(?=\w)|no\s+problem[.!]*\s+(?=\w))/i;
+const CANNED_TRANSITIONS = /\b((?:now,?\s+)?let'?s\s+(?:break\s+this\s+down|tackle\s+this|work\s+through\s+this|dive\s+(?:right\s+)?in(?:to)?)|moving\s+on\s+to|with\s+that\s+said|having\s+said\s+that)/gi;
+
+// Words that carry no content on their own — a sentence reduced to these
+// after phrase removal is packaging, not pedagogy, and gets dropped whole.
+const TRANSITION_FILLER_WORDS = new Set([
+  'alright', 'okay', 'ok', 'so', 'now', 'well', 'then', 'and', 'but',
+  'together', 'great', 'awesome', 'everyone', 'team', 'folks', 'again',
+]);
+
+/**
+ * After a leading phrase has been stripped, the sentence head may be an
+ * orphan: ", Jason! You're suggesting…" (production, 2026-07-26). Drop the
+ * stray punctuation and re-capitalize — but only when the head is a real
+ * word, never a math variable like "x = 2".
+ */
+function repairStrippedHead(text) {
+  let t = String(text || '').replace(/^\s*[,;:]+\s*/, '').trim();
+  if (/^[a-z][a-z]/.test(t)) t = t.charAt(0).toUpperCase() + t.slice(1);
+  return t;
+}
+
+// Sentence boundary scanners for the transition scrub. A '.' only counts as
+// a boundary when followed by whitespace (or end), so decimals like 3.5
+// never split a sentence.
+function sentenceStartIndex(text, from) {
+  for (let j = from - 1; j >= 0; j--) {
+    const c = text[j];
+    if (c === '\n') return j + 1;
+    if ('.!?:'.includes(c) && /\s/.test(text[j + 1] || '')) {
+      let k = j + 1;
+      while (k < from && /\s/.test(text[k])) k++;
+      return k;
+    }
+  }
+  return 0;
+}
+
+function sentenceEndIndex(text, from) {
+  for (let j = from; j < text.length; j++) {
+    const c = text[j];
+    if (c === '\n') return j;
+    if ('.!?:'.includes(c) && (j + 1 === text.length || /\s/.test(text[j + 1]))) return j + 1;
+  }
+  return text.length;
+}
+
+/**
+ * Is anything left of this sentence once the banned phrase is gone?
+ * A bare vocative (", Jason!") and filler words are not content.
+ */
+function remainderHasContent(remainder, firstName) {
+  if (/^\s*,\s*[A-Z][a-zA-Z]*\s*[!.?]*\s*$/.test(remainder.trim())) return false;
+  const fn = (firstName || '').toLowerCase();
+  const words = remainder.match(/[A-Za-z']+/g) || [];
+  return words.some((w) => {
+    const lower = w.toLowerCase();
+    return !TRANSITION_FILLER_WORDS.has(lower) && lower !== fn;
+  });
+}
+
+/**
+ * Remove banned transition phrases WITHOUT mangling the sentence they sit in.
+ *
+ * The old scrub replaced the phrase with '' wherever it appeared. When the
+ * phrase was the spine of its sentence, deletion left the trimmings behind
+ * (two live examples, production 2026-07-26):
+ *   "Let's work through this, Jason! You're…"         → ", Jason! You're…"
+ *   "Alright, let's work through this together. You…" → "Alright, together. You…"
+ *
+ * So the scrub is sentence-aware: find the sentence containing the phrase,
+ * delete the phrase, and if what's left carries no content (filler words, a
+ * bare vocative) drop the whole sentence. If real content remains, keep it
+ * and repair the seams — orphaned commas, doubled spaces, capitalization.
+ */
+function stripCannedTransitions(text, firstName) {
+  const finder = new RegExp(CANNED_TRANSITIONS.source, 'gi');
+  const ranges = [];
+  let m;
+  while ((m = finder.exec(text)) !== null) {
+    const a = sentenceStartIndex(text, m.index);
+    const b = sentenceEndIndex(text, finder.lastIndex);
+    const last = ranges[ranges.length - 1];
+    if (last && a <= last.b) last.b = Math.max(last.b, b);
+    else ranges.push({ a, b });
+  }
+  if (ranges.length === 0) return { text, changed: false };
+
+  let out = text;
+  for (let i = ranges.length - 1; i >= 0; i--) {
+    const { a, b } = ranges[i];
+    const sentence = out.slice(a, b);
+    const remainder = sentence.replace(new RegExp(CANNED_TRANSITIONS.source, 'gi'), '');
+    let replacement = '';
+    if (remainderHasContent(remainder, firstName)) {
+      replacement = repairStrippedHead(
+        remainder
+          .replace(/\s*,(\s*,)+/g, ',')
+          .replace(/\s+([,.!?;:])/g, '$1')
+          .replace(/ {2,}/g, ' ')
+      );
+    }
+    let tail = out.slice(b);
+    if (!replacement) {
+      tail = tail.replace(/^[ \t]+/, '');
+      if (/\n\s*$/.test(out.slice(0, a))) tail = tail.replace(/^\s+/, '');
+      // The dropped sentence may have introduced the one that follows
+      // ("…break this down: first, …") — re-capitalize its head.
+      if (/^[a-z][a-z]/.test(tail)) tail = tail.charAt(0).toUpperCase() + tail.slice(1);
+    }
+    out = out.slice(0, a) + replacement + tail;
+  }
+  return { text: out, changed: out !== text };
+}
+
 /**
  * Run all verification checks on the AI response.
  *
@@ -530,7 +648,8 @@ async function verify(responseText, context = {}) {
     if (noAnswerActions.includes(context.action) || noAnswerTypes.includes(context.messageType)) {
       const falseAffirmation = /^(that'?s\s+right[.!]*|correct[.!]*|exactly[.!]*|great\s+job[.!]*|perfect[.!]*|well\s+done[.!]*|yes[.!]*|you\s+got\s+it[.!]*|right\s+on[.!]*|bingo[.!]*)\s*/i;
       if (falseAffirmation.test(text.trim())) {
-        text = text.trim().replace(falseAffirmation, '').trim();
+        // repairStrippedHead: "Exactly, Jason! …" must not become ", Jason! …"
+        text = repairStrippedHead(text.trim().replace(falseAffirmation, ''));
         flags.push('false_affirmation_stripped');
         console.log(`[Verify] Stripped false affirmation (action: ${context.action}, messageType: ${context.messageType})`);
 
@@ -916,25 +1035,17 @@ async function verify(responseText, context = {}) {
   }
 
   // ── 2f. Canned phrase scrub ──
-  // The system prompt bans these, but GPT-4o-mini slips them in regularly.
-  // Strip the worst offenders instead of regenerating (cheaper, faster).
-  const CANNED_OPENERS = /^(great\s+question[.!]*\s*|that'?s\s+a\s+great\s+question[.!]*\s*|let'?s\s+dive\s+(right\s+)?in[.!]*\s*|i(?:'?d|\s+would)\s+(?:be\s+)?(?:happy|love)\s+to\s+help(?:\s+(?:you\s+)?with\s+that)?[.!]*\s*|i\s+can\s+(?:definitely|certainly)\s+help\s+(?:you\s+)?with\s+that[.!]*\s*|absolutely[.!]*\s+(?=\w)|certainly[.!]*\s+(?=\w)|of\s+course[.!]*\s+(?=\w)|no\s+problem[.!]*\s+(?=\w))/i;
-  const CANNED_TRANSITIONS = /\b((?:now,?\s+)?let'?s\s+(?:break\s+this\s+down|tackle\s+this|work\s+through\s+this|dive\s+(?:right\s+)?in(?:to)?)|moving\s+on\s+to|with\s+that\s+said|having\s+said\s+that)/gi;
-
+  // Patterns and helpers live at module scope (see stripCannedTransitions).
+  // Removal is sentence-aware: naive phrase deletion shipped mangled heads
+  // like ", Jason! You're suggesting…" to production (2026-07-26).
   if (CANNED_OPENERS.test(text.trim())) {
-    text = text.trim().replace(CANNED_OPENERS, '').trim();
-    // Capitalize the new first character
-    if (text.length > 0) {
-      text = text.charAt(0).toUpperCase() + text.slice(1);
-    }
+    text = repairStrippedHead(text.trim().replace(CANNED_OPENERS, ''));
     flags.push('canned_opener_stripped');
   }
 
-  const transitionCount = (text.match(CANNED_TRANSITIONS) || []).length;
-  if (transitionCount > 0) {
-    text = text.replace(CANNED_TRANSITIONS, '');
-    // Clean up double spaces left behind
-    text = text.replace(/  +/g, ' ').replace(/\n +/g, '\n').trim();
+  const transitionScrub = stripCannedTransitions(text, context.firstName);
+  if (transitionScrub.changed) {
+    text = transitionScrub.text.replace(/\n +/g, '\n').trim();
     flags.push('canned_transitions_stripped');
   }
 
@@ -1083,6 +1194,17 @@ async function verify(responseText, context = {}) {
   // with a comma across all student-facing prose. Runs after math has been
   // normalized into LaTeX, where minus is '-', so real math is untouched.
   text = replaceDashes(text);
+
+  // ── 8e. Orphaned sentence-head punctuation (production, 2026-07-26) ──
+  // Any strip above that eats the head of a sentence can leave its comma
+  // behind (", Jason! You're suggesting…"). The individual strips repair
+  // their own seams; this is the belt-and-braces pass so no path ships a
+  // sentence that opens with bare punctuation.
+  if (/^\s*[,;]/.test(text)) {
+    text = repairStrippedHead(text);
+    flags.push('orphaned_head_repaired');
+  }
+  text = text.replace(/([.!?])(\s+)[,;]+\s+(?=[A-Za-z])/g, '$1$2');
 
   // ── 9. Validate non-empty (after all stripping) ──
   if (!text || text.trim() === '') {
@@ -1418,4 +1540,6 @@ module.exports = {
   extractSystemTags,
   normalizeLatex,
   leadsWithDoubtOnCorrect,
+  stripCannedTransitions,
+  repairStrippedHead,
 };


### PR DESCRIPTION
## Problem

Two mangled tutor messages shipped to a student (owner transcript, 2026-07-26):

- `, Jason! You're suggesting we multiply…` — leading word(s) missing before the comma
- `Alright, together. You've got…` — the middle of "Alright, let's work through this together" eaten

## Root cause

`verify()`'s §2f canned-phrase scrub deleted banned transition phrases ("let's work through this", "let's tackle this", …) wherever they appeared and only collapsed double spaces afterward. When the phrase was the spine of its sentence, deletion left the trimmings behind — reproducing both production shapes exactly:

- "**Let's work through this**, Jason! You're suggesting…" → ", Jason! You're suggesting…"
- "Alright, **let's work through this** together. You've got…" → "Alright, together. You've got…"

The anchored opener strips (2b false-affirmation, `CANNED_OPENERS`) could orphan a vocative comma the same way ("Exactly, Jason!" → ", Jason!"). Ruled out: `extractSystemTags` (§8c already re-attaches newline-orphaned punctuation), `replaceDashes` (head-safe), and the regeneration paths (full rewrites, can't splice).

## Fix

- **`stripCannedTransitions()`** — sentence-aware removal. Locates the sentence containing the banned phrase (decimal-safe boundary scan, so "3.5" never splits a sentence), deletes the phrase, and if what's left carries no content (filler words, a bare vocative like ", Jason!") drops the whole sentence. Real content is kept with the seams repaired — orphaned commas, doubled spaces, capitalization.
- **`repairStrippedHead()`** — shared repair after the anchored strips (2b, `CANNED_OPENERS`): never ships a leading comma, and never "capitalizes" a math variable (`x = 2` stays `x`).
- **§8e safety net** — belt-and-braces pass at the choke point: any upstream strip that leaves a sentence opening with bare punctuation gets repaired before the reply ships.

## Tests

[tests/unit/mangledSentenceHeads.test.js](tests/unit/mangledSentenceHeads.test.js) — 11 tests pinned to both production shapes, the substantive-remainder path, decimal boundaries, the tag-orphan safety net, and clean-text pass-through. Existing verify-related suites (`pipeline`, `tutorValidation`, `bareProblemDrop`, `latexSplitDfrac`, +5 more): 287 tests green. Lint: 0 errors, warnings pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)