### PR TITLE
fix(cosmetics): board skins now reskin the Living Workspace

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -96,7 +96,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <!-- Personal status card modal (Progress button) -->
   <link rel="stylesheet" href="/css/status-card.css" />
   <!-- Cosmetics: equipped skins + shop modal -->
-  <link rel="stylesheet" href="/dist/css/chat-css2.a13da437.css" />
+  <link rel="stylesheet" href="/dist/css/chat-css2.f540e93d.css" />
   <!-- Coin surfacing: sidebar counter + fly-in reward animation -->
   <link rel="stylesheet" href="/css/coin-fx.css" />
   <!-- Full-body student character render -->

--- a/public/css/cosmetics.css
+++ b/public/css/cosmetics.css
@@ -337,3 +337,57 @@ body[data-skin-avatarframe] .psc-avatar-col .fba-stage,
 body[data-skin-avatarframe] .cr-player-card .cr-player-avatar > * {
   position: relative; z-index: 1;
 }
+
+/* =========================================================================
+ * BOARD SKINS on the LIVING WORKSPACE (owner: "the board skins also do not
+ * affect the live workspace"). The rules above paint #cr-workspace — but
+ * when the Living Workspace swaps in, .lws-root paints its own opaque
+ * --lws-grid-bg over the whole region, covering the skin entirely.
+ *
+ * Fix: each skin restyles the LWS through its token system — surface, cards,
+ * ink, accent — so the skin changes the board's whole character, not just a
+ * hidden backdrop. Selector is .lws-root.lws-dv-root (0,3,1) on purpose:
+ * living-workspace.css is injected AFTER this sheet, so its theme token
+ * setters (html[data-theme] .lws-root, 0,2,1) would win any tie — and a
+ * chalkboard you bought should look like a chalkboard in light OR dark mode.
+ * Overlays (source viewer, notebook) resolve the same tokens, so they match.
+ * ========================================================================= */
+
+/* Blueprint grid — engineering-paper blue. */
+body[data-skin-board="board.grid"] .lws-root.lws-dv-root {
+  --lws-grid-bg: #eef4ff;
+  --lws-card-bg: #ffffff;
+  --lws-card-border: rgba(30, 64, 175, 0.28);
+  --lws-card-ink: #18202b;
+  --lws-accent: #3b82f6;
+  background-image:
+    linear-gradient(rgba(59, 130, 246, 0.22) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(59, 130, 246, 0.22) 1px, transparent 1px);
+  background-size: 22px 22px;
+}
+
+/* Chalkboard — deep green slate, chalk-white ink, mint accent. */
+body[data-skin-board="board.chalk"] .lws-root.lws-dv-root {
+  --lws-grid-bg: #24322b;
+  --lws-card-bg: #2d3f36;
+  --lws-card-border: rgba(255, 255, 255, 0.24);
+  --lws-card-ink: #f2f7f4;
+  --lws-accent: #a7f3d0;
+  background-image: radial-gradient(rgba(255, 255, 255, 0.09) 1px, transparent 1px);
+  background-size: 7px 7px;
+}
+
+/* Cheetah — amber with spots, warm dark ink. */
+body[data-skin-board="board.cheetah"] .lws-root.lws-dv-root {
+  --lws-grid-bg: #f2c14e;
+  --lws-card-bg: #fff7e6;
+  --lws-card-border: rgba(91, 58, 26, 0.38);
+  --lws-card-ink: #3c2a12;
+  --lws-accent: #b45309;
+  background-image:
+    radial-gradient(circle at 20% 30%, #5b3a1a 9%, transparent 10%),
+    radial-gradient(circle at 62% 68%, #5b3a1a 8%, transparent 9%),
+    radial-gradient(circle at 82% 22%, #5b3a1a 7%, transparent 8%),
+    radial-gradient(circle at 35% 82%, #5b3a1a 8%, transparent 9%);
+  background-size: 64px 64px;
+}

--- a/public/dist/chat-bundles.manifest.json
+++ b/public/dist/chat-bundles.manifest.json
@@ -36,7 +36,7 @@
       ]
     },
     {
-      "href": "/dist/css/chat-css2.a13da437.css",
+      "href": "/dist/css/chat-css2.f540e93d.css",
       "files": [
         "/css/cosmetics.css",
         "/css/shop.css"

--- a/public/dist/css/chat-css2.f540e93d.css
+++ b/public/dist/css/chat-css2.f540e93d.css
@@ -339,6 +339,60 @@ body[data-skin-avatarframe] .cr-player-card .cr-player-avatar > * {
   position: relative; z-index: 1;
 }
 
+/* =========================================================================
+ * BOARD SKINS on the LIVING WORKSPACE (owner: "the board skins also do not
+ * affect the live workspace"). The rules above paint #cr-workspace — but
+ * when the Living Workspace swaps in, .lws-root paints its own opaque
+ * --lws-grid-bg over the whole region, covering the skin entirely.
+ *
+ * Fix: each skin restyles the LWS through its token system — surface, cards,
+ * ink, accent — so the skin changes the board's whole character, not just a
+ * hidden backdrop. Selector is .lws-root.lws-dv-root (0,3,1) on purpose:
+ * living-workspace.css is injected AFTER this sheet, so its theme token
+ * setters (html[data-theme] .lws-root, 0,2,1) would win any tie — and a
+ * chalkboard you bought should look like a chalkboard in light OR dark mode.
+ * Overlays (source viewer, notebook) resolve the same tokens, so they match.
+ * ========================================================================= */
+
+/* Blueprint grid — engineering-paper blue. */
+body[data-skin-board="board.grid"] .lws-root.lws-dv-root {
+  --lws-grid-bg: #eef4ff;
+  --lws-card-bg: #ffffff;
+  --lws-card-border: rgba(30, 64, 175, 0.28);
+  --lws-card-ink: #18202b;
+  --lws-accent: #3b82f6;
+  background-image:
+    linear-gradient(rgba(59, 130, 246, 0.22) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(59, 130, 246, 0.22) 1px, transparent 1px);
+  background-size: 22px 22px;
+}
+
+/* Chalkboard — deep green slate, chalk-white ink, mint accent. */
+body[data-skin-board="board.chalk"] .lws-root.lws-dv-root {
+  --lws-grid-bg: #24322b;
+  --lws-card-bg: #2d3f36;
+  --lws-card-border: rgba(255, 255, 255, 0.24);
+  --lws-card-ink: #f2f7f4;
+  --lws-accent: #a7f3d0;
+  background-image: radial-gradient(rgba(255, 255, 255, 0.09) 1px, transparent 1px);
+  background-size: 7px 7px;
+}
+
+/* Cheetah — amber with spots, warm dark ink. */
+body[data-skin-board="board.cheetah"] .lws-root.lws-dv-root {
+  --lws-grid-bg: #f2c14e;
+  --lws-card-bg: #fff7e6;
+  --lws-card-border: rgba(91, 58, 26, 0.38);
+  --lws-card-ink: #3c2a12;
+  --lws-accent: #b45309;
+  background-image:
+    radial-gradient(circle at 20% 30%, #5b3a1a 9%, transparent 10%),
+    radial-gradient(circle at 62% 68%, #5b3a1a 8%, transparent 9%),
+    radial-gradient(circle at 82% 22%, #5b3a1a 7%, transparent 8%),
+    radial-gradient(circle at 35% 82%, #5b3a1a 8%, transparent 9%);
+  background-size: 64px 64px;
+}
+
 /* --- /css/shop.css --- */
 /* shop.css — cosmetics shop modal. Brand: teal #12B3B3, hot pink #FF3B7F,
  * gold #FFC24B. Opened from the status card's Shop button. */


### PR DESCRIPTION
Owner report: *"the board skins also do not affect the live workspace currently."* Exactly the retired-surface failure mode from #1327, one slot over. **Stacked on #1327**; retargets on merge.

## Why nothing happened

Board skins paint `#cr-workspace`'s background. When the Living Workspace swaps in, `.lws-root` paints its own **opaque** `--lws-grid-bg` across the entire region — the purchased skin was rendering underneath, fully covered.

## What ships

Each skin now restyles the Living Workspace **through its token system** — surface color, card backgrounds, ink, accent, plus its signature pattern — so a skin changes the board's whole character rather than a hidden backdrop:

- **Blueprint grid** — engineering-paper blue, white cards, blue accent
- **Chalkboard** — deep green slate, chalk-white ink, mint accent
- **Cheetah** — amber with spots, warm dark ink

Details that matter:
- Selector is `.lws-root.lws-dv-root` (specificity 0,3,1) deliberately — `living-workspace.css` is lazily injected *after* this sheet, so its theme token setters would win any tie; a chalkboard you bought should look like a chalkboard in light **or** dark mode.
- The source-viewer and notebook overlays resolve the same tokens, so they match the skin automatically.
- JSXGraph reads grid colors via `getComputedStyle` on these tokens, so graphs pick the palette up too.
- Bundles regenerated (`cosmetics.css` ships in `chat-css2`); `chatBundleIntegrity` and full suite green.

## Post-deploy check

Equip Chalkboard in the shop → the whole board (column, cards, notebook overlay) goes slate-green immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)