### PR TITLE
fix(diagnose): multi-line shown work graded incorrect — 520=7x false negative (prod 2026-07-26)

### DIFF
--- a/jest.critical.config.js
+++ b/jest.critical.config.js
@@ -30,6 +30,9 @@ module.exports = {
     '<rootDir>/tests/unit/irt.test.js',
     '<rootDir>/tests/unit/knowledgeTracer.test.js',
     '<rootDir>/tests/unit/diagnoseArithmeticGuard.test.js',
+    '<rootDir>/tests/unit/diagnoseMultiLineAnswer.test.js',
+    '<rootDir>/tests/unit/diagnoseMultiStep.test.js',
+    '<rootDir>/tests/unit/derivationVerifier.test.js',
     '<rootDir>/tests/unit/mathSolver*.test.js',
     '<rootDir>/tests/golden/goldenTranscripts.test.js',
   ],
@@ -48,13 +51,13 @@ module.exports = {
   // Floors sit a few points below measured coverage to absorb cross-Node-version
   // branch-counting drift. Tighten as coverage improves.
   coverageThreshold: {
-    './utils/mathSolver.js': { statements: 73, branches: 63, functions: 84, lines: 76 },
+    './utils/mathSolver.js': { statements: 78, branches: 68, functions: 88, lines: 81 },
     './utils/irt.js': { statements: 90, branches: 82, functions: 95, lines: 90 },
     './utils/knowledgeTracer.js': { statements: 83, branches: 78, functions: 95, lines: 83 },
     './utils/verifyMetrics.js': { statements: 96, branches: 80, functions: 100, lines: 96 },
     './utils/pipeline/llmVerifier.js': { statements: 88, branches: 75, functions: 100, lines: 88 },
-    './utils/pipeline/observe.js': { statements: 70, branches: 66, functions: 90, lines: 74 },
+    './utils/pipeline/observe.js': { statements: 75, branches: 72, functions: 95, lines: 81 },
     './utils/pipeline/decide.js': { statements: 44, branches: 42, functions: 62, lines: 45 },
-    './utils/pipeline/diagnose.js': { statements: 44, branches: 43, functions: 42, lines: 46 },
+    './utils/pipeline/diagnose.js': { statements: 58, branches: 55, functions: 60, lines: 58 },
   },
 };

--- a/tests/unit/diagnoseMultiLineAnswer.test.js
+++ b/tests/unit/diagnoseMultiLineAnswer.test.js
@@ -1,0 +1,137 @@
+/**
+ * Production regression (DB inspection, 2026-07-26): a student solved the
+ * proportion 5/7 = x/20 with fully shown work —
+ *
+ *     520=7x        ← cross-multiplication, "5·20" written without the operator
+ *     100=7x
+ *     100/7 = x
+ *     CONFIRMED!
+ *
+ * — and the pipeline graded it INCORRECT, arming wrong-answer support on a
+ * correct solve (and, post-PR #1324, resetting demonstrated-competence trust).
+ *
+ * Three stacked causes, each pinned here:
+ *   1. observe.extractAnswer got nothing from multi-line work, so the message
+ *      classified general_math instead of answer_attempt.
+ *   2. The pinned board problem arrives as LaTeX (\frac{5}{7} = \frac{x}{20}),
+ *      which parseCleanProblem couldn't parse — so verifyDerivation had no
+ *      external target and anchored the chain on the student's own FIRST line
+ *      (520=7x → x = 520/7), marking the two CORRECT lines as the broken steps.
+ *   3. verifyDerivation failed the whole chain on the first literally-wrong
+ *      line even when the final line reached the right answer.
+ *
+ * The bar: this exact message must grade CORRECT with demonstratedReasoning.
+ */
+
+jest.mock('../../utils/logger', () => ({
+  child: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }),
+}));
+
+const { observe, extractAnswer, MESSAGE_TYPES } = require('../../utils/pipeline/observe');
+const { diagnose } = require('../../utils/pipeline/diagnose');
+const { parseCleanProblem } = require('../../utils/mathSolver');
+const { verifyDerivation } = require('../../utils/derivationVerifier');
+
+const MSG = '520=7x\n100=7x\n100/7 = x\nCONFIRMED!';
+const PIN_PLAIN = '5/7 = x/20';
+const PIN_LATEX = '\\frac{5}{7} = \\frac{x}{20}';
+
+const obs = () => observe(MSG, { recentUserMessages: [], recentAssistantMessages: [] });
+const recentAI = [{ content: 'Try this proportion: \\(\\frac{5}{7} = \\frac{x}{20}\\)' }];
+
+describe('multi-line answer extraction (observe)', () => {
+  it('takes the LAST math line as the answer candidate, earlier lines as work', () => {
+    const a = extractAnswer(MSG);
+    expect(a).not.toBeNull();
+    expect(a.value).toBe('100/7');
+    expect(a.hasExplanation).toBe(true);
+  });
+
+  it('classifies the message as an answer attempt, not a bare problem drop', () => {
+    const o = obs();
+    expect(o.messageType).toBe(MESSAGE_TYPES.ANSWER_ATTEMPT);
+    expect(o.isBareProblemDrop).toBe(false);
+  });
+
+  it('reads the mirrored assignment form "value = x"', () => {
+    expect(extractAnswer('100=7x\n100/7 = x').value).toBe('100/7');
+  });
+
+  it('does not treat an equation line as an answer', () => {
+    // Last math line is still work ("100=7x" has a coefficient·variable side);
+    // the strict answer shapes must not fire on it.
+    expect(extractAnswer('520=7x\n100=7x')).toBeNull();
+  });
+});
+
+describe('LaTeX pinned problems parse (mathSolver)', () => {
+  it('solves the \\frac proportion pin', () => {
+    const r = parseCleanProblem(PIN_LATEX);
+    expect(r.hasMath).toBe(true);
+    expect(r.problem.type).toBe('proportion');
+    expect(Number(r.solution.answer)).toBeCloseTo(100 / 7, 3);
+  });
+
+  it('still rejects prose and unknown LaTeX', () => {
+    expect(parseCleanProblem('\\text{Sarah bakes 3 batches every morning}').hasMath).toBe(false);
+  });
+});
+
+describe('derivation chain (verifyDerivation)', () => {
+  it('rescues the missing multiplication operator against a known target', () => {
+    const chain = verifyDerivation(MSG, PIN_PLAIN);
+    expect(chain.verifiable).toBe(true);
+    expect(chain.valid).toBe(true);
+    expect(chain.answerCorrect).toBe(true);
+    expect(chain.steps[0].rescuedAs).toBe('5*20');
+    expect(chain.firstBadStep).toBeNull();
+  });
+
+  it('anchors an unpinned chain on the LAST line, not the first', () => {
+    const chain = verifyDerivation(MSG);
+    expect(chain.targetSource).toBe('internal');
+    expect(Number(chain.target)).toBeCloseTo(100 / 7, 3);
+    expect(chain.answerCorrect).toBe(true);
+  });
+
+  it('final-line-wins: a broken earlier line never flips a correct answer', () => {
+    // Student garbles a middle line beyond rescue but lands the right answer.
+    const chain = verifyDerivation('3x - 5 = 16\n3x = 11\nx = 7', '3x - 5 = 16');
+    expect(chain.answerCorrect).toBe(true);   // grading: correct
+    expect(chain.valid).toBe(false);          // reasoning: not demonstrated
+    expect(chain.firstBadStep).toBe('3x = 11');
+  });
+
+  it('a genuinely wrong final answer still grades incorrect with the step pinpointed', () => {
+    const chain = verifyDerivation('3x - 5 = 16\n3x = 11\nx = 11/3', '3x - 5 = 16');
+    expect(chain.answerCorrect).toBe(false);
+    expect(chain.valid).toBe(false);
+    expect(chain.firstBadStep).toBe('3x = 11');
+  });
+});
+
+describe('end-to-end diagnose — the production message', () => {
+  it.each([
+    ['plain pin', PIN_PLAIN],
+    ['LaTeX pin', PIN_LATEX],
+  ])('grades CORRECT with demonstrated reasoning (%s)', async (_label, pin) => {
+    const d = await diagnose(obs(), {
+      recentAssistantMessages: recentAI,
+      recentUserMessages: [],
+      pinnedProblemTex: pin,
+    });
+    expect(d.type).toBe('correct');
+    expect(d.isCorrect).toBe(true);
+    expect(d.demonstratedReasoning).toBe(true);
+    expect(d.verificationSource).toBe('derivation');
+  });
+
+  it('grades CORRECT even with no pin at all (chat-only session)', async () => {
+    const d = await diagnose(obs(), {
+      recentAssistantMessages: [],
+      recentUserMessages: [],
+      pinnedProblemTex: null,
+    });
+    expect(d.isCorrect).toBe(true);
+  });
+});

--- a/utils/derivationVerifier.js
+++ b/utils/derivationVerifier.js
@@ -36,6 +36,35 @@ function resolveLine(line) {
   return String(parsed.solution.answer);
 }
 
+// Rescue a line that is literally wrong because the student wrote a product
+// with the multiplication sign missing: cross-multiplying 5/7 = x/20 as
+// "520=7x" (meaning 5·20 = 7x). Re-read each 2+ digit integer as a product of
+// its two halves and re-solve; accept only an interpretation that solves to
+// the chain's known target. Target-gated on purpose: this can only repair a
+// line into agreement with an answer we already trust — it can never flip a
+// genuinely wrong step to correct, because a wrong step's reinterpretations
+// don't land on the target except by coincidence.
+function rescueMissingOperator(line, target) {
+  const rx = /(?<![\d.])\d{2,}(?![\d.])/g;
+  let m;
+  while ((m = rx.exec(line)) !== null) {
+    const s = m[0];
+    for (let i = 1; i < s.length; i++) {
+      if (s[i] === '0' && s.length - i > 1) continue; // no leading-zero operand
+      // Substitute the evaluated product rather than inserting "*": a line like
+      // "5*20=7x" trips the solver's evaluation catch-all (it returns 100, the
+      // left side's value), while "100=7x" solves as the equation it is.
+      const product = Number(s.slice(0, i)) * Number(s.slice(i));
+      const candidate = line.slice(0, m.index) + String(product) + line.slice(m.index + s.length);
+      const solved = resolveLine(candidate);
+      if (solved !== null && verifyAnswer(solved, target).isCorrect === true) {
+        return { readAs: `${s.slice(0, i)}*${s.slice(i)}`, candidate, solved };
+      }
+    }
+  }
+  return null;
+}
+
 /**
  * @param {string} workText   the student's multi-line work
  * @param {string} [problemText] the posed problem; if omitted/unsolvable, the
@@ -51,31 +80,54 @@ function verifyDerivation(workText, problemText, knownTarget) {
   const lines = splitWorkLines(workText);
   if (lines.length < 2) return { verifiable: false, reason: 'not enough steps' };
 
-  // Reference answer: caller-supplied anchor first, else solve the posed problem,
-  // else fall back to the chain's own first line (internal consistency only).
+  // Reference answer: caller-supplied anchor first, else solve the posed problem.
   let target = knownTarget != null ? String(knownTarget) : (problemText ? resolveLine(problemText) : null);
+  const targetSource = knownTarget != null ? 'known' : (target != null ? 'problem' : 'internal');
 
   const steps = lines.map((line) => ({ line, solved: resolveLine(line) }));
   const solvable = steps.filter((s) => s.solved !== null);
   if (solvable.length < 2) return { verifiable: false, reason: 'not enough solvable steps' };
 
-  if (target == null) target = solvable[0].solved;
+  // No external anchor: the chain can only be checked for internal consistency,
+  // and the reference must be the LAST solvable line — the student's answer.
+  // Anchoring on the FIRST line graded the rest of a student's work against
+  // their own opening shorthand: with an unparseable pin, "520=7x / 100=7x /
+  // 100/7 = x" anchored on 520=7x and marked the two CORRECT lines bad.
+  if (target == null) target = solvable[solvable.length - 1].solved;
 
   let firstBadStepIndex = -1;
   for (let i = 0; i < steps.length; i++) {
     const s = steps[i];
     if (s.solved === null) continue; // unparseable line — can't judge it, skip
     s.ok = verifyAnswer(s.solved, target).isCorrect === true;
+    if (!s.ok) {
+      const rescue = rescueMissingOperator(s.line, target);
+      if (rescue) {
+        s.ok = true;
+        s.solved = rescue.solved;
+        s.rescuedAs = rescue.readAs; // e.g. "520" read as "5*20"
+      }
+    }
     if (!s.ok && firstBadStepIndex === -1) firstBadStepIndex = i;
   }
 
   const finalAnswer = solvable[solvable.length - 1].solved;
   const reachedAnswer = verifyAnswer(finalAnswer, target).isCorrect === true;
+  // `valid` is the whole chain checking out — the demonstrated-reasoning signal.
   const valid = firstBadStepIndex === -1 && reachedAnswer;
+  // `answerCorrect` is what grading must use: the final line IS the student's
+  // answer; earlier lines are shown work. A broken earlier line demotes
+  // demonstrated reasoning but must never flip a correct final answer to
+  // incorrect (that false negative arms wrong-answer support on a solve).
+  // With no external anchor there is no answer to be right ABOUT, so internal
+  // chains grade on consistency alone.
+  const answerCorrect = targetSource === 'internal' ? valid : reachedAnswer;
 
   return {
     verifiable: true,
     valid,
+    answerCorrect,
+    targetSource,                // 'known' | 'problem' | 'internal'
     finalAnswer,
     target,
     reachedAnswer,

--- a/utils/mathSolver.js
+++ b/utils/mathSolver.js
@@ -10,7 +10,7 @@
  * @module mathSolver
  */
 
-const { normalizeMathOperators, normalizeSpokenNumbers } = require('./mathUnicodeNormalizer');
+const { normalizeMathOperators, normalizeMathUnicode, normalizeSpokenNumbers } = require('./mathUnicodeNormalizer');
 const { evalExpression, expressionValue } = require('./rationalEvaluator');
 
 /**
@@ -3849,6 +3849,31 @@ function _isTrustedProblem(problem, source) {
     return true;
 }
 
+// LaTeX problem → plain math the regex engine can parse. Board pins arrive as
+// the LLM's board-command tex (e.g. "\frac{5}{7} = \frac{x}{20}"), which none
+// of the regex patterns can see — so the pinned problem silently failed to
+// parse and every grading path that anchors on it (derivation target, pin
+// override, canonical root set) fell back to something worse. In the 2026-07-26
+// incident that fallback anchored a student's chain on their own first line and
+// graded their correct proportion answer wrong.
+//
+// Returns a rewritten string, or null when the input carries no LaTeX or still
+// carries LaTeX after rewriting (nested \frac etc.) — callers then behave
+// exactly as before, so this only ever ADDS parses.
+function _latexToPlainMath(text) {
+    if (!/\\[a-zA-Z(\[]/.test(text)) return null;
+    let s = String(text).replace(/\\[dt]frac\b/g, '\\frac');
+    // \frac{a}{b} → (a)/(b), strips \(…\) delimiters and \left/\right (shared
+    // normalizer), then LaTeX operator spellings (\times, \div, …).
+    s = normalizeMathUnicode(s);
+    s = normalizeMathOperators(s);
+    if (/\\/.test(s)) return null; // nested/unknown LaTeX survived — don't guess
+    // Unwrap parens around a lone number or variable: "(5)/(7) = (x)/(20)" →
+    // "5/7 = x/20", the shape the proportion/linear patterns expect.
+    s = s.replace(/\(\s*(-?\d+(?:\.\d+)?|[a-z])\s*\)/gi, '$1').trim();
+    return s || null;
+}
+
 function parseCleanProblem(text) {
     if (!text || typeof text !== 'string') return { hasMath: false };
 
@@ -3856,6 +3881,13 @@ function parseCleanProblem(text) {
     if (direct.hasMath && direct.solution?.success
         && _isTrustedProblem(direct.problem, text)) {
         return direct;
+    }
+
+    // LaTeX input (board pins, MathLive) — rewrite to plain math and retry.
+    const plain = _latexToPlainMath(text);
+    if (plain && plain !== text) {
+        const viaLatex = parseCleanProblem(plain);
+        if (viaLatex.hasMath) return viaLatex;
     }
 
     // Slow path: pull math substrings out of conversational prose and

--- a/utils/pipeline/diagnose.js
+++ b/utils/pipeline/diagnose.js
@@ -183,15 +183,15 @@ async function diagnoseTransformation(observation, context) {
   // never "how did you do it?"). correctAnswer stays null so nothing is revealed.
   const chain = verifyDerivation(rawText, context.pinnedProblemTex);
   if (chain.verifiable) {
-    console.log(`[Diagnose] Derivation ${chain.valid ? 'valid' : `broke at "${chain.firstBadStep}"`}`);
+    console.log(`[Diagnose] Derivation ${chain.valid ? 'valid' : `${chain.answerCorrect ? 'answer correct, work' : ''} broke at "${chain.firstBadStep}"`}`);
     return {
-      type: chain.valid ? 'correct' : 'incorrect',
-      isCorrect: chain.valid,
+      type: chain.answerCorrect ? 'correct' : 'incorrect',
+      isCorrect: chain.answerCorrect,
       answer: chain.finalAnswer,
       correctAnswer: null,
       misconception: null,
       evidence: {
-        isCorrect: chain.valid,
+        isCorrect: chain.answerCorrect,
         independenceLevel: estimateIndependence(observation, context),
         misconceptionHit: null,
         responseTimeCategory: null,
@@ -482,7 +482,9 @@ async function diagnose(observation, context = {}) {
     // multi-step practice both grade correctly and get taught precisely.
     const chain = verifyDerivation(rawText, context.pinnedProblemTex, problemInfo.correctAnswer);
     if (chain.verifiable) {
-      isCorrect = chain.valid;
+      // The final line is the answer; `valid` (whole chain) feeds
+      // demonstratedReasoning below, never correctness.
+      isCorrect = chain.answerCorrect;
       correctAnswer = problemInfo.correctAnswer;
       verificationSource = 'derivation';
       derivation = chain;
@@ -507,6 +509,23 @@ async function diagnose(observation, context = {}) {
     isCorrect = true;
     correctAnswer = studentAnswer;
     verificationSource = 'arithmetic_override';
+  }
+
+  // ── Step 2a.4: Multi-line shown work with NO solvable posed problem ──
+  // The chain can still verify itself (each line resolves to the same value,
+  // ending on the stated answer). Before multi-line messages carried an
+  // extractable answer, these turns took the transformation path and got
+  // exactly this internal-consistency check — keep that coverage here so a
+  // chat-only session with an unparseable/absent pin doesn't regress to
+  // unverifiable (or worse, a guess).
+  if (isCorrect === null && multiRoot === null && /\n/.test(rawText)) {
+    const chain = verifyDerivation(rawText, context.pinnedProblemTex);
+    if (chain.verifiable) {
+      isCorrect = chain.answerCorrect;
+      verificationSource = 'derivation';
+      derivation = chain;
+      console.log(`[Diagnose] Internal chain: ${chain.valid ? 'consistent' : `broke at "${chain.firstBadStep}"`}`);
+    }
   }
 
   // ── Step 2a.5: SYMBOLIC verification (deterministic, before the LLM) ──

--- a/utils/pipeline/observe.js
+++ b/utils/pipeline/observe.js
@@ -46,6 +46,9 @@ const PATTERNS = {
   justNumber: /^(-?\d+\.?\d*)$/,
   fraction: /^(-?\d+\s*\/\s*\d+)$/,
   varAssignment: /^[a-z]\s*=\s*(-?\d+\.?\d*(?:\/\d+)?)/i,
+  // The mirrored form — "100/7 = x" — is how students often end shown work
+  // (the value lands on the left because that's the side they computed).
+  valueAssignment: /^(-?\d+\.?\d*(?:\s*\/\s*\d+)?)\s*=\s*[a-z]\s*[.!?]*$/i,
   answerPhrase: /(?:answer\s+is|i\s+got|it'?s|equals?|i\s+think\s+it'?s?|that'?s|so\s+it'?s)\s*(-?\d+\.?\d*(?:\s*\/\s*\d+)?)/i,
   // Proposed / self-check answer: a number or fraction the student offers for
   // confirmation — "…right? 10/24", "isn't that equal to 10/24?", "is it 5/12?",
@@ -129,12 +132,45 @@ const PATTERNS = {
  * Extract a student's answer from their message.
  * Returns { value, raw } or null if not an answer attempt.
  */
+/**
+ * Try the strict single-line answer shapes on one line of text.
+ * Returns the extracted value string or null. Used for the final line of
+ * multi-line shown work, where only unambiguous answer forms may win —
+ * an equation line like "100=7x" is still work, not an answer.
+ */
+function matchAnswerLine(line) {
+  let match;
+  if ((match = line.match(PATTERNS.varAssignment))) return match[1];
+  if ((match = line.match(PATTERNS.valueAssignment))) return match[1].replace(/\s/g, '');
+  if ((match = line.match(PATTERNS.justNumber))) return match[1];
+  if ((match = line.match(PATTERNS.fraction))) return match[1].replace(/\s/g, '');
+  if ((match = line.match(PATTERNS.mixedNumber))) return `${match[1]} ${match[2].replace(/\s/g, '')}`;
+  if ((match = line.match(PATTERNS.algebraicExpr))) return match[1].replace(/\s/g, '');
+  return null;
+}
+
 function extractAnswer(message) {
   const raw = message.trim();
   // Normalize speech-to-text negatives/number-words to signed digits BEFORE matching,
   // so a spoken "negative six" is recognized as the answer -6 (the numeric PATTERNS
   // only understand digits). `raw` keeps the original text for downstream use.
   const text = normalizeSpokenNumbers(raw);
+
+  // Multi-line shown work: the LAST math-bearing line is the answer candidate;
+  // the lines above it are work, which diagnose grades as a chain (and which
+  // feeds demonstratedReasoning — never the graded value). Without this branch
+  // a multi-line solve matched no pattern at all, classified general_math, and
+  // could end up graded off its own first line (the "520=7x" false negative).
+  if (/\n/.test(text)) {
+    const mathLines = text
+      .split(/[\n\r]+/)
+      .map(l => l.trim().replace(/^\s*(?:step\s*\d+\s*[:.)-]?|\d+\s*[.)]|[-*•])\s*/i, ''))
+      .filter(l => l && /\d/.test(l));
+    if (mathLines.length >= 2) {
+      const value = matchAnswerLine(mathLines[mathLines.length - 1]);
+      if (value) return { value, raw, hasExplanation: true };
+    }
+  }
 
   // For short, direct answers (< 100 chars): try all patterns
   if (text.length <= 100) {


### PR DESCRIPTION
## Production false negative

Student message (verbatim, DB inspection 2026-07-26), answering the pinned proportion \`5/7 = x/20\`:

```
520=7x
100=7x
100/7 = x
CONFIRMED!
```

This is a **correct** solve — "520" is 5·20 written without the operator. The pipeline graded it \`problemResult='incorrect'\` ("Alright, Jason, let's take a closer look at your work"), arming wrong-answer support on a correct solve and, post-#1324, resetting demonstrated-competence trust mode.

## Root cause (three stacked failures, reproduced deterministically)

1. **observe**: \`extractAnswer\` matched nothing on multi-line work → classified \`general_math\` (and \`isBareProblemDrop=true\`), routed to the transformation path. Neither the deterministic solver's answer path nor the LLM verifier verdict was ever consulted — \`verifyDerivation\` returned a verdict first.
2. **mathSolver**: the pinned board problem arrives as LaTeX (\`\frac{5}{7} = \frac{x}{20}\`), which \`parseCleanProblem\` could not parse. With no external target, \`verifyDerivation\` anchored the chain on the student's own **first** line (\`520=7x\` → x = 520/7 ≈ 74.3) and marked the two **correct** lines as the broken steps.
3. **derivationVerifier**: the whole chain failed on the first literally-wrong line even when the final line reached the right answer (\`reachedAnswer: true\` was computed and then ignored).

## Fix

- **observe.js** — on multi-line messages, the **last** math-bearing line is the answer candidate (strict shapes only, including the new mirrored \`100/7 = x\` form); earlier lines are shown work for the chain grader. The turn now classifies as \`answer_attempt\`, so the LLM verifier fires in parallel too.
- **mathSolver.js** — \`parseCleanProblem\` rewrites simple LaTeX (\`\frac\`, \`\dfrac\`, operators, atom parens) to plain math and retries; nested/unknown LaTeX still safely returns \`hasMath:false\`.
- **derivationVerifier.js** —
  - grading now follows \`answerCorrect\` (final line vs target); \`valid\` (whole chain) feeds \`demonstratedReasoning\` only, so a broken earlier line demotes reasoning but never flips a correct answer to incorrect;
  - missing-operator rescue: a concatenated integer (\`520\`) is re-read as a product (\`5*20\`), accepted **only** when the reinterpretation solves to the already-known target — it can repair a line into agreement but never flip a genuinely wrong step;
  - with no external anchor, internal consistency anchors on the **last** solvable line (the answer), not the first.
- **diagnose.js** — both derivation call sites grade from \`answerCorrect\`; multi-line attempts with no solvable posed problem keep the internal-consistency chain check they used to get via the transformation path.

## The bar

\`tests/unit/diagnoseMultiLineAnswer.test.js\` pins the exact production message against the pinned problem in plain, LaTeX, and absent-pin forms: **grades \`correct\` with \`demonstratedReasoning=true\`** — plus final-line-wins and no-false-flip guards.

Genuinely wrong chains still grade incorrect with \`firstBadStep\` pinpointed (existing tests unchanged).

## Testing

- 293 unit suites / 4,451 tests pass; 28 integration suites / 233 tests pass.
- ESLint: no errors on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)