### PR TITLE
fix(cosmetics): remaining-slot audit — stronger board/theme/calculator skins, rainbow pedestal

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -96,7 +96,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <!-- Personal status card modal (Progress button) -->
   <link rel="stylesheet" href="/css/status-card.css" />
   <!-- Cosmetics: equipped skins + shop modal -->
-  <link rel="stylesheet" href="/dist/css/chat-css2.f540e93d.css" />
+  <link rel="stylesheet" href="/dist/css/chat-css2.29a6798a.css" />
   <!-- Coin surfacing: sidebar counter + fly-in reward animation -->
   <link rel="stylesheet" href="/css/coin-fx.css" />
   <!-- Full-body student character render -->

--- a/public/css/cosmetics.css
+++ b/public/css/cosmetics.css
@@ -103,6 +103,18 @@ body.cr-mode[data-theme-skin] .message.ai {
   background: color-mix(in srgb, var(--cr-accent) 8%, var(--cr-bubble-ai));
 }
 
+/* Carry the theme into the top bar too — chat-redesign.css paints the header a
+ * fixed dark navy regardless of theme, so without this the most visible strip
+ * of chrome never changed and an equipped theme was easy to miss. Mixing the
+ * accent INTO the dark navy keeps the header dark enough for its forced-light
+ * text (see the --cr-text override in chat-redesign.css). An equipped header
+ * SKIN owns the header outright, hence :not([data-skin-header]). */
+body.cr-mode[data-theme-skin]:not([data-skin-header]) .landing-header {
+  background: linear-gradient(180deg,
+    color-mix(in srgb, var(--cr-accent) 32%, rgba(11, 15, 26, 0.92)),
+    color-mix(in srgb, var(--cr-accent) 14%, rgba(11, 15, 26, 0.80)));
+}
+
 /* =========================================================================
  * CHAT BUBBLES  (data-skin-bubble) — the STUDENT'S OWN messages only.
  * Scoped under body.cr-mode .message.user to beat chat-redesign.css defaults.
@@ -220,9 +232,94 @@ body[data-skin-avatarframe="frame.rainbow"] .sc-avatar-img {
  * of the work itself is never touched.
  * ========================================================================= */
 
-/* ---- Board (data-skin-board) — skins the math workspace panel (#cr-workspace),
- * the surface the tutor's board/graph/tiles live on. The panel background shows
- * around and behind the work cards, never behind the math itself. ---- */
+/* ---- Board (data-skin-board) — skins the math workspace surface.
+ *
+ * The LIVE surface is the Living Workspace: chat-workspace.js mounts .lws-root
+ * inside #cr-workspace and it fully covers the panel (opaque background), so
+ * rules against #cr-workspace's own background are invisible while
+ * MM_FEATURES.livingWorkspace is 'live' (the default). The skins therefore
+ * repaint the LWS by overriding the --lws-* palette that BOTH the DOM
+ * derivation view and the canvas grid renderer read (getComputedStyle on
+ * .lws-root). Each skin ships a complete, contrast-safe palette (bg + grid
+ * lines + card + ink + accent), so it looks right in light and dark base mode
+ * alike — which is also why it's correct for the skin to outrank the
+ * html[data-theme] palettes in living-workspace.css: a chalkboard is dark even
+ * in light mode. That sheet is injected at runtime (cascades after this one),
+ * so the `html body` prefix here is load-bearing: it lifts specificity to
+ * (0,2,2), beating the (0,2,1) of `html[data-theme=…] .lws-root`.
+ * IEP / reduced-motion overrides are untouched (nothing here animates, and the
+ * accessibility sheets don't restyle .lws-*). */
+html body[data-skin-board="board.grid"] .lws-root {
+  /* True blueprint: deep drafting blue, pale grid lines. */
+  --lws-grid-bg: #123c78;
+  --lws-grid-minor: rgba(190, 214, 255, 0.22);
+  --lws-grid-major: rgba(190, 214, 255, 0.40);
+  --lws-grid-border: rgba(190, 214, 255, 0.55);
+  --lws-card-bg: #1a4c95;
+  --lws-card-border: rgba(190, 214, 255, 0.40);
+  --lws-card-ink: #eef4ff;
+  --lws-accent: #8db9ff;
+}
+html body[data-skin-board="board.chalk"] .lws-root {
+  /* Classroom slate green, chalk-white ink. */
+  --lws-grid-bg: #2a3d33;
+  --lws-grid-minor: rgba(255, 255, 255, 0.06);
+  --lws-grid-major: rgba(255, 255, 255, 0.12);
+  --lws-grid-border: rgba(255, 255, 255, 0.26);
+  --lws-card-bg: #35493e;
+  --lws-card-border: rgba(255, 255, 255, 0.20);
+  --lws-card-ink: #f2f7ef;
+  --lws-accent: #a7e8c0;
+}
+/* Chalkboards have chalk speckle, not graph lines — swap the derivation view's
+ * line grid for a fine dot texture (idea from the first LWS board pass, #1329). */
+html body[data-skin-board="board.chalk"] .lws-root .lws-dv {
+  background-image: radial-gradient(rgba(255, 255, 255, 0.09) 1px, transparent 1px);
+  background-size: 7px 7px;
+}
+html body[data-skin-board="board.cheetah"] .lws-root {
+  /* Warm savanna tan behind the math (SOLID — §6: patterns never sit behind
+   * text); the actual spots live on chrome below. */
+  --lws-grid-bg: #eccf96;
+  --lws-grid-minor: rgba(91, 58, 26, 0.10);
+  --lws-grid-major: rgba(91, 58, 26, 0.18);
+  --lws-grid-border: rgba(91, 58, 26, 0.40);
+  --lws-card-bg: #f7e8c8;
+  --lws-card-border: rgba(91, 58, 26, 0.35);
+  --lws-card-ink: #3b2510;
+  --lws-accent: #c2410c;
+}
+/* Cheetah spots on CHROME only: a 14px frame band around the surface (a
+ * full-bleed ::before masked down to its outer edge) plus the finished-problem
+ * rail. The spot tile is sized to the band (small tile, chunky spots) so whole
+ * spots fit inside it instead of getting sliced into specks.
+ * pointer-events:none keeps panning/clicks working under the band. */
+html body[data-skin-board="board.cheetah"] .lws-root::before {
+  content: '';
+  position: absolute; inset: 0; z-index: 8;
+  pointer-events: none;
+  padding: 14px;
+  background-color: #d9a441;
+  background-image:
+    radial-gradient(circle at 25% 35%, #5b3a1a 22%, transparent 24%),
+    radial-gradient(circle at 75% 72%, #5b3a1a 18%, transparent 20%),
+    radial-gradient(circle at 65% 18%, #7a4a1f 14%, transparent 16%);
+  background-size: 26px 26px;
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  mask-composite: exclude;
+}
+html body[data-skin-board="board.cheetah"] .lws-root .lws-dv-rail {
+  background:
+    radial-gradient(circle at 22% 40%, rgba(91, 58, 26, 0.45) 8%, transparent 9%),
+    radial-gradient(circle at 70% 65%, rgba(91, 58, 26, 0.45) 7%, transparent 8%),
+    linear-gradient(180deg, rgba(236, 207, 150, 0.96), rgba(236, 207, 150, 0.80));
+  background-size: 48px 48px, 48px 48px, 100% 100%;
+}
+
+/* Legacy tabbed board (livingWorkspace:'off' kill switch only) — the panel
+ * background shows around and behind the work cards, never behind the math. */
 body[data-skin-board="board.grid"] #cr-workspace {
   background-color: #eef4ff;
   background-image:
@@ -256,18 +353,73 @@ body[data-skin-calculator="calc.hotpink"] #floating-calculator .calculator-heade
   background: linear-gradient(135deg, #ff5db1, #ff2e93) !important;
   color: #fff !important;
 }
+/* .calculator-title carries its own color, so inheritance alone doesn't flip it. */
+body[data-skin-calculator="calc.hotpink"] #floating-calculator .calculator-title {
+  color: #fff;
+}
 body[data-skin-calculator="calc.hotpink"] #floating-calculator .calculator-body {
   background: #fff0f7 !important;
 }
+/* The keypad is most of the calculator's face — leaving the buttons in the
+ * default navy-slate made the skin read as "just a border". The #id in these
+ * selectors outspecifies calculator.css's class rules (incl. its :hover
+ * variants), so no !important is needed on the button overrides. */
+body[data-skin-calculator="calc.hotpink"] #floating-calculator .btn-number,
+body[data-skin-calculator="calc.hotpink"] #floating-calculator .btn-operator,
+body[data-skin-calculator="calc.hotpink"] #floating-calculator .btn-function {
+  background: linear-gradient(145deg, #ff9dcb, #ff5db1);
+  color: #5c0a33;
+}
+body[data-skin-calculator="calc.hotpink"] #floating-calculator .calc-btn .primary {
+  color: #5c0a33;
+}
+body[data-skin-calculator="calc.hotpink"] #floating-calculator .calc-btn .secondary {
+  color: #9c0f56;
+}
+body[data-skin-calculator="calc.hotpink"] #floating-calculator .btn-arrow {
+  background: linear-gradient(145deg, #ff77b9, #e94f9c);
+  color: #fff;
+  border-color: #c2367e;
+}
+body[data-skin-calculator="calc.hotpink"] #floating-calculator .btn-clear,
+body[data-skin-calculator="calc.hotpink"] #floating-calculator .btn-clear:hover {
+  background: linear-gradient(145deg, #8f0f4e, #6e0a3b);
+}
+body[data-skin-calculator="calc.hotpink"] #floating-calculator .btn-enter,
+body[data-skin-calculator="calc.hotpink"] #floating-calculator .btn-enter:hover {
+  background: linear-gradient(145deg, #ff2e93, #d81b7a);
+  color: #fff;
+}
+
+/* Carbon fiber: gunmetal weave + racing-red trim. The old version was a dark
+ * border on an already-dark calculator — invisible from two feet away. */
 body[data-skin-calculator="calc.carbon"] #floating-calculator {
-  border: 2px solid #2b2f36 !important;
+  border: 2px solid #14161a !important;
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.7), 0 0 0 1px #d90429 !important;
 }
 body[data-skin-calculator="calc.carbon"] #floating-calculator .calculator-header-bar {
   background: #16181c !important;
   color: #e5e7eb !important;
+  border-bottom: 2px solid #d90429 !important;
 }
 body[data-skin-calculator="calc.carbon"] #floating-calculator .calculator-body {
   background: repeating-linear-gradient(45deg, #23262c 0 5px, #1e2126 5px 10px) !important;
+}
+body[data-skin-calculator="calc.carbon"] #floating-calculator .btn-number,
+body[data-skin-calculator="calc.carbon"] #floating-calculator .btn-operator,
+body[data-skin-calculator="calc.carbon"] #floating-calculator .btn-function {
+  background: linear-gradient(145deg, #31353c, #1c1f24);
+  color: #e5e7eb;
+}
+body[data-skin-calculator="calc.carbon"] #floating-calculator .btn-arrow {
+  background: linear-gradient(145deg, #24272d, #17191d);
+  color: #ff4d5e;
+  border-color: #0e1013;
+}
+body[data-skin-calculator="calc.carbon"] #floating-calculator .btn-enter,
+body[data-skin-calculator="calc.carbon"] #floating-calculator .btn-enter:hover {
+  background: linear-gradient(145deg, #d90429, #a4031f);
+  color: #fff;
 }
 
 /* ---- Header (data-skin-header) — patterns the top bar strip ---- */
@@ -280,7 +432,9 @@ body[data-skin-header="header.camo"] .landing-header {
   background-size: 90px 90px, 120px 120px, 70px 70px, 100% 100%;
 }
 body[data-skin-header="header.wave"] .landing-header {
-  background-image: linear-gradient(135deg, #667eea, #22d3ee 50%, #06b6d4);
+  /* Deepened from the original #667eea→#22d3ee: the header's forced-light
+   * pills/text washed out on the bright cyan half. */
+  background-image: linear-gradient(135deg, #4f46e5, #0284c7 55%, #0e7490);
 }
 
 
@@ -332,62 +486,35 @@ body[data-skin-avatarframe="frame.neon"] .cr-player-card .cr-player-avatar::afte
     50% { opacity: 0.55; }
   }
 }
+/* Rainbow Halo pedestal — the legendary frame was the only one with NO pedestal
+ * variant, so the most expensive frame had the weakest render. Conic ring via
+ * the mask-out-the-center trick (the pedestal's center must stay transparent —
+ * there's no known cover color to fake it with). Glow is a drop-shadow filter
+ * because a box-shadow would be clipped by the mask; the spin animation carries
+ * the same drop-shadow so it isn't lost while animating. */
+body[data-skin-avatarframe="frame.rainbow"] .psc-avatar-col::after,
+body[data-skin-avatarframe="frame.rainbow"] .cr-player-card .cr-player-avatar::after {
+  border: 4px solid transparent;
+  background: conic-gradient(from 0deg, #ff5db1, #ffd93b, #4ade80, #22d3ee, #a855f7, #ff5db1) border-box;
+  -webkit-mask: linear-gradient(#000 0 0) padding-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask: linear-gradient(#000 0 0) padding-box, linear-gradient(#000 0 0);
+  mask-composite: exclude;
+  filter: drop-shadow(0 0 10px rgba(168, 85, 247, 0.75));
+}
+@media (prefers-reduced-motion: no-preference) {
+  body[data-skin-avatarframe="frame.rainbow"] .psc-avatar-col::after,
+  body[data-skin-avatarframe="frame.rainbow"] .cr-player-card .cr-player-avatar::after {
+    animation: cosmetic-rainbow-pedestal 3.5s linear infinite;
+  }
+  @keyframes cosmetic-rainbow-pedestal {
+    from { filter: drop-shadow(0 0 10px rgba(168, 85, 247, 0.75)) hue-rotate(0deg); }
+    to   { filter: drop-shadow(0 0 10px rgba(168, 85, 247, 0.75)) hue-rotate(360deg); }
+  }
+}
+
 /* The figure stands ON the ring, not behind it. */
 body[data-skin-avatarframe] .psc-avatar-col .fba-stage,
 body[data-skin-avatarframe] .cr-player-card .cr-player-avatar > * {
   position: relative; z-index: 1;
-}
-
-/* =========================================================================
- * BOARD SKINS on the LIVING WORKSPACE (owner: "the board skins also do not
- * affect the live workspace"). The rules above paint #cr-workspace — but
- * when the Living Workspace swaps in, .lws-root paints its own opaque
- * --lws-grid-bg over the whole region, covering the skin entirely.
- *
- * Fix: each skin restyles the LWS through its token system — surface, cards,
- * ink, accent — so the skin changes the board's whole character, not just a
- * hidden backdrop. Selector is .lws-root.lws-dv-root (0,3,1) on purpose:
- * living-workspace.css is injected AFTER this sheet, so its theme token
- * setters (html[data-theme] .lws-root, 0,2,1) would win any tie — and a
- * chalkboard you bought should look like a chalkboard in light OR dark mode.
- * Overlays (source viewer, notebook) resolve the same tokens, so they match.
- * ========================================================================= */
-
-/* Blueprint grid — engineering-paper blue. */
-body[data-skin-board="board.grid"] .lws-root.lws-dv-root {
-  --lws-grid-bg: #eef4ff;
-  --lws-card-bg: #ffffff;
-  --lws-card-border: rgba(30, 64, 175, 0.28);
-  --lws-card-ink: #18202b;
-  --lws-accent: #3b82f6;
-  background-image:
-    linear-gradient(rgba(59, 130, 246, 0.22) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(59, 130, 246, 0.22) 1px, transparent 1px);
-  background-size: 22px 22px;
-}
-
-/* Chalkboard — deep green slate, chalk-white ink, mint accent. */
-body[data-skin-board="board.chalk"] .lws-root.lws-dv-root {
-  --lws-grid-bg: #24322b;
-  --lws-card-bg: #2d3f36;
-  --lws-card-border: rgba(255, 255, 255, 0.24);
-  --lws-card-ink: #f2f7f4;
-  --lws-accent: #a7f3d0;
-  background-image: radial-gradient(rgba(255, 255, 255, 0.09) 1px, transparent 1px);
-  background-size: 7px 7px;
-}
-
-/* Cheetah — amber with spots, warm dark ink. */
-body[data-skin-board="board.cheetah"] .lws-root.lws-dv-root {
-  --lws-grid-bg: #f2c14e;
-  --lws-card-bg: #fff7e6;
-  --lws-card-border: rgba(91, 58, 26, 0.38);
-  --lws-card-ink: #3c2a12;
-  --lws-accent: #b45309;
-  background-image:
-    radial-gradient(circle at 20% 30%, #5b3a1a 9%, transparent 10%),
-    radial-gradient(circle at 62% 68%, #5b3a1a 8%, transparent 9%),
-    radial-gradient(circle at 82% 22%, #5b3a1a 7%, transparent 8%),
-    radial-gradient(circle at 35% 82%, #5b3a1a 8%, transparent 9%);
-  background-size: 64px 64px;
 }

--- a/public/dist/chat-bundles.manifest.json
+++ b/public/dist/chat-bundles.manifest.json
@@ -36,7 +36,7 @@
       ]
     },
     {
-      "href": "/dist/css/chat-css2.f540e93d.css",
+      "href": "/dist/css/chat-css2.29a6798a.css",
       "files": [
         "/css/cosmetics.css",
         "/css/shop.css"

--- a/public/dist/css/chat-css2.29a6798a.css
+++ b/public/dist/css/chat-css2.29a6798a.css
@@ -104,6 +104,18 @@ body.cr-mode[data-theme-skin] .message.ai {
   background: color-mix(in srgb, var(--cr-accent) 8%, var(--cr-bubble-ai));
 }
 
+/* Carry the theme into the top bar too — chat-redesign.css paints the header a
+ * fixed dark navy regardless of theme, so without this the most visible strip
+ * of chrome never changed and an equipped theme was easy to miss. Mixing the
+ * accent INTO the dark navy keeps the header dark enough for its forced-light
+ * text (see the --cr-text override in chat-redesign.css). An equipped header
+ * SKIN owns the header outright, hence :not([data-skin-header]). */
+body.cr-mode[data-theme-skin]:not([data-skin-header]) .landing-header {
+  background: linear-gradient(180deg,
+    color-mix(in srgb, var(--cr-accent) 32%, rgba(11, 15, 26, 0.92)),
+    color-mix(in srgb, var(--cr-accent) 14%, rgba(11, 15, 26, 0.80)));
+}
+
 /* =========================================================================
  * CHAT BUBBLES  (data-skin-bubble) — the STUDENT'S OWN messages only.
  * Scoped under body.cr-mode .message.user to beat chat-redesign.css defaults.
@@ -221,9 +233,94 @@ body[data-skin-avatarframe="frame.rainbow"] .sc-avatar-img {
  * of the work itself is never touched.
  * ========================================================================= */
 
-/* ---- Board (data-skin-board) — skins the math workspace panel (#cr-workspace),
- * the surface the tutor's board/graph/tiles live on. The panel background shows
- * around and behind the work cards, never behind the math itself. ---- */
+/* ---- Board (data-skin-board) — skins the math workspace surface.
+ *
+ * The LIVE surface is the Living Workspace: chat-workspace.js mounts .lws-root
+ * inside #cr-workspace and it fully covers the panel (opaque background), so
+ * rules against #cr-workspace's own background are invisible while
+ * MM_FEATURES.livingWorkspace is 'live' (the default). The skins therefore
+ * repaint the LWS by overriding the --lws-* palette that BOTH the DOM
+ * derivation view and the canvas grid renderer read (getComputedStyle on
+ * .lws-root). Each skin ships a complete, contrast-safe palette (bg + grid
+ * lines + card + ink + accent), so it looks right in light and dark base mode
+ * alike — which is also why it's correct for the skin to outrank the
+ * html[data-theme] palettes in living-workspace.css: a chalkboard is dark even
+ * in light mode. That sheet is injected at runtime (cascades after this one),
+ * so the `html body` prefix here is load-bearing: it lifts specificity to
+ * (0,2,2), beating the (0,2,1) of `html[data-theme=…] .lws-root`.
+ * IEP / reduced-motion overrides are untouched (nothing here animates, and the
+ * accessibility sheets don't restyle .lws-*). */
+html body[data-skin-board="board.grid"] .lws-root {
+  /* True blueprint: deep drafting blue, pale grid lines. */
+  --lws-grid-bg: #123c78;
+  --lws-grid-minor: rgba(190, 214, 255, 0.22);
+  --lws-grid-major: rgba(190, 214, 255, 0.40);
+  --lws-grid-border: rgba(190, 214, 255, 0.55);
+  --lws-card-bg: #1a4c95;
+  --lws-card-border: rgba(190, 214, 255, 0.40);
+  --lws-card-ink: #eef4ff;
+  --lws-accent: #8db9ff;
+}
+html body[data-skin-board="board.chalk"] .lws-root {
+  /* Classroom slate green, chalk-white ink. */
+  --lws-grid-bg: #2a3d33;
+  --lws-grid-minor: rgba(255, 255, 255, 0.06);
+  --lws-grid-major: rgba(255, 255, 255, 0.12);
+  --lws-grid-border: rgba(255, 255, 255, 0.26);
+  --lws-card-bg: #35493e;
+  --lws-card-border: rgba(255, 255, 255, 0.20);
+  --lws-card-ink: #f2f7ef;
+  --lws-accent: #a7e8c0;
+}
+/* Chalkboards have chalk speckle, not graph lines — swap the derivation view's
+ * line grid for a fine dot texture (idea from the first LWS board pass, #1329). */
+html body[data-skin-board="board.chalk"] .lws-root .lws-dv {
+  background-image: radial-gradient(rgba(255, 255, 255, 0.09) 1px, transparent 1px);
+  background-size: 7px 7px;
+}
+html body[data-skin-board="board.cheetah"] .lws-root {
+  /* Warm savanna tan behind the math (SOLID — §6: patterns never sit behind
+   * text); the actual spots live on chrome below. */
+  --lws-grid-bg: #eccf96;
+  --lws-grid-minor: rgba(91, 58, 26, 0.10);
+  --lws-grid-major: rgba(91, 58, 26, 0.18);
+  --lws-grid-border: rgba(91, 58, 26, 0.40);
+  --lws-card-bg: #f7e8c8;
+  --lws-card-border: rgba(91, 58, 26, 0.35);
+  --lws-card-ink: #3b2510;
+  --lws-accent: #c2410c;
+}
+/* Cheetah spots on CHROME only: a 14px frame band around the surface (a
+ * full-bleed ::before masked down to its outer edge) plus the finished-problem
+ * rail. The spot tile is sized to the band (small tile, chunky spots) so whole
+ * spots fit inside it instead of getting sliced into specks.
+ * pointer-events:none keeps panning/clicks working under the band. */
+html body[data-skin-board="board.cheetah"] .lws-root::before {
+  content: '';
+  position: absolute; inset: 0; z-index: 8;
+  pointer-events: none;
+  padding: 14px;
+  background-color: #d9a441;
+  background-image:
+    radial-gradient(circle at 25% 35%, #5b3a1a 22%, transparent 24%),
+    radial-gradient(circle at 75% 72%, #5b3a1a 18%, transparent 20%),
+    radial-gradient(circle at 65% 18%, #7a4a1f 14%, transparent 16%);
+  background-size: 26px 26px;
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  mask-composite: exclude;
+}
+html body[data-skin-board="board.cheetah"] .lws-root .lws-dv-rail {
+  background:
+    radial-gradient(circle at 22% 40%, rgba(91, 58, 26, 0.45) 8%, transparent 9%),
+    radial-gradient(circle at 70% 65%, rgba(91, 58, 26, 0.45) 7%, transparent 8%),
+    linear-gradient(180deg, rgba(236, 207, 150, 0.96), rgba(236, 207, 150, 0.80));
+  background-size: 48px 48px, 48px 48px, 100% 100%;
+}
+
+/* Legacy tabbed board (livingWorkspace:'off' kill switch only) — the panel
+ * background shows around and behind the work cards, never behind the math. */
 body[data-skin-board="board.grid"] #cr-workspace {
   background-color: #eef4ff;
   background-image:
@@ -257,18 +354,73 @@ body[data-skin-calculator="calc.hotpink"] #floating-calculator .calculator-heade
   background: linear-gradient(135deg, #ff5db1, #ff2e93) !important;
   color: #fff !important;
 }
+/* .calculator-title carries its own color, so inheritance alone doesn't flip it. */
+body[data-skin-calculator="calc.hotpink"] #floating-calculator .calculator-title {
+  color: #fff;
+}
 body[data-skin-calculator="calc.hotpink"] #floating-calculator .calculator-body {
   background: #fff0f7 !important;
 }
+/* The keypad is most of the calculator's face — leaving the buttons in the
+ * default navy-slate made the skin read as "just a border". The #id in these
+ * selectors outspecifies calculator.css's class rules (incl. its :hover
+ * variants), so no !important is needed on the button overrides. */
+body[data-skin-calculator="calc.hotpink"] #floating-calculator .btn-number,
+body[data-skin-calculator="calc.hotpink"] #floating-calculator .btn-operator,
+body[data-skin-calculator="calc.hotpink"] #floating-calculator .btn-function {
+  background: linear-gradient(145deg, #ff9dcb, #ff5db1);
+  color: #5c0a33;
+}
+body[data-skin-calculator="calc.hotpink"] #floating-calculator .calc-btn .primary {
+  color: #5c0a33;
+}
+body[data-skin-calculator="calc.hotpink"] #floating-calculator .calc-btn .secondary {
+  color: #9c0f56;
+}
+body[data-skin-calculator="calc.hotpink"] #floating-calculator .btn-arrow {
+  background: linear-gradient(145deg, #ff77b9, #e94f9c);
+  color: #fff;
+  border-color: #c2367e;
+}
+body[data-skin-calculator="calc.hotpink"] #floating-calculator .btn-clear,
+body[data-skin-calculator="calc.hotpink"] #floating-calculator .btn-clear:hover {
+  background: linear-gradient(145deg, #8f0f4e, #6e0a3b);
+}
+body[data-skin-calculator="calc.hotpink"] #floating-calculator .btn-enter,
+body[data-skin-calculator="calc.hotpink"] #floating-calculator .btn-enter:hover {
+  background: linear-gradient(145deg, #ff2e93, #d81b7a);
+  color: #fff;
+}
+
+/* Carbon fiber: gunmetal weave + racing-red trim. The old version was a dark
+ * border on an already-dark calculator — invisible from two feet away. */
 body[data-skin-calculator="calc.carbon"] #floating-calculator {
-  border: 2px solid #2b2f36 !important;
+  border: 2px solid #14161a !important;
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.7), 0 0 0 1px #d90429 !important;
 }
 body[data-skin-calculator="calc.carbon"] #floating-calculator .calculator-header-bar {
   background: #16181c !important;
   color: #e5e7eb !important;
+  border-bottom: 2px solid #d90429 !important;
 }
 body[data-skin-calculator="calc.carbon"] #floating-calculator .calculator-body {
   background: repeating-linear-gradient(45deg, #23262c 0 5px, #1e2126 5px 10px) !important;
+}
+body[data-skin-calculator="calc.carbon"] #floating-calculator .btn-number,
+body[data-skin-calculator="calc.carbon"] #floating-calculator .btn-operator,
+body[data-skin-calculator="calc.carbon"] #floating-calculator .btn-function {
+  background: linear-gradient(145deg, #31353c, #1c1f24);
+  color: #e5e7eb;
+}
+body[data-skin-calculator="calc.carbon"] #floating-calculator .btn-arrow {
+  background: linear-gradient(145deg, #24272d, #17191d);
+  color: #ff4d5e;
+  border-color: #0e1013;
+}
+body[data-skin-calculator="calc.carbon"] #floating-calculator .btn-enter,
+body[data-skin-calculator="calc.carbon"] #floating-calculator .btn-enter:hover {
+  background: linear-gradient(145deg, #d90429, #a4031f);
+  color: #fff;
 }
 
 /* ---- Header (data-skin-header) — patterns the top bar strip ---- */
@@ -281,7 +433,9 @@ body[data-skin-header="header.camo"] .landing-header {
   background-size: 90px 90px, 120px 120px, 70px 70px, 100% 100%;
 }
 body[data-skin-header="header.wave"] .landing-header {
-  background-image: linear-gradient(135deg, #667eea, #22d3ee 50%, #06b6d4);
+  /* Deepened from the original #667eea→#22d3ee: the header's forced-light
+   * pills/text washed out on the bright cyan half. */
+  background-image: linear-gradient(135deg, #4f46e5, #0284c7 55%, #0e7490);
 }
 
 
@@ -333,64 +487,37 @@ body[data-skin-avatarframe="frame.neon"] .cr-player-card .cr-player-avatar::afte
     50% { opacity: 0.55; }
   }
 }
+/* Rainbow Halo pedestal — the legendary frame was the only one with NO pedestal
+ * variant, so the most expensive frame had the weakest render. Conic ring via
+ * the mask-out-the-center trick (the pedestal's center must stay transparent —
+ * there's no known cover color to fake it with). Glow is a drop-shadow filter
+ * because a box-shadow would be clipped by the mask; the spin animation carries
+ * the same drop-shadow so it isn't lost while animating. */
+body[data-skin-avatarframe="frame.rainbow"] .psc-avatar-col::after,
+body[data-skin-avatarframe="frame.rainbow"] .cr-player-card .cr-player-avatar::after {
+  border: 4px solid transparent;
+  background: conic-gradient(from 0deg, #ff5db1, #ffd93b, #4ade80, #22d3ee, #a855f7, #ff5db1) border-box;
+  -webkit-mask: linear-gradient(#000 0 0) padding-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask: linear-gradient(#000 0 0) padding-box, linear-gradient(#000 0 0);
+  mask-composite: exclude;
+  filter: drop-shadow(0 0 10px rgba(168, 85, 247, 0.75));
+}
+@media (prefers-reduced-motion: no-preference) {
+  body[data-skin-avatarframe="frame.rainbow"] .psc-avatar-col::after,
+  body[data-skin-avatarframe="frame.rainbow"] .cr-player-card .cr-player-avatar::after {
+    animation: cosmetic-rainbow-pedestal 3.5s linear infinite;
+  }
+  @keyframes cosmetic-rainbow-pedestal {
+    from { filter: drop-shadow(0 0 10px rgba(168, 85, 247, 0.75)) hue-rotate(0deg); }
+    to   { filter: drop-shadow(0 0 10px rgba(168, 85, 247, 0.75)) hue-rotate(360deg); }
+  }
+}
+
 /* The figure stands ON the ring, not behind it. */
 body[data-skin-avatarframe] .psc-avatar-col .fba-stage,
 body[data-skin-avatarframe] .cr-player-card .cr-player-avatar > * {
   position: relative; z-index: 1;
-}
-
-/* =========================================================================
- * BOARD SKINS on the LIVING WORKSPACE (owner: "the board skins also do not
- * affect the live workspace"). The rules above paint #cr-workspace — but
- * when the Living Workspace swaps in, .lws-root paints its own opaque
- * --lws-grid-bg over the whole region, covering the skin entirely.
- *
- * Fix: each skin restyles the LWS through its token system — surface, cards,
- * ink, accent — so the skin changes the board's whole character, not just a
- * hidden backdrop. Selector is .lws-root.lws-dv-root (0,3,1) on purpose:
- * living-workspace.css is injected AFTER this sheet, so its theme token
- * setters (html[data-theme] .lws-root, 0,2,1) would win any tie — and a
- * chalkboard you bought should look like a chalkboard in light OR dark mode.
- * Overlays (source viewer, notebook) resolve the same tokens, so they match.
- * ========================================================================= */
-
-/* Blueprint grid — engineering-paper blue. */
-body[data-skin-board="board.grid"] .lws-root.lws-dv-root {
-  --lws-grid-bg: #eef4ff;
-  --lws-card-bg: #ffffff;
-  --lws-card-border: rgba(30, 64, 175, 0.28);
-  --lws-card-ink: #18202b;
-  --lws-accent: #3b82f6;
-  background-image:
-    linear-gradient(rgba(59, 130, 246, 0.22) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(59, 130, 246, 0.22) 1px, transparent 1px);
-  background-size: 22px 22px;
-}
-
-/* Chalkboard — deep green slate, chalk-white ink, mint accent. */
-body[data-skin-board="board.chalk"] .lws-root.lws-dv-root {
-  --lws-grid-bg: #24322b;
-  --lws-card-bg: #2d3f36;
-  --lws-card-border: rgba(255, 255, 255, 0.24);
-  --lws-card-ink: #f2f7f4;
-  --lws-accent: #a7f3d0;
-  background-image: radial-gradient(rgba(255, 255, 255, 0.09) 1px, transparent 1px);
-  background-size: 7px 7px;
-}
-
-/* Cheetah — amber with spots, warm dark ink. */
-body[data-skin-board="board.cheetah"] .lws-root.lws-dv-root {
-  --lws-grid-bg: #f2c14e;
-  --lws-card-bg: #fff7e6;
-  --lws-card-border: rgba(91, 58, 26, 0.38);
-  --lws-card-ink: #3c2a12;
-  --lws-accent: #b45309;
-  background-image:
-    radial-gradient(circle at 20% 30%, #5b3a1a 9%, transparent 10%),
-    radial-gradient(circle at 62% 68%, #5b3a1a 8%, transparent 9%),
-    radial-gradient(circle at 82% 22%, #5b3a1a 7%, transparent 8%),
-    radial-gradient(circle at 35% 82%, #5b3a1a 8%, transparent 9%);
-  background-size: 64px 64px;
 }
 
 /* --- /css/shop.css --- */

--- a/public/js/modules/shop.js
+++ b/public/js/modules/shop.js
@@ -100,13 +100,13 @@ const PREVIEW = {
     'frame.gold':      'linear-gradient(135deg,#f6d365,#d4af37)',
     'frame.neon':      'linear-gradient(135deg,#22d3ee,#7c4dff)',
     'frame.rainbow':   'conic-gradient(from 0deg,#ff5db1,#ffd93b,#4ade80,#22d3ee,#a855f7,#ff5db1)',
-    'board.grid':      'repeating-linear-gradient(0deg,#e6f0ff 0 5px,#c7dbff 5px 6px)',
-    'board.chalk':     '#24322b',
-    'board.cheetah':   'radial-gradient(circle at 30% 30%,#5b3a1a 20%,transparent 21%),#f2c14e',
+    'board.grid':      'repeating-linear-gradient(0deg,#123c78 0 5px,#3f6cb4 5px 6px)',
+    'board.chalk':     '#2a3d33',
+    'board.cheetah':   'radial-gradient(circle at 30% 30%,#5b3a1a 20%,transparent 21%),#eccf96',
     'calc.hotpink':    'linear-gradient(135deg,#ff5db1,#ff2e93)',
-    'calc.carbon':     'repeating-linear-gradient(45deg,#2b2f36 0 4px,#23262c 4px 8px)',
+    'calc.carbon':     'linear-gradient(180deg,#d90429 0 12%,transparent 12%),repeating-linear-gradient(45deg,#2b2f36 0 4px,#23262c 4px 8px)',
     'header.camo':     'radial-gradient(circle at 30% 40%,#6b7d4f 30%,#5a6b42 31%)',
-    'header.wave':     'linear-gradient(135deg,#667eea,#22d3ee 50%,#06b6d4)',
+    'header.wave':     'linear-gradient(135deg,#4f46e5,#0284c7 55%,#0e7490)',
 };
 
 function swatchHTML(id, rarity) {


### PR DESCRIPTION
Follow-up to #1327 (avatar rings), same owner report ("many of the cosmetics don't yield noticeable changes"), auditing the five remaining slots against the DOM that actually renders today and applying the "would a kid notice this from two feet away?" bar.

**Overlap note:** while this was in flight, #1329 landed the first board-skins-on-LWS pass. This PR is rebased on top of it and **replaces its board block** — reasons below; its chalk-speckle texture idea is kept (credited in a comment).

## Per-slot results

| Slot | Verdict | Action |
|------|---------|--------|
| **board** | Was dead on the live surface (fixed minimally by #1329; superseded here) | Skins override the full `--lws-*` palette on `.lws-root` — **including the `--lws-grid-minor/major/border` line tokens #1329 left at base values**, so the derivation view's line grid AND the canvas grid renderer both recolor (canvas reads tokens via getComputedStyle; verified live in workspace-dev.html). Blueprint Grid is now a true blueprint (deep drafting blue, pale lines) instead of #1329's near-invisible pale-blue-on-pale-gray; Chalkboard keeps the slate-green + chalk-dot texture; **Cheetah's full-contrast spots no longer sit behind the math** — #1329 painted them directly under the derivation text, violating the §6 patterns-never-behind-math contract (COSMETICS_SHOP_DESIGN.md). Math now sits on solid savanna tan; spots live on chrome only (masked 14px frame band + finished-problem rail). Legacy `#cr-workspace` rules kept for the `livingWorkspace:'off'` kill switch. |
| **theme** | Working but weak | chat-redesign paints the header a fixed navy, so the most visible chrome never changed. Themes now tint it (accent color-mixed into the navy; forced-light text stays legible). An equipped header skin outranks the tint via `:not([data-skin-header])` — verified camo beats bubblegum. |
| **calculator** | Selectors current (`#floating-calculator` markup verified), effect weak | The keypad stayed default navy-slate, so skins read as "just a border". Both skins now restyle the buttons (incl. the `.primary`/`.secondary` spans that carry their own colors) + the title; Carbon Fiber gets gunmetal keys and racing-red trim/ENTER — its old dark-on-dark border was invisible. |
| **header** | Selectors current, effects strong | Wave deepened — the forced-light pills washed out on the bright cyan half. Camo untouched. |
| **bubble** | Selectors current (`.message.user`/`.message-text` in script.js), effects strong | No changes. |
| **avatarFrame** (gap in #1327) | Rainbow Halo — the 800-coin legendary — was the only frame with no pedestal variant | Added: conic ring via mask-composite (the pedestal center must stay transparent, so no cover-color trick), drop-shadow glow (box-shadow would be mask-clipped), hue-spin behind `prefers-reduced-motion`. |

## Precedence

living-workspace.css is runtime-injected (cascades after this sheet); the `html body` selector prefix lifts board skins to (0,2,2) over its `html[data-theme]` palettes (0,2,1) — intended, since each skin ships a complete contrast-safe palette (a chalkboard is dark in light mode too). IEP/high-contrast sheets don't restyle `.lws-*` or `.landing-header`; nothing new animates outside reduced-motion guards.

## Verification

- Board: all three skins exercised live in `workspace-dev.html` (palette + canvas grid recolor confirmed via screenshots; the final rebased file re-verified).
- Chrome slots: static harness with chat.html's real markup + the full CSS chain in production order — tinted header under bubblegum/neon, camo/wave headers, both calculators fully skinned, gold/holo bubbles, rainbow pedestal ring with the figure standing on it.
- Bundle rebuilt (`chat-css2.29a6798a`), superseded hashes removed, `chatBundleIntegrity` + `cosmeticsCatalog` suites green. Shop swatches updated to mirror the new looks (shop.js rides the 7-day static cache like prior shop commits; the CSS itself is hash-busted, so visible changes are instant on deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)