### PR TITLE
fix(cosmetics): avatar rings now render where students actually look

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -96,7 +96,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <!-- Personal status card modal (Progress button) -->
   <link rel="stylesheet" href="/css/status-card.css" />
   <!-- Cosmetics: equipped skins + shop modal -->
-  <link rel="stylesheet" href="/dist/css/chat-css2.047b015f.css" />
+  <link rel="stylesheet" href="/dist/css/chat-css2.a13da437.css" />
   <!-- Coin surfacing: sidebar counter + fly-in reward animation -->
   <link rel="stylesheet" href="/css/coin-fx.css" />
   <!-- Full-body student character render -->
@@ -2421,7 +2421,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <script defer src="/js/voice-subtitles.js?v=20260718b"></script>
   <!-- Whiteboard stack lazy-loaded via loadBoardTools() (see boardPanel block
        below) — only needed when the visual board is enabled (boardPanel:true). -->
-  <script src="/dist/js/chat-js3.895af699.js"></script>
+  <script src="/dist/js/chat-js3.0987956a.js"></script>
 <!-- returningUserModal.js removed — no longer used -->
   <script src="/dist/js/chat-js4.301bba99.js"></script>
 <link rel="stylesheet" href="/css/algebra-tiles.css">

--- a/public/css/cosmetics.css
+++ b/public/css/cosmetics.css
@@ -163,22 +163,22 @@ body[data-skin-avatarframe] .sc-avatar-img {
 /* Silver */
 body[data-skin-avatarframe="frame.silver"] .message-container.user .message-avatar img,
 body[data-skin-avatarframe="frame.silver"] .sc-avatar-img {
-  border: 2px solid #cbd5e1;
-  box-shadow: 0 0 0 1px #94a3b8, 0 0 6px rgba(203, 213, 225, 0.7);
+  border: 3px solid #cbd5e1;
+  box-shadow: 0 0 0 2px #94a3b8, 0 0 10px rgba(203, 213, 225, 0.95);
 }
 
 /* Gold */
 body[data-skin-avatarframe="frame.gold"] .message-container.user .message-avatar img,
 body[data-skin-avatarframe="frame.gold"] .sc-avatar-img {
-  border: 2px solid #f6d365;
-  box-shadow: 0 0 0 1px #d4af37, 0 0 8px rgba(212, 175, 55, 0.75);
+  border: 3px solid #f6d365;
+  box-shadow: 0 0 0 2px #d4af37, 0 0 12px rgba(212, 175, 55, 0.95);
 }
 
 /* Neon Pulse */
 body[data-skin-avatarframe="frame.neon"] .message-container.user .message-avatar img,
 body[data-skin-avatarframe="frame.neon"] .sc-avatar-img {
-  border: 2px solid #22d3ee;
-  box-shadow: 0 0 8px rgba(34, 211, 238, 0.9), 0 0 16px rgba(124, 77, 255, 0.6);
+  border: 3px solid #22d3ee;
+  box-shadow: 0 0 12px rgba(34, 211, 238, 1), 0 0 22px rgba(124, 77, 255, 0.8);
 }
 @media (prefers-reduced-motion: no-preference) {
   body[data-skin-avatarframe="frame.neon"] .message-container.user .message-avatar img,
@@ -281,4 +281,59 @@ body[data-skin-header="header.camo"] .landing-header {
 }
 body[data-skin-header="header.wave"] .landing-header {
   background-image: linear-gradient(135deg, #667eea, #22d3ee 50%, #06b6d4);
+}
+
+
+/* =========================================================================
+ * AVATAR FRAMES on the MARQUEE surfaces (owner: "cosmetics don't yield
+ * noticeable changes"). The old rules only ringed the ~32px chat-message
+ * avatar — invisible at that size — and the retired status card. The
+ * surfaces a student actually looks at are the full-body figure in
+ * My Progress (.psc-avatar-col) and the rail player card. Render the frame
+ * there as a glowing ground-ring pedestal under the standing figure.
+ * ========================================================================= */
+body[data-skin-avatarframe] .psc-avatar-col,
+body[data-skin-avatarframe] .cr-player-card .cr-player-avatar {
+  position: relative;
+}
+body[data-skin-avatarframe] .psc-avatar-col::after,
+body[data-skin-avatarframe] .cr-player-card .cr-player-avatar::after {
+  content: '';
+  position: absolute;
+  left: 50%; bottom: 2px;
+  width: 78%; height: 16px;
+  transform: translateX(-50%);
+  border-radius: 50%;
+  pointer-events: none;
+  z-index: 0;
+}
+body[data-skin-avatarframe="frame.silver"] .psc-avatar-col::after,
+body[data-skin-avatarframe="frame.silver"] .cr-player-card .cr-player-avatar::after {
+  border: 3px solid #cbd5e1;
+  box-shadow: 0 0 14px rgba(203, 213, 225, 0.9), inset 0 0 8px rgba(148, 163, 184, 0.6);
+}
+body[data-skin-avatarframe="frame.gold"] .psc-avatar-col::after,
+body[data-skin-avatarframe="frame.gold"] .cr-player-card .cr-player-avatar::after {
+  border: 3px solid #f6d365;
+  box-shadow: 0 0 18px rgba(212, 175, 55, 0.95), inset 0 0 10px rgba(212, 175, 55, 0.65);
+}
+body[data-skin-avatarframe="frame.neon"] .psc-avatar-col::after,
+body[data-skin-avatarframe="frame.neon"] .cr-player-card .cr-player-avatar::after {
+  border: 3px solid #22d3ee;
+  box-shadow: 0 0 18px rgba(34, 211, 238, 1), 0 0 30px rgba(124, 77, 255, 0.8), inset 0 0 12px rgba(34, 211, 238, 0.7);
+}
+@media (prefers-reduced-motion: no-preference) {
+  body[data-skin-avatarframe="frame.neon"] .psc-avatar-col::after,
+  body[data-skin-avatarframe="frame.neon"] .cr-player-card .cr-player-avatar::after {
+    animation: cosmetic-neon-breathe 2.2s ease-in-out infinite;
+  }
+  @keyframes cosmetic-neon-breathe {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.55; }
+  }
+}
+/* The figure stands ON the ring, not behind it. */
+body[data-skin-avatarframe] .psc-avatar-col .fba-stage,
+body[data-skin-avatarframe] .cr-player-card .cr-player-avatar > * {
+  position: relative; z-index: 1;
 }

--- a/public/dist/chat-bundles.manifest.json
+++ b/public/dist/chat-bundles.manifest.json
@@ -36,7 +36,7 @@
       ]
     },
     {
-      "href": "/dist/css/chat-css2.047b015f.css",
+      "href": "/dist/css/chat-css2.a13da437.css",
       "files": [
         "/css/cosmetics.css",
         "/css/shop.css"
@@ -69,7 +69,7 @@
       ]
     },
     {
-      "src": "/dist/js/chat-js3.895af699.js",
+      "src": "/dist/js/chat-js3.0987956a.js",
       "files": [
         "/js/chat-board-integration.js",
         "/js/floating-screener.js",

--- a/public/dist/css/chat-css2.a13da437.css
+++ b/public/dist/css/chat-css2.a13da437.css
@@ -164,22 +164,22 @@ body[data-skin-avatarframe] .sc-avatar-img {
 /* Silver */
 body[data-skin-avatarframe="frame.silver"] .message-container.user .message-avatar img,
 body[data-skin-avatarframe="frame.silver"] .sc-avatar-img {
-  border: 2px solid #cbd5e1;
-  box-shadow: 0 0 0 1px #94a3b8, 0 0 6px rgba(203, 213, 225, 0.7);
+  border: 3px solid #cbd5e1;
+  box-shadow: 0 0 0 2px #94a3b8, 0 0 10px rgba(203, 213, 225, 0.95);
 }
 
 /* Gold */
 body[data-skin-avatarframe="frame.gold"] .message-container.user .message-avatar img,
 body[data-skin-avatarframe="frame.gold"] .sc-avatar-img {
-  border: 2px solid #f6d365;
-  box-shadow: 0 0 0 1px #d4af37, 0 0 8px rgba(212, 175, 55, 0.75);
+  border: 3px solid #f6d365;
+  box-shadow: 0 0 0 2px #d4af37, 0 0 12px rgba(212, 175, 55, 0.95);
 }
 
 /* Neon Pulse */
 body[data-skin-avatarframe="frame.neon"] .message-container.user .message-avatar img,
 body[data-skin-avatarframe="frame.neon"] .sc-avatar-img {
-  border: 2px solid #22d3ee;
-  box-shadow: 0 0 8px rgba(34, 211, 238, 0.9), 0 0 16px rgba(124, 77, 255, 0.6);
+  border: 3px solid #22d3ee;
+  box-shadow: 0 0 12px rgba(34, 211, 238, 1), 0 0 22px rgba(124, 77, 255, 0.8);
 }
 @media (prefers-reduced-motion: no-preference) {
   body[data-skin-avatarframe="frame.neon"] .message-container.user .message-avatar img,
@@ -282,6 +282,61 @@ body[data-skin-header="header.camo"] .landing-header {
 }
 body[data-skin-header="header.wave"] .landing-header {
   background-image: linear-gradient(135deg, #667eea, #22d3ee 50%, #06b6d4);
+}
+
+
+/* =========================================================================
+ * AVATAR FRAMES on the MARQUEE surfaces (owner: "cosmetics don't yield
+ * noticeable changes"). The old rules only ringed the ~32px chat-message
+ * avatar — invisible at that size — and the retired status card. The
+ * surfaces a student actually looks at are the full-body figure in
+ * My Progress (.psc-avatar-col) and the rail player card. Render the frame
+ * there as a glowing ground-ring pedestal under the standing figure.
+ * ========================================================================= */
+body[data-skin-avatarframe] .psc-avatar-col,
+body[data-skin-avatarframe] .cr-player-card .cr-player-avatar {
+  position: relative;
+}
+body[data-skin-avatarframe] .psc-avatar-col::after,
+body[data-skin-avatarframe] .cr-player-card .cr-player-avatar::after {
+  content: '';
+  position: absolute;
+  left: 50%; bottom: 2px;
+  width: 78%; height: 16px;
+  transform: translateX(-50%);
+  border-radius: 50%;
+  pointer-events: none;
+  z-index: 0;
+}
+body[data-skin-avatarframe="frame.silver"] .psc-avatar-col::after,
+body[data-skin-avatarframe="frame.silver"] .cr-player-card .cr-player-avatar::after {
+  border: 3px solid #cbd5e1;
+  box-shadow: 0 0 14px rgba(203, 213, 225, 0.9), inset 0 0 8px rgba(148, 163, 184, 0.6);
+}
+body[data-skin-avatarframe="frame.gold"] .psc-avatar-col::after,
+body[data-skin-avatarframe="frame.gold"] .cr-player-card .cr-player-avatar::after {
+  border: 3px solid #f6d365;
+  box-shadow: 0 0 18px rgba(212, 175, 55, 0.95), inset 0 0 10px rgba(212, 175, 55, 0.65);
+}
+body[data-skin-avatarframe="frame.neon"] .psc-avatar-col::after,
+body[data-skin-avatarframe="frame.neon"] .cr-player-card .cr-player-avatar::after {
+  border: 3px solid #22d3ee;
+  box-shadow: 0 0 18px rgba(34, 211, 238, 1), 0 0 30px rgba(124, 77, 255, 0.8), inset 0 0 12px rgba(34, 211, 238, 0.7);
+}
+@media (prefers-reduced-motion: no-preference) {
+  body[data-skin-avatarframe="frame.neon"] .psc-avatar-col::after,
+  body[data-skin-avatarframe="frame.neon"] .cr-player-card .cr-player-avatar::after {
+    animation: cosmetic-neon-breathe 2.2s ease-in-out infinite;
+  }
+  @keyframes cosmetic-neon-breathe {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.55; }
+  }
+}
+/* The figure stands ON the ring, not behind it. */
+body[data-skin-avatarframe] .psc-avatar-col .fba-stage,
+body[data-skin-avatarframe] .cr-player-card .cr-player-avatar > * {
+  position: relative; z-index: 1;
 }
 
 /* --- /css/shop.css --- */

--- a/public/dist/js/chat-js3.0987956a.js
+++ b/public/dist/js/chat-js3.0987956a.js
@@ -3902,6 +3902,19 @@ class CourseManager {
     beginTeachingUnlessBaselinePending(diagnostic) {
         if (diagnostic && diagnostic.required) {
             this._baselinePending = true;
+            // Registration step: for the ACT baseline, take the student straight
+            // INTO the runner (which now lands on its Begin screen — no auto-timer)
+            // instead of just holding the greeting behind a dismissible card. The
+            // baseline becomes the door you walk through to reach the tutor, not a
+            // nag you can skip. The greeting stays held until the runner finishes
+            // and calls onBaselineComplete(); the welcome splash + its card remain
+            // behind the modal as the fallback if the student closes it early.
+            // Other required diagnostics keep the existing card-only behaviour.
+            // `typeof` guard: this file is also loaded in node by the unit tests,
+            // where `window` does not exist.
+            if (diagnostic.type === 'act-practice' && typeof window !== 'undefined' && window.openActTest) {
+                setTimeout(() => { try { window.openActTest(); } catch (e) {} }, 350);
+            }
             return;
         }
         this._baselinePending = false;
@@ -4425,6 +4438,19 @@ class LessonTracker {
     // --------------------------------------------------
 
     _render(pu) {
+        // ACT bootcamp: the course is a test→review→re-test loop, not a
+        // gradual-release scaffold, so render the loop view instead of the
+        // Warm-up/Learn/Practice stepper. Only for act-prep with bootcamp state.
+        if (pu && pu.bootcamp && pu.courseId === 'act-prep') {
+            return this._renderBootcamp(pu);
+        }
+        // Not in bootcamp mode — restore the standard tracker chrome if the
+        // bootcamp panel was showing.
+        const bcPanel = document.getElementById('lt-bootcamp');
+        if (bcPanel) bcPanel.style.display = 'none';
+        const ltContainer = document.querySelector('#lesson-tracker-wrapper .lt-container');
+        if (ltContainer) ltContainer.style.display = '';
+
         // Lesson breadcrumb (shows module > lesson context)
         this._renderBreadcrumb(pu);
 
@@ -4458,6 +4484,107 @@ class LessonTracker {
         if (wrapper && wrapper.style.display === 'none') {
             wrapper.style.display = 'block';
         }
+    }
+
+    // ── ACT bootcamp loop view (replaces the scaffold stepper for act-prep) ──
+    _renderBootcamp(pu) {
+        const wrapper = document.getElementById('lesson-tracker-wrapper');
+        if (!wrapper) return;
+        const ltContainer = wrapper.querySelector('.lt-container');
+        if (ltContainer) ltContainer.style.display = 'none';
+        let panel = document.getElementById('lt-bootcamp');
+        if (!panel) {
+            panel = document.createElement('div');
+            panel.id = 'lt-bootcamp';
+            panel.style.padding = '4px 0';
+            wrapper.appendChild(panel);
+        }
+        panel.innerHTML = this._bootcampHtml(pu.bootcamp, pu.diagnosticPlan);
+        panel.style.display = 'block';
+        wrapper.style.display = 'block';
+        this._wireBootcamp();
+        this._loadBootcampScore();
+    }
+
+    _bootcampHtml(bc, dp) {
+        const CAT = { 'integrating-essential-skills': 'Essential skills', 'number-quantity': 'Number & Quantity', algebra: 'Algebra', functions: 'Functions', geometry: 'Geometry', 'statistics-probability': 'Statistics & Probability' };
+        const label = (c) => CAT[c] || String(c || '').replace(/-/g, ' ');
+        const total = Array.isArray(bc.queue) ? bc.queue.length : 0;
+        const reviewed = Math.min(bc.index || 0, total);
+        const pct = total ? Math.round((100 * reviewed) / total) : 0;
+        const round = bc.round || 1;
+        const isReview = bc.phase === 'review' && total > 0;
+        const cur = isReview && Array.isArray(bc.queue) ? bc.queue[bc.index] : null;
+
+        const step = (icon, name, state) => {
+            const style = state === 'active'
+                ? 'background:rgba(255,255,255,.22);color:#fff;font-weight:600'
+                : state === 'done' ? 'color:rgba(255,255,255,.85)' : 'color:rgba(255,255,255,.5)';
+            return `<div style="flex:1;text-align:center;padding:8px 4px;border-radius:8px;font-size:12px;${style}"><i class="fas ${icon}"></i> ${name}</div>`;
+        };
+        const loop = `<div style="display:flex;gap:6px;margin:10px 0 14px">
+            ${step('fa-flag-checkered', 'Baseline', 'done')}
+            ${step('fa-bullseye', 'Review', isReview ? 'active' : 'done')}
+            ${step('fa-clipboard-list', 'Re-test', bc.phase === 'reassess' ? 'active' : 'todo')}
+            ${step('fa-chart-line', 'Compare', 'todo')}
+          </div>`;
+
+        const phaseCard = isReview ? `
+            <div style="background:rgba(255,255,255,.14);border-radius:12px;padding:12px 14px">
+              <div style="display:flex;justify-content:space-between;align-items:center;color:#fff;font-size:14px;font-weight:600;margin-bottom:8px"><span>Going over what you missed</span><span style="font-weight:500;font-size:12.5px;opacity:.85">${reviewed} of ${total} done</span></div>
+              <div style="height:7px;background:rgba(255,255,255,.22);border-radius:5px;overflow:hidden;margin-bottom:10px"><div style="width:${pct}%;height:100%;background:#fff;border-radius:5px"></div></div>
+              <div style="display:flex;justify-content:space-between;align-items:center;gap:10px;flex-wrap:wrap">
+                <span style="color:rgba(255,255,255,.9);font-size:12.5px">Up next: <strong>${cur ? label(cur.category) : '—'}</strong></span>
+                <button id="lt-bc-continue" style="background:#fff;color:#5b3ea8;border:0;border-radius:8px;padding:6px 14px;font-size:12.5px;font-weight:600;cursor:pointer">Continue in chat</button>
+              </div>
+            </div>` : `
+            <div style="background:rgba(255,255,255,.14);border-radius:12px;padding:12px 14px;display:flex;justify-content:space-between;align-items:center;gap:10px;flex-wrap:wrap">
+              <span style="color:#fff;font-size:13.5px;font-weight:500">You've reviewed your misses — take a fresh test to measure your gains.</span>
+              <button id="lt-bc-retest" style="background:#fff;color:#5b3ea8;border:0;border-radius:8px;padding:6px 14px;font-size:12.5px;font-weight:600;cursor:pointer">Take a fresh test</button>
+            </div>`;
+
+        const chips = (dp && (dp.focusCategories || dp.masteredCategories)) ? `
+            <div style="margin-top:12px;display:flex;flex-wrap:wrap;gap:6px;align-items:center">
+              ${(dp.focusCategories || []).map((c) => `<span style="background:rgba(255,255,255,.2);color:#fff;font-size:11.5px;padding:3px 9px;border-radius:20px">${label(c)}</span>`).join('')}
+              ${(dp.masteredCategories || []).map((c) => `<span style="background:rgba(255,255,255,.1);color:rgba(255,255,255,.75);font-size:11.5px;padding:3px 9px;border-radius:20px"><i class="fas fa-check" style="font-size:10px"></i> ${label(c)}</span>`).join('')}
+            </div>` : '';
+
+        return `
+          <div style="background:linear-gradient(135deg,#667eea,#764ba2);border-radius:14px;padding:14px 16px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif">
+            <div style="display:flex;justify-content:space-between;align-items:center;gap:10px;flex-wrap:wrap">
+              <span style="color:#fff;font-size:15px;font-weight:700">🎯 ACT bootcamp <span style="font-weight:500;font-size:12px;background:rgba(255,255,255,.2);padding:2px 9px;border-radius:20px;margin-left:4px">Round ${round}</span></span>
+              <span id="lt-bc-score" style="color:#fff;font-size:13px;opacity:.9"></span>
+            </div>
+            ${loop}
+            ${phaseCard}
+            ${chips}
+            <div style="margin-top:12px;text-align:right"><a id="lt-bc-progress" href="#" style="color:#fff;font-size:12px;opacity:.9;text-decoration:none"><i class="fas fa-chart-line"></i> See your progress</a></div>
+          </div>`;
+    }
+
+    _wireBootcamp() {
+        const cont = document.getElementById('lt-bc-continue');
+        if (cont) cont.addEventListener('click', () => {
+            const input = document.getElementById('user-input') || document.getElementById('chat-input');
+            if (input) input.focus();
+        });
+        const retest = document.getElementById('lt-bc-retest');
+        if (retest) retest.addEventListener('click', () => { if (window.openActTest) window.openActTest(); });
+        const prog = document.getElementById('lt-bc-progress');
+        if (prog) prog.addEventListener('click', (e) => { e.preventDefault(); if (window.openActProgress) window.openActProgress(); });
+    }
+
+    async _loadBootcampScore() {
+        try {
+            const fetcher = window.csrfFetch || window.fetch;
+            const r = await fetcher('/api/act-test/history').then((x) => x.json()).catch(() => null);
+            const a = ((r && r.attempts) || []).filter((x) => x.scaledScore != null);
+            const el = document.getElementById('lt-bc-score');
+            if (!el || !a.length) return;
+            if (a.length === 1) { el.textContent = `Score ${a[0].scaledScore}`; return; }
+            const first = a[0].scaledScore, latest = a[a.length - 1].scaledScore, d = latest - first;
+            el.innerHTML = `${first} &rarr; ${latest}${d > 0 ? ` <span style="background:rgba(255,255,255,.25);padding:1px 7px;border-radius:20px;font-size:11px">&#9650; +${d}</span>` : ''}`;
+        } catch (e) { /* non-fatal */ }
     }
 
     _renderBreadcrumb(pu) {


### PR DESCRIPTION
Owner report: *"many of the cosmetics don't yield noticeable changes. like the avatar rings."*

## Why they were invisible

The avatar-frame cosmetics only targeted two surfaces: the **~32px chat-message avatar** (where a 2px border is functionally invisible) and the **retired status-card portrait**. The surfaces a student actually looks at — the full-body figure in My Progress and the rail player card — had no ring rendering at all. So a purchased ring technically applied and practically didn't exist.

## What ships

- **A glowing ground-ring pedestal** under the standing figure on both marquee surfaces, per frame: silver, gold, neon (neon breathes; `prefers-reduced-motion` honored). The figure stands *on* its ring — visible from across the room, which is the point of buying one.
- The small chat-avatar ring strengthened (3px + real glow) so it reads at message size too.
- Bundles regenerated (`cosmetics.css` ships inside `chat-css2`): manifest + chat.html hashes updated, superseded hashed files removed. `chatBundleIntegrity` green; full suite green. The Dockerfile's deploy-time rebuild would have covered prod either way — committing keeps the repo true.

## Post-deploy check

Equip any frame in the shop → the pedestal appears under the My Progress figure immediately (live preview stamps the same attributes).

## Note for a follow-up

This is one slot of a broader pattern worth auditing: several cosmetic slots (board, calculator, header) should get the same "would a kid notice this from two feet away?" pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)