### PR TITLE
fix(visuals): strip nested-bracket visual tokens whole on the server side

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -139,7 +139,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
        the new surface beside the old board. Default OFF → zero impact. -->
   <script defer src="/js/living-workspace/chat-workspace.js?v=20260726b"></script>
   <!-- Final safety net: strips any inline visual tag no renderer handled -->
-  <script defer src="/js/stripVisualTags.js"></script>
+  <script defer src="/js/stripVisualTags.js?v=20260726"></script>
   <!-- Non-core libs (lazy-loaded after first interaction) -->
   <!-- confetti: loaded on demand when celebration triggers -->
   <script>

--- a/public/js/stripVisualTags.js
+++ b/public/js/stripVisualTags.js
@@ -35,9 +35,13 @@
     'COMPARISON', 'INEQUALITY', 'ALGEBRA_TILES', 'MULTI_REP', 'SEARCH_IMAGE',
   ];
 
-  // [NAME] or [NAME:...anything-but-]...]. Anchored to the whitelist so plain
-  // brackets ([0, 3], [a, b]) and LaTeX are never touched.
-  const TAG_RE = new RegExp('\\[(?:' + VISUAL_COMMANDS.join('|') + ')(?::[^\\]]*)?\\]', 'g');
+  // [NAME] or [NAME:params]. Params can nest ONE level of brackets
+  // (points=[-3,3], jumps=[(0,3,"+3")]) — same grammar as visualTokenParser.js;
+  // a bare [^\]]* stops at the first inner "]" and leaves ',label="..."]' as
+  // literal text. Anchored to the whitelist so plain brackets ([0, 3], [a, b])
+  // and LaTeX are never touched.
+  const PARAM = '(?:[^\\[\\]]|\\[[^\\]]*\\])';
+  const TAG_RE = new RegExp('\\[(?:' + VISUAL_COMMANDS.join('|') + ')(?::' + PARAM + '*)?\\]', 'g');
 
   /**
    * Remove any leftover (unrendered) visual command tags from a message.

--- a/tests/unit/visualTagNestedStrip.test.js
+++ b/tests/unit/visualTagNestedStrip.test.js
@@ -1,0 +1,91 @@
+/**
+ * Regression: visual tokens whose params nest one level of brackets
+ * (points=[-3,3], jumps=[(0,3,"+3")]) must be stripped WHOLE.
+ *
+ * Production transcript (2026-07-26): the tutor emitted
+ *   [NUMBER_LINE:min=-5,max=5,points=[-3,3],label="−3 and 3 are both 3 steps from zero"]
+ * and the server-side strip regex [^\]]+ stopped at the "]" closing points=[…],
+ * so the student saw the literal tail:
+ *   ,label="−3 and 3 are both 3 steps from zero"]
+ *
+ * The client-side grammar (public/js/visualTokenParser.js) was already fixed;
+ * these tests pin the four server/client strippers that were missed.
+ */
+
+const { parseVisualTeaching } = require('../../utils/visualTeachingParser');
+const { normalizeLatex } = require('../../utils/pipeline/verify');
+const { cleanTextForTTS } = require('../../utils/mathTTS');
+const { stripUnrenderedVisualTags } = require('../../public/js/stripVisualTags');
+
+const TRANSCRIPT_TOKEN =
+  '[NUMBER_LINE:min=-5,max=5,points=[-3,3],label="−3 and 3 are both 3 steps from zero"]';
+const LEAKED_TAIL = ',label=';
+
+describe('visualTeachingParser.parseVisualTeaching — nested-bracket strip', () => {
+  it('strips the exact production NUMBER_LINE token whole', () => {
+    const { cleanedText } = parseVisualTeaching(
+      `Distance from zero.\n\n${TRANSCRIPT_TOKEN}\n\nLook at that number line.`
+    );
+    expect(cleanedText).not.toContain(LEAKED_TAIL);
+    expect(cleanedText).not.toContain('NUMBER_LINE');
+    expect(cleanedText).toContain('Distance from zero.');
+    expect(cleanedText).toContain('Look at that number line.');
+  });
+
+  it('strips NUMBER_LINE with jumps=[(…)] params whole', () => {
+    const { cleanedText } = parseVisualTeaching(
+      'Add: [NUMBER_LINE:min=0,max=10,jumps=[(0,3,"+3"),(3,7,"+4")],label="Adding"] done'
+    );
+    expect(cleanedText.replace(/\s+/g, ' ')).toBe('Add: done');
+  });
+
+  it('strips COUNTERS with nested list params whole', () => {
+    const { cleanedText } = parseVisualTeaching(
+      'See [COUNTERS:pos=3,neg=5,pairs=[1,2],label="Zero pairs"] here'
+    );
+    expect(cleanedText).not.toContain(LEAKED_TAIL);
+    expect(cleanedText).not.toContain('COUNTERS');
+  });
+
+  it('still strips simple tokens with no nesting', () => {
+    const { cleanedText } = parseVisualTeaching('a [NUMBER_LINE:min=-5,max=5,highlight=3] b');
+    expect(cleanedText.replace(/\s+/g, ' ')).toBe('a b');
+  });
+});
+
+describe('verify.normalizeLatex — protects whole nested tokens from LaTeX pass', () => {
+  it('round-trips a NUMBER_LINE token with points=[…] unchanged', () => {
+    const input = `Here you go:\n${TRANSCRIPT_TOKEN}`;
+    expect(normalizeLatex(input)).toBe(input);
+  });
+
+  it('round-trips a FUNCTION_GRAPH token with bracketed params unchanged', () => {
+    const input = 'Graph: [FUNCTION_GRAPH:fn=x^2,points=[(1,1),(2,4)],title="Squares"]';
+    expect(normalizeLatex(input)).toBe(input);
+  });
+});
+
+describe('mathTTS.cleanTextForTTS — never reads a leaked tail aloud', () => {
+  it('removes the whole nested NUMBER_LINE token', () => {
+    const out = cleanTextForTTS(`Look at the number line. ${TRANSCRIPT_TOKEN}`);
+    expect(out).not.toContain(LEAKED_TAIL);
+    expect(out).not.toContain('label');
+    expect(out).toContain('Look at the number line.');
+  });
+
+  it('still removes flat tokens', () => {
+    expect(cleanTextForTTS('a [DIAGRAM:triangle] b')).toBe('a b');
+  });
+});
+
+describe('stripVisualTags.stripUnrenderedVisualTags — client safety net', () => {
+  it('strips the whole nested NUMBER_LINE token', () => {
+    const out = stripUnrenderedVisualTags(`Distance. ${TRANSCRIPT_TOKEN} See?`);
+    expect(out).toBe('Distance. See?');
+  });
+
+  it('still never touches interval notation or plain brackets', () => {
+    expect(stripUnrenderedVisualTags('The solution is [0, 3].')).toBe('The solution is [0, 3].');
+    expect(stripUnrenderedVisualTags('Points [1,2] and [3,4].')).toBe('Points [1,2] and [3,4].');
+  });
+});

--- a/utils/mathTTS.js
+++ b/utils/mathTTS.js
@@ -171,7 +171,10 @@ function cleanTextForTTS(text) {
   let cleaned = text;
 
   // Remove visual commands: [DIAGRAM:...], [FUNCTION_GRAPH:...], etc.
-  cleaned = cleaned.replace(/\[(DIAGRAM|FUNCTION_GRAPH|SLIDER_GRAPH|POINTS|DERIVATIVE_GRAPH|VELOCITY_GRAPH|RATIONAL_GRAPH|NUMBER_LINE|FRACTION|PIE_CHART|BAR_CHART|UNIT_CIRCLE|AREA_MODEL|SEARCH_IMAGE|WHITEBOARD_WRITE|EQUATION_SOLVE|STEPS|\/STEPS|OLD|NEW|FOCUS|TRIANGLE_PROBLEM)[^\]]*\]/g, '');
+  // Params can nest one level of brackets (points=[-3,3]) — match whole
+  // "[...]" groups too, or the strip stops at the first inner "]" and TTS
+  // reads the leftover tail (',label="..."]') aloud.
+  cleaned = cleaned.replace(/\[(DIAGRAM|FUNCTION_GRAPH|SLIDER_GRAPH|POINTS|DERIVATIVE_GRAPH|VELOCITY_GRAPH|RATIONAL_GRAPH|NUMBER_LINE|FRACTION|PIE_CHART|BAR_CHART|UNIT_CIRCLE|AREA_MODEL|SEARCH_IMAGE|WHITEBOARD_WRITE|EQUATION_SOLVE|STEPS|\/STEPS|OLD|NEW|FOCUS|TRIANGLE_PROBLEM)(?:[^\[\]]|\[[^\]]*\])*\]/g, '');
 
   // Remove markdown headers (### Title → Title)
   cleaned = cleaned.replace(/^#{1,6}\s+/gm, '');

--- a/utils/pipeline/verify.js
+++ b/utils/pipeline/verify.js
@@ -1300,8 +1300,12 @@ function normalizeLatex(text) {
     'INEQUALITY', 'ALGEBRA_TILES', 'MULTI_REP',
     'DERIVATIVE_GRAPH', 'RATIONAL_GRAPH', 'VELOCITY_GRAPH',
   ];
+  // Params can nest one level of brackets (points=[-3,3], jumps=[(0,3,"+3")]).
+  // A bare [^\]]+ stops at the first inner "]", protecting only a truncated
+  // prefix and leaving the tail exposed to the LaTeX normalizer.
+  const NESTED_PARAM = '(?:[^\\[\\]]|\\[[^\\]]*\\])';
   const visualCmdRegex = new RegExp(
-    `\\[(${VISUAL_CMD_NAMES.join('|')}):([^\\]]+)\\]`, 'g'
+    `\\[(${VISUAL_CMD_NAMES.join('|')}):(${NESTED_PARAM}+)\\]`, 'g'
   );
   result = result.replace(visualCmdRegex, (match) => {
     visualCmdBlocks.push(match);

--- a/utils/visualTeachingParser.js
+++ b/utils/visualTeachingParser.js
@@ -5,6 +5,7 @@
 // ============================================
 
 const { parseAIDrawingCommands } = require('./aiDrawingTools');
+const { tokenRegex } = require('../public/js/visualTokenParser');
 
 /**
  * Parse all visual teaching commands from AI response
@@ -341,15 +342,16 @@ function parseVisualTeaching(aiResponseText) {
 
     // --- COUNTER COMMANDS ---
     // [COUNTERS:...] - Handled inline by inlineChatVisuals.js (key=value format).
-    // Strip any COUNTERS tags so they don't appear as raw text.
-    const countersRegex = /\[COUNTERS:[^\]]+\]/g;
-    cleanedText = cleanedText.replace(countersRegex, '');
+    // Strip any COUNTERS tags so they don't appear as raw text. Params can nest
+    // one level of brackets (points=[...], jumps=[(...)]) — tokenRegex captures
+    // the whole token; a bare [^\]]+ stops at the first inner "]" and leaves the
+    // tail (',label="..."]') in the student-visible text.
+    cleanedText = cleanedText.replace(tokenRegex('COUNTERS'), '');
 
     // --- MANIPULATIVE COMMANDS ---
     // [NUMBER_LINE:...] - Handled inline by inlineChatVisuals.js (key=value format).
     // Strip any NUMBER_LINE tags so they don't appear as raw text.
-    const numberLineRegex = /\[NUMBER_LINE:[^\]]+\]/g;
-    cleanedText = cleanedText.replace(numberLineRegex, '');
+    cleanedText = cleanedText.replace(tokenRegex('NUMBER_LINE'), '');
 
     // [FRACTION_BARS:numerator,denominator] - Show fraction visualization
     const fractionBarsRegex = /\[FRACTION_BARS:(\d+),(\d+)\]/g;


### PR DESCRIPTION
## Problem

Production transcript (2026-07-26, absolute-value session): the student saw this literal text in a tutor message:

```
,label="−3 and 3 are both 3 steps from zero"]
```

The tutor emitted `[NUMBER_LINE:min=-5,max=5,points=[-3,3],label="…"]`. Several strippers still use non-nesting `[^\]]+` regexes, which stop at the `]` closing `points=[…]` — so the token is stripped only up to there and the tail leaks into the student-visible message.

The client-side grammar (`public/js/visualTokenParser.js`) was already fixed for exactly this; these four strippers were missed:

## Changes

- **`utils/visualTeachingParser.js`** — NUMBER_LINE + COUNTERS strips now use the shared `tokenRegex` grammar. This is the exact leak site: `verify.js` persists this function's `cleanedText` as the final message.
- **`utils/pipeline/verify.js`** — `normalizeLatex`'s visual-command protection pass now captures whole nested tokens (previously it protected only a truncated prefix from LaTeX mangling).
- **`utils/mathTTS.js`** — TTS strip is nesting-aware, so the leaked tail is never read aloud.
- **`public/js/stripVisualTags.js`** — client-side final safety net upgraded to the same grammar; added a `?v=` cache-bust in `chat.html` (the script tag had none).

## Tests

New `tests/unit/visualTagNestedStrip.test.js` pins all four surfaces using the exact production token, plus `jumps=[(…)]` and COUNTERS variants, and re-asserts interval notation (`[0, 3]`) is never touched. All 48 tests in the adjacent suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)