### PR TITLE
fix(tutor): level-appropriate scaffolding for returning students

### DIFF
--- a/models/tutorPlan.js
+++ b/models/tutorPlan.js
@@ -250,7 +250,14 @@ tutorPlanSchema.methods.getCurrentNotes = function (limit = 20) {
 tutorPlanSchema.statics.familiarityToMode = function (familiarity) {
   const mapping = {
     'never-seen': 'instruct',
-    'introduced': 'instruct',
+    // 'introduced' requires totalAttempts >= 1 (see inferFamiliarity) — the
+    // student HAS seen this skill. Mapping it to 'instruct' restarted the full
+    // gradual-release sequence at the 'vocabulary' phase for returning
+    // students, with the prompt asserting "they have NEVER seen it before"
+    // ("why we starting over?" — production, 2026-07-26). Guide mode is the
+    // right posture: activate prior knowledge, practice Socratically, and drop
+    // to direct instruction only if they turn out to be stuck.
+    'introduced': 'guide',
     'developing': 'guide',
     'proficient': 'strengthen',
     'mastered': 'leverage'

--- a/tests/unit/scaffoldingContinuity.test.js
+++ b/tests/unit/scaffoldingContinuity.test.js
@@ -1,0 +1,182 @@
+/**
+ * Regression: level-appropriate scaffolding for RETURNING students.
+ *
+ * Production transcript (2026-07-26): a student said "Let's keep working on
+ * Absolute Value" — a skill with prior recorded attempts — and the tutor
+ * restarted the full gradual-release sequence from the vocabulary phase
+ * ("Let's build this from the ground up!"). The student: "why we starting
+ * over?". After five first-try-correct answers the tutor was still demanding
+ * "walk me through how you arrived at that."
+ *
+ * Root causes pinned here:
+ *  1. familiarityToMode mapped 'introduced' (>= 1 attempt) to 'instruct',
+ *     identical to 'never-seen' (covered in tutorPlanModel.test.js).
+ *  2. The plan layer asserted "They have NEVER seen it before" as fact with
+ *     no prior-progress counterweight in the prompt.
+ *  3. Streak counters ran over raw assistant messages, so unstamped probing
+ *     turns evicted real wins from the window — the more the tutor probed,
+ *     the less streak evidence it had to stop probing.
+ *  4. "why we starting over?" matched no back-off pattern.
+ *  5. buildSkillMasteryContext silently dropped 'practicing' /
+ *     'needs-review' / 're-fragile' skills from the prompt.
+ */
+
+const { buildModeDirective } = require('../../utils/promptPlanLayer');
+const { observe } = require('../../utils/pipeline/observe');
+const { buildSkillMasteryContext } = require('../../utils/promptCompact');
+const { resolveSkill } = require('../../utils/skillFamiliarityResolver');
+
+describe('promptPlanLayer.buildModeDirective — never lies about prior work', () => {
+  const target = { skillId: 'absolute-value', displayName: 'Absolute Value', instructionalMode: 'instruct', instructionPhase: 'vocabulary' };
+
+  it('still calls a genuinely never-seen skill novel', () => {
+    const out = buildModeDirective(target, { familiarity: 'never-seen', priorEvidence: null });
+    expect(out).toContain('NEVER seen it before');
+  });
+
+  it('does NOT assert "never seen" when the record shows prior attempts', () => {
+    const out = buildModeDirective(target, {
+      familiarity: 'introduced',
+      priorEvidence: { totalAttempts: 9, scorePct: 62, status: 'practicing' },
+    });
+    expect(out).not.toContain('NEVER seen it before');
+    expect(out).toContain('PRIOR PROGRESS ON THIS SKILL: 9 recorded attempts');
+    expect(out).toContain('~62% mastery score');
+  });
+
+  it('guide mode carries the prior-progress facts and a no-restart directive', () => {
+    const guideTarget = { ...target, instructionalMode: 'guide', instructionPhase: null };
+    const out = buildModeDirective(guideTarget, {
+      familiarity: 'introduced',
+      priorEvidence: { totalAttempts: 4, scorePct: null, status: 'practicing' },
+    });
+    expect(out).toContain('PRIOR PROGRESS ON THIS SKILL: 4 recorded attempts');
+    expect(out).toContain('do NOT re-introduce vocabulary');
+  });
+});
+
+describe('observe — streaks survive probing turns', () => {
+  it('counts problem outcomes from recentProblemResults, not raw messages', () => {
+    // Five wins whose stamps are interleaved with 5 unstamped probing turns.
+    // Under the old last-6-messages window only ~3 stamps were visible.
+    const obs = observe('7', {
+      recentUserMessages: [{ content: '5' }, { content: '7' }],
+      recentAssistantMessages: [
+        { content: 'walk me through that?' },          // probing, unstamped
+        { content: 'right!', problemResult: 'correct' },
+        { content: 'why does that work?' },            // probing, unstamped
+        { content: 'yes!', problemResult: 'correct' },
+        { content: 'can you explain?' },               // probing, unstamped
+        { content: 'correct again', problemResult: 'correct' },
+      ],
+      recentProblemResults: ['correct', 'correct', 'correct', 'correct', 'correct'],
+    });
+    expect(obs.streaks.recentCorrectCount).toBe(5);
+    expect(obs.streaks.recentWrongCount).toBe(0);
+  });
+
+  it('falls back to stamped messages when recentProblemResults is absent', () => {
+    const obs = observe('7', {
+      recentUserMessages: [],
+      recentAssistantMessages: [
+        { content: 'probe' },
+        { content: 'right', problemResult: 'correct' },
+        { content: 'probe again' },
+        { content: 'right', problemResult: 'correct' },
+      ],
+    });
+    expect(obs.streaks.recentCorrectCount).toBe(2);
+    expect(obs.streaks.recentWrongCount).toBe(0);
+  });
+
+  it('still counts wrongs inside the outcome window', () => {
+    const obs = observe('7', {
+      recentUserMessages: [],
+      recentAssistantMessages: [],
+      recentProblemResults: ['correct', 'incorrect', 'correct'],
+    });
+    expect(obs.streaks.recentWrongCount).toBe(1);
+    expect(obs.streaks.recentCorrectCount).toBe(2);
+  });
+});
+
+describe('observe — "why we starting over?" is a back-off signal', () => {
+  const ctx = { recentUserMessages: [], recentAssistantMessages: [] };
+
+  it.each([
+    'why we starting over?',
+    'why are we starting over',
+    'why are you starting over?',
+    'we already did this',
+    'we did this already',
+    'we learned this before',
+    'we went over this last time',
+  ])('matches: %s', (msg) => {
+    expect(observe(msg, ctx).assertsCompetence).toBe(true);
+  });
+
+  it.each([
+    'can we start over?',          // a REQUEST to restart, not a complaint
+    'I want to start over',
+    'lets do this',
+  ])('does not match: %s', (msg) => {
+    expect(observe(msg, ctx).assertsCompetence).toBe(false);
+  });
+});
+
+describe('promptCompact.buildSkillMasteryContext — no silent status drops', () => {
+  it('surfaces practicing / needs-review / re-fragile skills', () => {
+    const userProfile = {
+      skillMastery: new Map([
+        ['absolute-value', { status: 'practicing', totalAttempts: 9 }],
+        ['integer-operations', { status: 'needs-review' }],
+        ['order-of-operations', { status: 're-fragile' }],
+        ['fractions', { status: 'mastered', masteredDate: new Date('2026-05-01') }],
+      ]),
+    };
+    const out = buildSkillMasteryContext(userProfile);
+    expect(out).toContain('Absolute Value (9 attempts)');
+    expect(out).toContain('RESUME, never restart from scratch');
+    expect(out).toContain('Integer Operations');
+    expect(out).toContain('Order Of Operations');
+    expect(out).toContain('now fragile');
+    expect(out).toContain('Fractions');
+  });
+});
+
+describe('skillFamiliarityResolver.resolveSkill — exposes prior evidence', () => {
+  it('returns priorEvidence with attempts and normalized score', async () => {
+    const skillCache = {
+      'absolute-value': { skillId: 'absolute-value', displayName: 'Absolute Value', prerequisites: [] },
+    };
+    const mastery = new Map([
+      ['absolute-value', { status: 'practicing', masteryScore: 0.62, totalAttempts: 9 }],
+    ]);
+    const res = await resolveSkill('absolute-value', mastery, { skillCache });
+    expect(res.familiarity).toBe('developing');
+    expect(res.instructionalMode).toBe('guide');
+    expect(res.priorEvidence).toEqual({ totalAttempts: 9, scorePct: 62, status: 'practicing' });
+  });
+
+  it('an introduced skill (1-2 attempts) resolves to guide, not instruct', async () => {
+    const skillCache = {
+      'absolute-value': { skillId: 'absolute-value', displayName: 'Absolute Value', prerequisites: [] },
+    };
+    const mastery = new Map([
+      ['absolute-value', { status: 'learning', masteryScore: 30, totalAttempts: 1 }],
+    ]);
+    const res = await resolveSkill('absolute-value', mastery, { skillCache });
+    expect(res.familiarity).toBe('introduced');
+    expect(res.instructionalMode).toBe('guide');
+  });
+
+  it('never-seen still resolves to instruct', async () => {
+    const skillCache = {
+      'new-skill': { skillId: 'new-skill', displayName: 'New Skill', prerequisites: [] },
+    };
+    const res = await resolveSkill('new-skill', new Map(), { skillCache });
+    expect(res.familiarity).toBe('never-seen');
+    expect(res.instructionalMode).toBe('instruct');
+    expect(res.priorEvidence).toBeNull();
+  });
+});

--- a/tests/unit/tutorPlanModel.test.js
+++ b/tests/unit/tutorPlanModel.test.js
@@ -68,7 +68,10 @@ describe('TutorPlan.methods.getCurrentNotes', () => {
 describe('TutorPlan.statics.familiarityToMode', () => {
   test.each([
     ['never-seen', 'instruct'],
-    ['introduced', 'instruct'],
+    // 'introduced' means totalAttempts >= 1 — the student has seen this skill.
+    // It must NOT map to instruct: that restarted the gradual-release sequence
+    // at 'vocabulary' for returning students ("why we starting over?").
+    ['introduced', 'guide'],
     ['developing', 'guide'],
     ['proficient', 'strengthen'],
     ['mastered', 'leverage'],

--- a/utils/pipeline/index.js
+++ b/utils/pipeline/index.js
@@ -113,9 +113,19 @@ async function runPipeline(message, ctx) {
     .filter(msg => msg.role === 'assistant')
     .slice(-6);
 
+  // Streak evidence must survive probing turns: assistant messages with no
+  // problemResult stamp (explanation requests, encouragement) would otherwise
+  // push real wins out of the 6-message window. Hand observe the last 6
+  // STAMPED outcomes from the full conversation instead.
+  const recentProblemResults = ctx.conversation.messages
+    .filter(msg => msg.role === 'assistant' && msg.problemResult)
+    .slice(-6)
+    .map(msg => msg.problemResult);
+
   const observation = observe(message, {
     recentUserMessages,
     recentAssistantMessages,
+    recentProblemResults,
     hasRecentUpload: ctx.hasRecentUpload || false,
   });
 
@@ -363,7 +373,14 @@ async function runPipeline(message, ctx) {
       const canon = canonicalSkillId(id);
       return get(canon) ?? (canon !== id ? get(id) : null) ?? null;
     };
-    const activeSkillId = ctx.activeSkill ? ctx.activeSkill.skillId : null;
+    // Fall back to the plan's current target, mirroring the persist-side
+    // attribution (updateLearningEngines). Without the fallback, free chat —
+    // where ctx.activeSkill is always null — WRITES BKT/FSRS evidence under
+    // the plan target every turn but can never read it back, so the evidence
+    // layer runs blind on exactly the sessions that need it.
+    const activeSkillId = ctx.activeSkill?.skillId
+      || tutorPlan?.currentTarget?.skillId
+      || null;
 
     // Get BKT state for active skill (from user's learningEngines data)
     const bktState = readEngine(ctx.user.learningEngines?.bkt, activeSkillId);

--- a/utils/pipeline/observe.js
+++ b/utils/pipeline/observe.js
@@ -125,7 +125,12 @@ const PATTERNS = {
   // only unambiguous "back off" phrasings match. Drives a DURABLE back-off mode
   // (see observe(): once asserted, the tutor stops probing correct answers and
   // raises difficulty for the rest of the session).
-  competenceAssertion: /\b(too\s+easy|this\s+is\s+(?:so\s+|way\s+)?easy|i\s+(?:already\s+)?know\s+(?:this\s+stuff|the\s+steps|how\s+to|it\s+already|this\s+already)|i\s+know\s+this\s+already|i\s+(?:don'?t|do\s+not)\s+need\s+(?:the\s+)?help|stop\s+(?:asking|explaining|quizzing)|quit\s+asking|i\s+got\s+this|i\s+can\s+do\s+(?:these|those|them|this\s+too)|(?:2nd|second)\s+grader|why\s+are\s+you\s+(?:asking|quizzing)\s+me)\b/i,
+  // "why (are) we starting over" and "we already did this" are complaints
+  // about RE-TEACHING known material — the same back-off signal ("why we
+  // starting over?" — production, 2026-07-26, triggered nothing). Note the
+  // question form is required for starting-over: a bare "can we start over?"
+  // is a REQUEST to restart, not a complaint.
+  competenceAssertion: /\b(too\s+easy|this\s+is\s+(?:so\s+|way\s+)?easy|i\s+(?:already\s+)?know\s+(?:this\s+stuff|the\s+steps|how\s+to|it\s+already|this\s+already)|i\s+know\s+this\s+already|i\s+(?:don'?t|do\s+not)\s+need\s+(?:the\s+)?help|stop\s+(?:asking|explaining|quizzing)|quit\s+asking|i\s+got\s+this|i\s+can\s+do\s+(?:these|those|them|this\s+too)|(?:2nd|second)\s+grader|why\s+are\s+you\s+(?:asking|quizzing)\s+me|why\s+(?:are\s+)?(?:we|you)\s+start(?:ing)?\s+(?:this\s+)?over|we\s+(?:already\s+(?:did|learned|covered|went\s+over)\s+this|(?:did|learned|covered|went\s+over)\s+this\s+(?:already|before|last\s+time)))\b/i,
 };
 
 /**
@@ -598,17 +603,28 @@ function observe(message, context = {}) {
   // Detect streaks from recent history
   const streaks = detectStreaks(context.recentUserMessages || []);
 
-  // Count recent wrong answers
-  const recentWrongCount = (context.recentAssistantMessages || [])
-    .filter(msg => msg.problemResult === 'incorrect').length;
-
-  // Count recent correct answers — the symmetric "on a roll" signal. Without
-  // this the pipeline could only ever ratchet support UP (on wrong streaks)
-  // and never DOWN, so a fluent student kept getting the same problem broken
-  // into micro-steps (the "over-scaffolding" failure). decide's CONFIRM_CORRECT
-  // branch reads this to advance / gather data / teach-back instead.
-  const recentCorrectCount = (context.recentAssistantMessages || [])
-    .filter(msg => msg.problemResult === 'correct').length;
+  // Count recent wrong/correct answers over PROBLEM OUTCOMES, not raw
+  // messages. Probing turns ("walk me through how you got that") produce
+  // assistant messages with NO problemResult stamp, and under the old
+  // last-6-messages window each such turn evicted a real win from the
+  // streak — so the more the tutor probed, the less streak evidence it had
+  // to stop probing (self-reinforcing loop, production 2026-07-26: five
+  // first-try corrects and the tutor still demanded explanations).
+  // recentProblemResults, when provided, is the last 6 STAMPED outcomes
+  // regardless of how many unstamped turns sit between them.
+  //
+  // recentCorrectCount is the symmetric "on a roll" signal. Without it the
+  // pipeline could only ever ratchet support UP (on wrong streaks) and
+  // never DOWN, so a fluent student kept getting the same problem broken
+  // into micro-steps (the "over-scaffolding" failure). decide's
+  // CONFIRM_CORRECT branch reads this to advance / gather data / teach-back.
+  const stampedResults = context.recentProblemResults
+    || (context.recentAssistantMessages || [])
+      .filter(msg => msg.problemResult)
+      .map(msg => msg.problemResult);
+  const resultWindow = stampedResults.slice(-6);
+  const recentWrongCount = resultWindow.filter(r => r === 'incorrect').length;
+  const recentCorrectCount = resultWindow.filter(r => r === 'correct').length;
 
   // ── Classify: check high-confidence intent signals FIRST ──
   //

--- a/utils/promptCompact.js
+++ b/utils/promptCompact.js
@@ -890,24 +890,37 @@ Assessment pending. For regular tutoring requests, just help them. Do NOT sugges
 HOWEVER: If the student demonstrates SIGNIFICANT struggle with skills well below their grade level (e.g., a 5th grader can't multiply single digits, multiple "idk" responses, expressed frustration like "math sucks"), THEN gently re-mention the Starting Point button: "Hey, remember that Starting Point button on the left? It's not a test you can fail — it just helps me figure out the best way to help you. Want to give it a try?" Keep it casual and low-pressure. Only suggest this ONCE per session after observing clear struggle.`;
   }
 
-  const mastered = [], learning = [], ready = [];
+  // Every non-locked status must land in a bucket. 'practicing',
+  // 'needs-review' and 're-fragile' used to fall through silently, so a
+  // student mid-way through a skill appeared NOWHERE in this block — and the
+  // model, seeing no history, re-taught the skill from scratch.
+  const mastered = [], learning = [], ready = [], practicing = [], review = [];
 
   for (const [skillId, data] of userProfile.skillMastery) {
     if (filterToSkill && skillId !== filterToSkill) continue;
     const display = skillId.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
     if (data.status === 'mastered') mastered.push({ display, date: data.masteredDate });
     else if (data.status === 'learning') learning.push({ display, notes: data.notes });
+    else if (data.status === 'practicing') practicing.push({ display, attempts: data.totalAttempts || 0 });
+    else if (data.status === 'needs-review' || data.status === 're-fragile') review.push({ display });
     else if (data.status === 'ready') ready.push({ display });
   }
 
   mastered.sort((a, b) => new Date(b.date) - new Date(a.date));
+  practicing.sort((a, b) => b.attempts - a.attempts);
 
   let ctx = '--- SKILL PROGRESSION ---\n';
   if (mastered.length) {
     ctx += `Mastered (${mastered.length}): ${mastered.slice(0, 5).map(s => s.display).join(', ')}${mastered.length > 5 ? ` +${mastered.length - 5} more` : ''}\n`;
   }
+  if (practicing.length) {
+    ctx += `In progress (has real prior work — RESUME, never restart from scratch): ${practicing.slice(0, 5).map(s => s.attempts ? `${s.display} (${s.attempts} attempts)` : s.display).join(', ')}${practicing.length > 5 ? ` +${practicing.length - 5} more` : ''}\n`;
+  }
   if (learning.length) {
     ctx += `Learning: ${learning.map(s => s.display).join(', ')}\n`;
+  }
+  if (review.length) {
+    ctx += `Previously learned, now fragile (quick refresh, not full re-teach): ${review.slice(0, 5).map(s => s.display).join(', ')}${review.length > 5 ? ` +${review.length - 5} more` : ''}\n`;
   }
   if (ready.length) {
     ctx += `Ready: ${ready.slice(0, 5).map(s => s.display).join(', ')}${ready.length > 5 ? ` +${ready.length - 5} more` : ''}\n`;
@@ -1042,4 +1055,4 @@ Guidelines:
 }
 
 
-module.exports = { generateSystemPrompt, buildIepAccommodationsPrompt, STATIC_RULES, buildStaticRules, RULE_1_SOCRATIC, RULE_1_TEACHING, detectManipulativeContext };
+module.exports = { generateSystemPrompt, buildIepAccommodationsPrompt, STATIC_RULES, buildStaticRules, RULE_1_SOCRATIC, RULE_1_TEACHING, detectManipulativeContext, buildSkillMasteryContext };

--- a/utils/promptPlanLayer.js
+++ b/utils/promptPlanLayer.js
@@ -137,10 +137,30 @@ function buildModeDirective(target, skillResolution) {
 
   const parts = [];
 
+  // Concrete prior-progress facts from the resolver, when it saw a mastery
+  // entry with real attempts. These are the counterweight to any mode text:
+  // the model must never be told a skill is brand-new when the record says
+  // otherwise ("why we starting over?" — production, 2026-07-26).
+  const evidence = skillResolution?.priorEvidence;
+  const hasPriorWork = (evidence?.totalAttempts || 0) > 0;
+  const priorProgressLine = hasPriorWork
+    ? `PRIOR PROGRESS ON THIS SKILL: ${evidence.totalAttempts} recorded attempt${evidence.totalAttempts === 1 ? '' : 's'}`
+      + (evidence.scorePct !== null && evidence.scorePct !== undefined ? `, ~${evidence.scorePct}% mastery score` : '')
+      + '. Pick up where they left off — do NOT re-introduce vocabulary or restart the concept from scratch, and NEVER tell them you are starting over.'
+    : null;
+
   switch (mode) {
     case 'instruct':
       parts.push(`🔑 INSTRUCTIONAL MODE: DIRECT INSTRUCTION for "${skillName}"`);
-      parts.push('This skill is NOVEL to the student. They have NEVER seen it before.');
+      if (!hasPriorWork && (!skillResolution?.familiarity || skillResolution.familiarity === 'never-seen')) {
+        parts.push('This skill is NOVEL to the student. They have NEVER seen it before.');
+      } else {
+        // Defensive: instruct mode should only arise for never-seen skills,
+        // but if it ever fires with prior work on record, do not assert a
+        // false history to the model.
+        parts.push('The student has SOME prior exposure to this skill. Refresh briefly and verify what they remember — do NOT restart from zero as if it were brand new.');
+        if (priorProgressLine) parts.push(priorProgressLine);
+      }
       parts.push('CRITICAL OVERRIDE: The standard "never give answers / always use Socratic questioning"');
       parts.push('rule is MODIFIED for this interaction. During modeling (I Do), you SHOW worked');
       parts.push('examples with full solutions and think-aloud CONCEPTUAL reasoning. The student');
@@ -201,7 +221,9 @@ function buildModeDirective(target, skillResolution) {
       parts.push(`INSTRUCTIONAL MODE: GUIDED for "${skillName}"`);
       parts.push('Student has seen this before but it is not solid. Socratic questioning is appropriate.');
       parts.push('Activate prior knowledge: "Remember when we..." or "You have seen this before..."');
+      parts.push('Start from where they left off — a quick warm-up problem beats re-explaining the concept.');
       parts.push('If they are more stuck than expected, you may need to reteach (drop to direct instruction).');
+      if (priorProgressLine) parts.push(priorProgressLine);
       break;
 
     case 'strengthen':

--- a/utils/skillFamiliarityResolver.js
+++ b/utils/skillFamiliarityResolver.js
@@ -45,15 +45,17 @@ const INSTRUCTIONAL_MODES = {
  * @param {string} skillId - The skill to check
  * @returns {string} One of the FAMILIARITY values
  */
-function assessFamiliarity(skillMastery, skillId) {
+function readMasteryEntry(skillMastery, skillId) {
   // skillMastery may be a Mongoose Map whose keys are ENCODED (dots -> "_"), so
   // read by the encoded key first, then fall back to the raw id for a plain map
   // or a pre-fix legacy entry.
   const enc = encodeMasteryKey(skillId);
   const read = (k) => (skillMastery instanceof Map ? skillMastery.get(k) : skillMastery?.[k]);
-  const entry = read(enc) || read(skillId);
+  return read(enc) || read(skillId) || null;
+}
 
-  return TutorPlan.inferFamiliarity(entry || null);
+function assessFamiliarity(skillMastery, skillId) {
+  return TutorPlan.inferFamiliarity(readMasteryEntry(skillMastery, skillId));
 }
 
 /**
@@ -172,8 +174,22 @@ async function resolveSkill(skillId, skillMastery, options = {}) {
   const { skillCache = {} } = options;
 
   // 1. Assess the target skill itself
-  const familiarity = assessFamiliarity(skillMastery, skillId);
+  const masteryEntry = readMasteryEntry(skillMastery, skillId);
+  const familiarity = TutorPlan.inferFamiliarity(masteryEntry);
   const instructionalMode = familiarityToMode(familiarity);
+
+  // Concrete prior-progress facts for the prompt layer. Without these, the
+  // mode directive is the model's ONLY signal about history — and when it
+  // claimed "never seen it before" about a returning student, nothing in the
+  // prompt could contradict it.
+  const rawScore = typeof masteryEntry?.masteryScore === 'number' ? masteryEntry.masteryScore : null;
+  const priorEvidence = masteryEntry
+    ? {
+        totalAttempts: masteryEntry.totalAttempts || 0,
+        scorePct: rawScore === null ? null : Math.round(rawScore <= 1 ? rawScore * 100 : rawScore),
+        status: masteryEntry.status || null,
+      }
+    : null;
 
   // 2. Get the skill document for teaching guidance
   let skillDoc = skillCache[skillId];
@@ -196,6 +212,7 @@ async function resolveSkill(skillId, skillMastery, options = {}) {
     displayName: skillDoc?.displayName || skillId,
     familiarity,
     instructionalMode,
+    priorEvidence,
     prerequisites,
     teachingPlan,
     teachingGuidance: skillDoc?.teachingGuidance || null,

--- a/utils/skillFocusBuilder.js
+++ b/utils/skillFocusBuilder.js
@@ -13,9 +13,13 @@
  *     in-progress). These map to guide/strengthen/leverage modes, which stay
  *     Socratic-compatible. It never seeds `never-seen` frontier skills, so it
  *     can't trigger the answer-dumping INSTRUCT mode against an off-plan
- *     question. Proactive brand-new-skill introduction stays reactive /
- *     course-driven until the on-plan detector is proven (see
- *     docs/COURSES_IN_FLOW_DESIGN.md, open question #2).
+ *     question. (NOTE: this invariant used to be broken — `introduced` was
+ *     seeded here but mapped to INSTRUCT in familiarityToMode, which restarted
+ *     full ground-up teaching for returning students. familiarityToMode now
+ *     maps `introduced` → guide, making the claim above true.) Proactive
+ *     brand-new-skill introduction stays reactive / course-driven until the
+ *     on-plan detector is proven (see docs/COURSES_IN_FLOW_DESIGN.md, open
+ *     question #2).
  *   - Only runs when the active queue is EMPTY, so it never thrashes an
  *     in-flight plan or overrides course / teacher / student-set focus.
  *   - Skips course sessions entirely (the course drives its own queue).


### PR DESCRIPTION
## Problem

Production transcript (2026-07-26, Kandy's absolute-value session): a student resuming a skill they had prior recorded work on got the full ground-up re-teach ("Let's build this from the ground up! I want to make sure the word 'absolute value' actually means something to you"). The student pushed back — **"why we starting over?"** — and after five first-try-correct answers the tutor was *still* demanding "walk me through how you arrived at that."

## Root causes and fixes

**1. `introduced` mapped to full re-teach** ([models/tutorPlan.js](models/tutorPlan.js)) — `familiarityToMode` sent `'introduced'` (requires `totalAttempts >= 1`, i.e. a *returning* student) to `'instruct'`, identical to `'never-seen'`. Instruct mode restarts the gradual-release sequence at the **vocabulary** phase. Now maps to `'guide'` (activate prior knowledge, Socratic practice, drop to direct instruction only if stuck). This also makes `skillFocusBuilder`'s documented "never seeds skills that can trigger INSTRUCT" invariant actually true.

**2. The prompt asserted a false history** ([utils/promptPlanLayer.js](utils/promptPlanLayer.js)) — the instruct directive stated *"This skill is NOVEL to the student. They have NEVER seen it before"* as unconditional fact, with zero numeric prior-progress anywhere in the prompt to contradict it. The line is now gated on the resolver's familiarity, and a **PRIOR PROGRESS** line (attempts, mastery score, "do NOT re-introduce vocabulary or restart") is injected in guide mode. `resolveSkill()` now exposes `priorEvidence {totalAttempts, scorePct, status}` to feed it.

**3. Free chat wrote learning-engine evidence it could never read** ([utils/pipeline/index.js](utils/pipeline/index.js)) — BKT/FSRS/consistency were read under `ctx.activeSkill.skillId` (always null in free chat) while persist writes them under the plan target. Read side now mirrors persist's fallback to `tutorPlan.currentTarget.skillId`.

**4. Probing turns destroyed the streak evidence that should stop probing** ([utils/pipeline/observe.js](utils/pipeline/observe.js)) — streak counters ran over the last 6 raw assistant messages; probing turns carry no `problemResult` stamp, so each one evicted a real win from the window. A self-reinforcing loop: the more the tutor probed, the less streak evidence it had to stop. Counters now run over the last 6 stamped problem **outcomes**, regardless of interleaved unstamped turns.

**5. The complaint triggered no back-off** ([utils/pipeline/observe.js](utils/pipeline/observe.js)) — `competenceAssertion` didn't match "why we starting over?", so the durable back-off mode (clamp scaffolding, stop probing correct answers) never engaged. It now matches starting-over complaints and "we already did this" variants — question form required, so "can we start over?" (a genuine restart request) still doesn't match.

**Bonus: mid-skill students were invisible to the prompt** ([utils/promptCompact.js](utils/promptCompact.js)) — `buildSkillMasteryContext` silently dropped `practicing`, `needs-review`, and `re-fragile` statuses, so a student halfway through a skill appeared nowhere in SKILL PROGRESSION. All statuses now render, with attempt counts and resume-don't-restart framing.

## Tests

`tests/unit/scaffoldingContinuity.test.js` pins every fix using the production phrasing (including the exact "why we starting over?" message). `tutorPlanModel.test.js` mapping expectation updated with rationale. **Full unit suite: 298 suites, 4,499 tests passing.** ESLint clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)