### PR TITLE
fix(practice-pack): skill-matched packs + substantial 16-20 problem sheets

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -2487,7 +2487,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
      window.PlayerStatsCard.init(currentUser) once the user doc is fetched. -->
 <script defer src="/js/modules/playerStatsCard.js?v=20260724b"></script>
 <script src="/js/challengeCard.js?v=20260725f"></script>
-<script src="/js/script.js?v=20260726a" type="module"></script>
+<script src="/js/script.js?v=20260726b" type="module"></script>
   <script src="/js/guidedPath.js" type="module"></script>
   <script src="/dist/js/chat-js9.bc0be9a3.js"></script>
   <!-- Companion HOME screen (phones only; flag-gated OFF by default) -->

--- a/public/js/practicePack.js
+++ b/public/js/practicePack.js
@@ -20,7 +20,7 @@ class PracticePackManager {
     document.querySelectorAll('[data-action="print-practice-pack"]').forEach(btn => {
       btn.addEventListener('click', (e) => {
         const skillId = e.target.dataset.skillId || null;
-        const count = parseInt(e.target.dataset.count) || 8;
+        const count = parseInt(e.target.dataset.count) || 16;
         this.generatePack({ skillId, count });
       });
     });
@@ -52,10 +52,10 @@ class PracticePackManager {
           </select>
           <div class="practice-pack-row">
             <select id="practice-pack-count" class="practice-pack-select practice-pack-count-select">
-              <option value="5">5 problems</option>
-              <option value="8" selected>8 problems</option>
+              <option value="8">8 problems</option>
               <option value="12">12 problems</option>
-              <option value="15">15 problems</option>
+              <option value="16" selected>16 problems</option>
+              <option value="20">20 problems</option>
             </select>
             <label class="practice-pack-checkbox-label">
               <input type="checkbox" id="practice-pack-answer-key" />
@@ -71,7 +71,7 @@ class PracticePackManager {
     `;
 
     document.getElementById('practice-pack-generate-btn')?.addEventListener('click', () => {
-      const count = parseInt(document.getElementById('practice-pack-count')?.value) || 8;
+      const count = parseInt(document.getElementById('practice-pack-count')?.value) || 16;
       const skillId = document.getElementById('practice-pack-skill')?.value || null;
       const answerKey = document.getElementById('practice-pack-answer-key')?.checked || false;
       this.generatePack({ count, skillId, answerKey });
@@ -91,7 +91,7 @@ class PracticePackManager {
   }
 
   async generatePack(options = {}) {
-    const { skillId = null, count = 8, answerKey = false } = options;
+    const { skillId = null, count = 16, answerKey = false } = options;
     const statusEl = document.getElementById('practice-pack-status');
     const btn = document.getElementById('practice-pack-generate-btn');
 

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -3490,7 +3490,7 @@ document.addEventListener("DOMContentLoaded", () => {
                             paperPrompt.remove();
                             // Navigate to dashboard or trigger download directly
                             const currentSkillId = data.currentSkillId || null;
-                            const params = new URLSearchParams({ count: 5 });
+                            const params = new URLSearchParams({ count: 16 });
                             if (currentSkillId) params.set('skillId', currentSkillId);
                             fetch(`/api/practice-pack/generate?${params}`, { credentials: 'include' })
                                 .then(resp => {

--- a/public/student-dashboard.html
+++ b/public/student-dashboard.html
@@ -1007,7 +1007,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </script>
 <script src="/js/sessionManager.js"></script>
 <script src="/js/ux-enhancements.js"></script>
-<script src="/js/practicePack.js?v=20260725a"></script>
+<script src="/js/practicePack.js?v=20260726a"></script>
 <script src="/js/user-nudges.js"></script>
 </body>
 </html>

--- a/routes/practicePack.js
+++ b/routes/practicePack.js
@@ -37,8 +37,12 @@ try {
   logger.warn('[PracticePack] qrcode package not available — QR codes disabled');
 }
 
-const MAX_PROBLEMS = 15;
-const DEFAULT_PROBLEM_COUNT = 8;
+// Owner call (2026-07-26): a worksheet should be "a more substantial sheet,
+// 15-20 practice problems" — 8 read as thin. Default sits inside the owner's
+// range; the cap is its top end. Problems render with page-break-inside:
+// avoid, so longer packs paginate cleanly.
+const MAX_PROBLEMS = 20;
+const DEFAULT_PROBLEM_COUNT = 16;
 
 // Launch options for headless PDF rendering. Uses chrome-headless-shell
 // (bundled by Puppeteer via .puppeteerrc.cjs) instead of the system chromium

--- a/routes/practicePack.js
+++ b/routes/practicePack.js
@@ -19,6 +19,7 @@ const User = require('../models/user');
 const Problem = require('../models/problem');
 const Skill = require('../models/skill');
 const logger = require('../utils/logger').child({ route: 'practicePack' });
+const { skillLookupCandidates } = require('../utils/skillCanonicalizer');
 
 // Puppeteer for HTML → PDF rendering
 let puppeteer;
@@ -164,10 +165,17 @@ async function selectProblemsForPack(user, options = {}) {
     const remaining = count - problems.length;
     const needed = Math.min(problemsPerSkill, remaining);
 
+    // The problem bank is keyed by bank/legacy skill ids while skillMastery
+    // (where targetSkills come from) uses canonical unified ids — query under
+    // every id the bank might use, or the skill-targeted select silently
+    // matches nothing and the whole pack falls back to generic grade-band
+    // problems (owner-hit: an Absolute Value student got a fractions pack).
+    const sidCandidates = skillLookupCandidates(sid);
+
     // Try difficulty-banded first, then any difficulty for the skill — better
     // to give problems slightly off-level than to return an empty pack.
     let skillProblems = await Problem.find({
-      skillId: sid,
+      skillId: { $in: sidCandidates },
       isActive: true,
       problemId: { $nin: excludeIds },
       difficulty: {
@@ -178,7 +186,7 @@ async function selectProblemsForPack(user, options = {}) {
 
     if (skillProblems.length === 0) {
       skillProblems = await Problem.find({
-        skillId: sid,
+        skillId: { $in: sidCandidates },
         isActive: true,
         problemId: { $nin: excludeIds }
       }).limit(needed * 3);

--- a/tests/unit/practicePackHelpers.test.js
+++ b/tests/unit/practicePackHelpers.test.js
@@ -121,3 +121,21 @@ describe('toPdfBuffer', () => {
     expect(fixed.body.subarray(0, 5).toString('latin1')).toBe('%PDF-');
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The id-seam regression (owner-hit, 2026-07-26): an Absolute Value student's
+// "personalized" pack came back as fractions + integers, because the
+// skill-targeted Problem query used the mastery-side canonical id against a
+// bank keyed by legacy ids — zero matches → silent grade-band fallback.
+// Pin that the route sources its candidates from the shared resolver.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('skill-targeted selection uses id-tolerant lookup', () => {
+  test('practicePack routes problem queries through skillLookupCandidates', () => {
+    const fs = require('fs');
+    const src = fs.readFileSync(require.resolve('../../routes/practicePack'), 'utf8');
+    expect(src).toContain("require('../utils/skillCanonicalizer')");
+    expect(src).toContain('skillId: { $in: sidCandidates }');
+    // Both the banded and the any-difficulty query must use it.
+    expect(src.match(/skillId: \{ \$in: sidCandidates \}/g).length).toBe(2);
+  });
+});

--- a/tests/unit/practicePackHelpers.test.js
+++ b/tests/unit/practicePackHelpers.test.js
@@ -139,3 +139,12 @@ describe('skill-targeted selection uses id-tolerant lookup', () => {
     expect(src.match(/skillId: \{ \$in: sidCandidates \}/g).length).toBe(2);
   });
 });
+
+describe('pack size (owner: "a more substantial sheet, 15-20 problems")', () => {
+  test('defaults sit inside the owner range and the cap is its top end', () => {
+    const fs = require('fs');
+    const src = fs.readFileSync(require.resolve('../../routes/practicePack'), 'utf8');
+    expect(src).toContain('const MAX_PROBLEMS = 20;');
+    expect(src).toContain('const DEFAULT_PROBLEM_COUNT = 16;');
+  });
+});


### PR DESCRIPTION
Owner-hit, proven by artifact: test student **Kandy Cane**, working on **Absolute Value**, generated a practice pack containing… adding fractions and integer operations. Zero absolute value.

## Root cause — the id seam, fourth appearance

`selectProblemsForPack` pulls `targetSkills` from `user.skillMastery` (canonical unified ids) and queries the Problem bank with `skillId: sid` — but the bank is keyed by **bank/legacy ids**. Every skill-targeted query matched nothing, every skill came back empty, and the generator hit its safety net: *"if skill-based selection returned nothing usable, fall back to grade-band general problems so the user always gets SOME worksheet."* Working exactly as designed — silently masking that personalization had never worked for any crosswalked skill.

## Fix

Both skill-targeted queries (difficulty-banded and any-difficulty) now use `skillLookupCandidates()` from #1333 with `$in`. A regression test pins that both queries route through the shared resolver.

## The tally on this seam

1. Mastery bar freeze (split records) → 2. test-out "Skill not found" + frozen What's Next (#1333) → 3. this. Same fracture line each time: canonical mastery ids meeting legacy-keyed content banks. `skillLookupCandidates` is now the standard crossing; remaining single-id `Skill.findOne`/`Problem.find` call sites are worth a sweep.

## Verification

Full suite **4786 passed**, lint clean.

Manual QA: as Kandy — regenerate a pack while Absolute Value is the working skill → the pack should now lead with absolute-value problems (fallback only pads if the bank genuinely lacks enough).

🤖 Generated with [Claude Code](https://claude.com/claude-code)