### PR TITLE
fix(mastery): "Skill not found" on test-out + the frozen What's Next bar

### DIFF
--- a/routes/mastery.js
+++ b/routes/mastery.js
@@ -18,7 +18,7 @@ const { generateHint, trackHintUsage, analyzeHintUsage, shouldReteach } = requir
 const { analyzeError, generateReteaching, recordMisconception, markMisconceptionAddressed, analyzeMisconceptionPattern } = require('../utils/misconceptionDetector'); // TEACHING ENHANCEMENT
 const { getUnpluggedBadgeProgress } = require('../utils/unpluggedBadges');
 const { isSkillMastered, resolveMasteryKey, getSkillMasteryEntry, setSkillMasteryEntry, decodedMasteryMap } = require('../utils/masteryGuard');
-const { canonicalSkillId } = require('../utils/skillCanonicalizer');
+const { canonicalSkillId, skillLookupCandidates } = require('../utils/skillCanonicalizer');
 const { buildGraph, boardStates, bandProgress, nearestClosableBand, applyProofCascade } = require('../utils/skillClosure');
 const { currentRung, isInferred, canAdvance, advanceRung, clearsPrerequisites } = require('../utils/skillRung');
 const { confusedStudentOpener, scoreTeachBack } = require('../utils/teachBack');
@@ -2750,7 +2750,10 @@ router.get('/map', isAuthenticated, async (req, res) => {
 router.get('/challenge/:skillId', isAuthenticated, async (req, res) => {
   try {
     const skillId = canonicalSkillId(req.params.skillId);
-    const skill = await Skill.findOne({ skillId }).lean();
+    // The catalog is keyed by bank/legacy ids while mastery keys are unified —
+    // look the skill up under every id it might live as (owner-hit bug: the
+    // test-out card died with "Skill not found" on a resolvable skill).
+    const skill = await Skill.findOne({ skillId: { $in: skillLookupCandidates(req.params.skillId) } }).lean();
     if (!skill) return res.status(404).json({ error: 'Skill not found' });
 
     const user = await User.findById(req.user._id).lean();
@@ -2804,7 +2807,8 @@ router.post('/challenge/:skillId', isAuthenticated, async (req, res) => {
     }
 
     const skillId = canonicalSkillId(req.params.skillId);
-    const skill = await Skill.findOne({ skillId }).lean();
+    // Same id-tolerant lookup as the GET — see skillLookupCandidates.
+    const skill = await Skill.findOne({ skillId: { $in: skillLookupCandidates(req.params.skillId) } }).lean();
     if (!skill) return res.status(404).json({ error: 'Skill not found' });
 
     // Re-fetch the served problems by id so grading uses stored answers, never
@@ -2884,7 +2888,10 @@ router.post('/challenge/:skillId', isAuthenticated, async (req, res) => {
 router.get('/teachback/:skillId', isAuthenticated, async (req, res) => {
   try {
     const skillId = canonicalSkillId(req.params.skillId);
-    const skill = await Skill.findOne({ skillId }).lean();
+    // The catalog is keyed by bank/legacy ids while mastery keys are unified —
+    // look the skill up under every id it might live as (owner-hit bug: the
+    // test-out card died with "Skill not found" on a resolvable skill).
+    const skill = await Skill.findOne({ skillId: { $in: skillLookupCandidates(req.params.skillId) } }).lean();
     if (!skill) return res.status(404).json({ error: 'Skill not found' });
 
     const user = await User.findById(req.user._id).lean();

--- a/routes/student.js
+++ b/routes/student.js
@@ -400,7 +400,12 @@ router.get('/progress/summary', isAuthenticated, isStudent, async (req, res) => 
                     // into 4000 → clamped to a fake "100% mastered". Normalize.
                     const raw = Number(data.masteryScore) || 0;
                     const progress = Math.round(raw <= 1 ? raw * 100 : raw);
-                    learning.push({ skillId, displayName, progress });
+                    learning.push({
+                        skillId, displayName, progress,
+                        // For picking the CURRENT skill below — the one the
+                        // student is actually working, not map-order-first.
+                        lastTouched: data.lastPracticed || data.learningStarted || null,
+                    });
                 } else if (data.status === 'ready') {
                     ready.push({ skillId, displayName });
                 }
@@ -412,8 +417,13 @@ router.get('/progress/summary', isAuthenticated, isStudent, async (req, res) => 
                 recentMastery = mastered[0];
             }
 
-            // Current learning (first one)
+            // Current learning: the skill the student most recently WORKED,
+            // not whichever entry happens to iterate first. Map-order-first
+            // could pin an untouched placement seed on the card forever while
+            // live work updated a different entry (owner-hit: the What's Next
+            // bar "was at 78% the entire time" through five clean answers).
             if (learning.length > 0) {
+                learning.sort((a, b) => new Date(b.lastTouched || 0) - new Date(a.lastTouched || 0));
                 currentLearning = learning[0];
             }
 

--- a/tests/unit/skillLookupCandidates.test.js
+++ b/tests/unit/skillLookupCandidates.test.js
@@ -1,0 +1,47 @@
+/**
+ * Id-tolerant catalog lookup (owner-hit: the test-out challenge card died
+ * with "Skill not found", and the What's Next bar froze at its seeded score).
+ *
+ * The Skill catalog is keyed by bank/legacy ids; mastery state is keyed by
+ * canonical unified ids. Any single-id Skill.findOne straddling that seam
+ * misses. skillLookupCandidates returns every id the catalog might use.
+ */
+const { canonicalSkillId, skillLookupCandidates } = require('../../utils/skillCanonicalizer');
+
+describe('skillLookupCandidates', () => {
+  test('always includes the canonical id and the raw id, deduped', () => {
+    const out = skillLookupCandidates('some-unknown-skill');
+    expect(out).toContain('some-unknown-skill');
+    expect(out).toContain(canonicalSkillId('some-unknown-skill'));
+    expect(new Set(out).size).toBe(out.length);
+  });
+
+  test('a legacy id with a crosswalk yields canonical + legacy siblings', () => {
+    // Use a real crosswalk entry so this test tracks the shipped data.
+    const fs = require('fs'); const path = require('path');
+    const dir = path.join(__dirname, '../../seeds/unified-taxonomy');
+    const files = fs.readdirSync(dir).filter(f => f.endsWith('-crosswalk.json'));
+    let legacy = null, unified = null;
+    for (const f of files) {
+      const d = JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8'));
+      const rows = Array.isArray(d) ? d : (d.mappings || d.entries || []);
+      for (const r of rows) {
+        const l = r.legacyId || r.legacy_id, u = r.unifiedId || r.unified_id;
+        if (l && u) { legacy = l; unified = u; break; }
+      }
+      if (legacy) break;
+    }
+    if (!legacy) return; // minimal env without crosswalks — resolver degrades to identity
+    const out = skillLookupCandidates(legacy);
+    expect(out[0]).toBe(unified);            // canonical first
+    expect(out).toContain(legacy);           // raw survives
+    // Asking by the UNIFIED id must ALSO surface the legacy catalog key —
+    // that is the exact "Skill not found" hole.
+    expect(skillLookupCandidates(unified)).toContain(legacy);
+  });
+
+  test('junk is safe', () => {
+    expect(skillLookupCandidates(null)).toEqual([]);
+    expect(skillLookupCandidates('')).toEqual([]);
+  });
+});

--- a/utils/skillCanonicalizer.js
+++ b/utils/skillCanonicalizer.js
@@ -91,4 +91,27 @@ function _reset() {
   unifiedIds = null;
 }
 
-module.exports = { canonicalSkillId, isUnifiedSkillId, _reset };
+/**
+ * Every id the CATALOG might key a skill under, for a given input id — the
+ * canonical unified id, the raw id as given, and any legacy ids that map to
+ * the same canonical node. The Skill collection predates unification and is
+ * keyed by bank/legacy ids, so `Skill.findOne({ skillId: canonicalSkillId(x) })`
+ * misses whenever a crosswalk entry exists — the "Skill not found" challenge
+ * bug. Query with { skillId: { $in: skillLookupCandidates(x) } } instead.
+ */
+function skillLookupCandidates(skillId) {
+  if (!skillId) return [];
+  if (!legacyToUnified) build();
+  const raw = String(skillId);
+  const canon = canonicalSkillId(raw);
+  const out = [];
+  const push = (id) => { if (id && !out.includes(id)) out.push(id); };
+  push(canon);
+  push(raw);
+  for (const [legacy, unified] of legacyToUnified.entries()) {
+    if (unified === canon) push(legacy);
+  }
+  return out;
+}
+
+module.exports = { canonicalSkillId, isUnifiedSkillId, skillLookupCandidates, _reset };


### PR DESCRIPTION
Two owner-hit bugs from one screenshot, and they share a seam: **the Skill catalog is keyed by bank/legacy ids while mastery state is keyed by canonical unified ids.** Any single-id `Skill.findOne` straddling that seam misses.

## 1. Test-out: "Skill not found"

The student earned the test-out ("five clean answers in a row is no joke!") and the challenge card died. Both challenge endpoints did `Skill.findOne({ skillId: canonicalSkillId(param) })` — a canonical id the catalog has never heard of whenever a crosswalk entry exists. New `skillLookupCandidates()` (in the canonicalizer, next to the crosswalk data it inverts) returns every id the catalog might key the skill under — canonical, raw, and legacy siblings — and both endpoints now query with `$in`. Test pins the exact hole: asking by the unified id must surface the legacy catalog key.

## 2. What's Next "was at 78% the entire time"

`currentLearning` picked the **first** learning-status entry in map iteration order. That can be an untouched placement seed — pinned at its seeded score forever — while the student's live work updates a *different* entry. Five clean answers moved a real record; the card wasn't looking at it. Now it picks the most recently **practiced** learning skill, so the bar tracks the skill actually being worked, live.

## Verification

Full suite **4785 passed**, lint clean. New tests: candidates always include canonical+raw deduped; a real crosswalk row round-trips both directions; junk-safe.

Manual QA: as the student in the screenshot — "can I test out?" → the challenge card should load 5 problems; solve anything → the What's Next bar should move within the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)