### PR TITLE
feat(flags): Render env vars now control client feature flags

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -120,6 +120,7 @@ const imageSearchRoutes = require('../routes/imageSearch');
 const browserLockRoutes = require('../routes/browserLock');
 const practicePackRoutes = require('../routes/practicePack');
 const notebookRoutes = require('../routes/notebook');
+const { buildFeaturesScript } = require('../utils/featureFlags');
 const { desktopRouter: phoneLinkRoutes, phoneRouter: phoneUploadRoutes } = require('../routes/phoneLink');
 const transcriptFlagsRoutes = require('../routes/transcriptFlags');
 const notificationsRoutes = require('../routes/notifications');
@@ -274,6 +275,15 @@ function registerRoutes(app, { authLimiter, signupLimiter }) {
   app.use('/api/browser-lock', isAuthenticated, browserLockRoutes);
   app.use('/api/practice-pack', isAuthenticated, practicePackRoutes);
   app.use('/api/notebook', isAuthenticated, notebookRoutes);
+  // Server-controlled client flags: a tiny synchronous script chat.html loads
+  // BEFORE seeding MM_FEATURES, so a Render env var (e.g. livingWorkspace=off)
+  // flips a flag from the dashboard — no code change, no redeploy semantics
+  // beyond Render's own env-save restart. no-store: flips apply on next load.
+  app.get('/api/features.js', (req, res) => {
+    res.set('Content-Type', 'application/javascript');
+    res.set('Cache-Control', 'no-store');
+    res.send(buildFeaturesScript());
+  });
   // "Scan with your phone" desktop endpoints (session-authed). The public
   // phone-upload counterpart is registered earlier, before the /api auth
   // catch-alls (see the Public API routes block above).

--- a/public/chat.html
+++ b/public/chat.html
@@ -26,11 +26,14 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
        graph/tiles/calc tools) is hidden until it's polished; students keep chat
        with the tutor's work mirrored inline as cards. To bring the board back,
        set boardPanel: true (or delete this block). -->
+  <script src="/api/features.js"></script>
   <script>
     // livingWorkspace: 'live' — the Living Workspace replaces the legacy tabbed
     // board. boardPanel stays true so #cr-workspace (the mount slot) is visible;
     // the M-C swap hides the legacy tools *inside* it and mounts the new surface.
-    // Kill switch: set livingWorkspace:'off' here (legacy board returns untouched).
+    // Kill switch: set the `livingWorkspace` (or LIVING_WORKSPACE) env var on
+    // Render to 'off' — /api/features.js (loaded above) overrides this default
+    // from the dashboard, no code change needed. Editing here still works too.
     // courses: true — the "My Courses" sidebar entry point is live (structure-everywhere).
     // Kill switch: set courses:false here, or load with ?courses=0 to hide it for a session.
     window.MM_FEATURES = Object.assign({ boardPanel: true, livingWorkspace: 'live', courses: true }, window.MM_FEATURES || {});

--- a/tests/unit/featureFlags.test.js
+++ b/tests/unit/featureFlags.test.js
@@ -1,0 +1,52 @@
+/**
+ * Server-controlled client flags (utils/featureFlags.js).
+ *
+ * The owner's Render dashboard action — `livingWorkspace=live` — must be the
+ * authoritative switch. Whitelist-only emission: nothing from the env is ever
+ * interpolated raw into the served script.
+ */
+const { buildFeaturesScript, LWS_MODES } = require('../../utils/featureFlags');
+
+describe('buildFeaturesScript', () => {
+  test('the exact dashboard spelling works: livingWorkspace=live', () => {
+    const js = buildFeaturesScript({ livingWorkspace: 'live' });
+    expect(js).toContain('"livingWorkspace":"live"');
+  });
+
+  test('SCREAMING_SNAKE convention works and wins jointly', () => {
+    expect(buildFeaturesScript({ LIVING_WORKSPACE: 'off' })).toContain('"livingWorkspace":"off"');
+    for (const mode of LWS_MODES) {
+      expect(buildFeaturesScript({ LIVING_WORKSPACE: mode })).toContain(`"livingWorkspace":"${mode}"`);
+    }
+  });
+
+  test('invalid or absent values emit NO override — chat.html defaults stand', () => {
+    for (const env of [{}, { livingWorkspace: 'banana' }, { livingWorkspace: '' }, { livingWorkspace: 'LIVE ' }]) {
+      const js = buildFeaturesScript(env);
+      expect(js).not.toContain('livingWorkspace"');
+      expect(js).toContain('window.MM_FEATURES = window.MM_FEATURES || {};');
+    }
+  });
+
+  test('injection-shaped env values can never reach the script raw', () => {
+    const js = buildFeaturesScript({ livingWorkspace: '";alert(1);//', COURSES_FEATURE: '1;evil()' });
+    expect(js).not.toContain('alert');
+    expect(js).not.toContain('evil');
+  });
+
+  test('courses boolean flag parses 1/0/true/false only', () => {
+    expect(buildFeaturesScript({ COURSES_FEATURE: '0' })).toContain('"courses":false');
+    expect(buildFeaturesScript({ COURSES_FEATURE: 'true' })).toContain('"courses":true');
+    expect(buildFeaturesScript({ COURSES_FEATURE: 'maybe' })).not.toContain('courses');
+  });
+
+  test('chat.html loads the override BEFORE the seed, so env wins the merge', () => {
+    const fs = require('fs');
+    const html = fs.readFileSync(require.resolve('../../public/chat.html'), 'utf8');
+    const override = html.indexOf('/api/features.js');
+    const seed = html.indexOf('window.MM_FEATURES = Object.assign({ boardPanel');
+    expect(override).toBeGreaterThan(-1);
+    expect(seed).toBeGreaterThan(-1);
+    expect(override).toBeLessThan(seed);
+  });
+});

--- a/utils/featureFlags.js
+++ b/utils/featureFlags.js
@@ -1,0 +1,51 @@
+/**
+ * featureFlags.js — server-controlled client feature flags.
+ *
+ * chat.html seeds window.MM_FEATURES from hardcoded defaults; until now the
+ * only "kill switch" was editing that line and redeploying. This serves
+ * GET /api/features.js — a tiny synchronous script loaded BEFORE the seed —
+ * so a Render env var flips a flag with a dashboard save instead of a code
+ * change (the owner's exact action: livingWorkspace=live in the env screen).
+ *
+ * Precedence: env override → chat.html default (the seed's Object.assign
+ * merges the pre-set window.MM_FEATURES over its defaults). Absent or
+ * invalid env values emit nothing — the defaults stand.
+ *
+ * SECURITY: env values are matched against whitelists and only whitelisted
+ * LITERALS are emitted — nothing from the environment is interpolated raw
+ * into the script, so a mistyped value can never inject JS.
+ */
+'use strict';
+
+const LWS_MODES = ['off', 'dev', 'beta', 'live'];
+
+function boolFlag(v) {
+  if (v === '1' || v === 'true') return true;
+  if (v === '0' || v === 'false') return false;
+  return null;
+}
+
+/**
+ * @param {object} env - process.env (injectable for tests)
+ * @returns {string} JavaScript source for /api/features.js
+ */
+function buildFeaturesScript(env = process.env) {
+  const flags = {};
+
+  // Render env keys are conventionally SCREAMING_SNAKE; also accept the
+  // camelCase spelling since that is what exists in the dashboard today.
+  const lws = env.LIVING_WORKSPACE || env.livingWorkspace;
+  if (typeof lws === 'string' && LWS_MODES.includes(lws.trim())) {
+    flags.livingWorkspace = lws.trim();
+  }
+
+  const courses = boolFlag(env.COURSES_FEATURE || env.courses);
+  if (courses !== null) flags.courses = courses;
+
+  const body = Object.keys(flags).length
+    ? `window.MM_FEATURES = Object.assign(window.MM_FEATURES || {}, ${JSON.stringify(flags)});`
+    : 'window.MM_FEATURES = window.MM_FEATURES || {};';
+  return '// server feature-flag overrides — see utils/featureFlags.js\n' + body + '\n';
+}
+
+module.exports = { buildFeaturesScript, LWS_MODES };


### PR DESCRIPTION
Prompted by the owner's Render dashboard action — adding `livingWorkspace=live` to the env — which was **exactly the right instinct pointed at a variable nothing read**: `MM_FEATURES` is a client-side literal in chat.html, and the only kill switch was editing code and redeploying.

## What ships

- **`GET /api/features.js`** (`no-store`): serves whitelisted flag overrides from env. chat.html loads it **synchronously before** seeding `MM_FEATURES`, so env wins the merge; absent or invalid values emit nothing and the hardcoded defaults stand.
- Accepts **both spellings**: the dashboard's `livingWorkspace` (already sitting in the env screen) and conventional `LIVING_WORKSPACE`. Values are whitelist-matched (`off|dev|beta|live`) and emitted as literals via JSON.stringify — an injection-shaped env value can never reach the script (test-pinned).
- `courses` boolean included under the same contract.

## What this means operationally

The Living Workspace was **already live** via the hardcoded default (`chat.html:36`) — the env var you saved doesn't change today's behavior. What it buys is the thing that matters: **`livingWorkspace=off` in the dashboard is now a real kill switch** — legacy board returns on next page load after Render's env-save restart, zero code changes. Same lever for a `beta` stage if you ever want cohorting.

## Verification

Full suite **4793 passed**, lint clean. 6 new tests: both env spellings, full mode whitelist, invalid-value passthrough, injection-shaped values, boolean parsing, and the load-order pin (override script precedes the seed in chat.html).

🤖 Generated with [Claude Code](https://claude.com/claude-code)