### PR TITLE
fix(test-out): never improvise an ungraded quiz when skill resolution fails

### DIFF
--- a/tests/unit/testOutIntent.test.js
+++ b/tests/unit/testOutIntent.test.js
@@ -28,3 +28,56 @@ describe('detectTestOutIntent', () => {
     expect(detectTestOutIntent(t)).toBe(false);
   });
 });
+
+describe('resolveTestOutSkillId — no more silent null → improvised quiz', () => {
+  const { resolveTestOutSkillId, matchFocusSkillByName } = require('../../utils/testOutIntent');
+  const { recentPracticeSkillId } = require('../../utils/tutorPlanManager');
+
+  const base = { message: 'can I test out?', activeSkillId: null, tutorPlan: null, recentPracticeSkillId };
+
+  it('activeSkillId (mastery mode) wins outright', () => {
+    expect(resolveTestOutSkillId({ ...base, activeSkillId: 'abs-val' })).toBe('abs-val');
+  });
+
+  it('a skill NAMED in the message beats the plan target', () => {
+    const tutorPlan = {
+      currentTarget: { skillId: 'fractions' },
+      skillFocus: [
+        { skillId: 'abs-val', displayName: 'Absolute Value', status: 'resolved' },
+        { skillId: 'abs-val-eq', displayName: 'Absolute Value Equations', status: 'active' },
+      ],
+    };
+    expect(resolveTestOutSkillId({ ...base, message: 'test out of absolute value', tutorPlan }))
+      .toBe('abs-val');
+    // Longest name wins when both match
+    expect(resolveTestOutSkillId({ ...base, message: 'test out of absolute value equations', tutorPlan }))
+      .toBe('abs-val-eq');
+  });
+
+  it('falls back to currentTarget, then recent practice, then last session', () => {
+    expect(resolveTestOutSkillId({ ...base, tutorPlan: { currentTarget: { skillId: 'abs-val' } } }))
+      .toBe('abs-val');
+
+    const practicePlan = {
+      currentTarget: { skillId: null },
+      skillFocus: [{ skillId: 'abs-val', status: 'in-progress', lastWorkedOn: new Date() }],
+    };
+    expect(resolveTestOutSkillId({ ...base, tutorPlan: practicePlan })).toBe('abs-val');
+
+    // Kandy's case: fresh plan, but LAST SESSION was absolute value
+    const lastSessionPlan = { currentTarget: { skillId: null }, skillFocus: [], lastSession: { skillId: 'abs-val' } };
+    expect(resolveTestOutSkillId({ ...base, tutorPlan: lastSessionPlan })).toBe('abs-val');
+  });
+
+  it('returns null (for the no-improv directive) when nothing resolves', () => {
+    expect(resolveTestOutSkillId({ ...base })).toBeNull();
+    expect(resolveTestOutSkillId({ ...base, tutorPlan: { skillFocus: [] } })).toBeNull();
+  });
+
+  it('matchFocusSkillByName ignores short/absent names and non-matching messages', () => {
+    const plan = { skillFocus: [{ skillId: 's1', displayName: 'Abs' }, { skillId: 's2' }] };
+    expect(matchFocusSkillByName('test out of abs', plan)).toBeNull(); // name too short (< 4 chars)
+    expect(matchFocusSkillByName('can I test out?', { skillFocus: [{ skillId: 's3', displayName: 'Fractions' }] })).toBeNull();
+    expect(matchFocusSkillByName(null, plan)).toBeNull();
+  });
+});

--- a/utils/pipeline/index.js
+++ b/utils/pipeline/index.js
@@ -43,7 +43,7 @@ const { recordAttempt: recordConsistencyAttempt, initializeScore, categorizeDiff
 
 // Backbone: Tutor Plan + Skill Familiarity
 const { loadOrCreatePlan, resolveCurrentTarget, updatePlanAfterInteraction, advanceInstructionPhase, recentPracticeSkillId } = require('../tutorPlanManager');
-const { detectTestOutIntent } = require('../testOutIntent');
+const { detectTestOutIntent, resolveTestOutSkillId } = require('../testOutIntent');
 const { buildPlanLayer, shouldSuppressSocratic } = require('../promptPlanLayer');
 const { reassessFamiliarity } = require('../phaseEvidenceEvaluator');
 const { detectModeTransition } = require('../modeTransitionDetector');
@@ -315,13 +315,23 @@ async function runPipeline(message, ctx) {
   // via the challenge rung — the one proof path with no 3-context requirement,
   // so ambient practice and a test-out both have a real road to 100%.
   let launchChallenge = null;
+  let testOutIntentDetected = false;
   if (detectTestOutIntent(message)) {
-    const challengeSkillId = ctx.activeSkill?.skillId
-      || tutorPlan?.currentTarget?.skillId
-      || recentPracticeSkillId(tutorPlan);
+    testOutIntentDetected = true;
+    const challengeSkillId = resolveTestOutSkillId({
+      message,
+      activeSkillId: ctx.activeSkill?.skillId || null,
+      tutorPlan,
+      recentPracticeSkillId,
+    });
     if (challengeSkillId) {
       launchChallenge = { skillId: challengeSkillId };
       console.log(`[Pipeline] Test-out intent → launching challenge for ${challengeSkillId}`);
+    } else {
+      // MUST NOT be silent: with no directive the LLM accepts the request and
+      // improvises an ungraded quiz in prose (production, 2026-07-26). The
+      // no-improv directive is pushed below, next to the launch directive.
+      console.warn('[Pipeline] Test-out intent but no skill resolved — challenge NOT launched, no-improv directive pushed');
     }
   }
 
@@ -439,6 +449,10 @@ async function runPipeline(message, ctx) {
   if (launchChallenge) {
     decision.directives.push(
       'TEST-OUT: The student wants to prove they already know this skill, and a 5-problem challenge is being launched right in the chat immediately after your message. In ONE or two upbeat sentences, set it up: 5 problems, no hints, one shot — miss it and we just find the gap, nothing lost. Do NOT pose a problem yourself and do NOT start teaching; the challenge card handles the problems.'
+    );
+  } else if (testOutIntentDetected) {
+    decision.directives.push(
+      'TEST-OUT REQUEST, NO SKILL RESOLVED: The student asked to test out, but no target skill could be identified, so the real graded challenge could NOT be launched. Do NOT improvise a quiz in the chat — you cannot grade one, it will not be recorded, and it will not count toward the skill. Instead, in one or two sentences: confirm which skill they want to test out of (name the topic you have been working on if it is obvious), and ask them to say "test out of [that skill]" so the real 5-problem challenge can start.'
     );
   }
 

--- a/utils/testOutIntent.js
+++ b/utils/testOutIntent.js
@@ -27,4 +27,52 @@ function detectTestOutIntent(text) {
   return TEST_OUT.test(text);
 }
 
-module.exports = { detectTestOutIntent };
+/**
+ * Match a skill the student NAMED in their message against the plan's focus
+ * queue ("can I test out of absolute value?"). Any focus status counts — the
+ * student may name a skill whose entry was already resolved. Prefers the
+ * longest matching name so "absolute value equations" beats "absolute value".
+ */
+function matchFocusSkillByName(message, plan) {
+  if (!message || !Array.isArray(plan?.skillFocus) || plan.skillFocus.length === 0) return null;
+  const lower = String(message).toLowerCase();
+  let best = null;
+  for (const sf of plan.skillFocus) {
+    if (!sf?.skillId) continue;
+    const name = (sf.displayName || '').toLowerCase().trim();
+    if (name.length >= 4 && lower.includes(name)) {
+      if (!best || name.length > best.name.length) best = { name, skillId: sf.skillId };
+    }
+  }
+  return best ? best.skillId : null;
+}
+
+/**
+ * Resolve WHICH skill a test-out request is about.
+ *
+ * This used to be a three-step chain that could silently produce null (free
+ * chat has no activeSkill; a fresh plan may have no in-progress focus entry) —
+ * and on null the pipeline pushed NO directive, so the LLM accepted the
+ * request and improvised an ungraded 5-question quiz in prose, then broke its
+ * own no-hints rule turn after turn (production, 2026-07-26). The chain now
+ * also tries a skill named in the message and the last session's skill, and
+ * callers must handle null explicitly (see the pipeline's no-improv directive).
+ *
+ * @param {Object} params
+ * @param {string} params.message - The student's message
+ * @param {string|null} params.activeSkillId - ctx.activeSkill?.skillId (mastery mode)
+ * @param {Object|null} params.tutorPlan - The TutorPlan document
+ * @param {Function} params.recentPracticeSkillId - injected from tutorPlanManager
+ *   (parameter injection, not a require, to keep this module dependency-free)
+ * @returns {string|null}
+ */
+function resolveTestOutSkillId({ message, activeSkillId, tutorPlan, recentPracticeSkillId }) {
+  return activeSkillId
+    || matchFocusSkillByName(message, tutorPlan)
+    || tutorPlan?.currentTarget?.skillId
+    || (typeof recentPracticeSkillId === 'function' ? recentPracticeSkillId(tutorPlan) : null)
+    || tutorPlan?.lastSession?.skillId
+    || null;
+}
+
+module.exports = { detectTestOutIntent, matchFocusSkillByName, resolveTestOutSkillId };


### PR DESCRIPTION
## Problem

Production transcript (2026-07-26): the student asked **"can I test out?"** — which should launch the real graded 5-problem challenge card (shipped in #1313/#1333). But the pipeline's skill-resolution chain (`ctx.activeSkill → currentTarget → recentPracticeSkillId`) can silently return null: free chat has no `activeSkill`, and a fresh plan may have no in-progress focus entry. On null, **no directive was pushed at all**, so the LLM accepted the request and improvised an ungraded 5-question quiz in prose — then broke its own "no hints, one shot each" rule turn after turn (demanding walk-throughs of correct answers, losing track of the question count). Nothing was recorded toward the skill.

## Fix

**`utils/testOutIntent.js`** — new `resolveTestOutSkillId()` extends the chain with two real fallbacks:
- a skill **named in the message**, matched against the plan's focus queue with longest-name preference ("test out of absolute value equations" beats "absolute value"),
- the **last session's skillId** — which covers exactly the transcript case: returning student, fresh queue, prior session on the skill.

**`utils/pipeline/index.js`** — a null resolution is no longer silent. The decide stage gets an explicit no-improv directive: the graded challenge could not be launched, an in-chat quiz can't be graded or recorded, confirm the skill so the real challenge can start. Plus a `console.warn` so the miss path is observable.

Composes with #1338: that PR makes `tutorPlan.currentTarget` resolve in free chat far more often, so this fallback chain rarely gets past step one.

## Tests

Resolution chain pinned in `tests/unit/testOutIntent.test.js`: priority order, longest-name matching, the last-session fallback (the Kandy case), and the explicit-null contract. Full unit suite: **4,484 passing**; ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)