### PR TITLE
fix(visuals): number lines reach students again; tags never half-strip

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -139,7 +139,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
        the new surface beside the old board. Default OFF → zero impact. -->
   <script defer src="/js/living-workspace/chat-workspace.js?v=20260726b"></script>
   <!-- Final safety net: strips any inline visual tag no renderer handled -->
-  <script defer src="/js/stripVisualTags.js"></script>
+  <script defer src="/js/stripVisualTags.js?v=20260726a"></script>
   <!-- Non-core libs (lazy-loaded after first interaction) -->
   <!-- confetti: loaded on demand when celebration triggers -->
   <script>
@@ -2426,7 +2426,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
        below) — only needed when the visual board is enabled (boardPanel:true). -->
   <script src="/dist/js/chat-js3.9552db6c.js"></script>
 <!-- returningUserModal.js removed — no longer used -->
-  <script src="/dist/js/chat-js4.301bba99.js"></script>
+  <script src="/dist/js/chat-js4.10c0dbd2.js"></script>
 <link rel="stylesheet" href="/css/algebra-tiles.css">
   <!-- algebra-tiles.js lazy-loads itself on demand (inlineChatVisuals
        openAlgebraTilesWorkspace) — no static tag needed. -->

--- a/public/dist/chat-bundles.manifest.json
+++ b/public/dist/chat-bundles.manifest.json
@@ -80,7 +80,7 @@
       ]
     },
     {
-      "src": "/dist/js/chat-js4.301bba99.js",
+      "src": "/dist/js/chat-js4.10c0dbd2.js",
       "files": [
         "/js/diagram-display.js",
         "/js/inlineChatVisuals.js"

--- a/public/dist/js/chat-js4.10c0dbd2.js
+++ b/public/dist/js/chat-js4.10c0dbd2.js
@@ -864,7 +864,12 @@ class InlineChatVisuals {
             html = html.replace(regex, (match, params) => {
                 hasVisuals = true;
                 try {
-                    return handler(params);
+                    // Models write unicode minus/dashes in params (points=[−3,3]);
+                    // parseFloat('−3') is NaN, which made handlers reject valid
+                    // tags — the tag then leaked to the stripper half-eaten
+                    // (prod: ',label="−3 and 3…"]' in a student's chat). Params
+                    // are machine syntax, not prose: normalize to ASCII hyphen.
+                    return handler(String(params).replace(/[\u2212\u2013\u2014]/g, '-'));
                 } catch (error) {
                     console.error(`[InlineChatVisuals] Error rendering ${match}:`, error);
                     return `<div class="icv-error">⚠️ Could not render visual</div>`;

--- a/public/js/inlineChatVisuals.js
+++ b/public/js/inlineChatVisuals.js
@@ -191,7 +191,12 @@ class InlineChatVisuals {
             html = html.replace(regex, (match, params) => {
                 hasVisuals = true;
                 try {
-                    return handler(params);
+                    // Models write unicode minus/dashes in params (points=[−3,3]);
+                    // parseFloat('−3') is NaN, which made handlers reject valid
+                    // tags — the tag then leaked to the stripper half-eaten
+                    // (prod: ',label="−3 and 3…"]' in a student's chat). Params
+                    // are machine syntax, not prose: normalize to ASCII hyphen.
+                    return handler(String(params).replace(/[\u2212\u2013\u2014]/g, '-'));
                 } catch (error) {
                     console.error(`[InlineChatVisuals] Error rendering ${match}:`, error);
                     return `<div class="icv-error">⚠️ Could not render visual</div>`;

--- a/public/js/stripVisualTags.js
+++ b/public/js/stripVisualTags.js
@@ -35,9 +35,12 @@
     'COMPARISON', 'INEQUALITY', 'ALGEBRA_TILES', 'MULTI_REP', 'SEARCH_IMAGE',
   ];
 
-  // [NAME] or [NAME:...anything-but-]...]. Anchored to the whitelist so plain
-  // brackets ([0, 3], [a, b]) and LaTeX are never touched.
-  const TAG_RE = new RegExp('\\[(?:' + VISUAL_COMMANDS.join('|') + ')(?::[^\\]]*)?\\]', 'g');
+  // [NAME] or [NAME:params]. Params may nest ONE level of brackets
+  // (points=[-3,3], jumps=[(0,3),(3,7)]) — same grammar as VisualTokenParser.
+  // The old first-']' pattern ate half a nested tag and left the tail
+  // (',label="…"]') in the student's message. Anchored to the whitelist so
+  // plain brackets ([0, 3], [a, b]) and LaTeX are never touched.
+  const TAG_RE = new RegExp('\\[(?:' + VISUAL_COMMANDS.join('|') + ')(?::(?:[^\\[\\]]|\\[[^\\]]*\\])*)?\\]', 'g');
 
   /**
    * Remove any leftover (unrendered) visual command tags from a message.

--- a/tests/unit/visualTagNesting.test.js
+++ b/tests/unit/visualTagNesting.test.js
@@ -1,0 +1,36 @@
+/**
+ * The half-eaten visual tag (production, Kandy's session 2026-07-26):
+ * ',label="−3 and 3 are both 3 steps from zero"]' leaked into a tutor
+ * message. Chain of failure: unicode minus in params → renderer rejected the
+ * tag → safety-net stripper's first-']' regex ate only the head → tail
+ * shipped as student-visible text. All three layers pinned here.
+ */
+const { stripUnrenderedVisualTags } = require('../../public/js/stripVisualTags.js');
+const { verify } = require('../../utils/pipeline/verify');
+
+const PROD_TAG = '[NUMBER_LINE:min=-5,max=5,points=[−3,3],label="−3 and 3 are both 3 steps from zero"]';
+
+describe('stripVisualTags strips nested-bracket tags WHOLE', () => {
+  test('the exact production tag leaves no residue', () => {
+    const out = stripUnrenderedVisualTags(`Distance only cares how far. ${PROD_TAG} See both land 3 away.`);
+    expect(out).not.toContain('label=');
+    expect(out).not.toContain(']');
+    expect(out).toContain('Distance only cares how far.');
+    expect(out).toContain('See both land 3 away.');
+  });
+
+  test('plain brackets and intervals still never touched', () => {
+    const text = 'The interval [0, 3] and the pair [a, b] stay.';
+    expect(stripUnrenderedVisualTags(text)).toBe(text);
+  });
+});
+
+describe('the tag SURVIVES verify whole — students must see the number line', () => {
+  test('the tag round-trips verify without the tail being exposed', async () => {
+    const v = await verify(`Distance only cares how far. ${PROD_TAG}`, {});
+    // The whole tag must survive intact — no half-protection artifacts like
+    // a mangled tail or injected \( \) inside the label.
+    expect(v.text).toContain('label="−3 and 3 are both 3 steps from zero"]');
+    expect(v.text.match(/\[NUMBER_LINE:/g)).toHaveLength(1);
+  });
+});

--- a/utils/pipeline/verify.js
+++ b/utils/pipeline/verify.js
@@ -1300,8 +1300,11 @@ function normalizeLatex(text) {
     'INEQUALITY', 'ALGEBRA_TILES', 'MULTI_REP',
     'DERIVATIVE_GRAPH', 'RATIONAL_GRAPH', 'VELOCITY_GRAPH',
   ];
+  // Params may nest one level of brackets (points=[-3,3]) — the first-']'
+  // pattern protected only half the tag and exposed the tail to the LaTeX
+  // normalizer. Same grammar as VisualTokenParser / stripVisualTags.
   const visualCmdRegex = new RegExp(
-    `\\[(${VISUAL_CMD_NAMES.join('|')}):([^\\]]+)\\]`, 'g'
+    `\\[(${VISUAL_CMD_NAMES.join('|')}):((?:[^\\[\\]]|\\[[^\\]]*\\])+)\\]`, 'g'
   );
   result = result.replace(visualCmdRegex, (match) => {
     visualCmdBlocks.push(match);

--- a/utils/visualTeachingParser.js
+++ b/utils/visualTeachingParser.js
@@ -346,10 +346,14 @@ function parseVisualTeaching(aiResponseText) {
     cleanedText = cleanedText.replace(countersRegex, '');
 
     // --- MANIPULATIVE COMMANDS ---
-    // [NUMBER_LINE:...] - Handled inline by inlineChatVisuals.js (key=value format).
-    // Strip any NUMBER_LINE tags so they don't appear as raw text.
-    const numberLineRegex = /\[NUMBER_LINE:[^\]]+\]/g;
-    cleanedText = cleanedText.replace(numberLineRegex, '');
+    // [NUMBER_LINE:...] is rendered INLINE by the client (inlineChatVisuals'
+    // draggable number line) — the tag must SURVIVE to the browser. This used
+    // to strip it server-side "so it doesn't appear as raw text", which (a)
+    // deleted the visual for every student — the tutor narrated number lines
+    // nobody could see — and (b) leaked mangled tails into chat when the
+    // first-']' regex met nested params (prod: ',label="−3 and 3…"]').
+    // Unrendered leftovers are the client safety net's job (stripVisualTags,
+    // whitelist + nested-bracket-aware).
 
     // [FRACTION_BARS:numerator,denominator] - Show fraction visualization
     const fractionBarsRegex = /\[FRACTION_BARS:(\d+),(\d+)\]/g;


### PR DESCRIPTION
Owner screenshot: raw `,label="−3 and 3 are both 3 steps from zero"]` in a tutor message — beside prose saying *"look at that number line"* over a number line **no student could see**.

## Root-cause stack (worst first)

1. **The visual was deleted for everyone.** `visualTeachingParser` strips every `[NUMBER_LINE:…]` server-side — a relic from before the client renderer existed. `inlineChatVisuals` has a full draggable inline number line, and `visualCapabilities` teaches the model to emit the tag — the server strip meant main-path chat could never display one. Tutors have been narrating invisible number lines. **Strip removed**; the tag survives to the browser and renders.
2. **The leak that exposed it.** The strip's first-`]` regex choked on nested params (`points=[−3,3]`), eating the head and leaking the tail into student-visible text. The client safety net and `normalizeLatex`'s protector are now nested-bracket-tolerant (same grammar as `VisualTokenParser`).
3. **The renderer would have rejected it anyway**: unicode minus in params → `parseFloat` NaN. Params are machine syntax — unicode minus/dashes normalize to ASCII in params only.

Also trues up the repo: the committed manifest referenced `chat-js4.301bba99.js`, which was **never committed** (the exact #1285 drift, masked by the deploy-time rebuild).

## Verification

Full suite **4799 passed**, `chatBundleIntegrity` green, lint clean; regression tests pin the exact production tag through every layer. Post-deploy: ask about absolute value → a draggable number line appears inline, zero bracket junk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)