### PR TITLE
fix(verify): three tutor-output defects from the 2026-07-26 production screenshot

### DIFF
--- a/tests/unit/cleanSolveOverScaffold.test.js
+++ b/tests/unit/cleanSolveOverScaffold.test.js
@@ -1,0 +1,117 @@
+/**
+ * Clean-solve over-scaffolding + \div leak (owner screenshot, 2026-07-26).
+ *
+ * Production message, verbatim: the student wrote "120/4 = 30 miles per
+ * gallon. and 10 gallons at 30 mpg is 300 miles" — a correct first-try solve
+ * WITH the reasoning shown — and the tutor replied:
+ *
+ *   "Great job on your calculations, Jason! … Can you walk me through how
+ *    you got from 120 \div 4 to 30, and then how you multiplied that by 10
+ *    to get your final result? Let's work through it together to ensure we
+ *    understand each step clearly!"
+ *
+ * Three defects in one reply:
+ *  1. Re-justification of verified, already-shown work (over-scaffolding —
+ *     decide.js forbids it in a directive, but nothing enforced it).
+ *  2. Literal "\div" shown to the student — normalizeLatex converts ÷ to
+ *     \div but never wrapped bare operator math in \( \).
+ *  3. "Let's work through it together" slipped the canned-transition ban,
+ *     which only knew "work through this".
+ */
+jest.mock('../../utils/llmGateway', () => ({
+  callLLM: jest.fn(),
+  callLLMStream: jest.fn(),
+  callLLMStructured: jest.fn(),
+}));
+
+const { callLLM } = require('../../utils/llmGateway');
+const { verify, normalizeLatex, stripCannedTransitions } = require('../../utils/pipeline/verify');
+const { ACTIONS } = require('../../utils/pipeline/decide');
+
+const SCREENSHOT_REPLY =
+  "Great job on your calculations, Jason! I see you found the unit rate and then scaled it up. " +
+  "Can you walk me through how you got from 120 \\div 4 to 30, and then how you multiplied that by 10 to get your final result? " +
+  "Let's work through it together to ensure we understand each step clearly!";
+
+beforeEach(() => callLLM.mockReset());
+
+describe('re-justification guard on demonstrated reasoning', () => {
+  test('the screenshot reply regenerates into affirm-and-advance', async () => {
+    callLLM.mockResolvedValueOnce({
+      choices: [{ message: { content: 'Perfect solve — unit rate, then scale. Ready for a tougher one: how far on 7.5 gallons?' } }],
+    });
+    const v = await verify(SCREENSHOT_REPLY, {
+      action: ACTIONS.CONFIRM_CORRECT,
+      demonstratedReasoning: true,
+      firstName: 'Jason',
+    });
+    expect(v.flags).toContain('rejustification_detected');
+    expect(v.flags).toContain('rejustification_regenerated');
+    expect(v.text).not.toMatch(/walk me through/i);
+    expect(callLLM).toHaveBeenCalledTimes(1);
+  });
+
+  test('bare-answer turns (no demonstrated reasoning) may still ask for thinking', async () => {
+    const v = await verify('Nice work! How did you get 30 there?', {
+      action: ACTIONS.CONFIRM_CORRECT,
+      demonstratedReasoning: false,
+    });
+    expect(v.flags).not.toContain('rejustification_detected');
+    expect(v.text).toContain('How did you get 30 there?');
+    expect(callLLM).not.toHaveBeenCalled();
+  });
+
+  test('non-CONFIRM_CORRECT turns are untouched', async () => {
+    const v = await verify('Walk me through what you tried so far.', {
+      action: ACTIONS.HINT,
+      demonstratedReasoning: true,
+    });
+    expect(v.flags).not.toContain('rejustification_detected');
+    expect(callLLM).not.toHaveBeenCalled();
+  });
+
+  test('regen failure keeps the original text and flags it', async () => {
+    callLLM.mockRejectedValueOnce(new Error('LLM unavailable'));
+    const v = await verify(SCREENSHOT_REPLY, {
+      action: ACTIONS.CONFIRM_CORRECT,
+      demonstratedReasoning: true,
+      firstName: 'Jason',
+    });
+    expect(v.flags).toContain('rejustification_regeneration_failed');
+    expect(v.text.length).toBeGreaterThan(10);
+  });
+});
+
+describe('bare operator math gets wrapped (the \\div leak)', () => {
+  test('unicode ÷ ends up delimited, not as literal \\div text', () => {
+    const out = normalizeLatex('Can you walk me through how you got from 120 ÷ 4 to 30?');
+    expect(out).toMatch(/\\\(120\s*\\div\s+4\\\)/);
+  });
+
+  test('× with a result: "3 × 4 = 12" wraps whole equation', () => {
+    expect(normalizeLatex('So 3 × 4 = 12 here.')).toMatch(/\\\(3\s*\\times\s+4\s*=\s*12\\\)/);
+  });
+
+  test('already-delimited math is not double-wrapped', () => {
+    const out = normalizeLatex('Try \\(120 \\div 4\\) first.');
+    expect(out).toBe('Try \\(120 \\div 4\\) first.');
+  });
+});
+
+describe('"work through it together" is now a banned transition', () => {
+  test('the screenshot closing sentence drops whole, purpose clause included', () => {
+    const { text, changed } = stripCannedTransitions(
+      "Great thinking on the setup! Let's work through it together to ensure we understand each step clearly!",
+      'Jason'
+    );
+    expect(changed).toBe(true);
+    expect(text).toBe('Great thinking on the setup!');
+  });
+
+  test('"tackle that" and "break it down" variants match too', () => {
+    expect(stripCannedTransitions("Let's tackle that together. What is 6 times 7?", null).text)
+      .toBe('What is 6 times 7?');
+    expect(stripCannedTransitions("Let's break it down. What is the first factor?", null).text)
+      .toBe('What is the first factor?');
+  });
+});

--- a/tests/unit/pipelineIntegration.test.js
+++ b/tests/unit/pipelineIntegration.test.js
@@ -232,7 +232,10 @@ describe('Pipeline Integration: runPipeline', () => {
 
     const result = await runPipeline('I don\'t know how to do this', buildCtx(user, conversation));
 
-    expect(result.text).toContain('break it down');
+    // "Let's break it down" is a banned canned transition (verify §2f strips
+    // the filler sentence whole); the scaffolding question must survive.
+    expect(result.text).not.toContain('break it down');
+    expect(result.text).toContain('what operation can we use to get rid of the +5?');
     expect(result.xpBreakdown.tier1).toBe(2);
     expect(result.xpBreakdown.tier2).toBe(0);
   });

--- a/utils/pipeline/index.js
+++ b/utils/pipeline/index.js
@@ -572,6 +572,7 @@ async function runPipeline(message, ctx) {
     messageType: observation.messageType,
     correctAnswer: diagnosis.correctAnswer || null,
     diagnosisType: diagnosis.type,
+    demonstratedReasoning: diagnosis.demonstratedReasoning || false,
     verificationState: diagnosis.verificationState,
     hasRecentUpload: ctx.hasRecentUpload || false,
     isWorksheetFollowUp: observation.isWorksheetFollowUp || false,

--- a/utils/pipeline/verify.js
+++ b/utils/pipeline/verify.js
@@ -338,7 +338,9 @@ function extractSystemTags(responseText) {
 // The system prompt bans these, but the model slips them in regularly.
 // Stripped instead of regenerated (cheaper, faster).
 const CANNED_OPENERS = /^(great\s+question[.!]*\s*|that'?s\s+a\s+great\s+question[.!]*\s*|let'?s\s+dive\s+(right\s+)?in[.!]*\s*|i(?:'?d|\s+would)\s+(?:be\s+)?(?:happy|love)\s+to\s+help(?:\s+(?:you\s+)?with\s+that)?[.!]*\s*|i\s+can\s+(?:definitely|certainly)\s+help\s+(?:you\s+)?with\s+that[.!]*\s*|absolutely[.!]*\s+(?=\w)|certainly[.!]*\s+(?=\w)|of\s+course[.!]*\s+(?=\w)|no\s+problem[.!]*\s+(?=\w))/i;
-const CANNED_TRANSITIONS = /\b((?:now,?\s+)?let'?s\s+(?:break\s+this\s+down|tackle\s+this|work\s+through\s+this|dive\s+(?:right\s+)?in(?:to)?)|moving\s+on\s+to|with\s+that\s+said|having\s+said\s+that)/gi;
+// "this|that|it" variants: production shipped "Let's work through it together…"
+// (2026-07-26 screenshot) because the ban only knew "work through this".
+const CANNED_TRANSITIONS = /\b((?:now,?\s+)?let'?s\s+(?:break\s+(?:this|that|it)\s+down|tackle\s+(?:this|that|it)|work\s+through\s+(?:this|that|it)(?:\s+together)?|dive\s+(?:right\s+)?in(?:to)?)|moving\s+on\s+to|with\s+that\s+said|having\s+said\s+that)/gi;
 
 // Words that carry no content on their own — a sentence reduced to these
 // after phrase removal is packaging, not pedagogy, and gets dropped whole.
@@ -390,6 +392,11 @@ function sentenceEndIndex(text, from) {
  */
 function remainderHasContent(remainder, firstName) {
   if (/^\s*,\s*[A-Z][a-zA-Z]*\s*[!.?]*\s*$/.test(remainder.trim())) return false;
+  // A dangling purpose clause is packaging too: removing "let's work through
+  // it together" from "…together to ensure we understand each step clearly!"
+  // must not keep "To ensure we understand each step clearly!" as a sentence.
+  const lead = remainder.replace(/^[\s,;:]+/, '');
+  if (/^(?:to|so|in\s+order\s+to)\b/i.test(lead)) return false;
   const fn = (firstName || '').toLowerCase();
   const words = remainder.match(/[A-Za-z']+/g) || [];
   return words.some((w) => {
@@ -449,6 +456,7 @@ function stripCannedTransitions(text, firstName) {
     }
     out = out.slice(0, a) + replacement + tail;
   }
+  out = out.replace(/[ \t]+$/, '');
   return { text: out, changed: out !== text };
 }
 
@@ -785,6 +793,49 @@ async function verify(responseText, context = {}) {
         console.error('[Verify] False-rejection regeneration failed:', err.message);
         flags.push('false_rejection_regeneration_failed');
       }
+    }
+  }
+
+  // ── 2d-rejustify. Re-justification guard on demonstrated reasoning ──
+  // (production screenshot, 2026-07-26). The student wrote the full solution
+  // path ("120/4 = 30 mpg, and 10 gallons at 30 mpg is 300 miles") and the
+  // tutor still asked them to "walk me through how you got from 120 ÷ 4 to
+  // 30 … to ensure we understand each step clearly". decide.js already
+  // injects a directive forbidding exactly this on demonstrated-reasoning
+  // turns; this enforces it when the model ignores the directive. Gated on
+  // demonstratedReasoning so asking a bare-answer student to explain their
+  // thinking — legitimate data-gathering — is untouched.
+  const REJUSTIFY_REQUEST = /\b(?:walk|talk)\s+(?:me|us)\s+(?:back\s+)?through\b|\b(?:can|could)\s+you\s+(?:explain|show\s+me|tell\s+me)\s+how\s+you\s+(?:got|found|solved|arrived|figured)|\bhow\s+did\s+you\s+(?:get|arrive\s+at|come\s+up\s+with|figure\s+out)\b|\bexplain\s+(?:your|each)\s+(?:steps?|reasoning|thinking|work)\b/i;
+  if (!regeneratedThisPass
+      && context.action === ACTIONS.CONFIRM_CORRECT
+      && context.demonstratedReasoning
+      && REJUSTIFY_REQUEST.test(text)) {
+    flags.push('rejustification_detected');
+    console.log('[Verify] RE-JUSTIFICATION on demonstrated reasoning — student already showed verified-correct steps. Regenerating.');
+
+    try {
+      const correctionPrompt = 'The student solved the problem correctly AND wrote out their full reasoning — every step has been independently verified. Your previous response asked them to walk through or re-explain steps they already showed you. That is over-scaffolding: it signals doubt about verified-correct work and stalls their momentum. Rewrite: give specific praise naming what they did right (you can see their steps), then move the lesson FORWARD — a next problem, a slightly harder variant, or a transfer question. Do NOT ask them to repeat, re-explain, or walk through anything they already wrote.';
+      const regenerated = await callLLM(PRIMARY_CHAT_MODEL,
+        [{ role: 'system', content: correctionPrompt },
+         { role: 'assistant', content: text },
+         { role: 'user', content: 'Rewrite this response. Affirm the work they showed, then advance. No re-explaining requests.' }],
+        { temperature: 0.55, max_tokens: 1500 }
+      );
+      const regeneratedText = regenerated.choices[0]?.message?.content?.trim();
+      if (regeneratedText && regeneratedText.length > 10) {
+        text = regeneratedText;
+        flags.push('rejustification_regenerated');
+        regeneratedThisPass = true;
+
+        if (context.isStreaming && context.res) {
+          try {
+            context.res.write(`data: ${JSON.stringify({ type: 'replacement', content: text })}\n\n`);
+          } catch (e) { /* client disconnected */ }
+        }
+      }
+    } catch (err) {
+      console.error('[Verify] Re-justification regeneration failed:', err.message);
+      flags.push('rejustification_regeneration_failed');
     }
   }
 
@@ -1423,6 +1474,17 @@ function normalizeLatex(text) {
     protectedBlocks.push(match);
     return `@@PROTECTED_${protectedBlocks.length - 1}@@`;
   });
+
+  // ── 2c. Wrap bare operator math: "120 \div 4" → "\(120 \div 4\)" ──
+  // Pre-pass 1 converts unicode ÷/×/± to \div/\times/\pm but nothing below
+  // wraps them (step 4 only anchors on \frac-class commands), so the student
+  // saw literal "\div" in chat (production screenshot, 2026-07-26) — our own
+  // normalizer turned a readable "÷" into raw LaTeX source. Runs after the
+  // protection pass, so math already inside delimiters is never re-wrapped.
+  result = result.replace(
+    /\b(\d+(?:\.\d+)?(?:\s*\\(?:div|times|cdot|pm)\s*\d+(?:\.\d+)?)+(?:\s*=\s*-?\d+(?:\.\d+)?)?)/g,
+    '\\($1\\)'
+  );
 
   // ── 3. Fix bare parenthesized math: ( expr ) → \( expr \) ──
   result = result.replace(/(?<![\\a-zA-Z])\(\s*([^()]+?)\s*\)(?!\s*[=<>])/g, (match, inner) => {


### PR DESCRIPTION
Follow-up to #1323, from the owner's production screenshot of the same morning. One tutor reply to a clean first-try solve ("120/4 = 30 miles per gallon. and 10 gallons at 30 mpg is 300 miles") showed three defects at once:

## 1. Re-justification of already-shown work (over-scaffolding)

The student's message *was* the walkthrough, and the tutor still asked "Can you walk me through how you got from 120 ÷ 4 to 30…?" [decide.js](utils/pipeline/decide.js) already injects a directive forbidding exactly this on demonstrated-reasoning turns — the model ignored it, and nothing enforced it.

**Fix:** new §2d-rejustify guard in [verify.js](utils/pipeline/verify.js): on `CONFIRM_CORRECT` turns where `diagnosis.demonstratedReasoning` is true (correct answer + verified reasoning), a reply asking the student to walk through / re-explain their steps regenerates into affirm-and-advance. `demonstratedReasoning` now flows into the verify context ([index.js](utils/pipeline/index.js)). Bare-answer correct turns are untouched — asking those students to explain is legitimate data-gathering.

## 2. Literal `\div` shipped to the student

`normalizeLatex` converts unicode `÷`/`×` to `\div`/`\times` but nothing wrapped bare operator math (step 4 only anchors on `\frac`-class commands) — so our own normalizer turned a readable `÷` into raw LaTeX source in chat.

**Fix:** new step 2c wraps number-operator runs (`120 \div 4`, `3 \times 4 = 12`) in `\( \)`. Runs after the protection pass, so already-delimited math is never double-wrapped.

## 3. "Let's work through it together" beat the transition ban

The ban only knew "work through **this**". Widened to `this|that|it` (also for `tackle` / `break … down`, plus optional `together`), and a dangling purpose clause ("…to ensure we understand each step clearly!") now counts as no-content, so the sentence-aware scrub from #1323 drops the filler sentence whole instead of leaving "To ensure we understand each step clearly!" behind.

## Tests

[tests/unit/cleanSolveOverScaffold.test.js](tests/unit/cleanSolveOverScaffold.test.js) — 9 tests pinned to the screenshot reply verbatim (guard fires, guard-scoping negatives, regen-failure fallback, `\div`/`\times` wrapping, no double-wrap, transition variants). One stale expectation updated in `pipelineIntegration` (it pinned the now-banned phrase). Full unit suite: **4,441 tests / 292 suites green.** Lint: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)