### PR TITLE
fix(progress): student avatar rendered tiny — widen its column

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -105,7 +105,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <link rel="stylesheet" href="/css/workspace.css?v=20260723" />
   <!-- Enriched right-rail player card (stats band + expand-up progress panel).
        Loads AFTER workspace.css/avatar-fullbody.css so .psc-* rules win. -->
-  <link rel="stylesheet" href="/css/player-stats-card.css?v=20260724b" />
+  <link rel="stylesheet" href="/css/player-stats-card.css?v=20260726a" />
   <link rel="stylesheet" href="/css/challenge-card.css?v=20260725f" />
   <!-- Adjustable panels: resizable work board + minimizable tutor hero -->
   <link rel="stylesheet" href="/css/adjustable-panels.css?v=20260721" />

--- a/public/css/player-stats-card.css
+++ b/public/css/player-stats-card.css
@@ -61,10 +61,11 @@
    Skill lists + CTA run full width BELOW this block (in .psc-full). ── */
 .psc-top { display: flex; align-items: stretch; gap: 10px; }
 .psc-avatar-col {
-  flex: 0 0 96px;
+  flex: 0 0 130px;                   /* owner: 96px read as tiny — the column
+                                        width is what binds the figure's size */
   align-self: stretch;               /* match the identity stack's height */
   display: flex; align-items: flex-end; justify-content: center;
-  min-height: 230px;                 /* a standing figure, not a thumbnail */
+  min-height: 280px;                 /* a standing figure, not a thumbnail */
 }
 .psc-avatar-col #sidebar-avatar-panel, .psc-head-ava { width: 100%; display: flex; align-items: flex-end; justify-content: center; }
 /* Let the full-body render fill the column instead of the old 88px header size. */


### PR DESCRIPTION
Owner report: *"the student avatar looks tiny... can we increase the size?"*

The full-body figure in the My Progress rail is **width-bound** by its flex column — `flex: 0 0 96px` — so however tall the stage, the figure painted at thumbnail scale beside the level card. Column widened 96→130px (+35%), `min-height` 230→280px to match. The identity stack keeps its flexible right side; CSS-only, cache-busted.

Post-deploy check: My Progress → the figure should stand roughly shoulder-height to the Level card instead of ankle-height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)