### PR TITLE
fix(chat): gate worksheet-image re-threading on per-turn relevance

### DIFF
--- a/routes/chat.js
+++ b/routes/chat.js
@@ -61,7 +61,7 @@ const pdfOcr = require('../utils/pdfOcr');
 const { validateUpload, uploadRateLimiter } = require('../middleware/uploadSecurity');
 const { applyWorksheetGuard, isCheckWorkIntent } = require('../utils/worksheetGuard');
 const { UPLOAD_CONTEXT_REMINDER, WORKSHEET_REATTACH_REMINDER } = require('../utils/visualCapabilities');
-const { isImageStillActive, buildImageDataUrl, downscaleToDataUrl, findWorksheetInMessages } = require('../utils/activeWorksheetImage');
+const { isImageStillActive, buildImageDataUrl, downscaleToDataUrl, findWorksheetInMessages, referencesWorksheet } = require('../utils/activeWorksheetImage');
 const { verifyStudentWork } = require('../utils/pipeline/checkWorkVerifier');
 
 // When a student shares their work and asks to be checked, nudge the tutor to
@@ -868,7 +868,19 @@ async function runStudentTurn(req, res) {
         // silently fall back to text-only continuity.
         let activeWorksheetImageUrl = null;
         const worksheetVisionEnabled = process.env.UNIFIED_WORKSHEET_VISION !== 'false';
-        if (worksheetVisionEnabled && !hasUploadedFiles) {
+        // Vision continuity is opt-in PER TURN, not unconditional for the TTL
+        // window. Re-threading on every turn rewrote plain answers ("yep",
+        // "11") into look-at-this-image vision messages, and the tutor spent
+        // four straight turns narrating a screenshot instead of processing the
+        // student's answers (production, 2026-07-26). Only re-thread when the
+        // current message is actually about the sheet; other turns keep the
+        // cheap text-only continuity (activeWorksheet pin above).
+        const turnReferencesSheet = referencesWorksheet(combinedMessage) || isCheckWorkIntent(combinedMessage);
+        if (worksheetVisionEnabled && !hasUploadedFiles && !turnReferencesSheet
+            && (msgWorksheet.imageDataUrl || activeWorksheetImageDoc)) {
+            logger.debug('[worksheetVision] active image available but current turn does not reference it — text-only continuity');
+        }
+        if (worksheetVisionEnabled && !hasUploadedFiles && turnReferencesSheet) {
             if (msgWorksheet.imageDataUrl) {
                 activeWorksheetImageUrl = msgWorksheet.imageDataUrl;
                 logger.info('[worksheetVision] re-threading worksheet image from conversation message (reliable source)');
@@ -1216,11 +1228,16 @@ async function runStudentTurn(req, res) {
         }
 
         // Determine if student has recent uploads (used below for worksheet guard
-        // injection AND passed to the pipeline's observe stage).
+        // injection AND passed to the pipeline's observe stage). Scoped to THIS
+        // conversation: recentUploads is a user-wide query (kept that way for the
+        // cross-session uploads summary), but classification signals like
+        // CHECK_MY_WORK / isWorksheetFollowUp must not flip on for a full day in
+        // every unrelated conversation because of one upload somewhere else.
         const hasRecentUpload = recentUploads && recentUploads.length > 0 &&
             recentUploads.some(u => {
                 const daysAgo = Math.floor((Date.now() - new Date(u.uploadedAt)) / (1000 * 60 * 60 * 24));
-                return daysAgo <= 1;
+                return daysAgo <= 1 &&
+                    u.conversationId && String(u.conversationId) === String(activeConversation._id);
             });
 
         // Resolve the independent check-work verdict (kicked off earlier) and

--- a/tests/unit/activeWorksheetImage.test.js
+++ b/tests/unit/activeWorksheetImage.test.js
@@ -176,3 +176,45 @@ describe('activeWorksheetImage — findWorksheetInMessages', () => {
     expect(findWorksheetInMessages(messages, NOW).text).toBeNull();
   });
 });
+
+describe('referencesWorksheet — per-turn gate for vision re-threading', () => {
+  const { referencesWorksheet } = require('../../utils/activeWorksheetImage');
+
+  // The production failure (2026-07-26): a screenshot re-threaded on EVERY
+  // turn for 60 minutes rewrote each of these plain answers into a
+  // look-at-this-image vision message, and the tutor spent four straight
+  // turns narrating the screenshot instead of processing the answers.
+  it.each([
+    'yep',
+    '11',
+    '-8-3=-11',
+    '5',
+    'I think it is 12',
+    'ok lets keep going',
+    'idk',
+  ])('plain answer / chatter does NOT reference the sheet: %s', (msg) => {
+    expect(referencesWorksheet(msg)).toBe(false);
+  });
+
+  it.each([
+    'check #7',
+    'can you check my answer to problem 3?',
+    'what does question 2 say',
+    'is my work right?',
+    'am I on track?',
+    'look at the picture I sent',
+    'the next one on the worksheet',
+    'what I uploaded earlier',
+    'grade my answers',
+    'whats on there',
+  ])('sheet-referencing turns DO re-thread: %s', (msg) => {
+    expect(referencesWorksheet(msg)).toBe(true);
+  });
+
+  it('is safe on empty / non-string input', () => {
+    expect(referencesWorksheet('')).toBe(false);
+    expect(referencesWorksheet(null)).toBe(false);
+    expect(referencesWorksheet(undefined)).toBe(false);
+    expect(referencesWorksheet(42)).toBe(false);
+  });
+});

--- a/utils/activeWorksheetImage.js
+++ b/utils/activeWorksheetImage.js
@@ -134,11 +134,41 @@ function findWorksheetInMessages(messages, nowMs = Date.now(), ttlMinutes = ACTI
     return out;
 }
 
+// Does the CURRENT message actually talk about the uploaded sheet/image?
+// The re-thread used to be unconditional for the whole TTL window, which let a
+// one-off screenshot hijack every following turn: each "yep" / "11" was
+// rewritten into a vision message instructing the tutor to "read the image
+// and respond to what's actually there", so the tutor kept narrating the
+// screenshot instead of processing the student's answers (production,
+// 2026-07-26 — four consecutive derailed turns). Vision continuity is for
+// turns ABOUT the sheet; everything else gets text-only continuity.
+// Pure — no IO — so it's cheap to unit test.
+const WORKSHEET_REFERENCE = new RegExp(
+    [
+        '#\\s*\\d+',                                              // "#7"
+        '\\b(?:problem|question|number|exercise)\\s*\\d+\\b',     // "problem 3"
+        '\\b(?:the\\s+)?(?:next|last|first)\\s+(?:one|problem|question)\\b',
+        '\\b(?:worksheet|sheet|page|paper|picture|photo|image|screenshot|scan|upload(?:ed)?)\\b',
+        '\\bwhat\\s+i\\s+(?:sent|showed|shared|wrote|uploaded)\\b',
+        '\\b(?:check|grade|look\\s+at|see)\\s+(?:my|the|this|that|it)\\b',
+        '\\bmy\\s+(?:work|answer|answers|solution)s?\\b',
+        '\\bon\\s+there\\b',
+        '\\bam\\s+i\\s+on\\s+track\\b',
+    ].join('|'),
+    'i'
+);
+
+function referencesWorksheet(message) {
+    if (!message || typeof message !== 'string') return false;
+    return WORKSHEET_REFERENCE.test(message);
+}
+
 module.exports = {
     isImageStillActive,
     buildImageDataUrl,
     downscaleToDataUrl,
     findWorksheetInMessages,
+    referencesWorksheet,
     ACTIVE_IMAGE_TTL_MINUTES,
     MAX_IMAGE_BYTES,
 };


### PR DESCRIPTION
## Problem

Production transcript (2026-07-26): a student pasted a screenshot of the chat window itself, once. For the next **four turns** the tutor kept narrating it ("That's a screenshot of our chat, Kandy, still the same one from before!") instead of processing the student's plain-text answers ("yep", "11", "-8-3=-11") — including asking "what's −8−3?" immediately after the student wrote `-8-3=-11`.

Mechanism: the "worksheet vision continuity" feature re-attaches the most recent uploaded image to **every** user message for 60 minutes ([routes/chat.js](routes/chat.js) resolution + re-thread sites), each time rewriting the student's message into a multimodal turn whose reminder tells the model to *"read the image directly and respond to what's actually there."* The only gates were the TTL and a feature flag — nothing about whether the current turn had anything to do with the image.

## Fix

- **`utils/activeWorksheetImage.js`** — new pure helper `referencesWorksheet(message)`: does this turn actually talk about the sheet? (problem-number references like `#7` / "problem 3", sheet/photo/screenshot nouns, "check my answer", "am I on track", "what I uploaded", …)
- **`routes/chat.js`** — the vision re-thread now fires only when `referencesWorksheet(msg) || isCheckWorkIntent(msg)`. Plain answers and chatter keep the existing cheap **text** continuity (the pinned `activeWorksheet` text is untouched, so "#3 on the quiz" follow-ups still work — and those turns *do* re-thread the image, since they reference the sheet). A debug log records when an active image is deliberately not re-threaded.
- **`routes/chat.js`** — `hasRecentUpload` is now scoped to the current conversation. It was derived from a user-wide 1-day `StudentUpload` query, so one upload anywhere flipped `CHECK_MY_WORK` / `isWorksheetFollowUp` classification in every unrelated conversation for a full day. The user-wide query itself is kept — it feeds the cross-session uploads summary.

Rollback lever unchanged: `UNIFIED_WORKSHEET_VISION=false` still disables re-threading entirely.

## Tests

`referencesWorksheet` is pinned with the exact production turns — "yep" / "11" / "-8-3=-11" must not re-thread; "check #7" / "am I on track?" / "look at the picture I sent" must. Full unit suite: **4,497 passing**; ESLint clean (warnings pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)