### PR TITLE
feat(tutor): demonstrated competence — trust becomes the session default

### DIFF
--- a/tests/unit/demonstratedCompetence.test.js
+++ b/tests/unit/demonstratedCompetence.test.js
@@ -1,0 +1,54 @@
+/**
+ * Session-level trust (owner: "the system doesn't need students to walk
+ * through EVERY problem — especially once it is clear that this kid knows
+ * what he is talking about").
+ *
+ * Three verified-correct in the recent window, zero misses → trust becomes
+ * the DEFAULT on every branch: no explanation requests, scaffold capped so
+ * the assistance ladder records the work as independent. One wrong answer
+ * resets the default back to normal support.
+ */
+const { observe } = require('../../utils/pipeline/observe');
+const { decide } = require('../../utils/pipeline/decide');
+
+const correctMsg = { content: 'Right!', problemResult: 'correct' };
+const wrongMsg = { content: 'Not quite.', problemResult: 'incorrect' };
+const plainMsg = { content: 'What next?' };
+
+function decideWith(assistantHistory, message = 'x = 4', diagnosis = { type: 'answer', isCorrect: true, answer: '4', correctAnswer: '4' }) {
+  const obs = observe(message, { recentUserMessages: [], recentAssistantMessages: assistantHistory });
+  return decide(obs, diagnosis, { phaseState: null, activeSkill: null });
+}
+
+const hasTrust = d => d.directives.some(x => x.startsWith('DEMONSTRATED COMPETENCE'));
+
+describe('demonstrated competence', () => {
+  test('3 correct, 0 wrong → trust mode on, scaffold capped at 2', () => {
+    const d = decideWith([plainMsg, correctMsg, correctMsg, correctMsg]);
+    expect(hasTrust(d)).toBe(true);
+    expect(d.scaffoldLevel).toBeLessThanOrEqual(2);
+  });
+
+  test('applies on unverifiable turns too — trust is not gated on auto-checking', () => {
+    const d = decideWith(
+      [correctMsg, correctMsg, correctMsg],
+      'the sevens cross cancel so 20',
+      { type: 'unverifiable', isCorrect: null, answer: null, correctAnswer: null }
+    );
+    expect(hasTrust(d)).toBe(true);
+  });
+
+  test('a single wrong answer in the window resets the default', () => {
+    const d = decideWith([correctMsg, correctMsg, correctMsg, wrongMsg]);
+    expect(hasTrust(d)).toBe(false);
+  });
+
+  test('two correct is not yet a pattern', () => {
+    const d = decideWith([plainMsg, correctMsg, correctMsg]);
+    expect(hasTrust(d)).toBe(false);
+  });
+
+  test('empty history never trusts by accident', () => {
+    expect(hasTrust(decideWith([]))).toBe(false);
+  });
+});

--- a/utils/pipeline/decide.js
+++ b/utils/pipeline/decide.js
@@ -149,6 +149,14 @@ function decide(observation, diagnosis, context = {}) {
   // including a BKT "possible guessing" nudge that would re-inject probing.
   applyBackOffModifiers(decision, observation);
 
+  // Demonstrated competence runs across ALL branches (owner: "the system
+  // doesn't need students to walk through EVERY problem — especially once
+  // it is clear that this kid knows what he is talking about"). Per-branch
+  // streak nudges exist, but the DEFAULT had to flip session-wide: on a
+  // clean streak, trust is the baseline and an error is what re-opens
+  // probing — not the other way around.
+  applyDemonstratedCompetence(decision, observation);
+
   // One-ask rule runs LAST: whatever branch was chosen, if the tutor's
   // PREVIOUS message already asked this student to explain their work, this
   // reply must not ask again (owner-reported: chains of "can you walk me
@@ -157,6 +165,26 @@ function decide(observation, diagnosis, context = {}) {
   applyOneAskGuard(decision, context);
 
   return decision;
+}
+
+// Three verified-correct in the recent window with zero misses = competence
+// is established for this stretch of work. (The window is the last 6
+// assistant turns, so this is "the session lately", not ancient history —
+// and any wrong answer resets the default back to normal support.)
+const COMPETENCE_STREAK = 3;
+
+function applyDemonstratedCompetence(decision, observation) {
+  const streaks = observation?.streaks || {};
+  const correct = streaks.recentCorrectCount || 0;
+  const wrong = streaks.recentWrongCount || 0;
+  if (correct < COMPETENCE_STREAK || wrong > 0) return;
+
+  // Trusted work is light-touch work: cap the scaffold intensity so the
+  // assistance ladder records these solves as what they are — independent.
+  decision.scaffoldLevel = Math.min(decision.scaffoldLevel || 3, 2);
+  decision.directives.push(
+    `DEMONSTRATED COMPETENCE: ${correct} verified-correct in a row, zero misses — this student knows what they are doing. TRUST IS THE DEFAULT NOW: do NOT ask them to explain, show work, walk through steps, or "check together" — a wrong answer is the only thing that re-opens probing. Affirm in one short clause, then keep the session MOVING: harder problem, a new twist, a transfer context, or the next skill. At most one brief strategic check every few problems, never on consecutive turns.`
+  );
 }
 
 // The shapes an explanation-request takes in tutor replies. Deliberately


### PR DESCRIPTION
Owner: *"the system doesn't need students to walk through EVERY problem. especially once it is clear that this kid knows what he is talking about."*

## What changes

The per-branch correct-streak nudges existed, but the **default posture never flipped** — every new problem still opened with standard probing, and unverifiable turns (terse answers like "the sevens cross cancel") fell through to interrogation. New `decide` post-pass that runs on **every branch**:

**3 verified-correct in the recent window + zero misses → trust is the baseline.**
- No explanation requests, no walk-throughs, no "let's check together."
- A wrong answer is the *only* thing that re-opens probing — the burden of proof flips.
- Affirm in one short clause, keep the session moving: harder problem, new twist, transfer context, or next skill. At most one brief strategic check every few problems, never consecutive.
- **Scaffold caps at 2**, so the §12 assistance ladder records trusted solves as what they are: independent evidence.

One miss in the window resets to normal support. Composes with the one-ask guard (#1322): competence sets the posture, one-ask stops any residual repeat.

## Grounding

The signal is deterministic — `problemResult` stamps on recent assistant messages, verified against production data. Also surfaced while checking: the owner's "CONFIRMED!" turn in today's transcript was **falsely graded incorrect** (multi-line work `520=7x / 100=7x / 100/7=x` confused the verifier), which both broke the streak and armed wrong-answer support — multi-line answer verification is a follow-up worth prioritizing, since false negatives now cost trust mode too.

## Verification

Full suite **4749 passed**, lint clean. New tests: trust at 3-and-clean (scaffold capped), trust on unverifiable turns, single-miss reset, two-correct-not-yet, empty-history never trusts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)