### PR TITLE
fix(skills): sweep every mastery-side catalog lookup onto the id resolver

### DIFF
--- a/routes/mastery.js
+++ b/routes/mastery.js
@@ -18,7 +18,7 @@ const { generateHint, trackHintUsage, analyzeHintUsage, shouldReteach } = requir
 const { analyzeError, generateReteaching, recordMisconception, markMisconceptionAddressed, analyzeMisconceptionPattern } = require('../utils/misconceptionDetector'); // TEACHING ENHANCEMENT
 const { getUnpluggedBadgeProgress } = require('../utils/unpluggedBadges');
 const { isSkillMastered, resolveMasteryKey, getSkillMasteryEntry, setSkillMasteryEntry, decodedMasteryMap } = require('../utils/masteryGuard');
-const { canonicalSkillId, skillLookupCandidates } = require('../utils/skillCanonicalizer');
+const { canonicalSkillId, skillLookupCandidates, expandSkillIds, matchSkillDoc } = require('../utils/skillCanonicalizer');
 const { buildGraph, boardStates, bandProgress, nearestClosableBand, applyProofCascade } = require('../utils/skillClosure');
 const { currentRung, isInferred, canAdvance, advanceRung, clearsPrerequisites } = require('../utils/skillRung');
 const { confusedStudentOpener, scoreTeachBack } = require('../utils/teachBack');
@@ -642,8 +642,8 @@ router.post('/start-skill-practice', isAuthenticated, async (req, res) => {
       return res.status(404).json({ error: 'User not found' });
     }
 
-    // Get skill details
-    const skill = await Skill.findOne({ skillId }).lean();
+    // Get skill details (id may be mastery-side canonical or a bank id)
+    const skill = await Skill.findOne({ skillId: { $in: skillLookupCandidates(skillId) } }).lean();
 
     if (!skill) {
       return res.status(404).json({ error: 'Skill not found' });
@@ -1627,10 +1627,11 @@ router.get('/retention-checks-due', isAuthenticated, async (req, res) => {
 
     // Get skill details
     const skillIds = skillsDue.map(s => s.skillId);
-    const skills = await Skill.find({ skillId: { $in: skillIds } }).lean();
+    // Retention keys are mastery-side; the catalog is bank-keyed (id seam).
+    const skills = await Skill.find({ skillId: { $in: expandSkillIds(skillIds) } }).lean();
 
     const enrichedSkillsDue = skillsDue.map(({ skillId, skill }) => {
-      const skillData = skills.find(s => s.skillId === skillId);
+      const skillData = matchSkillDoc(skills, skillId);
       return {
         skillId,
         skillName: skillData?.displayName || skillId,
@@ -1962,8 +1963,8 @@ router.post('/update-pattern-progress', isAuthenticated, async (req, res) => {
       return res.status(404).json({ error: 'User not found' });
     }
 
-    // Get skill to determine pattern
-    const skill = await Skill.findOne({ skillId }).lean();
+    // Get skill to determine pattern (id-tolerant: see skillLookupCandidates)
+    const skill = await Skill.findOne({ skillId: { $in: skillLookupCandidates(skillId) } }).lean();
     if (!skill || !skill.patternId || !skill.tier) {
       return res.json({ success: true, message: 'Skill not part of pattern system' });
     }
@@ -2814,7 +2815,10 @@ router.post('/challenge/:skillId', isAuthenticated, async (req, res) => {
     // Re-fetch the served problems by id so grading uses stored answers, never
     // anything the client sent about correctness.
     const ids = submissions.map((s) => s.problemId).filter(Boolean);
-    const problems = await Problem.find({ _id: { $in: ids }, skillId }).lean();
+    // Filter by the RESOLVED catalog doc's own key: the GET serves problems
+    // whose skillId is the bank id, which the canonical `skillId` var may not
+    // equal — filtering by it graded an empty set (#1333 follow-through).
+    const problems = await Problem.find({ _id: { $in: ids }, skillId: skill.skillId }).lean();
     const result = gradeChallenge(problems, submissions);
 
     const user = await User.findById(req.user._id);
@@ -2934,7 +2938,7 @@ router.post('/teachback/:skillId', isAuthenticated, aiEndpointLimiter, async (re
     }
 
     const skillId = canonicalSkillId(req.params.skillId);
-    const skill = await Skill.findOne({ skillId }).lean();
+    const skill = await Skill.findOne({ skillId: { $in: skillLookupCandidates(req.params.skillId) } }).lean();
     if (!skill) return res.status(404).json({ error: 'Skill not found' });
 
     const user = await User.findById(req.user._id);

--- a/routes/practicePack.js
+++ b/routes/practicePack.js
@@ -952,8 +952,8 @@ router.get('/class-generate-pdf', isAuthenticated, async (req, res) => {
       return res.status(404).json({ error: 'No problems available for this skill and tier.' });
     }
 
-    // Look up skill display name
-    const skill = await Skill.findOne({ skillId });
+    // Look up skill display name (id-tolerant: see skillLookupCandidates)
+    const skill = await Skill.findOne({ skillId: { $in: skillLookupCandidates(skillId) } });
     const skillLabel = skill?.displayName || skillId.replace(/-/g, ' ');
     const tierLabel = { below: 'Approaching', onLevel: 'On Level', above: 'Advanced' }[tier] || tier;
     const title = `${skillLabel} — ${tierLabel}`;

--- a/routes/quarterlyGrowth.js
+++ b/routes/quarterlyGrowth.js
@@ -2,6 +2,7 @@
 // API endpoints for quarterly growth tracking and retention analytics
 
 const express = require('express');
+const { expandSkillIds, matchSkillDoc } = require('../utils/skillCanonicalizer');
 const router = express.Router();
 const User = require('../models/user');
 const Skill = require('../models/skill');
@@ -103,12 +104,12 @@ router.post('/checkpoint/:studentId', isTeacherOrAdmin, async (req, res) => {
     }
 
     // Load skill documents to get course/category info
-    const skillDocs = await Skill.find({ skillId: { $in: masteredSkillIds } });
-    const skillMap = new Map(skillDocs.map(s => [s.skillId, s]));
+    // Mastery keys vs bank-keyed catalog (id seam): expand + match.
+    const skillDocs = await Skill.find({ skillId: { $in: expandSkillIds(masteredSkillIds) } });
 
     for (const [skillId, data] of student.skillMastery) {
       if (data.status === 'mastered') {
-        const skillDoc = skillMap.get(skillId);
+        const skillDoc = matchSkillDoc(skillDocs, skillId);
         masteredSkills.push({
           skillId,
           masteredDate: data.masteredDate,

--- a/routes/review.js
+++ b/routes/review.js
@@ -11,6 +11,7 @@
  */
 
 const express = require('express');
+const { expandSkillIds, matchSkillDoc } = require('../utils/skillCanonicalizer');
 const router = express.Router();
 const { isAuthenticated } = require('../middleware/auth');
 const User = require('../models/user');
@@ -59,11 +60,11 @@ router.get('/smart-queue', isAuthenticated, async (req, res) => {
     // Enrich queue with skill display names
     if (queue.length > 0) {
       const skillIds = queue.map(s => s.skillId);
-      const skills = await Skill.find({ skillId: { $in: skillIds } }).lean();
-      const skillMap = new Map(skills.map(s => [s.skillId, s]));
+      // Queue keys are mastery-side; the catalog is bank-keyed (id seam).
+      const skills = await Skill.find({ skillId: { $in: expandSkillIds(skillIds) } }).lean();
 
       for (const item of queue) {
-        const doc = skillMap.get(item.skillId);
+        const doc = matchSkillDoc(skills, item.skillId);
         item.displayName = doc?.displayName || item.skillId;
         item.category = doc?.category || 'unknown';
       }
@@ -161,12 +162,12 @@ router.get('/due', isAuthenticated, async (req, res) => {
 
     // Load skill display names
     const skillIds = dueSkills.map(s => s.skillId);
-    const skills = await Skill.find({ skillId: { $in: skillIds } }).lean();
-    const skillMap = new Map(skills.map(s => [s.skillId, s]));
+    // Same id seam as above: expand, then match per original id.
+    const skills = await Skill.find({ skillId: { $in: expandSkillIds(skillIds) } }).lean();
 
     // Enrich with display names and categories
     const enrichedSkills = dueSkills.map(s => {
-      const skillDoc = skillMap.get(s.skillId);
+      const skillDoc = matchSkillDoc(skills, s.skillId);
       return {
         ...s,
         displayName: skillDoc?.displayName || s.skillId,

--- a/tests/unit/skillLookupCandidates.test.js
+++ b/tests/unit/skillLookupCandidates.test.js
@@ -45,3 +45,41 @@ describe('skillLookupCandidates', () => {
     expect(skillLookupCandidates('')).toEqual([]);
   });
 });
+
+describe('expandSkillIds / matchSkillDoc (the sweep helpers)', () => {
+  const { expandSkillIds, matchSkillDoc } = require('../../utils/skillCanonicalizer');
+
+  test('expand flattens candidate sets, deduped; junk-safe', () => {
+    const out = expandSkillIds(['skill-a', 'skill-b', 'skill-a']);
+    expect(out).toContain('skill-a');
+    expect(out).toContain('skill-b');
+    expect(new Set(out).size).toBe(out.length);
+    expect(expandSkillIds(null)).toEqual([]);
+  });
+
+  test('matchSkillDoc finds a doc keyed under ANY candidate form', () => {
+    const docs = [{ skillId: 'skill-a', displayName: 'A' }, { skillId: 'skill-b', displayName: 'B' }];
+    expect(matchSkillDoc(docs, 'skill-b').displayName).toBe('B');
+    expect(matchSkillDoc(docs, 'no-such-skill')).toBeNull();
+    expect(matchSkillDoc(null, 'skill-a')).toBeNull();
+  });
+
+  test('cross-form match: a legacy-keyed doc is found by its unified id', () => {
+    const fs = require('fs'); const path = require('path');
+    const dir = path.join(__dirname, '../../seeds/unified-taxonomy');
+    const files = fs.readdirSync(dir).filter(f => f.endsWith('-crosswalk.json'));
+    let legacy = null, unified = null;
+    for (const f of files) {
+      const d = JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8'));
+      const rows = Array.isArray(d) ? d : (d.mappings || d.entries || []);
+      for (const r of rows) {
+        const l = r.legacyId || r.legacy_id, u = r.unifiedId || r.unified_id;
+        if (l && u) { legacy = l; unified = u; break; }
+      }
+      if (legacy) break;
+    }
+    if (!legacy) return; // minimal env
+    expect(matchSkillDoc([{ skillId: legacy }], unified)).toEqual({ skillId: legacy });
+    expect(expandSkillIds([unified])).toContain(legacy);
+  });
+});

--- a/utils/skillCanonicalizer.js
+++ b/utils/skillCanonicalizer.js
@@ -114,4 +114,22 @@ function skillLookupCandidates(skillId) {
   return out;
 }
 
-module.exports = { canonicalSkillId, isUnifiedSkillId, skillLookupCandidates, _reset };
+/** $in-expansion of skillLookupCandidates over a list, deduped. */
+function expandSkillIds(ids) {
+  const out = [];
+  for (const id of Array.isArray(ids) ? ids : []) {
+    for (const c of skillLookupCandidates(id)) if (!out.includes(c)) out.push(c);
+  }
+  return out;
+}
+
+/**
+ * Find the catalog doc for a (possibly mastery-side) id among docs fetched
+ * with expandSkillIds — the doc may be keyed under any candidate form.
+ */
+function matchSkillDoc(docs, skillId) {
+  const cands = skillLookupCandidates(skillId);
+  return (Array.isArray(docs) ? docs : []).find(d => d && cands.includes(d.skillId)) || null;
+}
+
+module.exports = { canonicalSkillId, isUnifiedSkillId, skillLookupCandidates, expandSkillIds, matchSkillDoc, _reset };


### PR DESCRIPTION
The catalog-vs-mastery id seam has bitten four times in two days (mastery bar → test-out → What's Next → practice packs). This retires the bug class instead of waiting for head five.

## The sweep

Every remaining lookup that carries a **mastery-side id** (canonical unified) into a **bank-keyed collection** now routes through the shared resolver:

| Site | Fix |
|---|---|
| `mastery.js` start-skill-practice, update-pattern-progress, explain-back | single-id → candidates `$in` |
| `mastery.js` retention-due enrichment | `expandSkillIds` + `matchSkillDoc` |
| `mastery.js` **challenge submit** | **#1333 follow-through:** the submit re-fetched problems filtered by the canonical `skillId`, but the GET serves docs keyed by the bank id — grading ran on an empty set. Now filters by the resolved doc's own key. My miss; caught in this sweep before anyone hit it. |
| `review.js` both queue enrichments | expand + match |
| `quarterlyGrowth.js` mastered-skills enrichment | expand + match |
| `practicePack.js` class-pack title | candidates |

New helpers live in `skillCanonicalizer` next to the crosswalk data they invert: `expandSkillIds()` and `matchSkillDoc()`, both pure and pinned (including a cross-form test: a legacy-keyed doc found by its unified id, using real shipped crosswalk rows).

**Left alone on purpose:** lookups whose ids come *from* bank-side sources (screener problem/frontier ids, growth-check problems, ACT blueprint slots, badge configs) — already on the catalog's side of the seam. Each was checked, not skipped.

## Verification

Full suite **4790 passed**, lint clean, 3 new helper tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)